### PR TITLE
Nicer exceptions.

### DIFF
--- a/aws_client/lib/src/protocol/query.dart
+++ b/aws_client/lib/src/protocol/query.dart
@@ -61,7 +61,7 @@ class QueryProtocol {
       final fn = exceptionFnMap[code];
       final exception = fn != null
           ? fn(type, message)
-          : AwsException(type: type, code: code, message: message);
+          : GenericAwsException(type: type, code: code, message: message);
       throw exception;
     }
     if (resultWrapper != null) {

--- a/aws_client/lib/src/protocol/shared.dart
+++ b/aws_client/lib/src/protocol/shared.dart
@@ -33,12 +33,14 @@ class Uint8ListListConverter
   }
 }
 
-class AwsException implements Exception {
+abstract class AwsException implements Exception {}
+
+class GenericAwsException implements AwsException {
   final String type;
   final String code;
   final String message;
 
-  AwsException({this.type, this.code, this.message});
+  GenericAwsException({this.type, this.code, this.message});
 
   @override
   String toString() => '$code: $message';

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -222,8 +222,7 @@ ${builder.constructor()}
         writeln(
             '  \'$exception\': (type, message) => $exception(message: message),');
       } else {
-        writeln(
-            '  \'$exception\': (type, message) => $exception(),');
+        writeln('  \'$exception\': (type, message) => $exception(),');
       }
     }
     writeln('};');


### PR DESCRIPTION
- Exceptions that are not used in the response will be `GenericAwsException`, otherwise they will be `AwsException`.

- If there is a message member in the model, the `Function` in `Map<String, AwsExceptionFn>` will have it populated.
