### PR TITLE
Generator reads config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,4 @@ doc/api/
 *.iws
 
 # Generated directories
-**/generated/
 **/apis/

--- a/generator/config.yaml
+++ b/generator/config.yaml
@@ -1,0 +1,15 @@
+# Shared library version for each protocol
+shared_version:
+  json: 0.3.0-dev
+  rest-json: 0.3.0-dev
+  rest-xml: 0.3.0-dev
+  query: 0.3.0-dev
+  ec2: 0.3.0-dev
+
+# Packages to generate
+packages:
+  - aws_lambda_api # rest-json
+  - aws_dynamodb_api # json
+  - aws_sns_api # query
+  - aws_route53_api # rest-xml
+  - aws_ec2_api # ec2

--- a/generator/lib/builders/ec2_builder.dart
+++ b/generator/lib/builders/ec2_builder.dart
@@ -11,10 +11,9 @@ class Ec2ServiceBuilder extends ServiceBuilder {
   String constructor() => '';
 
   @override
-  String imports() => '';
+  String imports() => "import 'package:aws_client/src/protocol/ec2.dart';";
 
   @override
-  String operationContent(Operation operation) =>
-      '''// TODO: implement rest-json
+  String operationContent(Operation operation) => '''// TODO: implement ec2
       throw UnimplementedError();''';
 }

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -13,7 +13,7 @@ import 'package:aws_client.generator/model/shape.dart';
 
 import 'builders/query_builder.dart';
 
-File buildService(Api api) {
+String buildService(Api api) {
   api.initReferences();
 
   ServiceBuilder builder;
@@ -59,10 +59,7 @@ import 'package:aws_client/src/scoping_extensions.dart';
     ..putShapes(api)
     ..putExceptions(api);
 
-  return File(
-      '../aws_client/lib/generated/${api.directoryPath}/${api.fileBasename}.dart')
-    ..createSync(recursive: true)
-    ..writeAsStringSync(buf.toString());
+  return buf.toString();
 }
 
 extension StringBufferStuff on StringBuffer {

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -19,3 +19,6 @@ dev_dependencies:
   build_verify: ^1.1.1
   json_serializable: ^3.2.0
   test: ^1.0.0
+  version: ^1.0.0
+  dart_style: ^1.3.3
+  yaml: ^2.2.0


### PR DESCRIPTION
- The generator now reads a config file, much like `package:googleapis`.
- The config file specifies which services to generate
- The config file specifies which version of the shared package each protocol should use, uses local path in `dependency_overrides` when in `--dev`-mode.
- Uses dart_style programmatically instead of separate `dartfmt`.
- Bumps version in package when generated source differ from old source,
or when shared version in config differs and `--bump` is given as argument
- Generates packages