### PR TITLE
Remove use of 'markUsed()' where not correct

### DIFF
--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -106,7 +106,7 @@ ${builder.constructor()}
     operation.output?.shapeClass?.markUsed(false);
     write('  Future<${operation.returnType}> ${operation.methodName}(');
     if (useParameter) write('{');
-    parameterShape.markUsed(true);
+
     for (final member in parameterShape?.members ?? <Member>[]) {
       if (member.isRequired) {
         write('@_s.required ');


### PR DESCRIPTION
> Why is this call needed? I thought we don't want to generate the `*Input` classes...

_Originally posted by @isoos in https://github.com/agilord/aws_client/pull/116_

I misunderstood the purpose of that call, and it's not necessary. 