### PR TITLE
Optional part for JSON serialization.

### DIFF
--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -52,14 +52,16 @@ import 'package:shared_aws_api/shared.dart'
 export 'package:shared_aws_api/shared.dart' show AwsClientCredentials;
 """);
   buf.writeln(builder.imports());
-  if (api.generateJson) {
-    buf.writeln("part '${api.fileBasename}.g.dart';\n");
-  }
-  buf
+
+  final body = StringBuffer()
     ..putMainClass(api, builder)
     ..putShapes(api)
     ..putExceptions(api);
 
+  if (api.requiresJsonMethods) {
+    buf.writeln("part '${api.fileBasename}.g.dart';\n");
+  }
+  buf.writeln(body);
   return buf.toString();
 }
 

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -2,7 +2,6 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../utils/aws_names.dart';
 
-import 'dart_type.dart';
 import 'descriptor.dart';
 import 'operation.dart';
 import 'shape.dart';

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -2,6 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../utils/aws_names.dart';
 
+import 'dart_type.dart';
 import 'descriptor.dart';
 import 'operation.dart';
 import 'shape.dart';
@@ -61,6 +62,12 @@ class Api {
       usesJsonProtocol || usesRestJsonProtocol || usesQueryProtocol;
 
   bool get generateJson => generateFromJson || generateToJson;
+
+  bool get requiresJsonMethods =>
+      (generateFromJson &&
+          shapes.values.any((s) => s.isUsedInOutput && s.requiresJson)) ||
+      (generateToJson &&
+          shapes.values.any((s) => s.isUsedInInput && s.requiresJson));
 
   bool get generateFromXml => usesQueryProtocol || usesRestXmlProtocol;
 

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -134,6 +134,19 @@ class Shape {
 
   Iterable<Member> get queryMembers => _members.where((m) => m.isQuery);
 
+  bool get requiresJson {
+    if (type.isBasicType()) {
+      return false;
+    }
+    if (member != null && member.shapeClass.type.isBasicType()) {
+      return false;
+    }
+    if (value != null && value.shapeClass.type.isBasicType()) {
+      return false;
+    }
+    return true;
+  }
+
   Member get payloadMember =>
       _members.firstWhere((mem) => mem.name == payload, orElse: () => null);
 


### PR DESCRIPTION
`importexport` does not have any requirement for `toJson` or `fromJson`. We could probably do better and skip the annotations too, but it doesn't seem to have urgency other than not generating the `part 'importexport.g.dart';` block.