### PR TITLE
Fix statusCode check

### DIFF
--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -71,7 +71,7 @@ class JsonProtocol {
 
     final body = await rs.stream.bytesToString();
 
-    if (200 < rs.statusCode || rs.statusCode >= 300) {
+    if (rs.statusCode < 200 || rs.statusCode >= 300) {
       throwException(rs, body, exceptionFnMap);
     }
 

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -70,7 +70,7 @@ class RestJsonProtocol {
 
     final body = await rs.stream.bytesToString();
 
-    if (200 < rs.statusCode || rs.statusCode >= 300) {
+    if (rs.statusCode < 200 || rs.statusCode >= 300) {
       throwException(rs, body, exceptionFnMap);
     }
 


### PR DESCRIPTION
Some API returns 201 (created) and would then throw an exception due to this inversion.