### PR TITLE
Update the example template, to reflect automatic credential resolving

### DIFF
--- a/generator/lib/builders/example_builder.dart
+++ b/generator/lib/builders/example_builder.dart
@@ -5,8 +5,7 @@ String buildExampleReadme(Api api) => '''
 import 'package:${api.packageName}/${api.fileBasename}.dart';
 
 void main() {
-  final credentials = AwsClientCredentials(accessKey: '', secretKey: '');
-  final service = ${api.metadata.className}(region: 'eu-west-1', credentials: credentials);
+  final service = ${api.metadata.className}(region: 'eu-west-1');
   // See documentation on how to use ${api.metadata.className}
 }
 ```


### PR DESCRIPTION
Users does not seem to know that credentials work in a similar manner to other AWS SDKs.
There should probably be more documentation, but to make it a little more clear, the examples should show automatic credential resolving by default.