### PR TITLE
New library for shared utils.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,23 @@ jobs:
       os: linux
       env: PKGS="generator"
       script: ./tool/travis.sh dartfmt dartanalyzer
+    - stage: smoke_test
+      name: "SDK: stable; PKG: shared_aws_api; TASKS: [`dartfmt -n --set-exit-if-changed .`, `dartanalyzer --fatal-infos --fatal-warnings .`]"
+      dart: stable
+      os: linux
+      env: PKGS="shared_aws_api"
+      script: ./tool/travis.sh dartfmt dartanalyzer
     - stage: unit_test
       name: "SDK: stable; PKG: generator; TASKS: `pub run test -j 1 --run-skipped`"
       dart: stable
       os: linux
       env: PKGS="generator"
+      script: ./tool/travis.sh test
+    - stage: unit_test
+      name: "SDK: stable; PKG: shared_aws_api; TASKS: `pub run test -j 1 --run-skipped`"
+      dart: stable
+      os: linux
+      env: PKGS="shared_aws_api"
       script: ./tool/travis.sh test
 
 stages:

--- a/shared_aws_api/lib/credentials.dart
+++ b/shared_aws_api/lib/credentials.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2020, project contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'package:meta/meta.dart';
+
+/// AWS credentials.
+class AwsClientCredentials {
+  /// AWS access key
+  final String accessKey;
+
+  /// AWS secret key
+  final String secretKey;
+
+  /// AWS temporary credentials session token
+  final String sessionToken;
+
+  /// AWS credentials.
+  AwsClientCredentials({
+    @required this.accessKey,
+    @required this.secretKey,
+    this.sessionToken,
+  }) {
+    assert(accessKey != null);
+    assert(secretKey != null);
+  }
+}

--- a/shared_aws_api/mono_pkg.yaml
+++ b/shared_aws_api/mono_pkg.yaml
@@ -1,0 +1,11 @@
+# See https://github.com/dart-lang/mono_repo for details
+dart:
+  - stable
+
+stages:
+  - smoke_test:
+    - group:
+        - dartfmt
+        - dartanalyzer: --fatal-infos --fatal-warnings .
+  - unit_test:
+    - test: -j 1 --run-skipped

--- a/shared_aws_api/pubspec.yaml
+++ b/shared_aws_api/pubspec.yaml
@@ -1,0 +1,18 @@
+name: shared_aws_api
+description: Shared protocol implementation and utilities for generated AWS API clients.
+version: 0.1.0
+
+homepage: https://github.com/agilord/aws_client/tree/master/shared_aws_api
+
+environment:
+  sdk: '>=2.6.0 <3.0.0'
+
+dependencies:
+#  crypto: ^2.1.3
+#  http: ^0.12.0
+#  meta: ^1.1.8
+#  xml: ^3.7.0
+
+dev_dependencies:
+  pedantic: ^1.8.0+1
+  test: ^1.9.4

--- a/shared_aws_api/test/_placeholder_test.dart
+++ b/shared_aws_api/test/_placeholder_test.dart
@@ -1,0 +1,8 @@
+import 'package:test/test.dart';
+
+// TODO: remove this once we have moved query_test.dart
+void main() {
+  test('placeholder', () {
+    expect(true, true);
+  });
+}


### PR DESCRIPTION
#95 
This is really only the barebones. I'll do this in small pieces, as there are way too many moving parts right now.

Also: I'm starting renaming `Credentials` to `AwsClientCredentials`, and because of that, we may not need to use the `shared.` prefix at all.