### PR TITLE
Add batchWrite() to DocumentClient

### DIFF
--- a/document_client/lib/document_client.dart
+++ b/document_client/lib/document_client.dart
@@ -145,13 +145,13 @@ class DocumentClient {
 
     return BatchGetResponse(
       response.consumedCapacity,
-      response.responses.map(
+      response.responses?.map(
         (k, v) => MapEntry(
           k,
           v.map((e) => e.toJson()).toList(),
         ),
       ),
-      response.unprocessedKeys.map(
+      response.unprocessedKeys?.map(
         (k, v) => MapEntry(
           k,
           KeysAndProjection(

--- a/document_client/test/conversions.dart
+++ b/document_client/test/conversions.dart
@@ -5,8 +5,8 @@ import 'package:document_client/src/translator.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Translator', () {
-    test('translate back and forth between JSON and DynamoDB Input/Output', () {
+  group('Converting', () {
+    test('convert back and forth between JSON and DynamoDB Input/Output', () {
       final jsonPayload = {
         'foo': true,
         'bar': 'baz',

--- a/document_client/test/document_client.dart
+++ b/document_client/test/document_client.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:document_client/document_client.dart';
+import 'package:test/test.dart';
+import 'package:http/testing.dart';
+import 'package:http/http.dart';
+
+void main() {
+  group('Calling methods on document client', () {
+    test('calling get()', () async {
+      final mockClient = MockClient(
+        (req) async => Response(
+          jsonEncode({
+            'Item': {
+              'foo': {'BOOL': true},
+              'bar': {'S': 'baz'},
+              'fizz': {
+                'M': {
+                  'buzz1': {'B': 'AA=='},
+                  'buzz2': {
+                    'L': [
+                      {'S': 'stringyDingy'}
+                    ]
+                  },
+                  'buzz3': {
+                    'BS': ['AA==']
+                  },
+                  'buzz4': {
+                    'NS': ['1', '2', '3']
+                  }
+                }
+              },
+              'noCreativity': {'NULL': true}
+            },
+          }),
+          200,
+        ),
+      );
+
+      final dc = DocumentClient(
+        region: 'foo',
+        credentials: AwsClientCredentials(accessKey: '123', secretKey: '123'),
+        client: mockClient,
+      );
+
+      final ret = await dc.get(tableName: 'täjbel', key: {'Key': 'Peele'});
+
+      expect(
+          ret.item,
+          equals({
+            'foo': true,
+            'bar': 'baz',
+            'fizz': {
+              'buzz1': Uint8List(1),
+              'buzz2': ['stringyDingy'],
+              'buzz3': [Uint8List(1)],
+              'buzz4': [1, 2, 3]
+            },
+            'noCreativity': null
+          }));
+    });
+
+    test('calling batchGet()', () async {
+      final mockClient = MockClient(
+        (req) async => Response(
+          jsonEncode({
+            'Responses': {
+              'Table1': [
+                {
+                  'Key': {'S': 'Peele'}
+                },
+              ],
+            }
+          }),
+          200,
+        ),
+      );
+
+      final dc = DocumentClient(
+        region: 'foo',
+        credentials: AwsClientCredentials(accessKey: '123', secretKey: '123'),
+        client: mockClient,
+      );
+
+      final ret = await dc.batchGet(requestItems: {
+        'Table1': KeysAndProjection(
+          keys: [
+            {
+              'Key': 'Peele',
+            },
+          ],
+        ),
+      });
+
+      expect(
+        ret.responses,
+        equals({
+          'Table1': [
+            {
+              'Key': 'Peele',
+            }
+          ],
+        }),
+      );
+    });
+  });
+}

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -49,17 +49,17 @@ class Uint8ListConverter implements JsonConverter<Uint8List, String> {
 }
 
 class Uint8ListListConverter
-    implements JsonConverter<List<Uint8List>, List<String>> {
+    implements JsonConverter<List<Uint8List>, List<dynamic>> {
   const Uint8ListListConverter();
 
   @override
-  List<Uint8List> fromJson(List<String> json) {
+  List<Uint8List> fromJson(List<dynamic> json) {
     if (json == null) {
       return null;
     } else {
       return json.map((x) {
         if (x != null) {
-          return base64.decode(x);
+          return base64.decode(x as String);
         }
         return null;
       }).toList(growable: false);


### PR DESCRIPTION
There is a type bug in the `Uint8ListListConverter` which will break `AttributeValue.bs` decoding until a new version of `shared_aws_api` with the d3c0bce fix int this PR is in and released. 

DynamoDB will then have to be rebuilt with `build_runner` and released, depending on the new `shared_aws_api` version.

I've also added tests (that's how I found the bug ^^).