### PR TITLE
Optimise build_runner phase in package generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ doc/api/
 
 # Generated directories
 **/apis/
+/all_apis/lib/

--- a/all_apis/pubspec.yaml
+++ b/all_apis/pubspec.yaml
@@ -1,0 +1,16 @@
+name: all_apis
+publish_to: none
+
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+
+dependencies:
+  shared_aws_api:
+    path: ../shared_aws_api
+
+dev_dependencies:
+  build_runner:
+  json_serializable: ^3.3.0
+  test: ^1.14.2
+
+

--- a/generated/aws_accessanalyzer_api/pubspec.yaml
+++ b/generated/aws_accessanalyzer_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_accessanalyzer_api/test/ensure_build_test.dart
+++ b/generated/aws_accessanalyzer_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_accessanalyzer_api/accessanalyzer-2019-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_accessanalyzer_api'));
-
   t.test('ensure_compilation', () {
     AccessAnalyzer(
       region: '',

--- a/generated/aws_acm_api/pubspec.yaml
+++ b/generated/aws_acm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_acm_api/test/ensure_build_test.dart
+++ b/generated/aws_acm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_acm_api/acm-2015-12-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_acm_api'));
-
   t.test('ensure_compilation', () {
     ACM(
       region: '',

--- a/generated/aws_acm_pca_api/pubspec.yaml
+++ b/generated/aws_acm_pca_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_acm_pca_api/test/ensure_build_test.dart
+++ b/generated/aws_acm_pca_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_acm_pca_api/acm-pca-2017-08-22.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_acm_pca_api'));
-
   t.test('ensure_compilation', () {
     ACMPCA(
       region: '',

--- a/generated/aws_alexaforbusiness_api/pubspec.yaml
+++ b/generated/aws_alexaforbusiness_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_alexaforbusiness_api/test/ensure_build_test.dart
+++ b/generated/aws_alexaforbusiness_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_alexaforbusiness_api/alexaforbusiness-2017-11-09.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_alexaforbusiness_api'));
-
   t.test('ensure_compilation', () {
     AlexaForBusiness(
       region: '',

--- a/generated/aws_amplify_api/pubspec.yaml
+++ b/generated/aws_amplify_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_amplify_api/test/ensure_build_test.dart
+++ b/generated/aws_amplify_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_amplify_api/amplify-2017-07-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_amplify_api'));
-
   t.test('ensure_compilation', () {
     Amplify(
       region: '',

--- a/generated/aws_apigateway_api/pubspec.yaml
+++ b/generated/aws_apigateway_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_apigateway_api/test/ensure_build_test.dart
+++ b/generated/aws_apigateway_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_apigateway_api/apigateway-2015-07-09.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_apigateway_api'));
-
   t.test('ensure_compilation', () {
     APIGateway(
       region: '',

--- a/generated/aws_apigatewaymanagementapi_api/pubspec.yaml
+++ b/generated/aws_apigatewaymanagementapi_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_apigatewaymanagementapi_api/test/ensure_build_test.dart
+++ b/generated/aws_apigatewaymanagementapi_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_apigatewaymanagementapi_api/apigatewaymanagementapi-2018-11-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_apigatewaymanagementapi_api'));
-
   t.test('ensure_compilation', () {
     ApiGatewayManagementApi(
       region: '',

--- a/generated/aws_apigatewayv2_api/pubspec.yaml
+++ b/generated/aws_apigatewayv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_apigatewayv2_api/test/ensure_build_test.dart
+++ b/generated/aws_apigatewayv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_apigatewayv2_api/apigatewayv2-2018-11-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_apigatewayv2_api'));
-
   t.test('ensure_compilation', () {
     ApiGatewayV2(
       region: '',

--- a/generated/aws_appconfig_api/pubspec.yaml
+++ b/generated/aws_appconfig_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_appconfig_api/test/ensure_build_test.dart
+++ b/generated/aws_appconfig_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_appconfig_api/appconfig-2019-10-09.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_appconfig_api'));
-
   t.test('ensure_compilation', () {
     AppConfig(
       region: '',

--- a/generated/aws_application_autoscaling_api/pubspec.yaml
+++ b/generated/aws_application_autoscaling_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_application_autoscaling_api/test/ensure_build_test.dart
+++ b/generated/aws_application_autoscaling_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_application_autoscaling_api/application-autoscaling-2016-02-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_application_autoscaling_api'));
-
   t.test('ensure_compilation', () {
     ApplicationAutoScaling(
       region: '',

--- a/generated/aws_application_insights_api/pubspec.yaml
+++ b/generated/aws_application_insights_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_application_insights_api/test/ensure_build_test.dart
+++ b/generated/aws_application_insights_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_application_insights_api/application-insights-2018-11-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_application_insights_api'));
-
   t.test('ensure_compilation', () {
     ApplicationInsights(
       region: '',

--- a/generated/aws_appmesh_api/pubspec.yaml
+++ b/generated/aws_appmesh_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_appmesh_api/test/ensure_build_test.dart
+++ b/generated/aws_appmesh_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_appmesh_api/appmesh-2019-01-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_appmesh_api'));
-
   t.test('ensure_compilation', () {
     AppMesh(
       region: '',

--- a/generated/aws_appstream_api/pubspec.yaml
+++ b/generated/aws_appstream_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_appstream_api/test/ensure_build_test.dart
+++ b/generated/aws_appstream_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_appstream_api/appstream-2016-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_appstream_api'));
-
   t.test('ensure_compilation', () {
     AppStream(
       region: '',

--- a/generated/aws_appsync_api/pubspec.yaml
+++ b/generated/aws_appsync_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_appsync_api/test/ensure_build_test.dart
+++ b/generated/aws_appsync_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_appsync_api/appsync-2017-07-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_appsync_api'));
-
   t.test('ensure_compilation', () {
     AppSync(
       region: '',

--- a/generated/aws_athena_api/pubspec.yaml
+++ b/generated/aws_athena_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_athena_api/test/ensure_build_test.dart
+++ b/generated/aws_athena_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_athena_api/athena-2017-05-18.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_athena_api'));
-
   t.test('ensure_compilation', () {
     Athena(
       region: '',

--- a/generated/aws_autoscaling_api/pubspec.yaml
+++ b/generated/aws_autoscaling_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_autoscaling_api/test/ensure_build_test.dart
+++ b/generated/aws_autoscaling_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_autoscaling_api/autoscaling-2011-01-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_autoscaling_api'));
-
   t.test('ensure_compilation', () {
     AutoScaling(
       region: '',

--- a/generated/aws_autoscaling_plans_api/pubspec.yaml
+++ b/generated/aws_autoscaling_plans_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_autoscaling_plans_api/test/ensure_build_test.dart
+++ b/generated/aws_autoscaling_plans_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_autoscaling_plans_api/autoscaling-plans-2018-01-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_autoscaling_plans_api'));
-
   t.test('ensure_compilation', () {
     AutoScalingPlans(
       region: '',

--- a/generated/aws_backup_api/pubspec.yaml
+++ b/generated/aws_backup_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_backup_api/test/ensure_build_test.dart
+++ b/generated/aws_backup_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_backup_api/backup-2018-11-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_backup_api'));
-
   t.test('ensure_compilation', () {
     Backup(
       region: '',

--- a/generated/aws_batch_api/pubspec.yaml
+++ b/generated/aws_batch_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_batch_api/test/ensure_build_test.dart
+++ b/generated/aws_batch_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_batch_api/batch-2016-08-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_batch_api'));
-
   t.test('ensure_compilation', () {
     Batch(
       region: '',

--- a/generated/aws_budgets_api/pubspec.yaml
+++ b/generated/aws_budgets_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_budgets_api/test/ensure_build_test.dart
+++ b/generated/aws_budgets_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_budgets_api/budgets-2016-10-20.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_budgets_api'));
-
   t.test('ensure_compilation', () {
     Budgets(
       region: '',

--- a/generated/aws_ce_api/pubspec.yaml
+++ b/generated/aws_ce_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ce_api/test/ensure_build_test.dart
+++ b/generated/aws_ce_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_ce_api/ce-2017-10-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_ce_api'));
-
   t.test('ensure_compilation', () {
     CostExplorer(
       region: '',

--- a/generated/aws_chime_api/pubspec.yaml
+++ b/generated/aws_chime_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_chime_api/test/ensure_build_test.dart
+++ b/generated/aws_chime_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_chime_api/chime-2018-05-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_chime_api'));
-
   t.test('ensure_compilation', () {
     Chime(
       region: '',

--- a/generated/aws_cloud9_api/pubspec.yaml
+++ b/generated/aws_cloud9_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloud9_api/test/ensure_build_test.dart
+++ b/generated/aws_cloud9_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloud9_api/cloud9-2017-09-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloud9_api'));
-
   t.test('ensure_compilation', () {
     Cloud9(
       region: '',

--- a/generated/aws_clouddirectory_api/pubspec.yaml
+++ b/generated/aws_clouddirectory_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_clouddirectory_api/test/ensure_build_test.dart
+++ b/generated/aws_clouddirectory_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_clouddirectory_api/clouddirectory-2017-01-11.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_clouddirectory_api'));
-
   t.test('ensure_compilation', () {
     CloudDirectory(
       region: '',

--- a/generated/aws_cloudformation_api/pubspec.yaml
+++ b/generated/aws_cloudformation_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudformation_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudformation_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudformation_api/cloudformation-2010-05-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudformation_api'));
-
   t.test('ensure_compilation', () {
     CloudFormation(
       region: '',

--- a/generated/aws_cloudfront_api/pubspec.yaml
+++ b/generated/aws_cloudfront_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudfront_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudfront_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
-import 'package:aws_cloudfront_api/cloudfront-2018-11-05.dart';
-import 'package:build_verify/build_verify.dart';
+import 'package:aws_cloudfront_api/cloudfront-2019-03-26.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudfront_api'));
-
   t.test('ensure_compilation', () {
     CloudFront(
       region: '',

--- a/generated/aws_cloudhsm_api/pubspec.yaml
+++ b/generated/aws_cloudhsm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudhsm_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudhsm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudhsm_api/cloudhsm-2014-05-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudhsm_api'));
-
   t.test('ensure_compilation', () {
     CloudHSM(
       region: '',

--- a/generated/aws_cloudhsmv2_api/pubspec.yaml
+++ b/generated/aws_cloudhsmv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudhsmv2_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudhsmv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudhsmv2_api/cloudhsmv2-2017-04-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudhsmv2_api'));
-
   t.test('ensure_compilation', () {
     CloudHSMV2(
       region: '',

--- a/generated/aws_cloudsearch_api/pubspec.yaml
+++ b/generated/aws_cloudsearch_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudsearch_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudsearch_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
-import 'package:aws_cloudsearch_api/cloudsearch-2011-02-01.dart';
-import 'package:build_verify/build_verify.dart';
+import 'package:aws_cloudsearch_api/cloudsearch-2013-01-01.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudsearch_api'));
-
   t.test('ensure_compilation', () {
     CloudSearch(
       region: '',

--- a/generated/aws_cloudsearchdomain_api/pubspec.yaml
+++ b/generated/aws_cloudsearchdomain_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudsearchdomain_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudsearchdomain_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudsearchdomain_api/cloudsearchdomain-2013-01-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudsearchdomain_api'));
-
   t.test('ensure_compilation', () {
     CloudSearchDomain(
       region: '',

--- a/generated/aws_cloudtrail_api/pubspec.yaml
+++ b/generated/aws_cloudtrail_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudtrail_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudtrail_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudtrail_api/cloudtrail-2013-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudtrail_api'));
-
   t.test('ensure_compilation', () {
     CloudTrail(
       region: '',

--- a/generated/aws_cloudwatch_api/pubspec.yaml
+++ b/generated/aws_cloudwatch_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cloudwatch_api/test/ensure_build_test.dart
+++ b/generated/aws_cloudwatch_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cloudwatch_api/monitoring-2010-08-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cloudwatch_api'));
-
   t.test('ensure_compilation', () {
     CloudWatch(
       region: '',

--- a/generated/aws_codebuild_api/pubspec.yaml
+++ b/generated/aws_codebuild_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codebuild_api/test/ensure_build_test.dart
+++ b/generated/aws_codebuild_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codebuild_api/codebuild-2016-10-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codebuild_api'));
-
   t.test('ensure_compilation', () {
     CodeBuild(
       region: '',

--- a/generated/aws_codecommit_api/pubspec.yaml
+++ b/generated/aws_codecommit_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codecommit_api/test/ensure_build_test.dart
+++ b/generated/aws_codecommit_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codecommit_api/codecommit-2015-04-13.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codecommit_api'));
-
   t.test('ensure_compilation', () {
     CodeCommit(
       region: '',

--- a/generated/aws_codeguru_reviewer_api/pubspec.yaml
+++ b/generated/aws_codeguru_reviewer_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codeguru_reviewer_api/test/ensure_build_test.dart
+++ b/generated/aws_codeguru_reviewer_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codeguru_reviewer_api/codeguru-reviewer-2019-09-19.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codeguru_reviewer_api'));
-
   t.test('ensure_compilation', () {
     CodeGuruReviewer(
       region: '',

--- a/generated/aws_codeguruprofiler_api/pubspec.yaml
+++ b/generated/aws_codeguruprofiler_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codeguruprofiler_api/test/ensure_build_test.dart
+++ b/generated/aws_codeguruprofiler_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codeguruprofiler_api/codeguruprofiler-2019-07-18.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codeguruprofiler_api'));
-
   t.test('ensure_compilation', () {
     CodeGuruProfiler(
       region: '',

--- a/generated/aws_codepipeline_api/pubspec.yaml
+++ b/generated/aws_codepipeline_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codepipeline_api/test/ensure_build_test.dart
+++ b/generated/aws_codepipeline_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codepipeline_api/codepipeline-2015-07-09.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codepipeline_api'));
-
   t.test('ensure_compilation', () {
     CodePipeline(
       region: '',

--- a/generated/aws_codestar_api/pubspec.yaml
+++ b/generated/aws_codestar_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codestar_api/test/ensure_build_test.dart
+++ b/generated/aws_codestar_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codestar_api/codestar-2017-04-19.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codestar_api'));
-
   t.test('ensure_compilation', () {
     CodeStar(
       region: '',

--- a/generated/aws_codestar_connections_api/pubspec.yaml
+++ b/generated/aws_codestar_connections_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codestar_connections_api/test/ensure_build_test.dart
+++ b/generated/aws_codestar_connections_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_codestar_connections_api/codestar-connections-2019-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_codestar_connections_api'));
-
   t.test('ensure_compilation', () {
     CodeStarconnections(
       region: '',

--- a/generated/aws_codestar_notifications_api/pubspec.yaml
+++ b/generated/aws_codestar_notifications_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_codestar_notifications_api/test/ensure_build_test.dart
+++ b/generated/aws_codestar_notifications_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_codestar_notifications_api/codestar-notifications-2019-10-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_codestar_notifications_api'));
-
   t.test('ensure_compilation', () {
     CodeStarNotifications(
       region: '',

--- a/generated/aws_cognito_identity_api/pubspec.yaml
+++ b/generated/aws_cognito_identity_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cognito_identity_api/test/ensure_build_test.dart
+++ b/generated/aws_cognito_identity_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cognito_identity_api/cognito-identity-2014-06-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cognito_identity_api'));
-
   t.test('ensure_compilation', () {
     CognitoIdentity(
       region: '',

--- a/generated/aws_cognito_idp_api/pubspec.yaml
+++ b/generated/aws_cognito_idp_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cognito_idp_api/test/ensure_build_test.dart
+++ b/generated/aws_cognito_idp_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cognito_idp_api/cognito-idp-2016-04-18.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cognito_idp_api'));
-
   t.test('ensure_compilation', () {
     CognitoIdentityProvider(
       region: '',

--- a/generated/aws_cognito_sync_api/pubspec.yaml
+++ b/generated/aws_cognito_sync_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cognito_sync_api/test/ensure_build_test.dart
+++ b/generated/aws_cognito_sync_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cognito_sync_api/cognito-sync-2014-06-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_cognito_sync_api'));
-
   t.test('ensure_compilation', () {
     CognitoSync(
       region: '',

--- a/generated/aws_comprehend_api/pubspec.yaml
+++ b/generated/aws_comprehend_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_comprehend_api/test/ensure_build_test.dart
+++ b/generated/aws_comprehend_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_comprehend_api/comprehend-2017-11-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_comprehend_api'));
-
   t.test('ensure_compilation', () {
     Comprehend(
       region: '',

--- a/generated/aws_comprehendmedical_api/pubspec.yaml
+++ b/generated/aws_comprehendmedical_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_comprehendmedical_api/test/ensure_build_test.dart
+++ b/generated/aws_comprehendmedical_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_comprehendmedical_api/comprehendmedical-2018-10-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_comprehendmedical_api'));
-
   t.test('ensure_compilation', () {
     ComprehendMedical(
       region: '',

--- a/generated/aws_compute_optimizer_api/pubspec.yaml
+++ b/generated/aws_compute_optimizer_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_compute_optimizer_api/test/ensure_build_test.dart
+++ b/generated/aws_compute_optimizer_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_compute_optimizer_api/compute-optimizer-2019-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_compute_optimizer_api'));
-
   t.test('ensure_compilation', () {
     ComputeOptimizer(
       region: '',

--- a/generated/aws_configservice_api/pubspec.yaml
+++ b/generated/aws_configservice_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_configservice_api/test/ensure_build_test.dart
+++ b/generated/aws_configservice_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_configservice_api/config-2014-11-12.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_configservice_api'));
-
   t.test('ensure_compilation', () {
     ConfigService(
       region: '',

--- a/generated/aws_connect_api/pubspec.yaml
+++ b/generated/aws_connect_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_connect_api/test/ensure_build_test.dart
+++ b/generated/aws_connect_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_connect_api/connect-2017-08-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_connect_api'));
-
   t.test('ensure_compilation', () {
     Connect(
       region: '',

--- a/generated/aws_connectparticipant_api/pubspec.yaml
+++ b/generated/aws_connectparticipant_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_connectparticipant_api/test/ensure_build_test.dart
+++ b/generated/aws_connectparticipant_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_connectparticipant_api/connectparticipant-2018-09-07.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_connectparticipant_api'));
-
   t.test('ensure_compilation', () {
     ConnectParticipant(
       region: '',

--- a/generated/aws_cur_api/pubspec.yaml
+++ b/generated/aws_cur_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_cur_api/test/ensure_build_test.dart
+++ b/generated/aws_cur_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_cur_api/cur-2017-01-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_cur_api'));
-
   t.test('ensure_compilation', () {
     CostandUsageReportService(
       region: '',

--- a/generated/aws_dataexchange_api/pubspec.yaml
+++ b/generated/aws_dataexchange_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dataexchange_api/test/ensure_build_test.dart
+++ b/generated/aws_dataexchange_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dataexchange_api/dataexchange-2017-07-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_dataexchange_api'));
-
   t.test('ensure_compilation', () {
     DataExchange(
       region: '',

--- a/generated/aws_datapipeline_api/pubspec.yaml
+++ b/generated/aws_datapipeline_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_datapipeline_api/test/ensure_build_test.dart
+++ b/generated/aws_datapipeline_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_datapipeline_api/datapipeline-2012-10-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_datapipeline_api'));
-
   t.test('ensure_compilation', () {
     DataPipeline(
       region: '',

--- a/generated/aws_datasync_api/pubspec.yaml
+++ b/generated/aws_datasync_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_datasync_api/test/ensure_build_test.dart
+++ b/generated/aws_datasync_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_datasync_api/datasync-2018-11-09.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_datasync_api'));
-
   t.test('ensure_compilation', () {
     DataSync(
       region: '',

--- a/generated/aws_dax_api/pubspec.yaml
+++ b/generated/aws_dax_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dax_api/test/ensure_build_test.dart
+++ b/generated/aws_dax_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dax_api/dax-2017-04-19.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_dax_api'));
-
   t.test('ensure_compilation', () {
     DAX(
       region: '',

--- a/generated/aws_deploy_api/pubspec.yaml
+++ b/generated/aws_deploy_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_deploy_api/test/ensure_build_test.dart
+++ b/generated/aws_deploy_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_deploy_api/codedeploy-2014-10-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_deploy_api'));
-
   t.test('ensure_compilation', () {
     CodeDeploy(
       region: '',

--- a/generated/aws_detective_api/pubspec.yaml
+++ b/generated/aws_detective_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_detective_api/test/ensure_build_test.dart
+++ b/generated/aws_detective_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_detective_api/detective-2018-10-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_detective_api'));
-
   t.test('ensure_compilation', () {
     Detective(
       region: '',

--- a/generated/aws_devicefarm_api/pubspec.yaml
+++ b/generated/aws_devicefarm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_devicefarm_api/test/ensure_build_test.dart
+++ b/generated/aws_devicefarm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_devicefarm_api/devicefarm-2015-06-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_devicefarm_api'));
-
   t.test('ensure_compilation', () {
     DeviceFarm(
       region: '',

--- a/generated/aws_directconnect_api/pubspec.yaml
+++ b/generated/aws_directconnect_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_directconnect_api/test/ensure_build_test.dart
+++ b/generated/aws_directconnect_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_directconnect_api/directconnect-2012-10-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_directconnect_api'));
-
   t.test('ensure_compilation', () {
     DirectConnect(
       region: '',

--- a/generated/aws_discovery_api/pubspec.yaml
+++ b/generated/aws_discovery_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_discovery_api/test/ensure_build_test.dart
+++ b/generated/aws_discovery_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_discovery_api/discovery-2015-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_discovery_api'));
-
   t.test('ensure_compilation', () {
     ApplicationDiscoveryService(
       region: '',

--- a/generated/aws_dlm_api/pubspec.yaml
+++ b/generated/aws_dlm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dlm_api/test/ensure_build_test.dart
+++ b/generated/aws_dlm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dlm_api/dlm-2018-01-12.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_dlm_api'));
-
   t.test('ensure_compilation', () {
     DLM(
       region: '',

--- a/generated/aws_dms_api/pubspec.yaml
+++ b/generated/aws_dms_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dms_api/test/ensure_build_test.dart
+++ b/generated/aws_dms_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dms_api/dms-2016-01-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_dms_api'));
-
   t.test('ensure_compilation', () {
     DatabaseMigrationService(
       region: '',

--- a/generated/aws_docdb_api/pubspec.yaml
+++ b/generated/aws_docdb_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_docdb_api/test/ensure_build_test.dart
+++ b/generated/aws_docdb_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_docdb_api/docdb-2014-10-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_docdb_api'));
-
   t.test('ensure_compilation', () {
     DocDB(
       region: '',

--- a/generated/aws_ds_api/pubspec.yaml
+++ b/generated/aws_ds_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ds_api/test/ensure_build_test.dart
+++ b/generated/aws_ds_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_ds_api/ds-2015-04-16.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_ds_api'));
-
   t.test('ensure_compilation', () {
     DirectoryService(
       region: '',

--- a/generated/aws_dynamodb_api/pubspec.yaml
+++ b/generated/aws_dynamodb_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dynamodb_api/test/ensure_build_test.dart
+++ b/generated/aws_dynamodb_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dynamodb_api/dynamodb-2012-08-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_dynamodb_api'));
-
   t.test('ensure_compilation', () {
     DynamoDB(
       region: '',

--- a/generated/aws_dynamodbstreams_api/pubspec.yaml
+++ b/generated/aws_dynamodbstreams_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_dynamodbstreams_api/test/ensure_build_test.dart
+++ b/generated/aws_dynamodbstreams_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_dynamodbstreams_api/streams-dynamodb-2012-08-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_dynamodbstreams_api'));
-
   t.test('ensure_compilation', () {
     DynamoDBStreams(
       region: '',

--- a/generated/aws_ebs_api/pubspec.yaml
+++ b/generated/aws_ebs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ebs_api/test/ensure_build_test.dart
+++ b/generated/aws_ebs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ebs_api/ebs-2019-11-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ebs_api'));
-
   t.test('ensure_compilation', () {
     EBS(
       region: '',

--- a/generated/aws_ec2_api/pubspec.yaml
+++ b/generated/aws_ec2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ec2_api/test/ensure_build_test.dart
+++ b/generated/aws_ec2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ec2_api/ec2-2016-11-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ec2_api'));
-
   t.test('ensure_compilation', () {
     EC2(
       region: '',

--- a/generated/aws_ec2_instance_connect_api/pubspec.yaml
+++ b/generated/aws_ec2_instance_connect_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ec2_instance_connect_api/test/ensure_build_test.dart
+++ b/generated/aws_ec2_instance_connect_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ec2_instance_connect_api/ec2-instance-connect-2018-04-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_ec2_instance_connect_api'));
-
   t.test('ensure_compilation', () {
     EC2InstanceConnect(
       region: '',

--- a/generated/aws_ecr_api/pubspec.yaml
+++ b/generated/aws_ecr_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ecr_api/test/ensure_build_test.dart
+++ b/generated/aws_ecr_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ecr_api/ecr-2015-09-21.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ecr_api'));
-
   t.test('ensure_compilation', () {
     ECR(
       region: '',

--- a/generated/aws_ecs_api/pubspec.yaml
+++ b/generated/aws_ecs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ecs_api/test/ensure_build_test.dart
+++ b/generated/aws_ecs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ecs_api/ecs-2014-11-13.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ecs_api'));
-
   t.test('ensure_compilation', () {
     ECS(
       region: '',

--- a/generated/aws_efs_api/pubspec.yaml
+++ b/generated/aws_efs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_efs_api/test/ensure_build_test.dart
+++ b/generated/aws_efs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_efs_api/elasticfilesystem-2015-02-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_efs_api'));
-
   t.test('ensure_compilation', () {
     EFS(
       region: '',

--- a/generated/aws_eks_api/pubspec.yaml
+++ b/generated/aws_eks_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_eks_api/test/ensure_build_test.dart
+++ b/generated/aws_eks_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_eks_api/eks-2017-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_eks_api'));
-
   t.test('ensure_compilation', () {
     EKS(
       region: '',

--- a/generated/aws_elastic_inference_api/pubspec.yaml
+++ b/generated/aws_elastic_inference_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elastic_inference_api/test/ensure_build_test.dart
+++ b/generated/aws_elastic_inference_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elastic_inference_api/elastic-inference-2017-07-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_elastic_inference_api'));
-
   t.test('ensure_compilation', () {
     ElasticInference(
       region: '',

--- a/generated/aws_elasticache_api/pubspec.yaml
+++ b/generated/aws_elasticache_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elasticache_api/test/ensure_build_test.dart
+++ b/generated/aws_elasticache_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elasticache_api/elasticache-2015-02-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_elasticache_api'));
-
   t.test('ensure_compilation', () {
     ElastiCache(
       region: '',

--- a/generated/aws_elasticbeanstalk_api/pubspec.yaml
+++ b/generated/aws_elasticbeanstalk_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elasticbeanstalk_api/test/ensure_build_test.dart
+++ b/generated/aws_elasticbeanstalk_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elasticbeanstalk_api/elasticbeanstalk-2010-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_elasticbeanstalk_api'));
-
   t.test('ensure_compilation', () {
     ElasticBeanstalk(
       region: '',

--- a/generated/aws_elastictranscoder_api/pubspec.yaml
+++ b/generated/aws_elastictranscoder_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elastictranscoder_api/test/ensure_build_test.dart
+++ b/generated/aws_elastictranscoder_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elastictranscoder_api/elastictranscoder-2012-09-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_elastictranscoder_api'));
-
   t.test('ensure_compilation', () {
     ElasticTranscoder(
       region: '',

--- a/generated/aws_elb_api/pubspec.yaml
+++ b/generated/aws_elb_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elb_api/test/ensure_build_test.dart
+++ b/generated/aws_elb_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elb_api/elasticloadbalancing-2012-06-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_elb_api'));
-
   t.test('ensure_compilation', () {
     ElasticLoadBalancing(
       region: '',

--- a/generated/aws_elbv2_api/pubspec.yaml
+++ b/generated/aws_elbv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_elbv2_api/test/ensure_build_test.dart
+++ b/generated/aws_elbv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_elbv2_api/elasticloadbalancingv2-2015-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_elbv2_api'));
-
   t.test('ensure_compilation', () {
     ElasticLoadBalancingv2(
       region: '',

--- a/generated/aws_emr_api/pubspec.yaml
+++ b/generated/aws_emr_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_emr_api/test/ensure_build_test.dart
+++ b/generated/aws_emr_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_emr_api/elasticmapreduce-2009-03-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_emr_api'));
-
   t.test('ensure_compilation', () {
     EMR(
       region: '',

--- a/generated/aws_es_api/pubspec.yaml
+++ b/generated/aws_es_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_es_api/test/ensure_build_test.dart
+++ b/generated/aws_es_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_es_api/es-2015-01-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_es_api'));
-
   t.test('ensure_compilation', () {
     ElasticsearchService(
       region: '',

--- a/generated/aws_events_api/pubspec.yaml
+++ b/generated/aws_events_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_events_api/test/ensure_build_test.dart
+++ b/generated/aws_events_api/test/ensure_build_test.dart
@@ -1,16 +1,10 @@
-import 'package:aws_events_api/events-2015-10-07.dart';
-import 'package:build_verify/build_verify.dart';
+import 'package:aws_events_api/eventbridge-2015-10-07.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_events_api'));
-
   t.test('ensure_compilation', () {
-    CloudWatchEvents(
+    EventBridge(
       region: '',
       credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
     );

--- a/generated/aws_firehose_api/pubspec.yaml
+++ b/generated/aws_firehose_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_firehose_api/test/ensure_build_test.dart
+++ b/generated/aws_firehose_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_firehose_api/firehose-2015-08-04.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_firehose_api'));
-
   t.test('ensure_compilation', () {
     Firehose(
       region: '',

--- a/generated/aws_fms_api/pubspec.yaml
+++ b/generated/aws_fms_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_fms_api/test/ensure_build_test.dart
+++ b/generated/aws_fms_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_fms_api/fms-2018-01-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_fms_api'));
-
   t.test('ensure_compilation', () {
     FMS(
       region: '',

--- a/generated/aws_forecast_api/pubspec.yaml
+++ b/generated/aws_forecast_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_forecast_api/test/ensure_build_test.dart
+++ b/generated/aws_forecast_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_forecast_api/forecast-2018-06-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_forecast_api'));
-
   t.test('ensure_compilation', () {
     ForecastService(
       region: '',

--- a/generated/aws_forecastquery_api/pubspec.yaml
+++ b/generated/aws_forecastquery_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_forecastquery_api/test/ensure_build_test.dart
+++ b/generated/aws_forecastquery_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_forecastquery_api/forecastquery-2018-06-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_forecastquery_api'));
-
   t.test('ensure_compilation', () {
     ForecastQueryService(
       region: '',

--- a/generated/aws_frauddetector_api/pubspec.yaml
+++ b/generated/aws_frauddetector_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_frauddetector_api/test/ensure_build_test.dart
+++ b/generated/aws_frauddetector_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_frauddetector_api/frauddetector-2019-11-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_frauddetector_api'));
-
   t.test('ensure_compilation', () {
     FraudDetector(
       region: '',

--- a/generated/aws_fsx_api/pubspec.yaml
+++ b/generated/aws_fsx_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_fsx_api/test/ensure_build_test.dart
+++ b/generated/aws_fsx_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_fsx_api/fsx-2018-03-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_fsx_api'));
-
   t.test('ensure_compilation', () {
     FSx(
       region: '',

--- a/generated/aws_gamelift_api/pubspec.yaml
+++ b/generated/aws_gamelift_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_gamelift_api/test/ensure_build_test.dart
+++ b/generated/aws_gamelift_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_gamelift_api/gamelift-2015-10-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_gamelift_api'));
-
   t.test('ensure_compilation', () {
     GameLift(
       region: '',

--- a/generated/aws_glacier_api/pubspec.yaml
+++ b/generated/aws_glacier_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_glacier_api/test/ensure_build_test.dart
+++ b/generated/aws_glacier_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_glacier_api/glacier-2012-06-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_glacier_api'));
-
   t.test('ensure_compilation', () {
     Glacier(
       region: '',

--- a/generated/aws_globalaccelerator_api/pubspec.yaml
+++ b/generated/aws_globalaccelerator_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_globalaccelerator_api/test/ensure_build_test.dart
+++ b/generated/aws_globalaccelerator_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_globalaccelerator_api/globalaccelerator-2018-08-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_globalaccelerator_api'));
-
   t.test('ensure_compilation', () {
     GlobalAccelerator(
       region: '',

--- a/generated/aws_glue_api/pubspec.yaml
+++ b/generated/aws_glue_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_glue_api/test/ensure_build_test.dart
+++ b/generated/aws_glue_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_glue_api/glue-2017-03-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_glue_api'));
-
   t.test('ensure_compilation', () {
     Glue(
       region: '',

--- a/generated/aws_greengrass_api/pubspec.yaml
+++ b/generated/aws_greengrass_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_greengrass_api/test/ensure_build_test.dart
+++ b/generated/aws_greengrass_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_greengrass_api/greengrass-2017-06-07.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_greengrass_api'));
-
   t.test('ensure_compilation', () {
     Greengrass(
       region: '',

--- a/generated/aws_groundstation_api/pubspec.yaml
+++ b/generated/aws_groundstation_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_groundstation_api/test/ensure_build_test.dart
+++ b/generated/aws_groundstation_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_groundstation_api/groundstation-2019-05-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_groundstation_api'));
-
   t.test('ensure_compilation', () {
     GroundStation(
       region: '',

--- a/generated/aws_guardduty_api/pubspec.yaml
+++ b/generated/aws_guardduty_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_guardduty_api/test/ensure_build_test.dart
+++ b/generated/aws_guardduty_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_guardduty_api/guardduty-2017-11-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_guardduty_api'));
-
   t.test('ensure_compilation', () {
     GuardDuty(
       region: '',

--- a/generated/aws_health_api/pubspec.yaml
+++ b/generated/aws_health_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_health_api/test/ensure_build_test.dart
+++ b/generated/aws_health_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_health_api/health-2016-08-04.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_health_api'));
-
   t.test('ensure_compilation', () {
     Health(
       region: '',

--- a/generated/aws_iam_api/pubspec.yaml
+++ b/generated/aws_iam_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iam_api/test/ensure_build_test.dart
+++ b/generated/aws_iam_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iam_api/iam-2010-05-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_iam_api'));
-
   t.test('ensure_compilation', () {
     IAM(
       region: '',

--- a/generated/aws_imagebuilder_api/pubspec.yaml
+++ b/generated/aws_imagebuilder_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_imagebuilder_api/test/ensure_build_test.dart
+++ b/generated/aws_imagebuilder_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_imagebuilder_api/imagebuilder-2019-12-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_imagebuilder_api'));
-
   t.test('ensure_compilation', () {
     Imagebuilder(
       region: '',

--- a/generated/aws_importexport_api/pubspec.yaml
+++ b/generated/aws_importexport_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_importexport_api/test/ensure_build_test.dart
+++ b/generated/aws_importexport_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_importexport_api/importexport-2010-06-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_importexport_api'));
-
   t.test('ensure_compilation', () {
     ImportExport(
       region: '',

--- a/generated/aws_inspector_api/pubspec.yaml
+++ b/generated/aws_inspector_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_inspector_api/test/ensure_build_test.dart
+++ b/generated/aws_inspector_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_inspector_api/inspector-2016-02-16.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_inspector_api'));
-
   t.test('ensure_compilation', () {
     Inspector(
       region: '',

--- a/generated/aws_iot1click_devices_api/pubspec.yaml
+++ b/generated/aws_iot1click_devices_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iot1click_devices_api/test/ensure_build_test.dart
+++ b/generated/aws_iot1click_devices_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iot1click_devices_api/devices-2018-05-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iot1click_devices_api'));
-
   t.test('ensure_compilation', () {
     IoT1ClickDevicesService(
       region: '',

--- a/generated/aws_iot1click_projects_api/pubspec.yaml
+++ b/generated/aws_iot1click_projects_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iot1click_projects_api/test/ensure_build_test.dart
+++ b/generated/aws_iot1click_projects_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iot1click_projects_api/iot1click-projects-2018-05-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iot1click_projects_api'));
-
   t.test('ensure_compilation', () {
     IoT1ClickProjects(
       region: '',

--- a/generated/aws_iot_api/pubspec.yaml
+++ b/generated/aws_iot_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iot_api/test/ensure_build_test.dart
+++ b/generated/aws_iot_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iot_api/iot-2015-05-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_iot_api'));
-
   t.test('ensure_compilation', () {
     IoT(
       region: '',

--- a/generated/aws_iot_data_api/pubspec.yaml
+++ b/generated/aws_iot_data_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iot_data_api/test/ensure_build_test.dart
+++ b/generated/aws_iot_data_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iot_data_api/iot-data-2015-05-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iot_data_api'));
-
   t.test('ensure_compilation', () {
     IoTDataPlane(
       region: '',

--- a/generated/aws_iot_jobs_data_api/pubspec.yaml
+++ b/generated/aws_iot_jobs_data_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iot_jobs_data_api/test/ensure_build_test.dart
+++ b/generated/aws_iot_jobs_data_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iot_jobs_data_api/iot-jobs-data-2017-09-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iot_jobs_data_api'));
-
   t.test('ensure_compilation', () {
     IoTJobsDataPlane(
       region: '',

--- a/generated/aws_iotanalytics_api/pubspec.yaml
+++ b/generated/aws_iotanalytics_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iotanalytics_api/test/ensure_build_test.dart
+++ b/generated/aws_iotanalytics_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iotanalytics_api/iotanalytics-2017-11-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iotanalytics_api'));
-
   t.test('ensure_compilation', () {
     IoTAnalytics(
       region: '',

--- a/generated/aws_iotevents_api/pubspec.yaml
+++ b/generated/aws_iotevents_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iotevents_api/test/ensure_build_test.dart
+++ b/generated/aws_iotevents_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iotevents_api/iotevents-2018-07-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iotevents_api'));
-
   t.test('ensure_compilation', () {
     IoTEvents(
       region: '',

--- a/generated/aws_iotevents_data_api/pubspec.yaml
+++ b/generated/aws_iotevents_data_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iotevents_data_api/test/ensure_build_test.dart
+++ b/generated/aws_iotevents_data_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iotevents_data_api/iotevents-data-2018-10-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iotevents_data_api'));
-
   t.test('ensure_compilation', () {
     IoTEventsData(
       region: '',

--- a/generated/aws_iotsecuretunneling_api/pubspec.yaml
+++ b/generated/aws_iotsecuretunneling_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iotsecuretunneling_api/test/ensure_build_test.dart
+++ b/generated/aws_iotsecuretunneling_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iotsecuretunneling_api/iotsecuretunneling-2018-10-05.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iotsecuretunneling_api'));
-
   t.test('ensure_compilation', () {
     IoTSecureTunneling(
       region: '',

--- a/generated/aws_iotthingsgraph_api/pubspec.yaml
+++ b/generated/aws_iotthingsgraph_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_iotthingsgraph_api/test/ensure_build_test.dart
+++ b/generated/aws_iotthingsgraph_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_iotthingsgraph_api/iotthingsgraph-2018-09-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_iotthingsgraph_api'));
-
   t.test('ensure_compilation', () {
     IoTThingsGraph(
       region: '',

--- a/generated/aws_kafka_api/pubspec.yaml
+++ b/generated/aws_kafka_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kafka_api/test/ensure_build_test.dart
+++ b/generated/aws_kafka_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kafka_api/kafka-2018-11-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kafka_api'));
-
   t.test('ensure_compilation', () {
     Kafka(
       region: '',

--- a/generated/aws_kendra_api/pubspec.yaml
+++ b/generated/aws_kendra_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kendra_api/test/ensure_build_test.dart
+++ b/generated/aws_kendra_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kendra_api/kendra-2019-02-03.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kendra_api'));
-
   t.test('ensure_compilation', () {
     Kendra(
       region: '',

--- a/generated/aws_kinesis_api/pubspec.yaml
+++ b/generated/aws_kinesis_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesis_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesis_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kinesis_api/kinesis-2013-12-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kinesis_api'));
-
   t.test('ensure_compilation', () {
     Kinesis(
       region: '',

--- a/generated/aws_kinesis_video_archived_media_api/pubspec.yaml
+++ b/generated/aws_kinesis_video_archived_media_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesis_video_archived_media_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesis_video_archived_media_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_kinesis_video_archived_media_api/kinesis-video-archived-media-2017-09-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_kinesis_video_archived_media_api'));
-
   t.test('ensure_compilation', () {
     KinesisVideoArchivedMedia(
       region: '',

--- a/generated/aws_kinesis_video_media_api/pubspec.yaml
+++ b/generated/aws_kinesis_video_media_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesis_video_media_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesis_video_media_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kinesis_video_media_api/kinesis-video-media-2017-09-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kinesis_video_media_api'));
-
   t.test('ensure_compilation', () {
     KinesisVideoMedia(
       region: '',

--- a/generated/aws_kinesis_video_signaling_api/pubspec.yaml
+++ b/generated/aws_kinesis_video_signaling_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesis_video_signaling_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesis_video_signaling_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_kinesis_video_signaling_api/kinesis-video-signaling-2019-12-04.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_kinesis_video_signaling_api'));
-
   t.test('ensure_compilation', () {
     KinesisVideoSignalingChannels(
       region: '',

--- a/generated/aws_kinesisanalytics_api/pubspec.yaml
+++ b/generated/aws_kinesisanalytics_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesisanalytics_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesisanalytics_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kinesisanalytics_api/kinesisanalytics-2015-08-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kinesisanalytics_api'));
-
   t.test('ensure_compilation', () {
     KinesisAnalytics(
       region: '',

--- a/generated/aws_kinesisanalyticsv2_api/pubspec.yaml
+++ b/generated/aws_kinesisanalyticsv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesisanalyticsv2_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesisanalyticsv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kinesisanalyticsv2_api/kinesisanalyticsv2-2018-05-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kinesisanalyticsv2_api'));
-
   t.test('ensure_compilation', () {
     KinesisAnalyticsV2(
       region: '',

--- a/generated/aws_kinesisvideo_api/pubspec.yaml
+++ b/generated/aws_kinesisvideo_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kinesisvideo_api/test/ensure_build_test.dart
+++ b/generated/aws_kinesisvideo_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kinesisvideo_api/kinesisvideo-2017-09-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_kinesisvideo_api'));
-
   t.test('ensure_compilation', () {
     KinesisVideo(
       region: '',

--- a/generated/aws_kms_api/pubspec.yaml
+++ b/generated/aws_kms_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_kms_api/test/ensure_build_test.dart
+++ b/generated/aws_kms_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_kms_api/kms-2014-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_kms_api'));
-
   t.test('ensure_compilation', () {
     KMS(
       region: '',

--- a/generated/aws_lakeformation_api/pubspec.yaml
+++ b/generated/aws_lakeformation_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_lakeformation_api/test/ensure_build_test.dart
+++ b/generated/aws_lakeformation_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_lakeformation_api/lakeformation-2017-03-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_lakeformation_api'));
-
   t.test('ensure_compilation', () {
     LakeFormation(
       region: '',

--- a/generated/aws_lambda_api/pubspec.yaml
+++ b/generated/aws_lambda_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_lambda_api/test/ensure_build_test.dart
+++ b/generated/aws_lambda_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
-import 'package:aws_lambda_api/lambda-2014-11-11.dart';
-import 'package:build_verify/build_verify.dart';
+import 'package:aws_lambda_api/lambda-2015-03-31.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_lambda_api'));
-
   t.test('ensure_compilation', () {
     Lambda(
       region: '',

--- a/generated/aws_lex_models_api/pubspec.yaml
+++ b/generated/aws_lex_models_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_lex_models_api/test/ensure_build_test.dart
+++ b/generated/aws_lex_models_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_lex_models_api/lex-models-2017-04-19.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_lex_models_api'));
-
   t.test('ensure_compilation', () {
     LexModelBuildingService(
       region: '',

--- a/generated/aws_lex_runtime_api/pubspec.yaml
+++ b/generated/aws_lex_runtime_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_lex_runtime_api/test/ensure_build_test.dart
+++ b/generated/aws_lex_runtime_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_lex_runtime_api/runtime.lex-2016-11-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_lex_runtime_api'));
-
   t.test('ensure_compilation', () {
     LexRuntimeService(
       region: '',

--- a/generated/aws_license_manager_api/pubspec.yaml
+++ b/generated/aws_license_manager_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_license_manager_api/test/ensure_build_test.dart
+++ b/generated/aws_license_manager_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_license_manager_api/license-manager-2018-08-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_license_manager_api'));
-
   t.test('ensure_compilation', () {
     LicenseManager(
       region: '',

--- a/generated/aws_lightsail_api/pubspec.yaml
+++ b/generated/aws_lightsail_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_lightsail_api/test/ensure_build_test.dart
+++ b/generated/aws_lightsail_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_lightsail_api/lightsail-2016-11-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_lightsail_api'));
-
   t.test('ensure_compilation', () {
     Lightsail(
       region: '',

--- a/generated/aws_logs_api/pubspec.yaml
+++ b/generated/aws_logs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_logs_api/test/ensure_build_test.dart
+++ b/generated/aws_logs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_logs_api/logs-2014-03-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_logs_api'));
-
   t.test('ensure_compilation', () {
     CloudWatchLogs(
       region: '',

--- a/generated/aws_machinelearning_api/pubspec.yaml
+++ b/generated/aws_machinelearning_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_machinelearning_api/test/ensure_build_test.dart
+++ b/generated/aws_machinelearning_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_machinelearning_api/machinelearning-2014-12-12.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_machinelearning_api'));
-
   t.test('ensure_compilation', () {
     MachineLearning(
       region: '',

--- a/generated/aws_macie_api/pubspec.yaml
+++ b/generated/aws_macie_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_macie_api/test/ensure_build_test.dart
+++ b/generated/aws_macie_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_macie_api/macie-2017-12-19.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_macie_api'));
-
   t.test('ensure_compilation', () {
     Macie(
       region: '',

--- a/generated/aws_managedblockchain_api/pubspec.yaml
+++ b/generated/aws_managedblockchain_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_managedblockchain_api/test/ensure_build_test.dart
+++ b/generated/aws_managedblockchain_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_managedblockchain_api/managedblockchain-2018-09-24.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_managedblockchain_api'));
-
   t.test('ensure_compilation', () {
     ManagedBlockchain(
       region: '',

--- a/generated/aws_marketplace_catalog_api/pubspec.yaml
+++ b/generated/aws_marketplace_catalog_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_marketplace_catalog_api/test/ensure_build_test.dart
+++ b/generated/aws_marketplace_catalog_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_marketplace_catalog_api/marketplace-catalog-2018-09-17.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_marketplace_catalog_api'));
-
   t.test('ensure_compilation', () {
     MarketplaceCatalog(
       region: '',

--- a/generated/aws_marketplace_entitlement_api/pubspec.yaml
+++ b/generated/aws_marketplace_entitlement_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_marketplace_entitlement_api/test/ensure_build_test.dart
+++ b/generated/aws_marketplace_entitlement_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_marketplace_entitlement_api/entitlement.marketplace-2017-01-11.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_marketplace_entitlement_api'));
-
   t.test('ensure_compilation', () {
     MarketplaceEntitlementService(
       region: '',

--- a/generated/aws_marketplacecommerceanalytics_api/pubspec.yaml
+++ b/generated/aws_marketplacecommerceanalytics_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_marketplacecommerceanalytics_api/test/ensure_build_test.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_marketplacecommerceanalytics_api/marketplacecommerceanalytics-2015-07-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_marketplacecommerceanalytics_api'));
-
   t.test('ensure_compilation', () {
     MarketplaceCommerceAnalytics(
       region: '',

--- a/generated/aws_mediaconnect_api/pubspec.yaml
+++ b/generated/aws_mediaconnect_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediaconnect_api/test/ensure_build_test.dart
+++ b/generated/aws_mediaconnect_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediaconnect_api/mediaconnect-2018-11-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediaconnect_api'));
-
   t.test('ensure_compilation', () {
     MediaConnect(
       region: '',

--- a/generated/aws_mediaconvert_api/pubspec.yaml
+++ b/generated/aws_mediaconvert_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediaconvert_api/test/ensure_build_test.dart
+++ b/generated/aws_mediaconvert_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediaconvert_api/mediaconvert-2017-08-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediaconvert_api'));
-
   t.test('ensure_compilation', () {
     MediaConvert(
       region: '',

--- a/generated/aws_medialive_api/pubspec.yaml
+++ b/generated/aws_medialive_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_medialive_api/test/ensure_build_test.dart
+++ b/generated/aws_medialive_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_medialive_api/medialive-2017-10-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_medialive_api'));
-
   t.test('ensure_compilation', () {
     MediaLive(
       region: '',

--- a/generated/aws_mediapackage_api/pubspec.yaml
+++ b/generated/aws_mediapackage_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediapackage_api/test/ensure_build_test.dart
+++ b/generated/aws_mediapackage_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediapackage_api/mediapackage-2017-10-12.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediapackage_api'));
-
   t.test('ensure_compilation', () {
     MediaPackage(
       region: '',

--- a/generated/aws_mediapackage_vod_api/pubspec.yaml
+++ b/generated/aws_mediapackage_vod_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediapackage_vod_api/test/ensure_build_test.dart
+++ b/generated/aws_mediapackage_vod_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediapackage_vod_api/mediapackage-vod-2018-11-07.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediapackage_vod_api'));
-
   t.test('ensure_compilation', () {
     MediaPackageVod(
       region: '',

--- a/generated/aws_mediastore_api/pubspec.yaml
+++ b/generated/aws_mediastore_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediastore_api/test/ensure_build_test.dart
+++ b/generated/aws_mediastore_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediastore_api/mediastore-2017-09-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediastore_api'));
-
   t.test('ensure_compilation', () {
     MediaStore(
       region: '',

--- a/generated/aws_mediastore_data_api/pubspec.yaml
+++ b/generated/aws_mediastore_data_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediastore_data_api/test/ensure_build_test.dart
+++ b/generated/aws_mediastore_data_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediastore_data_api/mediastore-data-2017-09-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediastore_data_api'));
-
   t.test('ensure_compilation', () {
     MediaStoreData(
       region: '',

--- a/generated/aws_mediatailor_api/pubspec.yaml
+++ b/generated/aws_mediatailor_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mediatailor_api/test/ensure_build_test.dart
+++ b/generated/aws_mediatailor_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mediatailor_api/mediatailor-2018-04-23.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mediatailor_api'));
-
   t.test('ensure_compilation', () {
     MediaTailor(
       region: '',

--- a/generated/aws_meteringmarketplace_api/pubspec.yaml
+++ b/generated/aws_meteringmarketplace_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_meteringmarketplace_api/test/ensure_build_test.dart
+++ b/generated/aws_meteringmarketplace_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_meteringmarketplace_api/meteringmarketplace-2016-01-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_meteringmarketplace_api'));
-
   t.test('ensure_compilation', () {
     MarketplaceMetering(
       region: '',

--- a/generated/aws_mgh_api/pubspec.yaml
+++ b/generated/aws_mgh_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mgh_api/test/ensure_build_test.dart
+++ b/generated/aws_mgh_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mgh_api/AWSMigrationHub-2017-05-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_mgh_api'));
-
   t.test('ensure_compilation', () {
     MigrationHub(
       region: '',

--- a/generated/aws_migrationhub_config_api/pubspec.yaml
+++ b/generated/aws_migrationhub_config_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_migrationhub_config_api/test/ensure_build_test.dart
+++ b/generated/aws_migrationhub_config_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_migrationhub_config_api/migrationhub-config-2019-06-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_migrationhub_config_api'));
-
   t.test('ensure_compilation', () {
     MigrationHubConfig(
       region: '',

--- a/generated/aws_mobile_api/pubspec.yaml
+++ b/generated/aws_mobile_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mobile_api/test/ensure_build_test.dart
+++ b/generated/aws_mobile_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mobile_api/mobile-2017-07-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mobile_api'));
-
   t.test('ensure_compilation', () {
     Mobile(
       region: '',

--- a/generated/aws_mq_api/pubspec.yaml
+++ b/generated/aws_mq_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mq_api/test/ensure_build_test.dart
+++ b/generated/aws_mq_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_mq_api/mq-2017-11-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_mq_api'));
-
   t.test('ensure_compilation', () {
     MQ(
       region: '',

--- a/generated/aws_mturk_api/pubspec.yaml
+++ b/generated/aws_mturk_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_mturk_api/test/ensure_build_test.dart
+++ b/generated/aws_mturk_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_mturk_api/mturk-requester-2017-01-17.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_mturk_api'));
-
   t.test('ensure_compilation', () {
     MTurk(
       region: '',

--- a/generated/aws_neptune_api/pubspec.yaml
+++ b/generated/aws_neptune_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_neptune_api/test/ensure_build_test.dart
+++ b/generated/aws_neptune_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_neptune_api/neptune-2014-10-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_neptune_api'));
-
   t.test('ensure_compilation', () {
     Neptune(
       region: '',

--- a/generated/aws_networkmanager_api/pubspec.yaml
+++ b/generated/aws_networkmanager_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_networkmanager_api/test/ensure_build_test.dart
+++ b/generated/aws_networkmanager_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_networkmanager_api/networkmanager-2019-07-05.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_networkmanager_api'));
-
   t.test('ensure_compilation', () {
     NetworkManager(
       region: '',

--- a/generated/aws_opsworks_api/pubspec.yaml
+++ b/generated/aws_opsworks_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_opsworks_api/test/ensure_build_test.dart
+++ b/generated/aws_opsworks_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_opsworks_api/opsworks-2013-02-18.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_opsworks_api'));
-
   t.test('ensure_compilation', () {
     OpsWorks(
       region: '',

--- a/generated/aws_opsworks_cm_api/pubspec.yaml
+++ b/generated/aws_opsworks_cm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_opsworks_cm_api/test/ensure_build_test.dart
+++ b/generated/aws_opsworks_cm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_opsworks_cm_api/opsworkscm-2016-11-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_opsworks_cm_api'));
-
   t.test('ensure_compilation', () {
     OpsWorksCM(
       region: '',

--- a/generated/aws_organizations_api/pubspec.yaml
+++ b/generated/aws_organizations_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_organizations_api/test/ensure_build_test.dart
+++ b/generated/aws_organizations_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_organizations_api/organizations-2016-11-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_organizations_api'));
-
   t.test('ensure_compilation', () {
     Organizations(
       region: '',

--- a/generated/aws_outposts_api/pubspec.yaml
+++ b/generated/aws_outposts_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_outposts_api/test/ensure_build_test.dart
+++ b/generated/aws_outposts_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_outposts_api/outposts-2019-12-03.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_outposts_api'));
-
   t.test('ensure_compilation', () {
     Outposts(
       region: '',

--- a/generated/aws_personalize_api/pubspec.yaml
+++ b/generated/aws_personalize_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_personalize_api/test/ensure_build_test.dart
+++ b/generated/aws_personalize_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_personalize_api/personalize-2018-05-22.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_personalize_api'));
-
   t.test('ensure_compilation', () {
     Personalize(
       region: '',

--- a/generated/aws_personalize_events_api/pubspec.yaml
+++ b/generated/aws_personalize_events_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_personalize_events_api/test/ensure_build_test.dart
+++ b/generated/aws_personalize_events_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_personalize_events_api/personalize-events-2018-03-22.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_personalize_events_api'));
-
   t.test('ensure_compilation', () {
     PersonalizeEvents(
       region: '',

--- a/generated/aws_personalize_runtime_api/pubspec.yaml
+++ b/generated/aws_personalize_runtime_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_personalize_runtime_api/test/ensure_build_test.dart
+++ b/generated/aws_personalize_runtime_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_personalize_runtime_api/personalize-runtime-2018-05-22.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_personalize_runtime_api'));
-
   t.test('ensure_compilation', () {
     PersonalizeRuntime(
       region: '',

--- a/generated/aws_pi_api/pubspec.yaml
+++ b/generated/aws_pi_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_pi_api/test/ensure_build_test.dart
+++ b/generated/aws_pi_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_pi_api/pi-2018-02-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_pi_api'));
-
   t.test('ensure_compilation', () {
     PI(
       region: '',

--- a/generated/aws_pinpoint_api/pubspec.yaml
+++ b/generated/aws_pinpoint_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_pinpoint_api/test/ensure_build_test.dart
+++ b/generated/aws_pinpoint_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_pinpoint_api/pinpoint-2016-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_pinpoint_api'));
-
   t.test('ensure_compilation', () {
     Pinpoint(
       region: '',

--- a/generated/aws_pinpoint_email_api/pubspec.yaml
+++ b/generated/aws_pinpoint_email_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_pinpoint_email_api/test/ensure_build_test.dart
+++ b/generated/aws_pinpoint_email_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_pinpoint_email_api/pinpoint-email-2018-07-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_pinpoint_email_api'));
-
   t.test('ensure_compilation', () {
     PinpointEmail(
       region: '',

--- a/generated/aws_pinpoint_sms_voice_api/pubspec.yaml
+++ b/generated/aws_pinpoint_sms_voice_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_pinpoint_sms_voice_api/test/ensure_build_test.dart
+++ b/generated/aws_pinpoint_sms_voice_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_pinpoint_sms_voice_api/pinpoint-sms-voice-2018-09-05.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_pinpoint_sms_voice_api'));
-
   t.test('ensure_compilation', () {
     PinpointSMSVoice(
       region: '',

--- a/generated/aws_polly_api/pubspec.yaml
+++ b/generated/aws_polly_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_polly_api/test/ensure_build_test.dart
+++ b/generated/aws_polly_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_polly_api/polly-2016-06-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_polly_api'));
-
   t.test('ensure_compilation', () {
     Polly(
       region: '',

--- a/generated/aws_pricing_api/pubspec.yaml
+++ b/generated/aws_pricing_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_pricing_api/test/ensure_build_test.dart
+++ b/generated/aws_pricing_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_pricing_api/pricing-2017-10-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_pricing_api'));
-
   t.test('ensure_compilation', () {
     Pricing(
       region: '',

--- a/generated/aws_qldb_api/pubspec.yaml
+++ b/generated/aws_qldb_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_qldb_api/test/ensure_build_test.dart
+++ b/generated/aws_qldb_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_qldb_api/qldb-2019-01-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_qldb_api'));
-
   t.test('ensure_compilation', () {
     QLDB(
       region: '',

--- a/generated/aws_qldb_session_api/pubspec.yaml
+++ b/generated/aws_qldb_session_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_qldb_session_api/test/ensure_build_test.dart
+++ b/generated/aws_qldb_session_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_qldb_session_api/qldb-session-2019-07-11.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_qldb_session_api'));
-
   t.test('ensure_compilation', () {
     QLDBSession(
       region: '',

--- a/generated/aws_quicksight_api/pubspec.yaml
+++ b/generated/aws_quicksight_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_quicksight_api/test/ensure_build_test.dart
+++ b/generated/aws_quicksight_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_quicksight_api/quicksight-2018-04-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_quicksight_api'));
-
   t.test('ensure_compilation', () {
     QuickSight(
       region: '',

--- a/generated/aws_ram_api/pubspec.yaml
+++ b/generated/aws_ram_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ram_api/test/ensure_build_test.dart
+++ b/generated/aws_ram_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ram_api/ram-2018-01-04.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ram_api'));
-
   t.test('ensure_compilation', () {
     RAM(
       region: '',

--- a/generated/aws_rds_api/pubspec.yaml
+++ b/generated/aws_rds_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_rds_api/test/ensure_build_test.dart
+++ b/generated/aws_rds_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_rds_api/rds-2014-10-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_rds_api'));
-
   t.test('ensure_compilation', () {
     RDS(
       region: '',

--- a/generated/aws_rds_data_api/pubspec.yaml
+++ b/generated/aws_rds_data_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_rds_data_api/test/ensure_build_test.dart
+++ b/generated/aws_rds_data_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_rds_data_api/rds-data-2018-08-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_rds_data_api'));
-
   t.test('ensure_compilation', () {
     RDSDataService(
       region: '',

--- a/generated/aws_redshift_api/pubspec.yaml
+++ b/generated/aws_redshift_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_redshift_api/test/ensure_build_test.dart
+++ b/generated/aws_redshift_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_redshift_api/redshift-2012-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_redshift_api'));
-
   t.test('ensure_compilation', () {
     Redshift(
       region: '',

--- a/generated/aws_rekognition_api/pubspec.yaml
+++ b/generated/aws_rekognition_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_rekognition_api/test/ensure_build_test.dart
+++ b/generated/aws_rekognition_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_rekognition_api/rekognition-2016-06-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_rekognition_api'));
-
   t.test('ensure_compilation', () {
     Rekognition(
       region: '',

--- a/generated/aws_resource_groups_api/pubspec.yaml
+++ b/generated/aws_resource_groups_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_resource_groups_api/test/ensure_build_test.dart
+++ b/generated/aws_resource_groups_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_resource_groups_api/resource-groups-2017-11-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_resource_groups_api'));
-
   t.test('ensure_compilation', () {
     ResourceGroups(
       region: '',

--- a/generated/aws_resourcegroupstaggingapi_api/pubspec.yaml
+++ b/generated/aws_resourcegroupstaggingapi_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_resourcegroupstaggingapi_api/test/ensure_build_test.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/test/ensure_build_test.dart
@@ -1,15 +1,8 @@
 import 'package:aws_resourcegroupstaggingapi_api/resourcegroupstaggingapi-2017-01-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory:
-              'generated/aws_resourcegroupstaggingapi_api'));
-
   t.test('ensure_compilation', () {
     ResourceGroupsTaggingAPI(
       region: '',

--- a/generated/aws_robomaker_api/pubspec.yaml
+++ b/generated/aws_robomaker_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_robomaker_api/test/ensure_build_test.dart
+++ b/generated/aws_robomaker_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_robomaker_api/robomaker-2018-06-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_robomaker_api'));
-
   t.test('ensure_compilation', () {
     RoboMaker(
       region: '',

--- a/generated/aws_route53_api/pubspec.yaml
+++ b/generated/aws_route53_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_route53_api/test/ensure_build_test.dart
+++ b/generated/aws_route53_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_route53_api/route53-2013-04-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_route53_api'));
-
   t.test('ensure_compilation', () {
     Route53(
       region: '',

--- a/generated/aws_route53domains_api/pubspec.yaml
+++ b/generated/aws_route53domains_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_route53domains_api/test/ensure_build_test.dart
+++ b/generated/aws_route53domains_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_route53domains_api/route53domains-2014-05-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_route53domains_api'));
-
   t.test('ensure_compilation', () {
     Route53Domains(
       region: '',

--- a/generated/aws_route53resolver_api/pubspec.yaml
+++ b/generated/aws_route53resolver_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_route53resolver_api/test/ensure_build_test.dart
+++ b/generated/aws_route53resolver_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_route53resolver_api/route53resolver-2018-04-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_route53resolver_api'));
-
   t.test('ensure_compilation', () {
     Route53Resolver(
       region: '',

--- a/generated/aws_s3_api/pubspec.yaml
+++ b/generated/aws_s3_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_s3_api/test/ensure_build_test.dart
+++ b/generated/aws_s3_api/test/ensure_build_test.dart
@@ -1,12 +1,8 @@
 import 'package:aws_s3_api/s3-2006-03-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: 'generated/aws_s3_api'));
-
   t.test('ensure_compilation', () {
     S3(
       region: '',

--- a/generated/aws_s3control_api/pubspec.yaml
+++ b/generated/aws_s3control_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_s3control_api/test/ensure_build_test.dart
+++ b/generated/aws_s3control_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_s3control_api/s3control-2018-08-20.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_s3control_api'));
-
   t.test('ensure_compilation', () {
     S3Control(
       region: '',

--- a/generated/aws_sagemaker_a2i_runtime_api/pubspec.yaml
+++ b/generated/aws_sagemaker_a2i_runtime_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sagemaker_a2i_runtime_api/test/ensure_build_test.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sagemaker_a2i_runtime_api/sagemaker-a2i-runtime-2019-11-07.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_sagemaker_a2i_runtime_api'));
-
   t.test('ensure_compilation', () {
     AugmentedAIRuntime(
       region: '',

--- a/generated/aws_sagemaker_api/pubspec.yaml
+++ b/generated/aws_sagemaker_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sagemaker_api/test/ensure_build_test.dart
+++ b/generated/aws_sagemaker_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sagemaker_api/sagemaker-2017-07-24.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_sagemaker_api'));
-
   t.test('ensure_compilation', () {
     SageMaker(
       region: '',

--- a/generated/aws_sagemaker_runtime_api/pubspec.yaml
+++ b/generated/aws_sagemaker_runtime_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sagemaker_runtime_api/test/ensure_build_test.dart
+++ b/generated/aws_sagemaker_runtime_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sagemaker_runtime_api/runtime.sagemaker-2017-05-13.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_sagemaker_runtime_api'));
-
   t.test('ensure_compilation', () {
     SageMakerRuntime(
       region: '',

--- a/generated/aws_savingsplans_api/pubspec.yaml
+++ b/generated/aws_savingsplans_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_savingsplans_api/test/ensure_build_test.dart
+++ b/generated/aws_savingsplans_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_savingsplans_api/savingsplans-2019-06-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_savingsplans_api'));
-
   t.test('ensure_compilation', () {
     SavingsPlans(
       region: '',

--- a/generated/aws_schemas_api/pubspec.yaml
+++ b/generated/aws_schemas_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_schemas_api/test/ensure_build_test.dart
+++ b/generated/aws_schemas_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_schemas_api/schemas-2019-12-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_schemas_api'));
-
   t.test('ensure_compilation', () {
     Schemas(
       region: '',

--- a/generated/aws_sdb_api/pubspec.yaml
+++ b/generated/aws_sdb_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sdb_api/test/ensure_build_test.dart
+++ b/generated/aws_sdb_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sdb_api/sdb-2009-04-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sdb_api'));
-
   t.test('ensure_compilation', () {
     SimpleDB(
       region: '',

--- a/generated/aws_secretsmanager_api/pubspec.yaml
+++ b/generated/aws_secretsmanager_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_secretsmanager_api/test/ensure_build_test.dart
+++ b/generated/aws_secretsmanager_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_secretsmanager_api/secretsmanager-2017-10-17.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_secretsmanager_api'));
-
   t.test('ensure_compilation', () {
     SecretsManager(
       region: '',

--- a/generated/aws_securityhub_api/pubspec.yaml
+++ b/generated/aws_securityhub_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_securityhub_api/test/ensure_build_test.dart
+++ b/generated/aws_securityhub_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_securityhub_api/securityhub-2018-10-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_securityhub_api'));
-
   t.test('ensure_compilation', () {
     SecurityHub(
       region: '',

--- a/generated/aws_serverlessrepo_api/pubspec.yaml
+++ b/generated/aws_serverlessrepo_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_serverlessrepo_api/test/ensure_build_test.dart
+++ b/generated/aws_serverlessrepo_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_serverlessrepo_api/serverlessrepo-2017-09-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_serverlessrepo_api'));
-
   t.test('ensure_compilation', () {
     ServerlessApplicationRepository(
       region: '',

--- a/generated/aws_service_quotas_api/pubspec.yaml
+++ b/generated/aws_service_quotas_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_service_quotas_api/test/ensure_build_test.dart
+++ b/generated/aws_service_quotas_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_service_quotas_api/service-quotas-2019-06-24.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_service_quotas_api'));
-
   t.test('ensure_compilation', () {
     ServiceQuotas(
       region: '',

--- a/generated/aws_servicecatalog_api/pubspec.yaml
+++ b/generated/aws_servicecatalog_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_servicecatalog_api/test/ensure_build_test.dart
+++ b/generated/aws_servicecatalog_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_servicecatalog_api/servicecatalog-2015-12-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_servicecatalog_api'));
-
   t.test('ensure_compilation', () {
     ServiceCatalog(
       region: '',

--- a/generated/aws_servicediscovery_api/pubspec.yaml
+++ b/generated/aws_servicediscovery_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_servicediscovery_api/test/ensure_build_test.dart
+++ b/generated/aws_servicediscovery_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_servicediscovery_api/servicediscovery-2017-03-14.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_servicediscovery_api'));
-
   t.test('ensure_compilation', () {
     ServiceDiscovery(
       region: '',

--- a/generated/aws_ses_api/pubspec.yaml
+++ b/generated/aws_ses_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ses_api/test/ensure_build_test.dart
+++ b/generated/aws_ses_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ses_api/email-2010-12-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ses_api'));
-
   t.test('ensure_compilation', () {
     SES(
       region: '',

--- a/generated/aws_sesv2_api/pubspec.yaml
+++ b/generated/aws_sesv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sesv2_api/test/ensure_build_test.dart
+++ b/generated/aws_sesv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sesv2_api/sesv2-2019-09-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_sesv2_api'));
-
   t.test('ensure_compilation', () {
     SESV2(
       region: '',

--- a/generated/aws_shield_api/pubspec.yaml
+++ b/generated/aws_shield_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_shield_api/test/ensure_build_test.dart
+++ b/generated/aws_shield_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_shield_api/shield-2016-06-02.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_shield_api'));
-
   t.test('ensure_compilation', () {
     Shield(
       region: '',

--- a/generated/aws_signer_api/pubspec.yaml
+++ b/generated/aws_signer_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_signer_api/test/ensure_build_test.dart
+++ b/generated/aws_signer_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_signer_api/signer-2017-08-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_signer_api'));
-
   t.test('ensure_compilation', () {
     Signer(
       region: '',

--- a/generated/aws_sms_api/pubspec.yaml
+++ b/generated/aws_sms_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sms_api/test/ensure_build_test.dart
+++ b/generated/aws_sms_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sms_api/sms-2016-10-24.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sms_api'));
-
   t.test('ensure_compilation', () {
     SMS(
       region: '',

--- a/generated/aws_snowball_api/pubspec.yaml
+++ b/generated/aws_snowball_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_snowball_api/test/ensure_build_test.dart
+++ b/generated/aws_snowball_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_snowball_api/snowball-2016-06-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_snowball_api'));
-
   t.test('ensure_compilation', () {
     Snowball(
       region: '',

--- a/generated/aws_sns_api/pubspec.yaml
+++ b/generated/aws_sns_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sns_api/test/ensure_build_test.dart
+++ b/generated/aws_sns_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sns_api/sns-2010-03-31.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sns_api'));
-
   t.test('ensure_compilation', () {
     SNS(
       region: '',

--- a/generated/aws_sqs_api/pubspec.yaml
+++ b/generated/aws_sqs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sqs_api/test/ensure_build_test.dart
+++ b/generated/aws_sqs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sqs_api/sqs-2012-11-05.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sqs_api'));
-
   t.test('ensure_compilation', () {
     SQS(
       region: '',

--- a/generated/aws_ssm_api/pubspec.yaml
+++ b/generated/aws_ssm_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_ssm_api/test/ensure_build_test.dart
+++ b/generated/aws_ssm_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_ssm_api/ssm-2014-11-06.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_ssm_api'));
-
   t.test('ensure_compilation', () {
     SSM(
       region: '',

--- a/generated/aws_sso_api/pubspec.yaml
+++ b/generated/aws_sso_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sso_api/test/ensure_build_test.dart
+++ b/generated/aws_sso_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sso_api/sso-2019-06-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sso_api'));
-
   t.test('ensure_compilation', () {
     SSO(
       region: '',

--- a/generated/aws_sso_oidc_api/pubspec.yaml
+++ b/generated/aws_sso_oidc_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sso_oidc_api/test/ensure_build_test.dart
+++ b/generated/aws_sso_oidc_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sso_oidc_api/sso-oidc-2019-06-10.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_sso_oidc_api'));
-
   t.test('ensure_compilation', () {
     SSOOIDC(
       region: '',

--- a/generated/aws_storagegateway_api/pubspec.yaml
+++ b/generated/aws_storagegateway_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_storagegateway_api/test/ensure_build_test.dart
+++ b/generated/aws_storagegateway_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_storagegateway_api/storagegateway-2013-06-30.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_storagegateway_api'));
-
   t.test('ensure_compilation', () {
     StorageGateway(
       region: '',

--- a/generated/aws_sts_api/pubspec.yaml
+++ b/generated/aws_sts_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_sts_api/test/ensure_build_test.dart
+++ b/generated/aws_sts_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_sts_api/sts-2011-06-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_sts_api'));
-
   t.test('ensure_compilation', () {
     STS(
       region: '',

--- a/generated/aws_support_api/pubspec.yaml
+++ b/generated/aws_support_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_support_api/test/ensure_build_test.dart
+++ b/generated/aws_support_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_support_api/support-2013-04-15.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_support_api'));
-
   t.test('ensure_compilation', () {
     Support(
       region: '',

--- a/generated/aws_swf_api/pubspec.yaml
+++ b/generated/aws_swf_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_swf_api/test/ensure_build_test.dart
+++ b/generated/aws_swf_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_swf_api/swf-2012-01-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_swf_api'));
-
   t.test('ensure_compilation', () {
     SWF(
       region: '',

--- a/generated/aws_textract_api/pubspec.yaml
+++ b/generated/aws_textract_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_textract_api/test/ensure_build_test.dart
+++ b/generated/aws_textract_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_textract_api/textract-2018-06-27.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_textract_api'));
-
   t.test('ensure_compilation', () {
     Textract(
       region: '',

--- a/generated/aws_transcribe_api/pubspec.yaml
+++ b/generated/aws_transcribe_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_transcribe_api/test/ensure_build_test.dart
+++ b/generated/aws_transcribe_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_transcribe_api/transcribe-2017-10-26.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_transcribe_api'));
-
   t.test('ensure_compilation', () {
     TranscribeService(
       region: '',

--- a/generated/aws_transfer_api/pubspec.yaml
+++ b/generated/aws_transfer_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_transfer_api/test/ensure_build_test.dart
+++ b/generated/aws_transfer_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_transfer_api/transfer-2018-11-05.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_transfer_api'));
-
   t.test('ensure_compilation', () {
     Transfer(
       region: '',

--- a/generated/aws_translate_api/pubspec.yaml
+++ b/generated/aws_translate_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_translate_api/test/ensure_build_test.dart
+++ b/generated/aws_translate_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_translate_api/translate-2017-07-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_translate_api'));
-
   t.test('ensure_compilation', () {
     Translate(
       region: '',

--- a/generated/aws_waf_api/pubspec.yaml
+++ b/generated/aws_waf_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_waf_api/test/ensure_build_test.dart
+++ b/generated/aws_waf_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_waf_api/waf-2015-08-24.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_waf_api'));
-
   t.test('ensure_compilation', () {
     WAF(
       region: '',

--- a/generated/aws_waf_regional_api/pubspec.yaml
+++ b/generated/aws_waf_regional_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_waf_regional_api/test/ensure_build_test.dart
+++ b/generated/aws_waf_regional_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_waf_regional_api/waf-regional-2016-11-28.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_waf_regional_api'));
-
   t.test('ensure_compilation', () {
     WAFRegional(
       region: '',

--- a/generated/aws_wafv2_api/pubspec.yaml
+++ b/generated/aws_wafv2_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_wafv2_api/test/ensure_build_test.dart
+++ b/generated/aws_wafv2_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_wafv2_api/wafv2-2019-07-29.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_wafv2_api'));
-
   t.test('ensure_compilation', () {
     WAFV2(
       region: '',

--- a/generated/aws_workdocs_api/pubspec.yaml
+++ b/generated/aws_workdocs_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_workdocs_api/test/ensure_build_test.dart
+++ b/generated/aws_workdocs_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_workdocs_api/workdocs-2016-05-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_workdocs_api'));
-
   t.test('ensure_compilation', () {
     WorkDocs(
       region: '',

--- a/generated/aws_worklink_api/pubspec.yaml
+++ b/generated/aws_worklink_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_worklink_api/test/ensure_build_test.dart
+++ b/generated/aws_worklink_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_worklink_api/worklink-2018-09-25.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_worklink_api'));
-
   t.test('ensure_compilation', () {
     WorkLink(
       region: '',

--- a/generated/aws_workmail_api/pubspec.yaml
+++ b/generated/aws_workmail_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_workmail_api/test/ensure_build_test.dart
+++ b/generated/aws_workmail_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_workmail_api/workmail-2017-10-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_workmail_api'));
-
   t.test('ensure_compilation', () {
     WorkMail(
       region: '',

--- a/generated/aws_workmailmessageflow_api/pubspec.yaml
+++ b/generated/aws_workmailmessageflow_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_workmailmessageflow_api/test/ensure_build_test.dart
+++ b/generated/aws_workmailmessageflow_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_workmailmessageflow_api/workmailmessageflow-2019-05-01.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_workmailmessageflow_api'));
-
   t.test('ensure_compilation', () {
     WorkMailMessageFlow(
       region: '',

--- a/generated/aws_workspaces_api/pubspec.yaml
+++ b/generated/aws_workspaces_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.1
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_workspaces_api/test/ensure_build_test.dart
+++ b/generated/aws_workspaces_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_workspaces_api/workspaces-2015-04-08.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () => expectBuildClean(
-          packageRelativeDirectory: 'generated/aws_workspaces_api'));
-
   t.test('ensure_compilation', () {
     WorkSpaces(
       region: '',

--- a/generated/aws_xray_api/pubspec.yaml
+++ b/generated/aws_xray_api/pubspec.yaml
@@ -13,9 +13,6 @@ dependencies:
   shared_aws_api: ^0.2.2
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 

--- a/generated/aws_xray_api/test/ensure_build_test.dart
+++ b/generated/aws_xray_api/test/ensure_build_test.dart
@@ -1,14 +1,8 @@
 import 'package:aws_xray_api/xray-2016-04-12.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test(
-      'ensure_build',
-      () =>
-          expectBuildClean(packageRelativeDirectory: 'generated/aws_xray_api'));
-
   t.test('ensure_compilation', () {
     XRay(
       region: '',

--- a/generator/lib/builders/pubspec_builder.dart
+++ b/generator/lib/builders/pubspec_builder.dart
@@ -33,9 +33,6 @@ dependencies:
   shared_aws_api: ${protocolConfig.shared}
 
 dev_dependencies:
-  build_runner: ^1.10.1
-  json_serializable: ^3.3.0
-  build_verify: ^1.1.1
   test: ^1.14.2
 
 $dependenciesOverride

--- a/generator/lib/builders/test_builder.dart
+++ b/generator/lib/builders/test_builder.dart
@@ -2,14 +2,10 @@ import 'package:aws_client.generator/model/api.dart';
 
 String buildTest(String packageRelativeDirectory, Api api) =>
     '''import 'package:${api.packageName}/${api.fileBasename}.dart';
-import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart' as t;
 
 @t.Tags(['presubmit-only'])
 void main() {
-  t.test('ensure_build',
-      () => expectBuildClean(packageRelativeDirectory: '$packageRelativeDirectory'));
-
   t.test('ensure_compilation', () {
     ${api.metadata.className}(
       region: '',

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -249,23 +249,25 @@ in the config file, from the downloaded models.''';
         serviceFile.writeAsStringSync(serviceText);
 
         final latestBuiltApiVersion = latestBuiltApi[api.metadata.serviceId];
+        final latestBuiltApiVersionDate =
+            DateTime.parse(latestBuiltApiVersion ?? '1900-01-01');
 
-        if (latestBuiltApiVersion == null ||
-            latestBuiltApiVersion.compareTo(api.metadata.apiVersion) < 0) {
+        if (latestBuiltApiVersionDate
+                .compareTo(DateTime.parse(api.metadata.apiVersion)) <
+            0) {
           latestBuiltApi[api.metadata.serviceId] = api.metadata.apiVersion;
           readmeFile.writeAsStringSync(buildReadmeMd(api));
           exampleFile.writeAsStringSync(buildExampleReadme(api));
+          final pathParts = baseDir.split('/')..removeAt(0);
+          final ensureBuildTestContent =
+              _formatter.format(buildTest(pathParts.join('/'), api));
+          File('$baseDir/test/ensure_build_test.dart')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(ensureBuildTestContent);
         }
 
         touchedDirs.add(baseDir);
         generatedApis[api.packageName] = api.metadata.serviceFullName;
-
-        final pathParts = baseDir.split('/')..removeAt(0);
-        final ensureBuildTestContent =
-            _formatter.format(buildTest(pathParts.join('/'), api));
-        File('$baseDir/test/ensure_build_test.dart')
-          ..createSync(recursive: true)
-          ..writeAsStringSync(ensureBuildTestContent);
       } on UnrecognizedKeysException catch (e) {
         print('Error deserializing $service');
         print(e.message);

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   html: ^0.14.0
   http: ^0.12.0
   json_annotation: ^3.0.0
+  path: ^1.7.0
+  pool: ^1.4.0
+  process_runner: ^3.1.1
 
 dev_dependencies:
   pedantic: ^1.8.0+1


### PR DESCRIPTION
Fixes #258 

This PR refactors the generate command so the `build_runner` phase is only run once. 
It generates all the apis in a temporary `all_apis` package, runs `build_runner` on it and then copies the generated file in their final destination.

On my machine, I can run the `generate` command in less than 2 minutes from a clean repository (and 30 seconds on the next run).