### PR TITLE
Expose build_runner dependencies without prefix

### DIFF
--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -162,9 +162,9 @@ ${builder.constructor()}
 
         if (shape.api.generateJson) {
           if (member.dartType == 'Uint8List') {
-            writeln('@shared.Uint8ListConverter()');
+            writeln('@Uint8ListConverter()');
           } else if (member.dartType == 'List<Uint8List>') {
-            writeln('@shared.Uint8ListListConverter()');
+            writeln('@Uint8ListListConverter()');
           }
           writeln("  @JsonKey(name: '${member.name}')");
         }

--- a/generator/lib/library_builder.dart
+++ b/generator/lib/library_builder.dart
@@ -46,6 +46,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart' as _meta;
 
 import 'package:aws_client/shared.dart' as shared;
+import 'package:aws_client/shared.dart' show Uint8ListConverter, Uint8ListListConverter;
 """);
   buf.writeln(builder.imports());
   if (api.generateJson) {


### PR DESCRIPTION
build_runner doesn't handle import prefixes, show these specifically without prefix