### PR TITLE
Fix: ec2 protocol

### DIFF
--- a/aws_client/lib/src/protocol/ec2.dart
+++ b/aws_client/lib/src/protocol/ec2.dart
@@ -1,5 +1,5 @@
 import 'package:http_client/http_client.dart';
 
 Request buildRequest(Map<String, dynamic> spec, Map<String, dynamic> data) {
-  throw Exception('Protocol not implemented: "rest" ');
+  throw Exception('Protocol not implemented: "ec2" ');
 }


### PR DESCRIPTION
Not sure about this, but the sample `ec2-2016[...].dart` imports `'package:aws_client/src/protocol/ec2.dart';` and there is nothing that imports `rest.dart`.