### PR TITLE
rest-xml: Don't throw exception when body is empty.

### DIFF
--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -55,9 +55,12 @@ class RestXmlProtocol {
     final rq = _buildRequest(method, requestUri, queryParams, payload, headers);
     final rs = await _client.send(rq);
     final body = await rs.stream.bytesToString();
-    final root = XmlDocument.parse(body);
-    var elem = root.rootElement;
-    if (elem.name.local == 'ErrorResponse') {
+    XmlDocument root;
+    if (body?.isNotEmpty == true) {
+      root = XmlDocument.parse(body);
+    }
+    var elem = root?.rootElement;
+    if (elem?.name?.local == 'ErrorResponse') {
       final error = elem.findElements('Error').first;
       final type = error.findElements('Type').first.text;
       final code = error.findElements('Code').first.text;
@@ -68,10 +71,10 @@ class RestXmlProtocol {
           : GenericAwsException(type: type, code: code, message: message);
       throw exception;
     }
-    if (resultWrapper != null) {
+    if (resultWrapper != null && elem != null) {
       elem = elem.findElements(resultWrapper).first;
     }
-    return RestXmlResponse(rs.headers, elem);
+    return RestXmlResponse(rs.headers, elem ?? XmlElement(XmlName('empty')));
   }
 
   Request _buildRequest(


### PR DESCRIPTION
When all response data is in the response headers, and response body is
empty, the correct behavior should be that the send() function is not
crashing, but returning an empty XmlElement.

This aims to solve #206.