### PR TITLE
Timestamp changes

### DIFF
--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -12982,7 +12982,8 @@ class GetObjectOutput {
           .extractHeaderStringValue(headers, 'x-amz-object-lock-mode')
           ?.toObjectLockMode(),
       objectLockRetainUntilDate: _s.extractHeaderDateTimeValue(
-          headers, 'x-amz-object-lock-retain-until-date'),
+          headers, 'x-amz-object-lock-retain-until-date',
+          parser: _s.iso8601FromJson),
       partsCount: _s.extractHeaderIntValue(headers, 'x-amz-mp-parts-count'),
       replicationStatus: _s
           .extractHeaderStringValue(headers, 'x-amz-replication-status')
@@ -13420,7 +13421,8 @@ class HeadObjectOutput {
           .extractHeaderStringValue(headers, 'x-amz-object-lock-mode')
           ?.toObjectLockMode(),
       objectLockRetainUntilDate: _s.extractHeaderDateTimeValue(
-          headers, 'x-amz-object-lock-retain-until-date'),
+          headers, 'x-amz-object-lock-retain-until-date',
+          parser: _s.iso8601FromJson),
       partsCount: _s.extractHeaderIntValue(headers, 'x-amz-mp-parts-count'),
       replicationStatus: _s
           .extractHeaderStringValue(headers, 'x-amz-replication-status')
@@ -14119,7 +14121,8 @@ class LifecycleExpiration {
   });
   factory LifecycleExpiration.fromXml(_s.XmlElement elem) {
     return LifecycleExpiration(
-      date: _s.extractXmlDateTimeValue(elem, 'Date'),
+      date:
+          _s.extractXmlDateTimeValue(elem, 'Date', parser: _s.iso8601FromJson),
       days: _s.extractXmlIntValue(elem, 'Days'),
       expiredObjectDeleteMarker:
           _s.extractXmlBoolValue(elem, 'ExpiredObjectDeleteMarker'),
@@ -15870,7 +15873,8 @@ class ObjectLockRetention {
   factory ObjectLockRetention.fromXml(_s.XmlElement elem) {
     return ObjectLockRetention(
       mode: _s.extractXmlStringValue(elem, 'Mode')?.toObjectLockRetentionMode(),
-      retainUntilDate: _s.extractXmlDateTimeValue(elem, 'RetainUntilDate'),
+      retainUntilDate: _s.extractXmlDateTimeValue(elem, 'RetainUntilDate',
+          parser: _s.iso8601FromJson),
     );
   }
 
@@ -18558,7 +18562,8 @@ class Transition {
   });
   factory Transition.fromXml(_s.XmlElement elem) {
     return Transition(
-      date: _s.extractXmlDateTimeValue(elem, 'Date'),
+      date:
+          _s.extractXmlDateTimeValue(elem, 'Date', parser: _s.iso8601FromJson),
       days: _s.extractXmlIntValue(elem, 'Days'),
       storageClass: _s
           .extractXmlStringValue(elem, 'StorageClass')

--- a/shared_aws_api/test/generated/output/json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/json/timestamp_members.dart
@@ -70,9 +70,7 @@ class OutputShape {
       toJson: unixTimestampToJson)
   final DateTime timeArg;
   @_s.JsonKey(
-      name: 'TimeCustom',
-      fromJson: unixTimestampFromJson,
-      toJson: unixTimestampToJson)
+      name: 'TimeCustom', fromJson: rfc822FromJson, toJson: rfc822ToJson)
   final DateTime timeCustom;
   @_s.JsonKey(
       name: 'TimeFormat', fromJson: iso8601FromJson, toJson: iso8601ToJson)

--- a/shared_aws_api/test/generated/output/json/timestamp_members.g.dart
+++ b/shared_aws_api/test/generated/output/json/timestamp_members.g.dart
@@ -12,7 +12,7 @@ OutputShape _$OutputShapeFromJson(Map<String, dynamic> json) {
         ? null
         : TimeContainer.fromJson(json['StructMember'] as Map<String, dynamic>),
     timeArg: unixTimestampFromJson(json['TimeArg']),
-    timeCustom: unixTimestampFromJson(json['TimeCustom']),
+    timeCustom: rfc822FromJson(json['TimeCustom'] as String),
     timeFormat: iso8601FromJson(json['TimeFormat'] as String),
   );
 }

--- a/shared_aws_api/test/generated/output/query/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/query/timestamp_members.dart
@@ -73,8 +73,10 @@ class OutputShape {
           .extractXmlChild(elem, 'StructMember')
           ?.let((e) => TimeContainer.fromXml(e)),
       timeArg: _s.extractXmlDateTimeValue(elem, 'TimeArg'),
-      timeCustom: _s.extractXmlDateTimeValue(elem, 'TimeCustom'),
-      timeFormat: _s.extractXmlDateTimeValue(elem, 'TimeFormat'),
+      timeCustom: _s.extractXmlDateTimeValue(elem, 'TimeCustom',
+          parser: _s.rfc822FromJson),
+      timeFormat: _s.extractXmlDateTimeValue(elem, 'TimeFormat',
+          parser: _s.unixTimestampFromJson),
     );
   }
 }
@@ -89,7 +91,8 @@ class TimeContainer {
   });
   factory TimeContainer.fromXml(_s.XmlElement elem) {
     return TimeContainer(
-      bar: _s.extractXmlDateTimeValue(elem, 'bar'),
+      bar: _s.extractXmlDateTimeValue(elem, 'bar',
+          parser: _s.unixTimestampFromJson),
       foo: _s.extractXmlDateTimeValue(elem, 'foo'),
     );
   }

--- a/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
@@ -67,12 +67,12 @@ class OutputShape {
       name: 'x-amz-timearg', fromJson: rfc822FromJson, toJson: rfc822ToJson)
   final DateTime timeArgInHeader;
   @_s.JsonKey(
-      name: 'TimeCustom',
-      fromJson: unixTimestampFromJson,
-      toJson: unixTimestampToJson)
+      name: 'TimeCustom', fromJson: rfc822FromJson, toJson: rfc822ToJson)
   final DateTime timeCustom;
   @_s.JsonKey(
-      name: 'x-amz-timecustom', fromJson: rfc822FromJson, toJson: rfc822ToJson)
+      name: 'x-amz-timecustom',
+      fromJson: unixTimestampFromJson,
+      toJson: unixTimestampToJson)
   final DateTime timeCustomInHeader;
   @_s.JsonKey(
       name: 'TimeFormat', fromJson: iso8601FromJson, toJson: iso8601ToJson)

--- a/shared_aws_api/test/generated/output/rest-json/timestamp_members.g.dart
+++ b/shared_aws_api/test/generated/output/rest-json/timestamp_members.g.dart
@@ -13,8 +13,8 @@ OutputShape _$OutputShapeFromJson(Map<String, dynamic> json) {
         : TimeContainer.fromJson(json['StructMember'] as Map<String, dynamic>),
     timeArg: unixTimestampFromJson(json['TimeArg']),
     timeArgInHeader: rfc822FromJson(json['x-amz-timearg'] as String),
-    timeCustom: unixTimestampFromJson(json['TimeCustom']),
-    timeCustomInHeader: rfc822FromJson(json['x-amz-timecustom'] as String),
+    timeCustom: rfc822FromJson(json['TimeCustom'] as String),
+    timeCustomInHeader: unixTimestampFromJson(json['x-amz-timecustom']),
     timeFormat: iso8601FromJson(json['TimeFormat'] as String),
     timeFormatInHeader: iso8601FromJson(json['x-amz-timeformat'] as String),
   );

--- a/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
@@ -67,12 +67,16 @@ class OutputShape {
           ?.let((e) => TimeContainer.fromXml(e)),
       timeArg: _s.extractXmlDateTimeValue(elem, 'TimeArg'),
       timeArgInHeader: _s.extractHeaderDateTimeValue(headers, 'x-amz-timearg'),
-      timeCustom: _s.extractXmlDateTimeValue(elem, 'TimeCustom'),
-      timeCustomInHeader:
-          _s.extractHeaderDateTimeValue(headers, 'x-amz-timecustom'),
-      timeFormat: _s.extractXmlDateTimeValue(elem, 'TimeFormat'),
-      timeFormatInHeader:
-          _s.extractHeaderDateTimeValue(headers, 'x-amz-timeformat'),
+      timeCustom: _s.extractXmlDateTimeValue(elem, 'TimeCustom',
+          parser: _s.rfc822FromJson),
+      timeCustomInHeader: _s.extractHeaderDateTimeValue(
+          headers, 'x-amz-timecustom',
+          parser: _s.unixTimestampFromJson),
+      timeFormat: _s.extractXmlDateTimeValue(elem, 'TimeFormat',
+          parser: _s.unixTimestampFromJson),
+      timeFormatInHeader: _s.extractHeaderDateTimeValue(
+          headers, 'x-amz-timeformat',
+          parser: _s.unixTimestampFromJson),
     );
   }
 }
@@ -87,7 +91,8 @@ class TimeContainer {
   });
   factory TimeContainer.fromXml(_s.XmlElement elem) {
     return TimeContainer(
-      bar: _s.extractXmlDateTimeValue(elem, 'bar'),
+      bar: _s.extractXmlDateTimeValue(elem, 'bar',
+          parser: _s.unixTimestampFromJson),
       foo: _s.extractXmlDateTimeValue(elem, 'foo'),
     );
   }


### PR DESCRIPTION
- Respect timestampFormat when extracting from the header
- Parse DateTime as UTC
- Allow RFC822 parser to read 'GMT' instead of 'Z'

This PR fixes a few tests in the test suite

See the first commit for the actual code change.