### PR TITLE
Add sessionToken field to Credentials, and add it to request headers

### DIFF
--- a/lib/src/credentials.dart
+++ b/lib/src/credentials.dart
@@ -10,8 +10,11 @@ class Credentials {
   /// AWS secret key
   final String secretKey;
 
+  /// AWS temporary credentials session token
+  final String sessionToken;
+
   /// AWS credentials.
-  Credentials({this.accessKey, this.secretKey}) {
+  Credentials({this.accessKey, this.secretKey, this.sessionToken}) {
     assert(accessKey != null);
     assert(secretKey != null);
   }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -221,6 +221,9 @@ class AwsRequestBuilder {
     });
     String signature =
         new Hmac(sha256, signingKey).convert(utf8.encode(toSign)).toString();
+    if (credentials.sessionToken != null) {
+      headers['X-Amz-Security-Token'] = credentials.sessionToken;
+    }
 
     String auth = '$_aws4HmacSha256 '
         'Credential=${credentials.accessKey}/${credentialList.join('/')}, '


### PR DESCRIPTION
Add `sessionToken` field to Credentials, and add it to (unsigned) request headers as `X-Amz-Security-Token`.