### PR TITLE
Improvements

### DIFF
--- a/generator/config.yaml
+++ b/generator/config.yaml
@@ -35,6 +35,8 @@ packages:
   - aws_sns_api
   - aws_sqs_api
   - aws_sts_api
+  - aws_neptune_api
+  - aws_docdb_api
 ## rest-xml protocol APIs
   - aws_cloudfront_api
   - aws_route53_api

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -215,7 +215,8 @@ ${builder.constructor()}
       if (shape.api.generateJson) {
         writeln(
             '@_s.JsonSerializable(includeIfNull: false, explicitToJson: true, '
-            'createFactory: ${shape.isUsedInOutput}, createToJson: ${shape.isUsedInInput})');
+            'createFactory: ${shape.isUsedInOutput && shape.api.generateFromJson},'
+            'createToJson: ${shape.isUsedInInput && shape.api.generateToJson})');
       }
 
       final extendsBlock = shape.exception ? 'implements _s.AwsException ' : '';

--- a/generator/lib/builders/pubspec_builder.dart
+++ b/generator/lib/builders/pubspec_builder.dart
@@ -33,10 +33,10 @@ dependencies:
   shared_aws_api: ${protocolConfig.shared}
 
 dev_dependencies:
-  build_runner: ^1.7.2
-  json_serializable: ^3.2.0
+  build_runner: ^1.8.1
+  json_serializable: ^3.3.0
   build_verify: ^1.1.1
-  test: ^1.9.4
+  test: ^1.14.2
 
 $dependenciesOverride
 ''';

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -46,16 +46,24 @@ class Api {
   }
 
   bool get usesQueryProtocol => metadata.protocol == 'query';
+
   bool get usesJsonProtocol => metadata.protocol == 'json';
+
   bool get usesRestJsonProtocol => metadata.protocol == 'rest-json';
+
   bool get usesRestXmlProtocol => metadata.protocol == 'rest-xml';
+
   bool get usesEc2Protocol => metadata.protocol == 'ec2';
 
   bool get generateFromJson => usesJsonProtocol || usesRestJsonProtocol;
-  bool get generateToJson => usesJsonProtocol || usesRestJsonProtocol;
+
+  bool get generateToJson =>
+      usesJsonProtocol || usesRestJsonProtocol || usesQueryProtocol;
+
   bool get generateJson => generateFromJson || generateToJson;
 
   bool get generateFromXml => usesQueryProtocol || usesRestXmlProtocol;
+
   bool get generateToXml => usesRestXmlProtocol;
 
   String get directoryPath {
@@ -105,6 +113,7 @@ class Api {
   }
 
   List<String> _exceptions;
+
   List<String> get exceptions {
     if (_exceptions == null) {
       final set = operations?.values

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -79,9 +79,9 @@ class Api {
 
   String get packageBaseName {
     final candidates = <String>[
-      metadata.endpointPrefix,
       metadata.uid?.split('-20')?.first,
       metadata.className.toLowerCase(),
+      metadata.endpointPrefix
     ];
     final identified = candidates
         .firstWhere((c) => awsCliServiceNames.contains(c), orElse: () => null);

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -119,13 +119,19 @@ class Shape {
   bool get hasMembers => _members.isNotEmpty;
 
   bool get hasEmptyMembers => _members.isEmpty;
+
   bool get hasHeaderMembers => headerMembers.isNotEmpty;
+
   bool get hasUriMembers => uriMembers.isNotEmpty;
+
   bool get hasQueryMembers => queryMembers.isNotEmpty;
+
   bool get hasNoBodyMembers => _members.where((m) => m.isBody).isEmpty;
 
   Iterable<Member> get headerMembers => _members.where((m) => m.isHeader);
+
   Iterable<Member> get uriMembers => _members.where((m) => m.isUri);
+
   Iterable<Member> get queryMembers => _members.where((m) => m.isQuery);
 
   Member get payloadMember =>
@@ -185,6 +191,7 @@ class Member {
   final bool xmlAttribute;
   @JsonKey(defaultValue: false)
   final bool eventpayload;
+  final List<String> tags;
 
   Member(
     this.shape,
@@ -203,6 +210,7 @@ class Member {
     this.streaming,
     this.xmlAttribute,
     this.eventpayload,
+    this.tags,
   );
 
   factory Member.fromJson(Map<String, dynamic> json) => _$MemberFromJson(json);
@@ -233,8 +241,11 @@ class Member {
   }
 
   bool get isHeader => location == 'header' || location == 'headers';
+
   bool get isUri => location == 'uri';
+
   bool get isQuery => location == 'querystring';
+
   bool get isBody => !isHeader && !isUri && !isQuery;
 }
 

--- a/generator/lib/model/shape.g.dart
+++ b/generator/lib/model/shape.g.dart
@@ -101,7 +101,8 @@ Member _$MemberFromJson(Map<String, dynamic> json) {
     'flattened',
     'streaming',
     'xmlAttribute',
-    'eventpayload'
+    'eventpayload',
+    'tags'
   ]);
   return Member(
     json['shape'] as String,
@@ -122,5 +123,6 @@ Member _$MemberFromJson(Map<String, dynamic> json) {
     json['streaming'] as bool ?? false,
     json['xmlAttribute'] as bool ?? false,
     json['eventpayload'] as bool ?? false,
+    (json['tags'] as List)?.map((e) => e as String)?.toList(),
   );
 }

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -119,6 +119,7 @@ Iterable<MapEntry<String, String>> _flatten(
     return;
   }
 
+  // TODO: to remove it once we call .toJson at request building time.
   if (data is! Map) {
     data = data.toJson();
   }

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -119,6 +119,10 @@ Iterable<MapEntry<String, String>> _flatten(
     return;
   }
 
+  if (data is! Map) {
+    data = data.toJson();
+  }
+
   if (data is Map) {
     var flat = false;
     if (prefixes.isEmpty) flat = true;


### PR DESCRIPTION
Two new services emerge out of this change, Neptune and DocDB. These were placed [under RDS](https://pub.dev/documentation/aws_rds_api/latest/neptune-2014-10-31/Neptune-class.html) before due to sharing the same endpoint prefix. They seem to be vastly different services though.

 - Readme and example is created for the latest version of the APIs.
 - Switch candidate priority in packageBaseName to differentiate
   APIs sharing endpointPrefix.
 - Update Member model class with new fields.