### PR TITLE
Fix generated exception classes (most of them).

### DIFF
--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -1,5 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
+import 'descriptor.dart';
 import 'operation.dart';
 import 'shape.dart';
 
@@ -32,9 +33,10 @@ class Api {
       o.api = this;
       o.initReferences();
     });
-    shapes?.values?.forEach((s) {
-      s.api = this;
-      s.initReferences();
+    shapes?.entries?.forEach((e) {
+      e.value.name = e.key;
+      e.value.api = this;
+      e.value.initReferences();
     });
   }
 
@@ -54,6 +56,20 @@ class Api {
   String get fileBasename {
     // TODO: lowercase file name
     return metadata.uid ?? '${metadata.endpointPrefix}-${metadata.apiVersion}';
+  }
+
+  List<String> _exceptions;
+  List<String> get exceptions {
+    if (_exceptions == null) {
+      final set = operations?.values
+              ?.expand((o) => o.errors ?? <Descriptor>[])
+              ?.map((d) => d.shape)
+              ?.where((s) => s != null)
+              ?.toSet() ??
+          <String>{};
+      _exceptions = set.toList()..sort();
+    }
+    return _exceptions;
   }
 }
 

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -13,6 +13,8 @@ class Shape {
   @JsonKey(ignore: true)
   Api api;
   @JsonKey(ignore: true)
+  String name;
+  @JsonKey(ignore: true)
   bool isNotUsed = false;
   final String type;
   @JsonKey(name: 'enum')
@@ -118,6 +120,8 @@ class Shape {
 
   Member get payloadMember =>
       _members.firstWhere((mem) => mem.name == payload, orElse: () => null);
+
+  bool get isException => api.exceptions.contains(name);
 }
 
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)


### PR DESCRIPTION
This is only a temporary fix, but it handles 98% of the exception errors we have with the current state. I think it would be better to have only a very limited `AwsException` class in the long run, and the generated classes expose their content as generated. But that is for a follow-up PR, this fix is badly needed.