### PR TITLE
Add URI-encoding for path in Request signature

### DIFF
--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -194,7 +194,7 @@ class AwsRequestBuilder {
 
     String canonical = ([
       method.toUpperCase(),
-      uri.path,
+      Uri.encodeFull(uri.path),
       canonicalQuery,
     ]
           ..addAll(canonicalHeaders)


### PR DESCRIPTION
I've added the least amount of URI encoding that solves my issue of having special characters in the `topic` portion of the AWS request path for IoT Publish.

Note: It seems the correct amount of URI encoding may in fact be *twice* (?) but I tried doing it twice here, and it did not work (doing it only once, as in this PR, does work).

> Normalize URI paths according to RFC 3986. Remove redundant and relative path components. Each path segment must be URI-encoded twice (except for Amazon S3 which only gets URI-encoded once).
>
> Example canonical URI with encoding
> `/documents%2520and%2520settings/`
>
> https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html