### PR TITLE
Generate packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,4 @@ doc/api/
 *.iws
 
 # Generated directories
-**/generated/
 **/apis/

--- a/generator/config.yaml
+++ b/generator/config.yaml
@@ -1,0 +1,15 @@
+# Shared library version for each protocol
+shared_version:
+  json: 0.3.0-dev
+  rest-json: 0.3.0-dev
+  rest-xml: 0.3.0-dev
+  query: 0.3.0-dev
+  ec2: 0.3.0-dev
+
+# Packages to generate
+packages:
+  - aws_lambda_api # rest-json
+  - aws_dynamodb_api # json
+  - aws_sns_api # query
+  - aws_route53_api # rest-xml
+  - aws_ec2_api # ec2

--- a/generator/lib/builders/ec2_builder.dart
+++ b/generator/lib/builders/ec2_builder.dart
@@ -11,10 +11,10 @@ class Ec2ServiceBuilder extends ServiceBuilder {
   String constructor() => '';
 
   @override
-  String imports() => '';
+  String imports() => "import 'package:aws_client/src/protocol/ec2.dart';";
 
   @override
   String operationContent(Operation operation) =>
-      '''// TODO: implement rest-json
+      '''// TODO: implement ec2
       throw UnimplementedError();''';
 }

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -3,7 +3,10 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:aws_client.generator/model/api.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:version/version.dart';
+import 'package:yaml/yaml.dart';
 
 import 'download_command.dart';
 import 'library_builder.dart';
@@ -24,99 +27,153 @@ class GenerateCommand extends Command {
         help: 'Downloads the definitions first before generating',
       )
       ..addFlag(
-        'build-runner',
-        abbr: 'b',
-        help: 'Runs build_runner to generate json_serialization classes',
-        defaultsTo: true,
-        negatable: true,
-      )
-      ..addFlag(
         'format',
         abbr: 'f',
         help: 'Runs dartfmt on the generated code',
         defaultsTo: true,
         negatable: true,
+      )
+      ..addFlag(
+        'bump',
+        abbr: 'b',
+        help: 'Automatically bump package versions on code changes',
+      )
+      ..addFlag(
+        'dev',
+        help: 'Generates packages in dev mode with dependency overrides'
+      )
+      ..addOption(
+        'config-file',
+        help: 'Configuration file describing package generation.',
+        defaultsTo: 'config.yaml',
       );
   }
 
   @override
   Future<void> run() async {
+    final stopwatch = Stopwatch()..start();
     if (argResults['download'] == true) {
       await DownloadCommand().run();
     }
     await _generateClasses();
 
-    if (argResults['build-runner'] == true) {
-      await _runBuildRunner();
-    }
-    if (argResults['format'] == true) {
-      await _runDartFmt();
-    }
+    print('Generator finished in ${stopwatch.elapsed}');
   }
-}
 
-Future _generateClasses() async {
-  print('Generating Dart classes...');
+  Future _generateClasses() async {
+    print('Generating Dart classes...');
 
-  final dir = Directory('./apis');
-  final files = dir.listSync();
-  final services = <String>{};
+    final config =
+        loadYaml(File(argResults['config-file'] as String).readAsStringSync());
+    final packagesToGenerate = config['packages'] as YamlList;
 
-  files.forEach((ent) {
-    final parts = ent.uri.pathSegments.last.split('.')
-      ..removeLast()
-      ..removeLast();
-    services.add(parts.join('.'));
-  });
+    final formatter = DartFormatter(fixes: StyleFix.all);
+    final dir = Directory('./apis');
+    final files = dir.listSync();
+    final services = <String>{};
 
-  services.forEach((service) {
-    final def = File('./apis/$service.normal.json');
+    files.forEach((ent) {
+      final parts = ent.uri.pathSegments.last.split('.')
+        ..removeLast()
+        ..removeLast();
+      services.add(parts.join('.'));
+    });
 
-    final defJson = jsonDecode(def.readAsStringSync()) as Map<String, dynamic>;
-    try {
-      final api = Api.fromJson(defJson);
-      if (api.isRecognized) {
-        print('Generating sources for package:${api.packageName}');
-        buildService(api);
-      } else {
-        print('API in ${def.path} was not recognized.');
+    services.forEach((service) {
+      final def = File('./apis/$service.normal.json');
+
+      final defJson =
+          jsonDecode(def.readAsStringSync()) as Map<String, dynamic>;
+
+      try {
+        final api = Api.fromJson(defJson);
+        if (api.isRecognized && packagesToGenerate.contains(api.packageName)) {
+          print(
+              'Generating ${api.fileBasename} for package:${api.packageName}');
+          var serviceText = buildService(api);
+
+          final serviceFile = File(
+              '../generated/${api.packageName}/lib/${api.fileBasename}.dart')
+            ..createSync(recursive: true);
+
+          if (argResults['format'] == true) {
+            serviceText = formatter.format(serviceText, uri: serviceFile.uri);
+          }
+
+          final pubspecSegments = serviceFile.uri.pathSegments.toList()
+            ..removeLast()
+            ..removeLast()
+            ..add('pubspec.yaml');
+
+          final pubspecUri = Uri(pathSegments: pubspecSegments);
+          final pubspec = File.fromUri(pubspecUri);
+          dynamic pubspecJson;
+          final sharedVersion =
+              config['shared_version'][api.metadata.protocol] as String;
+
+          final devMode = argResults['dev'] == true;
+
+          if (pubspec.existsSync() && !devMode) {
+            String oldServiceText;
+
+            if (serviceFile.existsSync()) {
+              oldServiceText = serviceFile.readAsStringSync();
+            }
+
+            pubspecJson = jsonDecode(pubspec.readAsStringSync());
+            final version = Version.parse(pubspecJson['version'] as String);
+            final bumpedVersion = version.incrementPatch().toString();
+            final shouldBump =
+                pubspecJson['dependencies']['aws_client'] != sharedVersion ||
+                    oldServiceText != serviceText;
+
+            if (shouldBump && argResults['bump'] == true) {
+              print(
+                  'Bumping ${api.packageName} from $version to $bumpedVersion');
+
+              pubspecJson['version'] = bumpedVersion;
+            }
+
+            pubspecJson['dependencies']['aws_client'] = sharedVersion;
+
+
+          } else {
+            pubspecJson = {
+              'environment': {'sdk': '>=2.6.0 <3.0.0'},
+              'version': '0.0.1',
+              'name': 'aws_client.${api.packageName}',
+              'dependencies': {
+                'json_annotation': '^3.0.0',
+                'aws_client': sharedVersion,
+                'http_client': '>=0.5.0 <2.0.0',
+              },
+              if (devMode)
+                'dependency_overrides': {
+                  'aws_client': {'path': '../../aws_client'},
+                },
+              'dev_dependencies': {
+                'build_runner': '^1.7.2',
+                'json_serializable': '^3.2.0'
+              },
+              'publish_to': 'none',
+            };
+          }
+
+          pubspec.writeAsStringSync(jsonEncode(pubspecJson));
+          serviceFile.writeAsStringSync(serviceText);
+        } else {
+          print('API in ${def.path} was not recognized.');
+        }
+      } on UnrecognizedKeysException catch (e) {
+        print('Error deserializing $service');
+        print(e.message);
+        rethrow;
+      } catch (e) {
+        print('Error "${e.runtimeType}" deserializing $service');
+        rethrow;
       }
-    } on UnrecognizedKeysException catch (e) {
-      print('Error deserializing $service');
-      print(e.message);
-      rethrow;
-    } catch (e) {
-      print('Error "${e.runtimeType}" deserializing $service');
-      rethrow;
-    }
-  });
+    });
 
-  print('Dart classes generated');
-}
-
-Future _runBuildRunner() async {
-  // Generate serialization classes
-  print('Running build_runner...');
-  final pr1 = await Process.run(
-    'pub',
-    ['run', 'build_runner', 'build'],
-    workingDirectory: '../aws_client',
-  );
-  print(pr1.stdout);
-  if (pr1.exitCode != 0 || (pr1.stderr as String).isNotEmpty) {
-    throw StateError('pub build error:\n${pr1.stderr}');
-  }
-}
-
-Future _runDartFmt() async {
-  // Format the generated classes
-  print('Running dartfmt...');
-  final pr2 = await Process.run(
-    'dartfmt',
-    ['--overwrite', '--fix', '.'],
-    workingDirectory: '../aws_client/lib',
-  );
-  if (pr2.exitCode != 0 || (pr2.stderr as String).isNotEmpty) {
-    throw StateError('dartfmt error:\n${pr2.stderr}');
+    print('Dart classes generated');
   }
 }

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -13,7 +13,7 @@ import 'package:aws_client.generator/model/shape.dart';
 
 import 'builders/query_builder.dart';
 
-File buildService(Api api) {
+String buildService(Api api) {
   api.initReferences();
 
   ServiceBuilder builder;
@@ -59,10 +59,7 @@ import 'package:aws_client/src/scoping_extensions.dart';
     ..putShapes(api)
     ..putExceptions(api);
 
-  return File(
-      '../aws_client/lib/generated/${api.directoryPath}/${api.fileBasename}.dart')
-    ..createSync(recursive: true)
-    ..writeAsStringSync(buf.toString());
+  return buf.toString();
 }
 
 extension StringBufferStuff on StringBuffer {

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -19,3 +19,6 @@ dev_dependencies:
   build_verify: ^1.1.1
   json_serializable: ^3.2.0
   test: ^1.0.0
+  version: ^1.0.0
+  dart_style: ^1.3.3
+  yaml: ^2.2.0


### PR DESCRIPTION
The `build_runner` step isn't feasible anymore, since the services are separate packages/projects.
Before running `pub run build_runner build` in a project, `pub get` has to be run first. 
This could of course be done for each project, but I think that is another step, e.g. when inspecting that particular package or when publishing.

There seems to be no way to dump JSON as YAML in Dart, so we will have to do with JSON for now.
I've verified that the generated packages work/gives no errors after `pub get && pub run build_runner build` has been run in the package.