### PR TITLE
Escape $ in rest-json protocol uri.

### DIFF
--- a/generator/lib/builders/rest_json_builder.dart
+++ b/generator/lib/builders/rest_json_builder.dart
@@ -50,7 +50,7 @@ class RestJsonServiceBuilder extends ServiceBuilder {
         buf.writeln('await _protocol.send(${payload.fieldName},');
       }
 
-      var uri = operation.http.requestUri;
+      var uri = operation.http.requestUri.replaceAll(r'$', r'\$');
       uriMembers?.forEach((m) {
         uri = uri.replaceAll('{${m.locationName}}', '\$${m.fieldName}');
       });


### PR DESCRIPTION
e.g. `lex-models` and `greengrass` has `/$[something]` at the end of their URLs, and it seems to be from their documentation that it is a legitimate string.