### PR TITLE
Re-export AwsClientCredentials 

### DIFF
--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -47,6 +47,8 @@ import 'dart:typed_data';
 
 import 'package:shared_aws_api/shared.dart' as _s;
 import 'package:shared_aws_api/shared.dart' show Uint8ListConverter, Uint8ListListConverter;
+
+export 'package:shared_aws_api/shared.dart' show AwsClientCredentials;
 """);
   buf.writeln(builder.imports());
   if (api.generateJson) {


### PR DESCRIPTION
When developers add a service as a dependency, the first problem when instantiating e.g. `SNS()` is to figure out where to get the `AwsClientCredentials` from. Either we require developers to add the shared library as well to their project, or we include the class in the service.