### PR TITLE
Generate only the serialization methods that are used.

### DIFF
--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -38,7 +38,7 @@ class Api {
       e.value.api = this;
       e.value.initReferences();
       if (e.value.exception) {
-        e.value.markUsed();
+        e.value.markUsed(false);
       }
     });
   }
@@ -48,6 +48,10 @@ class Api {
   bool get usesRestJsonProtocol => metadata.protocol == 'rest-json';
   bool get usesRestXmlProtocol => metadata.protocol == 'rest-xml';
   bool get usesEc2Protocol => metadata.protocol == 'ec2';
+
+  bool get generateFromJson => usesJsonProtocol || usesRestJsonProtocol;
+  bool get generateToJson => usesJsonProtocol || usesRestJsonProtocol;
+  bool get generateJson => generateFromJson || generateToJson;
 
   bool get generateFromXml => usesQueryProtocol || usesRestXmlProtocol;
   bool get generateToXml => usesRestXmlProtocol;

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -15,7 +15,9 @@ class Shape {
   @JsonKey(ignore: true)
   String name;
   @JsonKey(ignore: true)
-  bool isUsed = false;
+  bool isUsedInInput = false;
+  @JsonKey(ignore: true)
+  bool isUsedInOutput = false;
   final String type;
   @JsonKey(name: 'enum')
   final List<String> enumeration;
@@ -128,13 +130,18 @@ class Shape {
     return cn;
   }
 
-  void markUsed() {
-    if (isUsed) return;
-    isUsed = true;
-    members.forEach((m) => m.shapeClass.markUsed());
-    member?.shapeClass?.markUsed();
-    key?.shapeClass?.markUsed();
-    value?.shapeClass?.markUsed();
+  void markUsed(bool isInput) {
+    if (isInput && isUsedInInput) return;
+    if (!isInput && isUsedInOutput) return;
+    if (isInput) {
+      isUsedInInput = true;
+    } else {
+      isUsedInOutput = true;
+    }
+    members.forEach((m) => m.shapeClass.markUsed(isInput));
+    member?.shapeClass?.markUsed(isInput);
+    key?.shapeClass?.markUsed(isInput);
+    value?.shapeClass?.markUsed(isInput);
   }
 }
 


### PR DESCRIPTION
- `fromJson`, `toJson`, `fromXml`, `toXml` is generated only if the method is expected to be used
- `package:json_serializable` annotations are generated only if the API uses JSON.
- This reduces the total generated source code size from 29MB to 21MB (as of the current head).