### PR TITLE
Handle empty body in json protocol

### DIFF
--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -69,7 +69,9 @@ class JsonProtocol {
       throwException(rs, body, exceptionFnMap);
     }
 
-    final parsedBody = jsonDecode(body) as Map<String, dynamic>;
+    final parsedBody = body.isEmpty
+        ? <String, dynamic>{}
+        : jsonDecode(body) as Map<String, dynamic>;
 
     // TODO: replace return type with Map<String, dynamic> and discard the
     // JsonResponse class. The generated code will have to adjust as well.

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -66,7 +66,9 @@ class RestJsonProtocol {
       throwException(rs, body, exceptionFnMap);
     }
 
-    final parsedBody = jsonDecode(body) as Map<String, dynamic>;
+    final parsedBody = body.isEmpty
+        ? <String, dynamic>{}
+        : jsonDecode(body) as Map<String, dynamic>;
 
     return {
       ...rs.headers,


### PR DESCRIPTION
`body` can be empty and result in a jsonDecode error.