### PR TITLE
Half of the rest-xml skeleton.

### DIFF
--- a/aws_client/lib/src/protocol/rest-xml.dart
+++ b/aws_client/lib/src/protocol/rest-xml.dart
@@ -1,5 +1,61 @@
-import 'package:http_client/http_client.dart';
+import 'package:http/http.dart';
+import 'package:meta/meta.dart';
+import 'package:xml/xml.dart';
 
-Request buildRequest(Map<String, dynamic> spec, Map<String, dynamic> data) {
-  throw Exception('Protocol not implemented: "rest_xml" ');
+import '../credentials.dart';
+import 'shared.dart';
+
+class RestXmlProtocol {
+  final String _endpointUrl;
+  final Client _client;
+  final String _service;
+  final String _region;
+  final Credentials _credentials;
+
+  RestXmlProtocol._(
+    this._client,
+    this._service,
+    this._region,
+    this._endpointUrl,
+    this._credentials,
+  );
+
+  factory RestXmlProtocol({
+    Client client,
+    String service,
+    String region,
+    String endpointUrl,
+    Credentials credentials,
+  }) {
+    client ??= Client();
+    if (service == null || region == null) {
+      ArgumentError.checkNotNull(endpointUrl, 'endpointUrl');
+    }
+    endpointUrl ??= 'https://$service.$region.amazonaws.com';
+    service ??= _extractService(Uri.parse(endpointUrl));
+    region ??= _extractRegion(Uri.parse(endpointUrl));
+    return RestXmlProtocol._(client, service, region, endpointUrl, credentials);
+  }
+
+  Future<XmlElement> send({
+    @required String method,
+    @required String requestUri,
+    @required Map<String, AwsExceptionFn> exceptionFnMap,
+    Map<String, String> headers,
+  }) async {
+    print('$_endpointUrl$_client$_service$_region$_credentials');
+    throw UnimplementedError('rest-xml not implemented');
+  }
+}
+
+String _extractService(Uri uri) {
+  final parts = uri.host.split('.');
+  if (parts.length == 4) return parts.first;
+  throw Exception('Unable to detect service in ${uri.host}.');
+}
+
+String _extractRegion(Uri uri) {
+  final parts = uri.host.split('.');
+  if (parts.length == 4 && parts[1].contains('-')) return parts[1];
+  throw Exception('Unable to detect region in ${uri.host}.');
 }

--- a/generator/lib/builders/rest_xml_builder.dart
+++ b/generator/lib/builders/rest_xml_builder.dart
@@ -8,12 +8,38 @@ class RestXmlServiceBuilder extends ServiceBuilder {
   RestXmlServiceBuilder(this.api);
 
   @override
-  String constructor() => '';
+  String constructor() {
+    return '''
+    final RestXmlProtocol _protocol;
+    ${api.metadata.className}({@_meta.required String region, @_meta.required _src_credentials.Credentials credentials, Client client, String endpointUrl,})
+        : _protocol = RestXmlProtocol(client: client, service: \'${api.metadata.endpointPrefix}\', region: region, credentials: credentials, endpointUrl: endpointUrl,);
+    ''';
+  }
 
   @override
-  String imports() => 'import \'package:xml/xml.dart\';';
+  String imports() => 'import \'package:xml/xml.dart\';\n'
+      'import \'package:aws_client/src/protocol/rest-xml.dart\';';
 
   @override
-  String operationContent(Operation operation) => '''// TODO: implement rest-xml
-      throw UnimplementedError();''';
+  String operationContent(Operation operation) {
+//    final parameterShape = api.shapes[operation.parameterType];
+
+    final buf = StringBuffer();
+    buf.writeln('final headers = <String, String>{};');
+
+    final params = StringBuffer('method: \'${operation.http.method}\', '
+        'requestUri: \'${operation.http.requestUri}\', '
+        'headers: headers,'
+        'exceptionFnMap: _exceptionFns, ');
+    if (operation.output?.resultWrapper != null) {
+      params.write('resultWrapper: \'${operation.output.resultWrapper}\',');
+    }
+    if (operation.hasReturnType) {
+      buf.writeln('    final \$result = await _protocol.send($params);');
+      buf.writeln('    return ${operation.returnType}.fromXml(\$result);');
+    } else {
+      buf.writeln('    await _protocol.send($params);');
+    }
+    return buf.toString();
+  }
 }


### PR DESCRIPTION
This is the non-controversial part of the rest-xml protocol skeleton. I'm planning to reduce the code duplication after merging this.

The next part needs to decide how we want to (a) create the request and also (b) parse the response, as e.g. `fromXml` is not enough, as result headers need to be added too.