### PR TITLE
Headers are not sent with a RestXmlRequest

### DIFF
--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -63,9 +63,7 @@ class RestXmlProtocol {
       final code = error.findElements('Code').first.text;
       final message = error.findElements('Message').first.text;
       final fn = exceptionFnMap[code];
-      final exception = fn != null
-          ? fn(type, message)
-          : GenericAwsException(type: type, code: code, message: message);
+      final exception = fn != null ? fn(type, message) : GenericAwsException(type: type, code: code, message: message);
       throw exception;
     }
     if (resultWrapper != null) {
@@ -74,13 +72,7 @@ class RestXmlProtocol {
     return RestXmlResponse(rs.headers, elem);
   }
 
-  Request _buildRequest(
-    String method,
-    String requestUri,
-    Map<String, String> queryParams,
-    dynamic payload,
-    Map<String,String> headers
-  ) {
+  Request _buildRequest(String method, String requestUri, Map<String, String> queryParams, dynamic payload, Map<String, String> headers) {
     queryParams ??= <String, String>{};
     final rq = Request(
       method,
@@ -88,7 +80,7 @@ class RestXmlProtocol {
         '$_endpointUrl$requestUri',
       ).replace(queryParameters: queryParams.isEmpty ? null : queryParams),
     );
-    if(headers !=null){
+    if (headers != null) {
       rq.headers.addAll(headers);
     }
     if (payload is XmlElement) {
@@ -99,8 +91,7 @@ class RestXmlProtocol {
     } else if (payload is Uint8List) {
       rq.bodyBytes = payload;
     } else if (payload != null) {
-      throw UnimplementedError(
-          'Not implemented payload type: ${payload.runtimeType}');
+      throw UnimplementedError('Not implemented payload type: ${payload.runtimeType}');
     }
     // TODO: handle if the API is using different signing
     signAws4HmacSha256(

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -63,7 +63,9 @@ class RestXmlProtocol {
       final code = error.findElements('Code').first.text;
       final message = error.findElements('Message').first.text;
       final fn = exceptionFnMap[code];
-      final exception = fn != null ? fn(type, message) : GenericAwsException(type: type, code: code, message: message);
+      final exception = fn != null
+          ? fn(type, message)
+          : GenericAwsException(type: type, code: code, message: message);
       throw exception;
     }
     if (resultWrapper != null) {
@@ -72,7 +74,12 @@ class RestXmlProtocol {
     return RestXmlResponse(rs.headers, elem);
   }
 
-  Request _buildRequest(String method, String requestUri, Map<String, String> queryParams, dynamic payload, Map<String, String> headers) {
+  Request _buildRequest(
+      String method,
+      String requestUri,
+      Map<String, String> queryParams,
+      dynamic payload,
+      Map<String, String> headers) {
     queryParams ??= <String, String>{};
     final rq = Request(
       method,
@@ -91,7 +98,8 @@ class RestXmlProtocol {
     } else if (payload is Uint8List) {
       rq.bodyBytes = payload;
     } else if (payload != null) {
-      throw UnimplementedError('Not implemented payload type: ${payload.runtimeType}');
+      throw UnimplementedError(
+          'Not implemented payload type: ${payload.runtimeType}');
     }
     // TODO: handle if the API is using different signing
     signAws4HmacSha256(

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -52,7 +52,7 @@ class RestXmlProtocol {
     dynamic payload,
     String resultWrapper,
   }) async {
-    final rq = _buildRequest(method, requestUri, queryParams, payload);
+    final rq = _buildRequest(method, requestUri, queryParams, payload, headers);
     final rs = await _client.send(rq);
     final body = await rs.stream.bytesToString();
     final root = XmlDocument.parse(body);
@@ -79,6 +79,7 @@ class RestXmlProtocol {
     String requestUri,
     Map<String, String> queryParams,
     dynamic payload,
+    Map<String,String> headers
   ) {
     queryParams ??= <String, String>{};
     final rq = Request(
@@ -87,6 +88,9 @@ class RestXmlProtocol {
         '$_endpointUrl$requestUri',
       ).replace(queryParameters: queryParams.isEmpty ? null : queryParams),
     );
+    if(headers !=null){
+      rq.headers.addAll(headers);
+    }
     if (payload is XmlElement) {
       rq.body = payload.toXmlString();
       rq.headers['Content-Type'] = 'application/xml';
@@ -98,6 +102,7 @@ class RestXmlProtocol {
       throw UnimplementedError(
           'Not implemented payload type: ${payload.runtimeType}');
     }
+
     // TODO: handle if the API is using different signing
     signAws4HmacSha256(
       rq: rq,

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -102,7 +102,6 @@ class RestXmlProtocol {
       throw UnimplementedError(
           'Not implemented payload type: ${payload.runtimeType}');
     }
-
     // TODO: handle if the API is using different signing
     signAws4HmacSha256(
       rq: rq,


### PR DESCRIPTION
Hello, 

The headers map passed to the send() function of the RestXmlProtocol is not passed to the _buildRequest() method and are not sent to the server. As a result, S3 object metadatas cannot be uploaded.