### PR TITLE
Small fixes to rest-xml

### DIFF
--- a/aws_client/lib/src/protocol/_sign.dart
+++ b/aws_client/lib/src/protocol/_sign.dart
@@ -15,6 +15,8 @@ void signAws4HmacSha256({
   final date = _currentDateHeader();
   rq.headers['X-Amz-Date'] = date;
   rq.headers['Host'] = rq.url.host;
+  rq.headers['x-amz-content-sha256'] ??=
+      sha256.convert(rq.bodyBytes).toString();
 
   // sorted list of key:value header entries
   final canonicalHeaders = rq.headers.keys

--- a/aws_client/lib/src/protocol/rest-xml.dart
+++ b/aws_client/lib/src/protocol/rest-xml.dart
@@ -78,6 +78,7 @@ class RestXmlProtocol {
     Map<String, String> queryParams,
     dynamic payload,
   ) {
+    queryParams ??= <String, String>{};
     final rq = Request(
       method,
       Uri.parse(


### PR DESCRIPTION
The `x-amz-content-sha256` is required to S3, and it doesn't hurt the other services either.