### PR TITLE
Json protocol

### DIFF
--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -72,6 +72,11 @@ class JsonProtocol {
 
     final parsedBody = jsonDecode(body) as Map<String, dynamic>;
 
-    return JsonResponse(rs.headers, parsedBody);
+    // TODO: replace return type with Map<String, dynamic> and discard the
+    // JsonResponse class. The generated code will have to adjust as well.
+    return JsonResponse(rs.headers, {
+      ...parsedBody,
+      ...rs.headers,
+    });
   }
 }


### PR DESCRIPTION
This ensures that all data is returned as a `Map<String, dynamic>`, currently residing in `JsonResponse.body`.
This aims to be non breaking, but does not ensure that the services will be able to utilize the header data.
Header data is commonly referred to with its `locationName`, which has not been considered in the code generation thus far.