### PR TITLE
Add buildRequest method that populate the AwsRequestBuilder members

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -120,13 +120,18 @@ class AwsRequestBuilder {
     this.queryParameters,
   });
 
-  /// Initializes, signs and send the request.
-  Future<AwsResponse> sendRequest() async {
+  /// Initializes and signs a request.
+  Request generateRequest() {
     assert(credentials != null);
     assert(httpClient != null);
     _initDefaults();
     _sign();
-    Request rq = new Request(method, uri, headers: headers, body: body);
+    return new Request(method, uri, headers: headers, body: body);
+  }
+
+  /// Initializes, signs and send the request.
+  Future<AwsResponse> sendRequest() async {
+    Request rq = generateRequest();
     Response rs = await httpClient.send(rq);
     return new AwsResponse(
         rs.statusCode, rs.reasonPhrase, rs.headers.toSimpleMap(), rs.body);

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -121,7 +121,7 @@ class AwsRequestBuilder {
   });
 
   /// Initializes and signs a request.
-  Request generateRequest() {
+  Request buildRequest() {
     assert(credentials != null);
     assert(httpClient != null);
     _initDefaults();
@@ -131,7 +131,7 @@ class AwsRequestBuilder {
 
   /// Initializes, signs and send the request.
   Future<AwsResponse> sendRequest() async {
-    Request rq = generateRequest();
+    Request rq = buildRequest();
     Response rs = await httpClient.send(rq);
     return new AwsResponse(
         rs.statusCode, rs.reasonPhrase, rs.headers.toSimpleMap(), rs.body);


### PR DESCRIPTION
Add `generateRequest` method that populate the `AwsRequestBuilder` members and returns a `Request` (but does not send the request.)

Remove the (now) duplicate code from `sendRequest` and call this method to retain the same behaviour as before.