### PR TITLE
Fallback file name when metadata.uid is missing.

### DIFF
--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -53,13 +53,13 @@ import 'package:aws_client/src/scoping_extensions.dart';
 """);
   buf
     ..writeln(builder.imports())
-    ..writeln("part '${api.metadata.uid}.g.dart';\n")
+    ..writeln("part '${api.fileBasename}.g.dart';\n")
     ..putMainClass(api, builder)
     ..putShapes(api)
     ..putExceptions(api);
 
   return File(
-      '../aws_client/lib/generated/${api.metadata.className}/${api.metadata.uid}.dart')
+      '../aws_client/lib/generated/${api.directoryPath}/${api.fileBasename}.dart')
     ..createSync(recursive: true)
     ..writeAsStringSync(buf.toString());
 }

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -45,6 +45,16 @@ class Api {
   bool get usesEc2Protocol => metadata.protocol == 'ec2';
 
   bool get usesXml => usesQueryProtocol || usesRestXmlProtocol;
+
+  String get directoryPath {
+    // TODO: lowercase directory name
+    return metadata.className;
+  }
+
+  String get fileBasename {
+    // TODO: lowercase file name
+    return metadata.uid ?? '${metadata.endpointPrefix}-${metadata.apiVersion}';
+  }
 }
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)


### PR DESCRIPTION
- `lambda-2014-11-11` is one of the example of this
- I've added a TODO to lowercase both the directory and the filename, because IIRC it may cause issues on Windows. The exact detail (e.g. `applicationdirectoryservice` vs `application-directory-service` vs `ads`) is up to decide later, these are just placeholders now.