### PR TITLE
Change awsSdkJsReference to v2.659.0, which renders no changes

### DIFF
--- a/generator/config.yaml
+++ b/generator/config.yaml
@@ -1,4 +1,4 @@
-awsSdkJsReference: v2.673.0
+awsSdkJsReference: v2.659.0
 
 protocols:
   ec2:


### PR DESCRIPTION
on a clean `git clone` and running `dart bin/generate.dart generate --download`