### PR TITLE
Allow 'service' field in AwsRequestBuilder constructor to override detection from uri

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -168,7 +168,7 @@ class AwsRequestBuilder {
                 .first +
             'Z');
     region ??= _extractRegion(uri);
-    service = _extractService(uri);
+    service ??= _extractService(uri);
   }
 
   void _sign() {


### PR DESCRIPTION
Allow `service` field in `AwsRequestBuilder` constructor to override detection from `uri` (using `??=` operator).