### PR TITLE
Use Dart CLI to run pub

### DIFF
--- a/generated/aws_appmesh_api/test/ensure_build_test.dart
+++ b/generated/aws_appmesh_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_appmesh_api/appmesh-2018-10-01.dart';
+import 'package:aws_appmesh_api/appmesh-2019-01-25.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 

--- a/generated/aws_clouddirectory_api/test/ensure_build_test.dart
+++ b/generated/aws_clouddirectory_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_clouddirectory_api/clouddirectory-2016-05-10.dart';
+import 'package:aws_clouddirectory_api/clouddirectory-2017-01-11.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 

--- a/generated/aws_cloudfront_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudfront_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_cloudfront_api/cloudfront-2016-11-25.dart';
+import 'package:aws_cloudfront_api/cloudfront-2018-11-05.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 

--- a/generated/aws_events_api/README.md
+++ b/generated/aws_events_api/README.md
@@ -1,4 +1,4 @@
-# AWS API client for Amazon EventBridge
+# AWS API client for Amazon CloudWatch Events
 
 **Warning: This is a generated library, some operations may not work.**
 

--- a/generated/aws_events_api/example/README.md
+++ b/generated/aws_events_api/example/README.md
@@ -1,8 +1,8 @@
 ```dart
-import 'package:aws_events_api/eventbridge-2015-10-07.dart';
+import 'package:aws_events_api/events-2015-10-07.dart';
 
 void main() {
-  final service = EventBridge(region: 'eu-west-1');
-  // See documentation on how to use EventBridge
+  final service = CloudWatchEvents(region: 'eu-west-1');
+  // See documentation on how to use CloudWatchEvents
 }
 ```

--- a/generated/aws_events_api/pubspec.yaml
+++ b/generated/aws_events_api/pubspec.yaml
@@ -1,5 +1,5 @@
 name: aws_events_api
-description: AWS API client for Amazon EventBridge (generated from SDK API specification).
+description: AWS API client for Amazon CloudWatch Events (generated from SDK API specification).
 version: 0.1.1
 homepage: https://github.com/agilord/aws_client/tree/master/generated/aws_events_api
 

--- a/generated/aws_events_api/test/ensure_build_test.dart
+++ b/generated/aws_events_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_events_api/eventbridge-2015-10-07.dart';
+import 'package:aws_events_api/events-2015-10-07.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
@@ -10,7 +10,7 @@ void main() {
           packageRelativeDirectory: 'generated/aws_events_api'));
 
   t.test('ensure_compilation', () {
-    EventBridge(
+    CloudWatchEvents(
       region: '',
       credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
     );

--- a/generated/aws_lambda_api/test/ensure_build_test.dart
+++ b/generated/aws_lambda_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_lambda_api/lambda-2015-03-31.dart';
+import 'package:aws_lambda_api/lambda-2014-11-11.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 

--- a/generated/aws_rds_api/test/ensure_build_test.dart
+++ b/generated/aws_rds_api/test/ensure_build_test.dart
@@ -1,4 +1,4 @@
-import 'package:aws_rds_api/rds-2013-02-12.dart';
+import 'package:aws_rds_api/rds-2014-10-31.dart';
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.g.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.g.dart
@@ -34,7 +34,7 @@ Map<String, dynamic> _$NodeConfigurationOptionsFilterToJson(
   writeNotNull(
       'Name', _$NodeConfigurationOptionsFilterNameEnumMap[instance.name]);
   writeNotNull('Operator', _$OperatorTypeEnumMap[instance.operator]);
-  writeNotNull('Values', instance.values);
+  writeNotNull('Value', instance.values);
   return val;
 }
 

--- a/generated/aws_sdb_api/lib/sdb-2009-04-15.g.dart
+++ b/generated/aws_sdb_api/lib/sdb-2009-04-15.g.dart
@@ -29,7 +29,7 @@ Map<String, dynamic> _$DeletableItemToJson(DeletableItem instance) {
     }
   }
 
-  writeNotNull('Name', instance.name);
+  writeNotNull('ItemName', instance.name);
   writeNotNull(
       'Attributes', instance.attributes?.map((e) => e?.toJson())?.toList());
   return val;
@@ -62,7 +62,7 @@ Map<String, dynamic> _$ReplaceableItemToJson(ReplaceableItem instance) {
 
   writeNotNull(
       'Attributes', instance.attributes?.map((e) => e?.toJson())?.toList());
-  writeNotNull('Name', instance.name);
+  writeNotNull('ItemName', instance.name);
   return val;
 }
 

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.g.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.g.dart
@@ -48,9 +48,9 @@ Map<String, dynamic> _$MessageAttributeValueToJson(
   }
 
   writeNotNull('DataType', instance.dataType);
-  writeNotNull('BinaryListValues', instance.binaryListValues);
+  writeNotNull('BinaryListValue', instance.binaryListValues);
   writeNotNull('BinaryValue', instance.binaryValue);
-  writeNotNull('StringListValues', instance.stringListValues);
+  writeNotNull('StringListValue', instance.stringListValues);
   writeNotNull('StringValue', instance.stringValue);
   return val;
 }
@@ -66,9 +66,9 @@ Map<String, dynamic> _$MessageSystemAttributeValueToJson(
   }
 
   writeNotNull('DataType', instance.dataType);
-  writeNotNull('BinaryListValues', instance.binaryListValues);
+  writeNotNull('BinaryListValue', instance.binaryListValues);
   writeNotNull('BinaryValue', instance.binaryValue);
-  writeNotNull('StringListValues', instance.stringListValues);
+  writeNotNull('StringListValue', instance.stringListValues);
   writeNotNull('StringValue', instance.stringValue);
   return val;
 }
@@ -86,12 +86,12 @@ Map<String, dynamic> _$SendMessageBatchRequestEntryToJson(
   writeNotNull('Id', instance.id);
   writeNotNull('MessageBody', instance.messageBody);
   writeNotNull('DelaySeconds', instance.delaySeconds);
-  writeNotNull('MessageAttributes',
+  writeNotNull('MessageAttribute',
       instance.messageAttributes?.map((k, e) => MapEntry(k, e?.toJson())));
   writeNotNull('MessageDeduplicationId', instance.messageDeduplicationId);
   writeNotNull('MessageGroupId', instance.messageGroupId);
   writeNotNull(
-      'MessageSystemAttributes',
+      'MessageSystemAttribute',
       instance.messageSystemAttributes
           ?.map((k, e) => MapEntry(k, e?.toJson())));
   return val;

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:aws_client.generator/builders/protocols/ec2_builder.dart';
@@ -10,7 +8,6 @@ import 'package:aws_client.generator/builders/protocols/rest_xml_builder.dart';
 import 'package:aws_client.generator/builders/protocols/service_builder.dart';
 import 'package:aws_client.generator/model/api.dart';
 import 'package:aws_client.generator/model/dart_type.dart';
-import 'package:aws_client.generator/model/descriptor.dart';
 import 'package:aws_client.generator/model/operation.dart';
 import 'package:aws_client.generator/model/shape.dart';
 
@@ -236,9 +233,6 @@ ${builder.constructor()}
         if (member.documentation != null) {
           writeln(dartdocComment(member.documentation));
         }
-
-        final shapeClass = member.shapeClass;
-        final valueEnum = shapeClass.enumeration;
 
         if (shape.requiresJson) {
           var dateTimeConversion = '';

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -246,7 +246,7 @@ in the config file, from the downloaded models.''';
 
         touchedDirs.add(baseDir);
         generatedApis[api.packageName] = api.metadata.serviceFullName;
-        
+
         final pathParts = baseDir.split('/')..removeAt(0);
         final ensureBuildTestContent =
             formatter.format(buildTest(pathParts.join('/'), api));
@@ -303,8 +303,9 @@ in the config file, from the downloaded models.''';
 
   Future<void> _getDependencies(String baseDir, {bool upgrade = true}) async {
     final pr = await Process.run(
-      'pub',
+      'dart',
       [
+        'pub',
         if (upgrade) 'upgrade',
         if (!upgrade) 'get',
         '--no-precompile',
@@ -323,13 +324,19 @@ in the config file, from the downloaded models.''';
     while (dirs.isNotEmpty) {
       final baseDir = dirs.removeLast();
       final dirsLeft = dirs.length;
-      if (optimize && await _directoryHasChanges(baseDir)) {
+      if (!optimize || await _directoryHasChanges(baseDir)) {
         print('Running build_runner in $baseDir, dirs left: $dirsLeft');
         await _getDependencies(baseDir, upgrade: upgrade);
 
         final pr = await Process.run(
-          'pub',
-          ['run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+          'dart',
+          [
+            'pub',
+            'run',
+            'build_runner',
+            'build',
+            '--delete-conflicting-outputs'
+          ],
           workingDirectory: baseDir,
         );
 

--- a/generator/lib/package_command.dart
+++ b/generator/lib/package_command.dart
@@ -260,8 +260,8 @@ class PublishCommand extends Command {
       print('$package: $currentPublishedVersion -> $version.');
       if (!isDryRun) {
         final pr = await Process.run(
-          'pub',
-          ['publish', '--force'],
+          'dart',
+          ['pub', 'publish', '--force'],
           workingDirectory: pkgDir,
         );
         print(pr.stdout

--- a/generator/lib/test_command.dart
+++ b/generator/lib/test_command.dart
@@ -27,8 +27,9 @@ class TestCommand extends Command {
 
   Future<void> _getDependencies(String baseDir, {bool upgrade = true}) async {
     final pr = await Process.run(
-      'pub',
+      'dart',
       [
+        'pub',
         if (upgrade) 'upgrade',
         if (!upgrade) 'get',
         '--no-precompile',
@@ -52,8 +53,9 @@ class TestCommand extends Command {
       await _getDependencies(baseDir);
 
       final pr = await Process.run(
-        'pub',
+        'dart',
         [
+          'pub',
           'run',
           'test',
           '-n',

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.0
 publish_to: none
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   archive: ^2.0.11


### PR DESCRIPTION
- Use `dart pub` to run the pub commands. If you only have a flutter installation in your path, you don't have the old `pub`.
- Fix the `--optimize-build` flag: `--no-optimize-build` was doing nothing instead of re-building everything.
- Remove dead code
- Regenerate everything
