### PR TITLE
Use pub upgrade instead of pub get

### DIFF
--- a/generator/bin/generate.dart
+++ b/generator/bin/generate.dart
@@ -1,11 +1,13 @@
 import 'package:args/command_runner.dart';
-
 import 'package:aws_client.generator/download_command.dart';
 import 'package:aws_client.generator/generate_command.dart';
 import 'package:aws_client.generator/package_command.dart';
 
 void main(List<String> arguments) async {
-  final runner = CommandRunner('generator', 'AWS API generator tool')
+  final runner = CommandRunner(
+    'dart bin/generate.dart',
+    'Dart AWS API generator tool',
+  )
     ..addCommand(DownloadCommand())
     ..addCommand(GenerateCommand())
     ..addCommand(PackageCommand());

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -23,7 +23,8 @@ class GenerateCommand extends Command {
 
   @override
   String get description =>
-      'Generates the API from the downloaded API definitions.';
+      '''Downloads API models (optional) and generates Dart clients, specified 
+in the config file, from the downloaded models.''';
 
   Config config;
 

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -242,7 +242,7 @@ class GenerateCommand extends Command {
             '${estimatedTimeLeft(latestPercentage, stopwatch.elapsed)} $latestMessage');
 
         if (await _directoryHasChanges(baseDir)) {
-          await _runPubGet(baseDir);
+          await _runPubUpgrade(baseDir);
 
           latestMessage = '- Running build_runner in $baseDir';
           printPercentageInPlace(latestPercentage,
@@ -276,10 +276,10 @@ class GenerateCommand extends Command {
     printPretty(notGeneratedApis);
   }
 
-  Future<void> _runPubGet(String baseDir) async {
+  Future<void> _runPubUpgrade(String baseDir) async {
     final pr = await Process.run(
       'pub',
-      ['get', '--no-precompile'],
+      ['upgrade', '--no-precompile'],
       workingDirectory: baseDir,
     );
     if (pr.exitCode != 0) {


### PR DESCRIPTION
When developing locally, the lockfile can create some discrepancies compared to Travis builds.
Warnings e.g. deprecations pops up in Travis and fails the build, so this aims to lessen those discrepancies.