### PR TITLE
The generator code failed on the OutputS3KeyPrefix pattern

### DIFF
--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -46,7 +46,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:shared_aws_api/shared.dart' as _s;
-import 'package:shared_aws_api/shared.dart' 
+import 'package:shared_aws_api/shared.dart'
   show Uint8ListConverter, Uint8ListListConverter ${api.generateJson ? ', rfc822fromJson, rfc822toJson, iso8601fromJson, iso8601toJson, unixFromJson, unixToJson' : ''};
 
 export 'package:shared_aws_api/shared.dart' show AwsClientCredentials;
@@ -140,7 +140,12 @@ ${builder.constructor()}
       final pattern = member.shapeClass?.pattern;
 
       if (pattern != null) {
-        writeln("_s.validateStringPattern('$name', $name, r'$pattern',);");
+        if (pattern.contains("'")) {
+          writeln("_s.validateStringPattern('$name', $name, r\"$pattern\",);");
+        } else {
+          writeln("_s.validateStringPattern('$name', $name, r'$pattern',);");
+        }
+
       }
     }
 

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -140,12 +140,7 @@ ${builder.constructor()}
       final pattern = member.shapeClass?.pattern;
 
       if (pattern != null) {
-        if (pattern.contains("'")) {
-          writeln("_s.validateStringPattern('$name', $name, r\"$pattern\",);");
-        } else {
-          writeln("_s.validateStringPattern('$name', $name, r'$pattern',);");
-        }
-
+        writeln("_s.validateStringPattern('$name', $name, r'''$pattern''',);");
       }
     }
 


### PR DESCRIPTION
In AWS Polly API definition, there's a pattern can be generated corrected:

```json
    "OutputS3KeyPrefix": {
      "type": "string",
      "pattern": "^[0-9a-zA-Z\\/\\!\\-_\\.\\*\\'\\(\\)]{0,800}$"
    }
```
We shall take care of this corner case.