### PR TITLE
Better enum value generation.

### DIFF
--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -194,11 +194,21 @@ class Member {
   }
 }
 
-extension on String {
+extension NameStuff on String {
   bool get isAllUpperCase => toUpperCase() == this;
 
-  bool get isReserved =>
-      <String>{'default', 'return', 'if', 'bool', 'null'}.contains(this);
+  bool get isReserved => <String>{
+        'bool',
+        'continue',
+        'default',
+        'false',
+        'if',
+        'in',
+        'new',
+        'null',
+        'return',
+        'true',
+      }.contains(this);
 
   String get lowercaseName {
     if (this == null || isEmpty) return this;


### PR DESCRIPTION
- abstract class
- lowercase field names, only contains allowed characters
- `$` prefix for reserved words (e.g. `$bool`) and numbers (e.g. `$3_6`).
- empty shape members are rendered too (some API methods use them)