### PR TITLE
Generate mono_pkg.yaml, build test

### DIFF
--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -12,6 +12,7 @@ import 'download_command.dart';
 import 'library_builder.dart';
 import 'model/config.dart';
 import 'pubspec_builder.dart';
+import 'test_builder.dart';
 
 class GenerateCommand extends Command {
   @override
@@ -174,6 +175,17 @@ class GenerateCommand extends Command {
         // TODO: once in git, detect if there was no change, and skip when not needed
         await _runBuildRunner(baseDir);
       }
+    }
+
+    final monoPkgFile = File('mono_pkg.yaml');
+
+    for (final baseDir in touchedDirs) {
+      final pathParts = baseDir.split('/')..removeAt(0);
+      File('$baseDir/test/ensure_build_test.dart')
+        ..createSync(recursive: true)
+        ..writeAsStringSync(buildTest(pathParts.join('/')));
+
+      monoPkgFile.copySync('$baseDir/mono_pkg.yaml');
     }
 
     print('Dart classes generated');

--- a/generator/lib/pubspec_builder.dart
+++ b/generator/lib/pubspec_builder.dart
@@ -34,6 +34,8 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.7.2
   json_serializable: ^3.2.0
+  build_verify: ^1.1.1
+  test: ^1.9.4
 $dependenciesOverride
 ''';
 }

--- a/generator/lib/test_builder.dart
+++ b/generator/lib/test_builder.dart
@@ -1,0 +1,11 @@
+String buildTest(String packageRelativeDirectory) =>
+    '''@Tags(['presubmit-only'])
+
+import 'package:build_verify/build_verify.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('ensure_build',
+      () => expectBuildClean(packageRelativeDirectory: '$packageRelativeDirectory'));
+}
+''';


### PR DESCRIPTION
- Copies `mono_pkg.yaml` in the generator package, to the generated package
- Creates a copy of `ensure_build_test.dart` with the right relative directory