### PR TITLE
Misc fixes: returnType, fieldName

### DIFF
--- a/generator/lib/builders/query_builder.dart
+++ b/generator/lib/builders/query_builder.dart
@@ -20,7 +20,6 @@ class QueryServiceBuilder extends ServiceBuilder {
 
   @override
   String operationContent(Operation operation) {
-    final hasReturnType = operation.returnType != 'void';
     final parameterShape = api.shapes[operation.parameterType];
     final useParameter = parameterShape != null && parameterShape.hasMembers;
 
@@ -38,7 +37,7 @@ class QueryServiceBuilder extends ServiceBuilder {
     if (operation.output?.resultWrapper != null) {
       params.write(', resultWrapper: \'${operation.output.resultWrapper}\',');
     }
-    if (hasReturnType) {
+    if (operation.hasReturnType) {
       buf.writeln('    final \$result = await _protocol.send($params);');
       buf.writeln('    return ${operation.returnType}.fromJson(\$result);');
     } else {

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -10,7 +10,6 @@ import 'package:aws_client.generator/model/operation.dart';
 import 'package:aws_client.generator/model/shape.dart';
 
 import 'builders/query_builder.dart';
-import 'model/dart_type.dart';
 
 File buildService(Api api) {
   api.initReferences();
@@ -126,16 +125,7 @@ ${builder.constructor()}
             '@JsonSerializable(includeIfNull: false, explicitToJson: true)');
         writeln('class $name {');
         for (final member in shape.members) {
-          String shapename = member.shape;
-          final Shape memberShape = shape.api.shapes[shapename];
-
-          final String type = memberShape.type;
-          if (type.isBasicType()) {
-            shapename = type.getDartType();
-          } else if (type.isMapOrList()) {
-            shapename = getListOrMapDartType(memberShape);
-          }
-
+          String shapename = member.dartType;
           final List<String> valueEnum =
               shape.api.shapes[member.shape].enumeration;
 

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -10,6 +10,7 @@ import 'package:aws_client.generator/model/operation.dart';
 import 'package:aws_client.generator/model/shape.dart';
 
 import 'builders/query_builder.dart';
+import 'model/dart_type.dart';
 
 File buildService(Api api) {
   api.initReferences();
@@ -52,95 +53,8 @@ import 'package:meta/meta.dart';
     ..writeAsStringSync(buf.toString());
 }
 
-String getListOrMapDartType(Shape shape) {
-  final StringBuffer buf = StringBuffer();
-  if (shape.type == 'list') {
-    buf.write('List<');
-
-    final String memberShape = shape.member?.shape;
-    final String memberType = shape.api.shapes[memberShape].type;
-
-    if (memberType.isBasicType()) {
-      buf.write(memberType.getDartType());
-    } else if (memberType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape.api.shapes[memberShape]);
-      buf.write(type);
-    } else {
-      buf.write(memberShape);
-    }
-    buf.write('>');
-  } else if (shape.type == 'map') {
-    buf.write('Map<');
-
-    final String memberKey = shape.key.shape;
-    final String memberKeyType = shape.api.shapes[memberKey].type;
-
-    if (memberKeyType.isBasicType()) {
-      buf.write(memberKeyType.getDartType());
-    } else if (memberKeyType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape.api.shapes[memberKey]);
-      buf.write(type);
-    } else {
-      buf.write(memberKey);
-    }
-    buf.write(', ');
-
-    final String memberValue = shape.value.shape;
-    final String memberValueType = shape.api.shapes[memberValue].type;
-
-    if (memberValueType.isBasicType()) {
-      buf.write(memberValueType.getDartType());
-    } else if (memberValueType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape..api.shapes[memberValue]);
-      buf.write(type);
-    } else {
-      buf.write(memberValue);
-    }
-
-    buf.write('>');
-  } else {
-    throw Exception('No type found');
-  }
-
-  return buf.toString();
-}
-
 extension Casting on dynamic {
   T cast<T>() => this is T ? this as T : null;
-}
-
-extension StringStuff on String {
-  bool isBasicType() =>
-      this == 'string' ||
-      this == 'boolean' ||
-      this == 'double' ||
-      this == 'integer' ||
-      this == 'long' ||
-      this == 'blob' ||
-      this == 'timestamp';
-
-  bool isMapOrList() => this == 'list' || this == 'map';
-
-  String getDartType() {
-    switch (this) {
-      case 'string':
-        return 'String';
-      case 'boolean':
-        return 'bool';
-      case 'double':
-        return this;
-      case 'integer':
-        return 'int';
-      case 'long':
-        return 'int';
-      case 'blob':
-        return 'blob';
-      case 'timestamp':
-        return 'DateTime';
-      default:
-        return '???';
-    }
-  }
 }
 
 extension StringBufferStuff on StringBuffer {

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -30,9 +30,11 @@ class Api {
   void initReferences() {
     operations?.values?.forEach((o) {
       o.api = this;
+      o.initReferences();
     });
     shapes?.values?.forEach((s) {
       s.api = this;
+      s.initReferences();
     });
   }
 

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -27,6 +27,15 @@ class Api {
 
   factory Api.fromJson(Map<String, dynamic> json) => _$ApiFromJson(json);
 
+  void initReferences() {
+    operations?.values?.forEach((o) {
+      o.api = this;
+    });
+    shapes?.values?.forEach((s) {
+      s.api = this;
+    });
+  }
+
   bool get usesQueryProtocol => metadata.protocol == 'query';
   bool get usesJsonProtocol => metadata.protocol == 'json';
   bool get usesRestJsonProtocol => metadata.protocol == 'rest-json';

--- a/generator/lib/model/dart_type.dart
+++ b/generator/lib/model/dart_type.dart
@@ -4,47 +4,13 @@ String getListOrMapDartType(Shape shape) {
   final StringBuffer buf = StringBuffer();
   if (shape.type == 'list') {
     buf.write('List<');
-
-    final String memberShape = shape.member?.shape;
-    final String memberType = shape.api.shapes[memberShape].type;
-
-    if (memberType.isBasicType()) {
-      buf.write(memberType.getDartType());
-    } else if (memberType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape.api.shapes[memberShape]);
-      buf.write(type);
-    } else {
-      buf.write(memberShape);
-    }
+    buf.write(shape.member.dartType);
     buf.write('>');
   } else if (shape.type == 'map') {
     buf.write('Map<');
-
-    final String memberKey = shape.key.shape;
-    final String memberKeyType = shape.api.shapes[memberKey].type;
-
-    if (memberKeyType.isBasicType()) {
-      buf.write(memberKeyType.getDartType());
-    } else if (memberKeyType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape.api.shapes[memberKey]);
-      buf.write(type);
-    } else {
-      buf.write(memberKey);
-    }
+    buf.write(shape.key.dartType);
     buf.write(', ');
-
-    final String memberValue = shape.value.shape;
-    final String memberValueType = shape.api.shapes[memberValue].type;
-
-    if (memberValueType.isBasicType()) {
-      buf.write(memberValueType.getDartType());
-    } else if (memberValueType.isMapOrList()) {
-      final String type = getListOrMapDartType(shape..api.shapes[memberValue]);
-      buf.write(type);
-    } else {
-      buf.write(memberValue);
-    }
-
+    buf.write(shape.value.dartType);
     buf.write('>');
   } else {
     throw Exception('No type found');

--- a/generator/lib/model/dart_type.dart
+++ b/generator/lib/model/dart_type.dart
@@ -1,0 +1,88 @@
+import 'shape.dart';
+
+String getListOrMapDartType(Shape shape) {
+  final StringBuffer buf = StringBuffer();
+  if (shape.type == 'list') {
+    buf.write('List<');
+
+    final String memberShape = shape.member?.shape;
+    final String memberType = shape.api.shapes[memberShape].type;
+
+    if (memberType.isBasicType()) {
+      buf.write(memberType.getDartType());
+    } else if (memberType.isMapOrList()) {
+      final String type = getListOrMapDartType(shape.api.shapes[memberShape]);
+      buf.write(type);
+    } else {
+      buf.write(memberShape);
+    }
+    buf.write('>');
+  } else if (shape.type == 'map') {
+    buf.write('Map<');
+
+    final String memberKey = shape.key.shape;
+    final String memberKeyType = shape.api.shapes[memberKey].type;
+
+    if (memberKeyType.isBasicType()) {
+      buf.write(memberKeyType.getDartType());
+    } else if (memberKeyType.isMapOrList()) {
+      final String type = getListOrMapDartType(shape.api.shapes[memberKey]);
+      buf.write(type);
+    } else {
+      buf.write(memberKey);
+    }
+    buf.write(', ');
+
+    final String memberValue = shape.value.shape;
+    final String memberValueType = shape.api.shapes[memberValue].type;
+
+    if (memberValueType.isBasicType()) {
+      buf.write(memberValueType.getDartType());
+    } else if (memberValueType.isMapOrList()) {
+      final String type = getListOrMapDartType(shape..api.shapes[memberValue]);
+      buf.write(type);
+    } else {
+      buf.write(memberValue);
+    }
+
+    buf.write('>');
+  } else {
+    throw Exception('No type found');
+  }
+
+  return buf.toString();
+}
+
+extension StringStuff on String {
+  bool isBasicType() =>
+      this == 'string' ||
+      this == 'boolean' ||
+      this == 'double' ||
+      this == 'integer' ||
+      this == 'long' ||
+      this == 'blob' ||
+      this == 'timestamp';
+
+  bool isMapOrList() => this == 'list' || this == 'map';
+
+  String getDartType() {
+    switch (this) {
+      case 'string':
+        return 'String';
+      case 'boolean':
+        return 'bool';
+      case 'double':
+        return this;
+      case 'integer':
+        return 'int';
+      case 'long':
+        return 'int';
+      case 'blob':
+        return 'blob';
+      case 'timestamp':
+        return 'DateTime';
+      default:
+        return '???';
+    }
+  }
+}

--- a/generator/lib/model/descriptor.dart
+++ b/generator/lib/model/descriptor.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'api.dart';
+import 'dart_type.dart';
 import 'error.dart';
 import 'xml_namespace.dart';
 
@@ -37,4 +38,17 @@ class Descriptor {
 
   factory Descriptor.fromJson(Map<String, dynamic> json) =>
       _$DescriptorFromJson(json);
+
+  String get dartType {
+    final shapeRef = api.shapes[shape];
+    final shapeRefType = shapeRef.type;
+
+    if (shapeRefType.isBasicType()) {
+      return shapeRefType.getDartType();
+    } else if (shapeRefType.isMapOrList()) {
+      return getListOrMapDartType(shapeRef);
+    } else {
+      return shape;
+    }
+  }
 }

--- a/generator/lib/model/descriptor.dart
+++ b/generator/lib/model/descriptor.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'api.dart';
 import 'error.dart';
 import 'xml_namespace.dart';
 
@@ -7,6 +8,8 @@ part 'descriptor.g.dart';
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class Descriptor {
+  @JsonKey(ignore: true)
+  Api api;
   final String shape;
   final String resultWrapper;
   final String locationName;

--- a/generator/lib/model/operation.dart
+++ b/generator/lib/model/operation.dart
@@ -53,8 +53,8 @@ class Operation {
       _$OperationFromJson(json);
 
   void initReferences() {
-    input.api = api;
-    output.api = api;
+    input?.api = api;
+    output?.api = api;
     errors?.forEach((e) => e.api = api);
   }
 

--- a/generator/lib/model/operation.dart
+++ b/generator/lib/model/operation.dart
@@ -1,11 +1,14 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'api.dart';
 import 'descriptor.dart';
 
 part 'operation.g.dart';
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class Operation {
+  @JsonKey(ignore: true)
+  Api api;
   final String name;
   final Http http;
   @JsonKey(defaultValue: '')
@@ -52,7 +55,18 @@ class Operation {
   String get methodName =>
       name.substring(0, 1).toLowerCase() + name.substring(1);
 
-  String get returnType => output?.shape ?? 'void';
+  bool get hasReturnType => returnType != 'void';
+
+  String get returnType {
+    String returnType = output?.shape ?? 'void';
+    final returnShape = api.shapes[returnType];
+    if (returnShape != null &&
+        returnShape?.type == 'structure' &&
+        returnShape.hasEmptyMembers) {
+      returnType = 'void';
+    }
+    return returnType;
+  }
 
   String get parameterType => input?.shape;
 }

--- a/generator/lib/model/operation.dart
+++ b/generator/lib/model/operation.dart
@@ -52,6 +52,12 @@ class Operation {
   factory Operation.fromJson(Map<String, dynamic> json) =>
       _$OperationFromJson(json);
 
+  void initReferences() {
+    input.api = api;
+    output.api = api;
+    errors?.forEach((e) => e.api = api);
+  }
+
   String get methodName =>
       name.substring(0, 1).toLowerCase() + name.substring(1);
 

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -100,6 +100,12 @@ class Shape {
 
   factory Shape.fromJson(Map<String, dynamic> json) => _$ShapeFromJson(json);
 
+  void initReferences() {
+    member.api = api;
+    key.api = api;
+    value.api = api;
+  }
+
   List<Member> get members => _members;
   bool get hasMembers => _members.isNotEmpty;
   bool get hasEmptyMembers => _members.isEmpty;

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'api.dart';
 import 'descriptor.dart';
 import 'error.dart';
 import 'xml_namespace.dart';
@@ -8,6 +9,8 @@ part 'shape.g.dart';
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class Shape {
+  @JsonKey(ignore: true)
+  Api api;
   final String type;
   @JsonKey(name: 'enum')
   final List<String> enumeration;
@@ -169,5 +172,6 @@ final _reservedNames = <String>{'default', 'return'};
 
 String _lowercaseName(String name) {
   if (name == null || name.isEmpty) return name;
+  if (name.startsWith('AWS')) name = name.replaceFirst('AWS', 'aws');
   return name.substring(0, 1).toLowerCase() + name.substring(1);
 }

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -1,6 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 
 import 'api.dart';
+import 'dart_type.dart';
 import 'descriptor.dart';
 import 'error.dart';
 import 'xml_namespace.dart';
@@ -104,6 +105,7 @@ class Shape {
     member?.api = api;
     key?.api = api;
     value?.api = api;
+    members.forEach((m) => m.api = api);
   }
 
   List<Member> get members => _members;
@@ -113,6 +115,8 @@ class Shape {
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class Member {
+  @JsonKey(ignore: true)
+  Api api;
   @JsonKey(ignore: true)
   String name;
   @JsonKey(ignore: true)
@@ -171,6 +175,18 @@ class Member {
     } else {
       return lc;
     }
+  }
+
+  String get dartType {
+    String dartType = shape;
+    final shapeRef = api.shapes[shape];
+    final String type = shapeRef.type;
+    if (type.isBasicType()) {
+      dartType = type.getDartType();
+    } else if (type.isMapOrList()) {
+      dartType = getListOrMapDartType(shapeRef);
+    }
+    return dartType;
   }
 }
 

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -101,9 +101,9 @@ class Shape {
   factory Shape.fromJson(Map<String, dynamic> json) => _$ShapeFromJson(json);
 
   void initReferences() {
-    member.api = api;
-    key.api = api;
-    value.api = api;
+    member?.api = api;
+    key?.api = api;
+    value?.api = api;
   }
 
   List<Member> get members => _members;


### PR DESCRIPTION
- Fixes where the `Future<void>` method still tried to return with a `.fromJson()` (single `returnType`)
- Fixes weird names, e.g. `aWSAccessToken` -> `awsAccessToken`.
- I've added reference to the top-level `Api` in `Shape`, `Operation` and `Descriptor`, as I'd like to unify and move the logic that generates the dart types (e.g. `List<Whatever>`).