### PR TITLE
Updated generator: query, pub get, API data models.

### DIFF
--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -222,7 +222,7 @@ class GenerateCommand extends Command {
     print('Running pub get in $baseDir ...');
     final pr = await Process.run(
       'pub',
-      ['get'],
+      ['get', '--no-precompile'],
       workingDirectory: baseDir,
     );
     if (pr.exitCode != 0) {

--- a/generator/lib/model/api.dart
+++ b/generator/lib/model/api.dart
@@ -57,8 +57,7 @@ class Api {
 
   bool get generateFromJson => usesJsonProtocol || usesRestJsonProtocol;
 
-  bool get generateToJson =>
-      usesJsonProtocol || usesRestJsonProtocol || usesQueryProtocol;
+  bool get generateToJson => usesJsonProtocol || usesRestJsonProtocol;
 
   bool get generateJson => generateFromJson || generateToJson;
 

--- a/generator/lib/model/operation.dart
+++ b/generator/lib/model/operation.dart
@@ -29,6 +29,7 @@ class Operation {
   @JsonKey(defaultValue: false)
   final bool endpointoperation;
   final bool internal;
+  final bool internalonly;
 
   Operation(
     this.name,
@@ -47,6 +48,7 @@ class Operation {
     this.endpointdiscovery,
     this.endpointoperation,
     this.internal,
+    this.internalonly,
   );
 
   factory Operation.fromJson(Map<String, dynamic> json) =>

--- a/generator/lib/model/operation.g.dart
+++ b/generator/lib/model/operation.g.dart
@@ -23,7 +23,8 @@ Operation _$OperationFromJson(Map<String, dynamic> json) {
     'alias',
     'endpointdiscovery',
     'endpointoperation',
-    'internal'
+    'internal',
+    'internalonly'
   ]);
   return Operation(
     json['name'] as String,
@@ -55,6 +56,7 @@ Operation _$OperationFromJson(Map<String, dynamic> json) {
     ),
     json['endpointoperation'] as bool ?? false,
     json['internal'] as bool,
+    json['internalonly'] as bool,
   );
 }
 

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -181,6 +181,8 @@ class Member {
   bool isRequired = false;
   final String shape;
   final String documentation;
+  @JsonKey(name: 'enum')
+  final List<String> enumeration;
   final String location;
   final String locationName;
   final String queryName;
@@ -209,6 +211,7 @@ class Member {
   Member(
     this.shape,
     this.documentation,
+      this.enumeration,
     this.location,
     this.locationName,
     this.queryName,

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -211,7 +211,7 @@ class Member {
   Member(
     this.shape,
     this.documentation,
-      this.enumeration,
+    this.enumeration,
     this.location,
     this.locationName,
     this.queryName,

--- a/generator/lib/model/shape.g.dart
+++ b/generator/lib/model/shape.g.dart
@@ -88,6 +88,7 @@ Member _$MemberFromJson(Map<String, dynamic> json) {
   $checkKeys(json, allowedKeys: const [
     'shape',
     'documentation',
+    'enum',
     'location',
     'locationName',
     'queryName',
@@ -107,6 +108,7 @@ Member _$MemberFromJson(Map<String, dynamic> json) {
   return Member(
     json['shape'] as String,
     json['documentation'] as String,
+    (json['enum'] as List)?.map((e) => e as String)?.toList(),
     json['location'] as String,
     json['locationName'] as String,
     json['queryName'] as String,


### PR DESCRIPTION
- `no-precompile` makes the full build faster
- `query` protocol does not have any use for the `toJson` methods, as we can't use them reliably to create the request body
- the latest API JSONs have a few extra attributes, added them