### PR TITLE
Fix datetime converter errors, speed up build time

### DIFF
--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -48,7 +48,7 @@ import 'dart:typed_data';
 
 import 'package:shared_aws_api/shared.dart' as _s;
 import 'package:shared_aws_api/shared.dart'
-  show Uint8ListConverter, Uint8ListListConverter ${api.generateJson ? ', rfc822fromJson, rfc822toJson, iso8601fromJson, iso8601toJson, unixFromJson, unixToJson' : ''};
+  show Uint8ListConverter, Uint8ListListConverter ${api.generateJson ? ', rfc822FromJson, rfc822ToJson, iso8601FromJson, iso8601ToJson, unixTimestampFromJson, unixTimestampToJson' : ''};
 """);
   buf.writeln(builder.imports());
   buf.writeln(

--- a/generator/lib/builders/pubspec_builder.dart
+++ b/generator/lib/builders/pubspec_builder.dart
@@ -33,7 +33,7 @@ dependencies:
   shared_aws_api: ${protocolConfig.shared}
 
 dev_dependencies:
-  build_runner: ^1.8.1
+  build_runner: ^1.10.1
   json_serializable: ^3.3.0
   build_verify: ^1.1.1
   test: ^1.14.2

--- a/shared_aws_api/CHANGELOG.md
+++ b/shared_aws_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Fix broken date serialization by unifying naming conventions to `${timeStampFormat}ToJson` and `${timeStampFormat}FromJson`
+
 ## 0.2.0
 
 - Fixes and breaking changes in protocol clients.

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -154,13 +154,13 @@ Iterable<MapEntry<String, String>> _flatten(
     String formattedDate;
     switch (timeStampFormat) {
       case 'iso8601':
-        formattedDate = iso8601toJson(data);
+        formattedDate = iso8601ToJson(data);
         break;
       case 'unixTimestamp':
         formattedDate = unixTimestampToJson(data).toString();
         break;
       case 'rfc822':
-        formattedDate = rfc822toJson(data);
+        formattedDate = rfc822ToJson(data);
         break;
     }
     yield MapEntry(key, formattedDate);

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -8,15 +8,20 @@ import 'package:xml/xml.dart';
 final rfc822Formatter = DateFormat("EEE, dd MMM yyyy HH:mm:ss 'Z'", 'en_US');
 final iso8601Formatter = DateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", 'en_US');
 
-DateTime rfc822fromJson(String date) => rfc822Formatter.parse(date);
+DateTime rfc822FromJson(String date) =>
+    date == null ? null : rfc822Formatter.parse(date);
 
-String rfc822toJson(DateTime date) => rfc822Formatter.format(date.toUtc());
+String rfc822ToJson(DateTime date) =>
+    date == null ? null : rfc822Formatter.format(date.toUtc());
 
-DateTime iso8601fromJson(String date) => iso8601Formatter.parse(date);
+DateTime iso8601FromJson(String date) =>
+    date == null ? null : iso8601Formatter.parse(date);
 
-String iso8601toJson(DateTime date) => iso8601Formatter.format(date.toUtc());
+String iso8601ToJson(DateTime date) =>
+    date == null ? null : iso8601Formatter.format(date.toUtc());
 
 DateTime unixTimestampFromJson(dynamic date) {
+  if (date == null) return null;
   if (date is String) {
     return DateTime.fromMillisecondsSinceEpoch(int.parse(date) * 1000);
   } else if (date is num) {
@@ -26,7 +31,8 @@ DateTime unixTimestampFromJson(dynamic date) {
   throw ArgumentError.value(date, 'date', 'Unknown date type, can not convert');
 }
 
-int unixTimestampToJson(DateTime date) => date.millisecondsSinceEpoch ~/ 1000;
+int unixTimestampToJson(DateTime date) =>
+    date == null ? null : date.millisecondsSinceEpoch ~/ 1000;
 
 class Uint8ListConverter implements JsonConverter<Uint8List, String> {
   const Uint8ListConverter();

--- a/shared_aws_api/pubspec.yaml
+++ b/shared_aws_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_aws_api
 description: Shared protocol implementation and utilities for generated AWS API clients.
-version: 0.2.0
+version: 0.2.1
 
 homepage: https://github.com/agilord/aws_client/tree/master/shared_aws_api
 


### PR DESCRIPTION
I made some mistakes naming the date serializer functions, which results in [broken packages](https://pub.dev/packages/aws_dynamodb_api/versions/0.1.0/score)(all packages with date serialization basically).
This fixes that problem hopefully, and **most important of all** it reduced the code generation time from ~80 minutes to ~12 on my machine with 8 cores! :tada: 