### PR TITLE
Use signingName to sign request

### DIFF
--- a/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
+++ b/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
@@ -44,7 +44,10 @@ class AccessAnalyzer {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'access-analyzer',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'access-analyzer',
+            signingName: 'access-analyzer',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_acm_api/lib/acm-2015-12-08.dart
+++ b/generated/aws_acm_api/lib/acm-2015-12-08.dart
@@ -33,7 +33,9 @@ class ACM {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'acm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'acm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
+++ b/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
@@ -49,7 +49,9 @@ class ACMPCA {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'acm-pca',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'acm-pca',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
+++ b/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
@@ -42,7 +42,9 @@ class AlexaForBusiness {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'a4b',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'a4b',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
+++ b/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
@@ -34,7 +34,10 @@ class Amplify {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'amplify',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'amplify',
+            signingName: 'amplify',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -37,7 +37,9 @@ class APIGateway {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'apigateway',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'apigateway',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
+++ b/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
@@ -38,7 +38,10 @@ class ApiGatewayManagementApi {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'execute-api',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'execute-api',
+            signingName: 'execute-api',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -33,7 +33,10 @@ class ApiGatewayV2 {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'apigateway',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'apigateway',
+            signingName: 'apigateway',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -38,7 +38,10 @@ class AppConfig {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'appconfig',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'appconfig',
+            signingName: 'appconfig',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
+++ b/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
@@ -98,7 +98,10 @@ class ApplicationAutoScaling {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'application-autoscaling',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'application-autoscaling',
+            signingName: 'application-autoscaling',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
+++ b/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
@@ -38,7 +38,10 @@ class ApplicationInsights {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'applicationinsights',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'applicationinsights',
+            signingName: 'applicationinsights',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -64,7 +64,10 @@ class AppMesh {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'appmesh',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'appmesh',
+            signingName: 'appmesh',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -61,7 +61,10 @@ class AppMesh {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'appmesh',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'appmesh',
+            signingName: 'appmesh',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
+++ b/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
@@ -47,7 +47,10 @@ class AppStream {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'appstream2',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'appstream2',
+            signingName: 'appstream',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -34,7 +34,10 @@ class AppSync {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'appsync',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'appsync',
+            signingName: 'appsync',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_athena_api/lib/athena-2017-05-18.dart
+++ b/generated/aws_athena_api/lib/athena-2017-05-18.dart
@@ -51,7 +51,9 @@ class Athena {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'athena',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'athena',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -38,7 +38,9 @@ class AutoScaling {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'autoscaling',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'autoscaling',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
+++ b/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
@@ -37,7 +37,10 @@ class AutoScalingPlans {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'autoscaling-plans',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'autoscaling-plans',
+            signingName: 'autoscaling-plans',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_backup_api/lib/backup-2018-11-15.dart
+++ b/generated/aws_backup_api/lib/backup-2018-11-15.dart
@@ -36,7 +36,9 @@ class Backup {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'backup',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'backup',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_batch_api/lib/batch-2016-08-10.dart
+++ b/generated/aws_batch_api/lib/batch-2016-08-10.dart
@@ -50,7 +50,9 @@ class Batch {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'batch',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'batch',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
+++ b/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
@@ -90,7 +90,9 @@ class Budgets {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'budgets',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'budgets',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ce_api/lib/ce-2017-10-25.dart
+++ b/generated/aws_ce_api/lib/ce-2017-10-25.dart
@@ -50,7 +50,10 @@ class CostExplorer {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ce',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ce',
+            signingName: 'ce',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_chime_api/lib/chime-2018-05-01.dart
+++ b/generated/aws_chime_api/lib/chime-2018-05-01.dart
@@ -75,7 +75,9 @@ class Chime {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'chime',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'chime',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
+++ b/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
@@ -34,7 +34,9 @@ class Cloud9 {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cloud9',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloud9',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
@@ -41,7 +41,10 @@ class CloudDirectory {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'clouddirectory',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'clouddirectory',
+            signingName: 'clouddirectory',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
@@ -41,7 +41,10 @@ class CloudDirectory {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'clouddirectory',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'clouddirectory',
+            signingName: 'clouddirectory',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -41,7 +41,9 @@ class CloudFormation {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'cloudformation',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudformation',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
@@ -27,7 +27,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
@@ -26,7 +26,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
@@ -26,7 +26,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
@@ -26,7 +26,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
@@ -26,7 +26,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
@@ -26,7 +26,9 @@ class CloudFront {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'cloudfront',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudfront',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
+++ b/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
@@ -39,7 +39,9 @@ class CloudHSM {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cloudhsm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudhsm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
+++ b/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
@@ -36,7 +36,10 @@ class CloudHSMV2 {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cloudhsmv2',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudhsmv2',
+            signingName: 'cloudhsm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -38,7 +38,9 @@ class CloudSearch {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'cloudsearch',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudsearch',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -38,7 +38,9 @@ class CloudSearch {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'cloudsearch',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudsearch',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
+++ b/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
@@ -45,7 +45,10 @@ class CloudSearchDomain {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'cloudsearchdomain',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudsearchdomain',
+            signingName: 'cloudsearch',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
+++ b/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
@@ -34,7 +34,9 @@ class CloudTrail {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cloudtrail',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cloudtrail',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -50,7 +50,9 @@ class CloudWatch {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'monitoring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'monitoring',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
+++ b/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
@@ -43,7 +43,9 @@ class CodeBuild {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codebuild',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codebuild',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
+++ b/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
@@ -35,7 +35,9 @@ class CodeCommit {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codecommit',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codecommit',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
+++ b/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
@@ -34,7 +34,10 @@ class CodeGuruReviewer {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'codeguru-reviewer',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codeguru-reviewer',
+            signingName: 'codeguru-reviewer',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -34,7 +34,10 @@ class CodeGuruProfiler {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'codeguru-profiler',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codeguru-profiler',
+            signingName: 'codeguru-profiler',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
+++ b/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
@@ -38,7 +38,9 @@ class CodePipeline {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codepipeline',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codepipeline',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
+++ b/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
@@ -35,7 +35,9 @@ class CodeStar {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codestar',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codestar',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
+++ b/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
@@ -73,7 +73,10 @@ class CodeStarconnections {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codestar-connections',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codestar-connections',
+            signingName: 'codestar-connections',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
+++ b/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
@@ -104,7 +104,10 @@ class CodeStarNotifications {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'codestar-notifications',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codestar-notifications',
+            signingName: 'codestar-notifications',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
+++ b/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
@@ -36,7 +36,9 @@ class CognitoIdentity {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cognito-identity',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cognito-identity',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
+++ b/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
@@ -40,7 +40,9 @@ class CognitoIdentityProvider {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cognito-idp',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cognito-idp',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
+++ b/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
@@ -41,7 +41,9 @@ class CognitoSync {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'cognito-sync',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cognito-sync',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
+++ b/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
@@ -36,7 +36,10 @@ class Comprehend {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'comprehend',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'comprehend',
+            signingName: 'comprehend',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
+++ b/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
@@ -34,7 +34,10 @@ class ComprehendMedical {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'comprehendmedical',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'comprehendmedical',
+            signingName: 'comprehendmedical',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
+++ b/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
@@ -45,7 +45,10 @@ class ComputeOptimizer {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'compute-optimizer',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'compute-optimizer',
+            signingName: 'compute-optimizer',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_configservice_api/lib/config-2014-11-12.dart
+++ b/generated/aws_configservice_api/lib/config-2014-11-12.dart
@@ -42,7 +42,9 @@ class ConfigService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'config',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'config',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_connect_api/lib/connect-2017-08-08.dart
+++ b/generated/aws_connect_api/lib/connect-2017-08-08.dart
@@ -45,7 +45,10 @@ class Connect {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'connect',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'connect',
+            signingName: 'connect',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
+++ b/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
@@ -40,7 +40,10 @@ class ConnectParticipant {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'participant.connect',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'participant.connect',
+            signingName: 'execute-api',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_cur_api/lib/cur-2017-01-06.dart
+++ b/generated/aws_cur_api/lib/cur-2017-01-06.dart
@@ -50,7 +50,10 @@ class CostandUsageReportService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'cur',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'cur',
+            signingName: 'cur',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
+++ b/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
@@ -53,7 +53,10 @@ class DataExchange {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'dataexchange',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dataexchange',
+            signingName: 'dataexchange',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
+++ b/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
@@ -54,7 +54,9 @@ class DataPipeline {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'datapipeline',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'datapipeline',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
+++ b/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
@@ -35,7 +35,10 @@ class DataSync {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'datasync',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'datasync',
+            signingName: 'datasync',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dax_api/lib/dax-2017-04-19.dart
+++ b/generated/aws_dax_api/lib/dax-2017-04-19.dart
@@ -39,7 +39,9 @@ class DAX {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'dax',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dax',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
+++ b/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
@@ -36,7 +36,9 @@ class CodeDeploy {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'codedeploy',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'codedeploy',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_detective_api/lib/detective-2018-10-26.dart
+++ b/generated/aws_detective_api/lib/detective-2018-10-26.dart
@@ -83,7 +83,10 @@ class Detective {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'api.detective',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.detective',
+            signingName: 'detective',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
+++ b/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
@@ -53,7 +53,9 @@ class DeviceFarm {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'devicefarm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'devicefarm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
+++ b/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
@@ -41,7 +41,9 @@ class DirectConnect {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'directconnect',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'directconnect',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
+++ b/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
@@ -39,7 +39,9 @@ class ApplicationDiscoveryService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'discovery',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'discovery',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
+++ b/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
@@ -35,7 +35,10 @@ class DLM {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'dlm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dlm',
+            signingName: 'dlm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dms_api/lib/dms-2016-01-01.dart
+++ b/generated/aws_dms_api/lib/dms-2016-01-01.dart
@@ -39,7 +39,9 @@ class DatabaseMigrationService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'dms',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dms',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -35,7 +35,10 @@ class DocDB {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+            signingName: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_ds_api/lib/ds-2015-04-16.dart
+++ b/generated/aws_ds_api/lib/ds-2015-04-16.dart
@@ -49,7 +49,9 @@ class DirectoryService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ds',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
@@ -37,7 +37,9 @@ class DynamoDB {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'dynamodb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dynamodb',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
@@ -37,7 +37,9 @@ class DynamoDB {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'dynamodb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'dynamodb',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
@@ -38,7 +38,10 @@ class DynamoDBStreams {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'streams.dynamodb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'streams.dynamodb',
+            signingName: 'dynamodb',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
+++ b/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
@@ -52,7 +52,9 @@ class EBS {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'ebs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ebs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
+++ b/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
@@ -36,7 +36,9 @@ class EC2InstanceConnect {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ec2-instance-connect',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ec2-instance-connect',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
+++ b/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
@@ -39,7 +39,10 @@ class ECR {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'api.ecr',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.ecr',
+            signingName: 'ecr',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
+++ b/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
@@ -42,7 +42,9 @@ class ECS {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ecs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ecs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
+++ b/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
@@ -39,7 +39,9 @@ class EFS {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'elasticfilesystem',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticfilesystem',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_eks_api/lib/eks-2017-11-01.dart
+++ b/generated/aws_eks_api/lib/eks-2017-11-01.dart
@@ -45,7 +45,10 @@ class EKS {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'eks',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'eks',
+            signingName: 'eks',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
+++ b/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
@@ -33,7 +33,10 @@ class ElasticInference {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'elastic-inference',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elastic-inference',
+            signingName: 'elastic-inference',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -36,7 +36,9 @@ class ElastiCache {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'elasticache',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticache',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -37,7 +37,9 @@ class ElasticBeanstalk {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'elasticbeanstalk',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticbeanstalk',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
+++ b/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
@@ -33,7 +33,9 @@ class ElasticTranscoder {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'elastictranscoder',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elastictranscoder',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
+++ b/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
@@ -42,7 +42,9 @@ class ElasticLoadBalancing {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'elasticloadbalancing',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticloadbalancing',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -44,7 +44,9 @@ class ElasticLoadBalancingv2 {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'elasticloadbalancing',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticloadbalancing',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
+++ b/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
@@ -36,7 +36,9 @@ class EMR {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'elasticmapreduce',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'elasticmapreduce',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_es_api/lib/es-2015-01-01.dart
+++ b/generated/aws_es_api/lib/es-2015-01-01.dart
@@ -34,7 +34,9 @@ class ElasticsearchService {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'es',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'es',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
+++ b/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
@@ -56,7 +56,9 @@ class EventBridge {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'events',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'events',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_events_api/lib/events-2015-10-07.dart
+++ b/generated/aws_events_api/lib/events-2015-10-07.dart
@@ -56,7 +56,9 @@ class CloudWatchEvents {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'events',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'events',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
+++ b/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
@@ -36,7 +36,9 @@ class Firehose {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'firehose',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'firehose',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_fms_api/lib/fms-2018-01-01.dart
+++ b/generated/aws_fms_api/lib/fms-2018-01-01.dart
@@ -38,7 +38,9 @@ class FMS {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'fms',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'fms',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
+++ b/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
@@ -33,7 +33,10 @@ class ForecastService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'forecast',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'forecast',
+            signingName: 'forecast',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
+++ b/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
@@ -33,7 +33,10 @@ class ForecastQueryService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'forecastquery',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'forecastquery',
+            signingName: 'forecast',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
+++ b/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
@@ -38,7 +38,9 @@ class FraudDetector {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'frauddetector',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'frauddetector',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
+++ b/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
@@ -34,7 +34,10 @@ class FSx {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'fsx',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'fsx',
+            signingName: 'fsx',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
+++ b/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
@@ -34,7 +34,9 @@ class GameLift {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'gamelift',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'gamelift',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
+++ b/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
@@ -71,7 +71,9 @@ class Glacier {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'glacier',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'glacier',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
+++ b/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
@@ -38,7 +38,10 @@ class GlobalAccelerator {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'globalaccelerator',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'globalaccelerator',
+            signingName: 'globalaccelerator',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_glue_api/lib/glue-2017-03-31.dart
+++ b/generated/aws_glue_api/lib/glue-2017-03-31.dart
@@ -33,7 +33,9 @@ class Glue {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'glue',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'glue',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
+++ b/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
@@ -39,7 +39,10 @@ class Greengrass {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'greengrass',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'greengrass',
+            signingName: 'greengrass',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
+++ b/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
@@ -37,7 +37,10 @@ class GroundStation {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'groundstation',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'groundstation',
+            signingName: 'groundstation',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
+++ b/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
@@ -49,7 +49,10 @@ class GuardDuty {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'guardduty',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'guardduty',
+            signingName: 'guardduty',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_health_api/lib/health-2016-08-04.dart
+++ b/generated/aws_health_api/lib/health-2016-08-04.dart
@@ -37,7 +37,9 @@ class Health {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'health',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'health',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -59,7 +59,9 @@ class IAM {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'iam',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'iam',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
+++ b/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
@@ -36,7 +36,10 @@ class Imagebuilder {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'imagebuilder',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'imagebuilder',
+            signingName: 'imagebuilder',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -38,7 +38,9 @@ class ImportExport {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'importexport',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'importexport',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
+++ b/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
@@ -36,7 +36,9 @@ class Inspector {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'inspector',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'inspector',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
+++ b/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
@@ -37,7 +37,10 @@ class IoT1ClickDevicesService {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'devices.iot1click',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'devices.iot1click',
+            signingName: 'iot1click',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
+++ b/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
@@ -33,7 +33,10 @@ class IoT1ClickProjects {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'projects.iot1click',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'projects.iot1click',
+            signingName: 'iot1click',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iot_api/lib/iot-2015-05-28.dart
+++ b/generated/aws_iot_api/lib/iot-2015-05-28.dart
@@ -39,7 +39,10 @@ class IoT {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'iot',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'iot',
+            signingName: 'execute-api',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
+++ b/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
@@ -38,7 +38,10 @@ class IoTDataPlane {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'data.iot',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'data.iot',
+            signingName: 'iotdata',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
+++ b/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
@@ -48,7 +48,10 @@ class IoTJobsDataPlane {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'data.jobs.iot',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'data.jobs.iot',
+            signingName: 'iot-jobs-data',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
+++ b/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
@@ -56,7 +56,10 @@ class IoTAnalytics {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'iotanalytics',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'iotanalytics',
+            signingName: 'iotanalytics',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
+++ b/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
@@ -36,7 +36,10 @@ class IoTEvents {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'iotevents',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'iotevents',
+            signingName: 'iotevents',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
+++ b/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
@@ -36,7 +36,10 @@ class IoTEventsData {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'data.iotevents',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'data.iotevents',
+            signingName: 'ioteventsdata',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
+++ b/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
@@ -34,7 +34,10 @@ class IoTSecureTunneling {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'api.tunneling.iot',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.tunneling.iot',
+            signingName: 'IoTSecuredTunneling',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
+++ b/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
@@ -38,7 +38,10 @@ class IoTThingsGraph {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'iotthingsgraph',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'iotthingsgraph',
+            signingName: 'iotthingsgraph',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
+++ b/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
@@ -35,7 +35,10 @@ class Kafka {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'kafka',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kafka',
+            signingName: 'kafka',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
+++ b/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
@@ -33,7 +33,10 @@ class Kendra {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'kendra',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kendra',
+            signingName: 'kendra',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
+++ b/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
@@ -34,7 +34,9 @@ class Kinesis {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'kinesis',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesis',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -33,7 +33,9 @@ class KinesisVideoArchivedMedia {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'kinesisvideo',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisvideo',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -33,7 +33,9 @@ class KinesisVideoMedia {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'kinesisvideo',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisvideo',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
+++ b/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
@@ -36,7 +36,9 @@ class KinesisVideoSignalingChannels {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'kinesisvideo',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisvideo',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
+++ b/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
@@ -41,7 +41,9 @@ class KinesisAnalytics {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'kinesisanalytics',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisanalytics',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
+++ b/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
@@ -37,7 +37,10 @@ class KinesisAnalyticsV2 {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'kinesisanalytics',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisanalytics',
+            signingName: 'kinesisanalytics',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
+++ b/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
@@ -33,7 +33,9 @@ class KinesisVideo {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'kinesisvideo',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kinesisvideo',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_kms_api/lib/kms-2014-11-01.dart
+++ b/generated/aws_kms_api/lib/kms-2014-11-01.dart
@@ -49,7 +49,9 @@ class KMS {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'kms',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'kms',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
+++ b/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
@@ -33,7 +33,10 @@ class LakeFormation {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'lakeformation',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'lakeformation',
+            signingName: 'lakeformation',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
+++ b/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
@@ -38,7 +38,9 @@ class Lambda {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'lambda',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'lambda',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -38,7 +38,9 @@ class Lambda {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'lambda',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'lambda',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
+++ b/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
@@ -35,7 +35,10 @@ class LexModelBuildingService {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'models.lex',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'models.lex',
+            signingName: 'lex',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -43,7 +43,10 @@ class LexRuntimeService {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'runtime.lex',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'runtime.lex',
+            signingName: 'lex',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
+++ b/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
@@ -34,7 +34,9 @@ class LicenseManager {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'license-manager',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'license-manager',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
+++ b/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
@@ -47,7 +47,9 @@ class Lightsail {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'lightsail',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'lightsail',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_logs_api/lib/logs-2014-03-28.dart
+++ b/generated/aws_logs_api/lib/logs-2014-03-28.dart
@@ -68,7 +68,9 @@ class CloudWatchLogs {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'logs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'logs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
+++ b/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
@@ -33,7 +33,9 @@ class MachineLearning {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'machinelearning',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'machinelearning',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_macie_api/lib/macie-2017-12-19.dart
+++ b/generated/aws_macie_api/lib/macie-2017-12-19.dart
@@ -40,7 +40,9 @@ class Macie {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'macie',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'macie',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
+++ b/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
@@ -39,7 +39,10 @@ class ManagedBlockchain {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'managedblockchain',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'managedblockchain',
+            signingName: 'managedblockchain',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
+++ b/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
@@ -40,7 +40,10 @@ class MarketplaceCatalog {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'catalog.marketplace',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'catalog.marketplace',
+            signingName: 'aws-marketplace',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
+++ b/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
@@ -34,7 +34,10 @@ class MarketplaceEntitlementService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'entitlement.marketplace',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'entitlement.marketplace',
+            signingName: 'aws-marketplace',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
@@ -33,7 +33,10 @@ class MarketplaceCommerceAnalytics {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'marketplacecommerceanalytics',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'marketplacecommerceanalytics',
+            signingName: 'marketplacecommerceanalytics',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
+++ b/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
@@ -33,7 +33,10 @@ class MediaConnect {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mediaconnect',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mediaconnect',
+            signingName: 'mediaconnect',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
+++ b/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
@@ -33,7 +33,10 @@ class MediaConvert {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mediaconvert',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mediaconvert',
+            signingName: 'mediaconvert',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
+++ b/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
@@ -33,7 +33,10 @@ class MediaLive {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'medialive',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'medialive',
+            signingName: 'medialive',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -33,7 +33,10 @@ class MediaPackage {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mediapackage',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mediapackage',
+            signingName: 'mediapackage',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -33,7 +33,10 @@ class MediaPackageVod {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mediapackage-vod',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mediapackage-vod',
+            signingName: 'mediapackage-vod',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
+++ b/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
@@ -34,7 +34,10 @@ class MediaStore {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'mediastore',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mediastore',
+            signingName: 'mediastore',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
+++ b/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
@@ -35,7 +35,10 @@ class MediaStoreData {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'data.mediastore',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'data.mediastore',
+            signingName: 'mediastore',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
+++ b/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
@@ -42,7 +42,10 @@ class MediaTailor {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'api.mediatailor',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.mediatailor',
+            signingName: 'mediatailor',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
+++ b/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
@@ -34,7 +34,10 @@ class MarketplaceMetering {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'metering.marketplace',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'metering.marketplace',
+            signingName: 'aws-marketplace',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
+++ b/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
@@ -40,7 +40,9 @@ class MigrationHub {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'mgh',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mgh',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
+++ b/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
@@ -58,7 +58,10 @@ class MigrationHubConfig {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'migrationhub-config',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'migrationhub-config',
+            signingName: 'mgh',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
+++ b/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
@@ -36,7 +36,10 @@ class Mobile {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mobile',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mobile',
+            signingName: 'AWSMobileHubService',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mq_api/lib/mq-2017-11-27.dart
+++ b/generated/aws_mq_api/lib/mq-2017-11-27.dart
@@ -36,7 +36,10 @@ class MQ {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'mq',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mq',
+            signingName: 'mq',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
+++ b/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
@@ -32,7 +32,9 @@ class MTurk {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'mturk-requester',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'mturk-requester',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -45,7 +45,10 @@ class Neptune {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+            signingName: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
+++ b/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
@@ -35,7 +35,10 @@ class NetworkManager {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'networkmanager',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'networkmanager',
+            signingName: 'networkmanager',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
+++ b/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
@@ -35,7 +35,9 @@ class OpsWorks {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'opsworks',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'opsworks',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
+++ b/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
@@ -36,7 +36,10 @@ class OpsWorksCM {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'opsworks-cm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'opsworks-cm',
+            signingName: 'opsworks-cm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
+++ b/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
@@ -32,7 +32,9 @@ class Organizations {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'organizations',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'organizations',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
+++ b/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
@@ -38,7 +38,10 @@ class Outposts {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'outposts',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'outposts',
+            signingName: 'outposts',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
+++ b/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
@@ -34,7 +34,10 @@ class Personalize {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'personalize',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'personalize',
+            signingName: 'personalize',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
+++ b/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
@@ -33,7 +33,10 @@ class PersonalizeEvents {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'personalize-events',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'personalize-events',
+            signingName: 'personalize',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
+++ b/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
@@ -33,7 +33,10 @@ class PersonalizeRuntime {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'personalize-runtime',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'personalize-runtime',
+            signingName: 'personalize',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_pi_api/lib/pi-2018-02-27.dart
+++ b/generated/aws_pi_api/lib/pi-2018-02-27.dart
@@ -50,7 +50,10 @@ class PI {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'pi',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'pi',
+            signingName: 'pi',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -33,7 +33,10 @@ class Pinpoint {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'pinpoint',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'pinpoint',
+            signingName: 'mobiletargeting',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
+++ b/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
@@ -35,7 +35,10 @@ class PinpointEmail {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'email',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'email',
+            signingName: 'ses',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
+++ b/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
@@ -33,7 +33,10 @@ class PinpointSMSVoice {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'sms-voice.pinpoint',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sms-voice.pinpoint',
+            signingName: 'sms-voice',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -39,7 +39,9 @@ class Polly {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'polly',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'polly',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
+++ b/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
@@ -64,7 +64,10 @@ class Pricing {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'api.pricing',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.pricing',
+            signingName: 'pricing',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
+++ b/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
@@ -33,7 +33,10 @@ class QLDB {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'qldb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'qldb',
+            signingName: 'qldb',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
+++ b/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
@@ -33,7 +33,10 @@ class QLDBSession {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'session.qldb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'session.qldb',
+            signingName: 'qldb',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
+++ b/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
@@ -36,7 +36,9 @@ class QuickSight {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'quicksight',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'quicksight',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ram_api/lib/ram-2018-01-04.dart
+++ b/generated/aws_ram_api/lib/ram-2018-01-04.dart
@@ -42,7 +42,9 @@ class RAM {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'ram',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ram',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -34,7 +34,9 @@ class RDS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -34,7 +34,9 @@ class RDS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -34,7 +34,9 @@ class RDS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -34,7 +34,9 @@ class RDS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -40,7 +40,9 @@ class RDS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'rds',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
+++ b/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
@@ -35,7 +35,10 @@ class RDSDataService {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'rds-data',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rds-data',
+            signingName: 'rds-data',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -45,7 +45,9 @@ class Redshift {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'redshift',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'redshift',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
+++ b/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
@@ -33,7 +33,9 @@ class Rekognition {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'rekognition',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'rekognition',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
+++ b/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
@@ -44,7 +44,10 @@ class ResourceGroups {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'resource-groups',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'resource-groups',
+            signingName: 'resource-groups',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
@@ -33,7 +33,9 @@ class ResourceGroupsTaggingAPI {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'tagging',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'tagging',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
+++ b/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
@@ -33,7 +33,10 @@ class RoboMaker {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'robomaker',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'robomaker',
+            signingName: 'robomaker',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -24,7 +24,9 @@ class Route53 {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'route53',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'route53',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
+++ b/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
@@ -34,7 +34,9 @@ class Route53Domains {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'route53domains',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'route53domains',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
+++ b/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
@@ -78,7 +78,9 @@ class Route53Resolver {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'route53resolver',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'route53resolver',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -23,7 +23,9 @@ class S3 {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 's3',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 's3',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -23,7 +23,10 @@ class S3Control {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 's3-control',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 's3-control',
+            signingName: 's3',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
@@ -77,7 +77,10 @@ class AugmentedAIRuntime {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'a2i-runtime.sagemaker',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'a2i-runtime.sagemaker',
+            signingName: 'sagemaker',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
+++ b/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
@@ -48,7 +48,10 @@ class SageMaker {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'api.sagemaker',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'api.sagemaker',
+            signingName: 'sagemaker',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
+++ b/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
@@ -33,7 +33,10 @@ class SageMakerRuntime {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'runtime.sagemaker',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'runtime.sagemaker',
+            signingName: 'sagemaker',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
+++ b/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
@@ -38,7 +38,9 @@ class SavingsPlans {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'savingsplans',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'savingsplans',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -33,7 +33,10 @@ class Schemas {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'schemas',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'schemas',
+            signingName: 'schemas',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
+++ b/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
@@ -51,7 +51,9 @@ class SimpleDB {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'sdb',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sdb',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
+++ b/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
@@ -34,7 +34,10 @@ class SecretsManager {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'secretsmanager',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'secretsmanager',
+            signingName: 'secretsmanager',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
+++ b/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
@@ -71,7 +71,10 @@ class SecurityHub {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'securityhub',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'securityhub',
+            signingName: 'securityhub',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
+++ b/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
@@ -81,7 +81,10 @@ class ServerlessApplicationRepository {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'serverlessrepo',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'serverlessrepo',
+            signingName: 'serverlessrepo',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
+++ b/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
@@ -49,7 +49,9 @@ class ServiceQuotas {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'servicequotas',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'servicequotas',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
+++ b/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
@@ -38,7 +38,9 @@ class ServiceCatalog {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'servicecatalog',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'servicecatalog',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
+++ b/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
@@ -39,7 +39,9 @@ class ServiceDiscovery {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'servicediscovery',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'servicediscovery',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -47,7 +47,10 @@ class SES {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'email',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'email',
+            signingName: 'ses',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
+++ b/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
@@ -35,7 +35,10 @@ class SESV2 {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'email',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'email',
+            signingName: 'ses',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_shield_api/lib/shield-2016-06-02.dart
+++ b/generated/aws_shield_api/lib/shield-2016-06-02.dart
@@ -39,7 +39,9 @@ class Shield {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'shield',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'shield',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_signer_api/lib/signer-2017-08-25.dart
+++ b/generated/aws_signer_api/lib/signer-2017-08-25.dart
@@ -46,7 +46,10 @@ class Signer {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'signer',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'signer',
+            signingName: 'signer',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sms_api/lib/sms-2016-10-24.dart
+++ b/generated/aws_sms_api/lib/sms-2016-10-24.dart
@@ -37,7 +37,9 @@ class SMS {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'sms',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sms',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
+++ b/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
@@ -42,7 +42,9 @@ class Snowball {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'snowball',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'snowball',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sns_api/lib/sns-2010-03-31.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.dart
@@ -43,7 +43,9 @@ class SNS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'sns',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sns',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -98,7 +98,9 @@ class SQS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'sqs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sqs',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
+++ b/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
@@ -40,7 +40,9 @@ class SSM {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ssm',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ssm',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sso_api/lib/sso-2019-06-10.dart
+++ b/generated/aws_sso_api/lib/sso-2019-06-10.dart
@@ -52,7 +52,10 @@ class SSO {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'portal.sso',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'portal.sso',
+            signingName: 'awsssoportal',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
+++ b/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
@@ -55,7 +55,10 @@ class SSOOIDC {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'oidc',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'oidc',
+            signingName: 'awsssooidc',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
+++ b/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
@@ -37,7 +37,9 @@ class StorageGateway {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'storagegateway',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'storagegateway',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_sts_api/lib/sts-2011-06-15.dart
+++ b/generated/aws_sts_api/lib/sts-2011-06-15.dart
@@ -41,7 +41,9 @@ class STS {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'sts',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'sts',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/generated/aws_support_api/lib/support-2013-04-15.dart
+++ b/generated/aws_support_api/lib/support-2013-04-15.dart
@@ -36,7 +36,9 @@ class Support {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'support',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'support',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_swf_api/lib/swf-2012-01-25.dart
+++ b/generated/aws_swf_api/lib/swf-2012-01-25.dart
@@ -38,7 +38,9 @@ class SWF {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'swf',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'swf',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_textract_api/lib/textract-2018-06-27.dart
+++ b/generated/aws_textract_api/lib/textract-2018-06-27.dart
@@ -35,7 +35,9 @@ class Textract {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'textract',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'textract',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
+++ b/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
@@ -33,7 +33,10 @@ class TranscribeService {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'transcribe',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'transcribe',
+            signingName: 'transcribe',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
+++ b/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
@@ -42,7 +42,10 @@ class Transfer {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'transfer',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'transfer',
+            signingName: 'transfer',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_translate_api/lib/translate-2017-07-01.dart
+++ b/generated/aws_translate_api/lib/translate-2017-07-01.dart
@@ -34,7 +34,10 @@ class Translate {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'translate',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'translate',
+            signingName: 'translate',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_waf_api/lib/waf-2015-08-24.dart
+++ b/generated/aws_waf_api/lib/waf-2015-08-24.dart
@@ -41,7 +41,9 @@ class WAF {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'waf',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'waf',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
+++ b/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
@@ -44,7 +44,9 @@ class WAFRegional {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'waf-regional',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'waf-regional',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
+++ b/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
@@ -107,7 +107,9 @@ class WAFV2 {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'wafv2',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'wafv2',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
+++ b/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
@@ -67,7 +67,9 @@ class WorkDocs {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'workdocs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'workdocs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
+++ b/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
@@ -40,7 +40,10 @@ class WorkLink {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'worklink',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'worklink',
+            signingName: 'worklink',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
+++ b/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
@@ -71,7 +71,9 @@ class WorkMail {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'workmail',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'workmail',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
+++ b/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
@@ -34,7 +34,9 @@ class WorkMailMessageFlow {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'workmailmessageflow',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'workmailmessageflow',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
+++ b/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
@@ -34,7 +34,9 @@ class WorkSpaces {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'workspaces',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'workspaces',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generated/aws_xray_api/lib/xray-2016-04-12.dart
+++ b/generated/aws_xray_api/lib/xray-2016-04-12.dart
@@ -34,7 +34,9 @@ class XRay {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'xray',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'xray',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/generator/lib/builders/protocols/json_builder.dart
+++ b/generator/lib/builders/protocols/json_builder.dart
@@ -13,7 +13,7 @@ class JsonServiceBuilder extends ServiceBuilder {
     return '''
   final _s.JsonProtocol _protocol;
   ${api.metadata.className}({$regionRequired String region, _s.AwsClientCredentials credentials, _s.Client client, String endpointUrl,})
-  : _protocol = _s.JsonProtocol(client: client, service: \'${api.metadata.endpointPrefix}\', region: region, credentials: credentials, endpointUrl: endpointUrl,);
+  : _protocol = _s.JsonProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
   ''';
   }
 

--- a/generator/lib/builders/protocols/query_builder.dart
+++ b/generator/lib/builders/protocols/query_builder.dart
@@ -15,7 +15,7 @@ class QueryServiceBuilder extends ServiceBuilder {
   final Map<String, _s.Shape> shapes;
 
   ${api.metadata.className}({$regionRequired String region, _s.AwsClientCredentials credentials, _s.Client client,})
-  : _protocol = _s.QueryProtocol(client: client, service: \'${api.metadata.endpointPrefix}\', region: region, credentials: credentials,),
+  : _protocol = _s.QueryProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials,),
   shapes = shapesJson.map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));
   ''';
   }

--- a/generator/lib/builders/protocols/rest_json_builder.dart
+++ b/generator/lib/builders/protocols/rest_json_builder.dart
@@ -13,7 +13,7 @@ class RestJsonServiceBuilder extends ServiceBuilder {
     return '''
   final _s.RestJsonProtocol _protocol;
   ${api.metadata.className}({$regionRequired String region, _s.AwsClientCredentials credentials, _s.Client client, String endpointUrl,})
-  : _protocol = _s.RestJsonProtocol(client: client, service: \'${api.metadata.endpointPrefix}\', region: region, credentials: credentials, endpointUrl: endpointUrl,);
+  : _protocol = _s.RestJsonProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
   ''';
   }
 

--- a/generator/lib/builders/protocols/rest_xml_builder.dart
+++ b/generator/lib/builders/protocols/rest_xml_builder.dart
@@ -16,7 +16,7 @@ class RestXmlServiceBuilder extends ServiceBuilder {
     return '''
     final _s.RestXmlProtocol _protocol;
     ${api.metadata.className}({$regionRequired String region, _s.AwsClientCredentials credentials, _s.Client client, String endpointUrl,})
-        : _protocol = _s.RestXmlProtocol(client: client, service: \'${api.metadata.endpointPrefix}\', region: region, credentials: credentials, endpointUrl: endpointUrl,);
+        : _protocol = _s.RestXmlProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
     ''';
   }
 

--- a/generator/lib/builders/protocols/service_builder.dart
+++ b/generator/lib/builders/protocols/service_builder.dart
@@ -1,3 +1,4 @@
+import 'package:aws_client.generator/model/api.dart';
 import 'package:aws_client.generator/model/operation.dart';
 import 'package:aws_client.generator/model/shape.dart';
 
@@ -55,5 +56,14 @@ abstract class ServiceBuilder {
             '${m.fieldName}?.let((v) => $varName[\'${m.locationName ?? m.name}\'] = $converter);');
       }
     });
+  }
+
+  String buildServiceMetadata(Api api) {
+    final args = StringBuffer();
+    args.writeln("endpointPrefix: '${api.metadata.endpointPrefix}',");
+    if (api.metadata.signingName != null) {
+      args.writeln("signingName: '${api.metadata.signingName}',");
+    }
+    return '_s.ServiceMetadata($args)';
   }
 }

--- a/shared_aws_api/lib/shared.dart
+++ b/shared_aws_api/lib/shared.dart
@@ -8,6 +8,7 @@ export 'package:xml/xml.dart'
 export 'src/credentials.dart';
 export 'src/model/shape.dart';
 export 'src/protocol/ec2.dart';
+export 'src/protocol/endpoint.dart' show ServiceMetadata;
 export 'src/protocol/json.dart';
 export 'src/protocol/query.dart';
 export 'src/protocol/rest-json.dart';

--- a/shared_aws_api/lib/src/protocol/_sign.dart
+++ b/shared_aws_api/lib/src/protocol/_sign.dart
@@ -5,10 +5,11 @@ import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 
 import '../credentials.dart';
+import 'endpoint.dart' show ServiceMetadata;
 
 void signAws4HmacSha256({
   @required Request rq,
-  @required String service,
+  @required ServiceMetadata service,
   @required String region,
   @required AwsClientCredentials credentials,
 }) {
@@ -42,7 +43,7 @@ void signAws4HmacSha256({
   final credentialList = [
     date.substring(0, 8),
     region,
-    service,
+    service.signingName ?? service.endpointPrefix,
     'aws4_request',
   ];
   const _aws4HmacSha256 = 'AWS4-HMAC-SHA256';

--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -22,7 +22,7 @@ class JsonProtocol {
 
   factory JsonProtocol({
     Client client,
-    String service,
+    ServiceMetadata service,
     String region,
     String endpointUrl,
     AwsClientCredentials credentials,

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -24,7 +24,7 @@ class QueryProtocol {
 
   factory QueryProtocol({
     Client client,
-    String service,
+    ServiceMetadata service,
     String region,
     String endpointUrl,
     AwsClientCredentials credentials,

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -21,7 +21,7 @@ class RestJsonProtocol {
 
   factory RestJsonProtocol({
     Client client,
-    String service,
+    ServiceMetadata service,
     String region,
     String endpointUrl,
     AwsClientCredentials credentials,

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -23,7 +23,7 @@ class RestXmlProtocol {
 
   factory RestXmlProtocol({
     Client client,
-    String service,
+    ServiceMetadata service,
     String region,
     String endpointUrl,
     AwsClientCredentials credentials,

--- a/shared_aws_api/test/generated/input/json/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/json/base64_encoded_blobs.dart
@@ -31,7 +31,9 @@ class Base64EncodedBlobs {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'Base64EncodedBlobs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Base64EncodedBlobs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/empty_maps.dart
+++ b/shared_aws_api/test/generated/input/json/empty_maps.dart
@@ -31,7 +31,9 @@ class EmptyMaps {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'EmptyMaps',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EmptyMaps',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/endpoint_host_trait_static_prefix.dart
+++ b/shared_aws_api/test/generated/input/json/endpoint_host_trait_static_prefix.dart
@@ -31,7 +31,9 @@ class EndpointHostTraitStaticPrefix {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'EndpointHostTraitStaticPrefix',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EndpointHostTraitStaticPrefix',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/enum.dart
+++ b/shared_aws_api/test/generated/input/json/enum.dart
@@ -31,7 +31,9 @@ class Enum {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/json/idempotency_token_auto_fill.dart
@@ -31,7 +31,9 @@ class IdempotencyTokenAutoFill {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'IdempotencyTokenAutoFill',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IdempotencyTokenAutoFill',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/nested_blobs.dart
+++ b/shared_aws_api/test/generated/input/json/nested_blobs.dart
@@ -31,7 +31,9 @@ class NestedBlobs {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'NestedBlobs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NestedBlobs',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/json/recursive_shapes.dart
@@ -33,7 +33,9 @@ class RecursiveShapes {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'RecursiveShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'RecursiveShapes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/scalar_members.dart
+++ b/shared_aws_api/test/generated/input/json/scalar_members.dart
@@ -31,7 +31,9 @@ class ScalarMembers {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/json/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/json/timestamp_values.dart
@@ -31,7 +31,9 @@ class TimestampValues {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'TimestampValues',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampValues',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
@@ -33,7 +33,9 @@ class Base64EncodedBlobs {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'Base64EncodedBlobs',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Base64EncodedBlobs',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
@@ -33,7 +33,9 @@ class Base64EncodedBlobsNested {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'Base64EncodedBlobsNested',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Base64EncodedBlobsNested',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
@@ -33,7 +33,9 @@ class EndpointHostTrait {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'EndpointHostTrait',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EndpointHostTrait',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/enum.dart
+++ b/shared_aws_api/test/generated/input/query/enum.dart
@@ -33,7 +33,9 @@ class Enum {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list.dart
@@ -33,7 +33,9 @@ class FlattenedList {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedList',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedList',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
@@ -33,7 +33,9 @@ class FlattenedListWithLocationName {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedListWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedListWithLocationName',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
@@ -33,7 +33,9 @@ class IdempotencyTokenAutoFill {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'IdempotencyTokenAutoFill',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IdempotencyTokenAutoFill',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/list_types.dart
+++ b/shared_aws_api/test/generated/input/query/list_types.dart
@@ -33,7 +33,9 @@ class ListTypes {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'ListTypes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListTypes',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/nested_structure_members.dart
+++ b/shared_aws_api/test/generated/input/query/nested_structure_members.dart
@@ -35,7 +35,9 @@ class NestedStructureMembers {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'NestedStructureMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NestedStructureMembers',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
@@ -33,7 +33,9 @@ class NonFlattenedListWithLocationName {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'NonFlattenedListWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NonFlattenedListWithLocationName',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/query/recursive_shapes.dart
@@ -35,7 +35,9 @@ class RecursiveShapes {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'RecursiveShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'RecursiveShapes',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/input/query/scalar_members.dart
@@ -33,7 +33,9 @@ class ScalarMembers {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
@@ -33,7 +33,9 @@ class SerializeFlattenedMapType {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'SerializeFlattenedMapType',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SerializeFlattenedMapType',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/serialize_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type.dart
@@ -33,7 +33,9 @@ class SerializeMapType {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'SerializeMapType',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SerializeMapType',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
@@ -33,7 +33,9 @@ class SerializeMapTypeWithLocationName {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'SerializeMapTypeWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SerializeMapTypeWithLocationName',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/query/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/query/timestamp_values.dart
@@ -33,7 +33,9 @@ class TimestampValues {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'TimestampValues',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampValues',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/input/rest-json/blob_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/blob_payload.dart
@@ -31,7 +31,9 @@ class BlobPayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'BlobPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BlobPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/boolean_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/boolean_in_querystring.dart
@@ -31,7 +31,9 @@ class BooleanInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'BooleanInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BooleanInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-json/endpoint_host_trait.dart
@@ -31,7 +31,9 @@ class EndpointHostTrait {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'EndpointHostTrait',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EndpointHostTrait',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-json/enum.dart
@@ -31,7 +31,9 @@ class Enum {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/rest-json/idempotency_token_auto_fill.dart
@@ -31,7 +31,9 @@ class IdempotencyTokenAutoFill {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'IdempotencyTokenAutoFill',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IdempotencyTokenAutoFill',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/json_value_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-json/json_value_trait.dart
@@ -33,7 +33,9 @@ class JSONValueTrait {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'JSONValueTrait',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'JSONValueTrait',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/named_locations_in_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/named_locations_in_json_body.dart
@@ -31,7 +31,9 @@ class NamedLocationsInJSONBody {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'NamedLocationsInJSONBody',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NamedLocationsInJSONBody',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/no_parameters.dart
+++ b/shared_aws_api/test/generated/input/rest-json/no_parameters.dart
@@ -31,7 +31,9 @@ class NoParameters {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'NoParameters',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NoParameters',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/omits_null_query_params,_but_serializes_empty_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-json/omits_null_query_params,_but_serializes_empty_strings.dart
@@ -31,7 +31,9 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'OmitsNullQueryParams,ButSerializesEmptyStrings',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'OmitsNullQueryParams,ButSerializesEmptyStrings',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/querystring_list_of_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-json/querystring_list_of_strings.dart
@@ -31,7 +31,9 @@ class QuerystringListOfStrings {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'QuerystringListOfStrings',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'QuerystringListOfStrings',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-json/recursive_shapes.dart
@@ -33,7 +33,9 @@ class RecursiveShapes {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'RecursiveShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'RecursiveShapes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
@@ -31,7 +31,9 @@ class SerializeBlobsInBody {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'SerializeBlobsInBody',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SerializeBlobsInBody',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
@@ -31,7 +31,9 @@ class StreamingPayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StreamingPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StreamingPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/string_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_payload.dart
@@ -31,7 +31,9 @@ class StringPayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StringPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
@@ -31,7 +31,9 @@ class StringToStringListMapsInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StringToStringListMapsInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringToStringListMapsInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
@@ -31,7 +31,9 @@ class StringToStringMapsInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StringToStringMapsInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringToStringMapsInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/structure_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/structure_payload.dart
@@ -33,7 +33,9 @@ class StructurePayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StructurePayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StructurePayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/rest-json/timestamp_values.dart
@@ -31,7 +31,9 @@ class TimestampValues {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'TimestampValues',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampValues',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter,_querystring_params,_headers_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter,_querystring_params,_headers_and_json_body.dart
@@ -33,7 +33,9 @@ class URIParameterQuerystringParamsHeadersAndJSONBody {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'URIParameter,QuerystringParams,HeadersAndJSONBody',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'URIParameter,QuerystringParams,HeadersAndJSONBody',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter,_querystring_params_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter,_querystring_params_and_json_body.dart
@@ -33,7 +33,9 @@ class URIParameterQuerystringParamsAndJSONBody {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'URIParameter,QuerystringParamsAndJSONBody',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'URIParameter,QuerystringParamsAndJSONBody',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
@@ -31,7 +31,9 @@ class URIParameterAndQuerystringParams {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'URIParameterAndQuerystringParams',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'URIParameterAndQuerystringParams',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
@@ -31,7 +31,9 @@ class URIParameterOnlyWithLocationName {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'URIParameterOnlyWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'URIParameterOnlyWithLocationName',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
@@ -31,7 +31,9 @@ class URIParameterOnlyWithNoLocationName {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'URIParameterOnlyWithNoLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'URIParameterOnlyWithNoLocationName',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/basic_xml_serialization.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/basic_xml_serialization.dart
@@ -23,7 +23,9 @@ class BasicXMLSerialization {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'BasicXMLSerialization',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BasicXMLSerialization',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/blob_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/blob_payload.dart
@@ -23,7 +23,9 @@ class BlobPayload {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'BlobPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BlobPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/blob_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/blob_shapes.dart
@@ -23,7 +23,9 @@ class BlobShapes {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'BlobShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BlobShapes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/boolean_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/boolean_in_querystring.dart
@@ -23,7 +23,9 @@ class BooleanInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'BooleanInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BooleanInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/endpoint_host_trait.dart
@@ -23,7 +23,9 @@ class EndpointHostTrait {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'EndpointHostTrait',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EndpointHostTrait',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -23,7 +23,9 @@ class Enum {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/flattened_lists.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/flattened_lists.dart
@@ -23,7 +23,9 @@ class FlattenedLists {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'FlattenedLists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedLists',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/flattened_lists_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/flattened_lists_with_locationname.dart
@@ -23,7 +23,9 @@ class FlattenedListsWithLocationName {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'FlattenedListsWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedListsWithLocationName',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
@@ -23,7 +23,9 @@ class GreedyKeys {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'GreedyKeys',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'GreedyKeys',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/header_maps.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/header_maps.dart
@@ -23,7 +23,9 @@ class HeaderMaps {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'HeaderMaps',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'HeaderMaps',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/idempotency_token_auto_fill.dart
@@ -23,7 +23,9 @@ class IdempotencyTokenAutoFill {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'IdempotencyTokenAutoFill',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IdempotencyTokenAutoFill',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/list_of_structures.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/list_of_structures.dart
@@ -23,7 +23,9 @@ class ListOfStructures {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'ListOfStructures',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListOfStructures',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/nested_structures.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/nested_structures.dart
@@ -23,7 +23,9 @@ class NestedStructures {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'NestedStructures',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NestedStructures',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists.dart
@@ -23,7 +23,9 @@ class NonFlattenedLists {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'NonFlattenedLists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NonFlattenedLists',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists_with_locationname.dart
@@ -23,7 +23,9 @@ class NonFlattenedListsWithLocationName {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'NonFlattenedListsWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NonFlattenedListsWithLocationName',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/omits_null_query_params,_but_serializes_empty_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/omits_null_query_params,_but_serializes_empty_strings.dart
@@ -23,7 +23,9 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'OmitsNullQueryParams,ButSerializesEmptyStrings',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'OmitsNullQueryParams,ButSerializesEmptyStrings',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/querystring_list_of_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/querystring_list_of_strings.dart
@@ -23,7 +23,9 @@ class QuerystringListOfStrings {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'QuerystringListOfStrings',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'QuerystringListOfStrings',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/recursive_shapes.dart
@@ -23,7 +23,9 @@ class RecursiveShapes {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'RecursiveShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'RecursiveShapes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/serialize_other_scalar_types.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/serialize_other_scalar_types.dart
@@ -23,7 +23,9 @@ class SerializeOtherScalarTypes {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'SerializeOtherScalarTypes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SerializeOtherScalarTypes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/string_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_payload.dart
@@ -23,7 +23,9 @@ class StringPayload {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'StringPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
@@ -23,7 +23,9 @@ class StringToStringListMapsInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'StringToStringListMapsInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringToStringListMapsInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
@@ -23,7 +23,9 @@ class StringToStringMapsInQuerystring {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'StringToStringMapsInQuerystring',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StringToStringMapsInQuerystring',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/structure_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/structure_payload.dart
@@ -23,7 +23,9 @@ class StructurePayload {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'StructurePayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StructurePayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
@@ -23,7 +23,9 @@ class TimestampShapes {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'TimestampShapes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampShapes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/input/rest-xml/xml_attribute.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/xml_attribute.dart
@@ -23,7 +23,9 @@ class XMLAttribute {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'XMLAttribute',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'XMLAttribute',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/blob_members.dart
+++ b/shared_aws_api/test/generated/output/json/blob_members.dart
@@ -33,7 +33,9 @@ class BlobMembers {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'BlobMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BlobMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/enum_output.dart
+++ b/shared_aws_api/test/generated/output/json/enum_output.dart
@@ -33,7 +33,9 @@ class EnumOutput {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'EnumOutput',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EnumOutput',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/ignores_extra_data.dart
+++ b/shared_aws_api/test/generated/output/json/ignores_extra_data.dart
@@ -33,7 +33,9 @@ class IgnoresExtraData {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'IgnoresExtraData',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IgnoresExtraData',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/lists.dart
+++ b/shared_aws_api/test/generated/output/json/lists.dart
@@ -33,7 +33,9 @@ class Lists {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'Lists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Lists',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/maps.dart
+++ b/shared_aws_api/test/generated/output/json/maps.dart
@@ -33,7 +33,9 @@ class Maps {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'Maps',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Maps',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/json/scalar_members.dart
@@ -33,7 +33,9 @@ class ScalarMembers {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/json/timestamp_members.dart
@@ -33,7 +33,9 @@ class TimestampMembers {
     String endpointUrl,
   }) : _protocol = _s.JsonProtocol(
           client: client,
-          service: 'TimestampMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/query/blob.dart
+++ b/shared_aws_api/test/generated/output/query/blob.dart
@@ -33,7 +33,9 @@ class Blob {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'Blob',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Blob',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/empty_string.dart
+++ b/shared_aws_api/test/generated/output/query/empty_string.dart
@@ -33,7 +33,9 @@ class EmptyString {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'EmptyString',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EmptyString',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/enum_output.dart
+++ b/shared_aws_api/test/generated/output/query/enum_output.dart
@@ -33,7 +33,9 @@ class EnumOutput {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'EnumOutput',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EnumOutput',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list.dart
@@ -33,7 +33,9 @@ class FlattenedList {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedList',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedList',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
@@ -33,7 +33,9 @@ class FlattenedListOfStructures {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedListOfStructures',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedListOfStructures',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
@@ -33,7 +33,9 @@ class FlattenedListWithLocationName {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedListWithLocationName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedListWithLocationName',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_map.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map.dart
@@ -33,7 +33,9 @@ class FlattenedMap {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedMap',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
@@ -33,7 +33,9 @@ class FlattenedMapInShapeDefinition {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedMapInShapeDefinition',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedMapInShapeDefinition',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
@@ -33,7 +33,9 @@ class FlattenedSingleElementList {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'FlattenedSingleElementList',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedSingleElementList',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/list_of_structures.dart
@@ -33,7 +33,9 @@ class ListOfStructures {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'ListOfStructures',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListOfStructures',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
+++ b/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
@@ -33,7 +33,9 @@ class ListWithCustomMemberName {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'ListWithCustomMemberName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListWithCustomMemberName',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/lists.dart
+++ b/shared_aws_api/test/generated/output/query/lists.dart
@@ -33,7 +33,9 @@ class Lists {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'Lists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Lists',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/named_map.dart
+++ b/shared_aws_api/test/generated/output/query/named_map.dart
@@ -33,7 +33,9 @@ class NamedMap {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'NamedMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NamedMap',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/normal_map.dart
+++ b/shared_aws_api/test/generated/output/query/normal_map.dart
@@ -33,7 +33,9 @@ class NormalMap {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'NormalMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NormalMap',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
+++ b/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
@@ -33,7 +33,9 @@ class NotAllMembersInResponse {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'NotAllMembersInResponse',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NotAllMembersInResponse',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/query/scalar_members.dart
@@ -33,7 +33,9 @@ class ScalarMembers {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/query/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/query/timestamp_members.dart
@@ -33,7 +33,9 @@ class TimestampMembers {
     _s.Client client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
-          service: 'TimestampMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampMembers',
+          ),
           region: region,
           credentials: credentials,
         ),

--- a/shared_aws_api/test/generated/output/rest-json/blob_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/blob_members.dart
@@ -33,7 +33,9 @@ class BlobMembers {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'BlobMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'BlobMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/complex_map_values.dart
+++ b/shared_aws_api/test/generated/output/rest-json/complex_map_values.dart
@@ -33,7 +33,9 @@ class ComplexMapValues {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'ComplexMapValues',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ComplexMapValues',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-json/enum.dart
@@ -33,7 +33,9 @@ class Enum {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/ignores_extra_data.dart
+++ b/shared_aws_api/test/generated/output/rest-json/ignores_extra_data.dart
@@ -33,7 +33,9 @@ class IgnoresExtraData {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'IgnoresExtraData',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IgnoresExtraData',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/ignores_undefined_output.dart
+++ b/shared_aws_api/test/generated/output/rest-json/ignores_undefined_output.dart
@@ -31,7 +31,9 @@ class IgnoresUndefinedOutput {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'IgnoresUndefinedOutput',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'IgnoresUndefinedOutput',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/json_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_payload.dart
@@ -33,7 +33,9 @@ class JSONPayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'JSONPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'JSONPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
@@ -33,7 +33,9 @@ class JSONValueTrait {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'JSONValueTrait',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'JSONValueTrait',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/lists.dart
+++ b/shared_aws_api/test/generated/output/rest-json/lists.dart
@@ -33,7 +33,9 @@ class Lists {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'Lists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Lists',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/lists_with_structure_member.dart
+++ b/shared_aws_api/test/generated/output/rest-json/lists_with_structure_member.dart
@@ -33,7 +33,9 @@ class ListsWithStructureMember {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'ListsWithStructureMember',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListsWithStructureMember',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/maps.dart
+++ b/shared_aws_api/test/generated/output/rest-json/maps.dart
@@ -33,7 +33,9 @@ class Maps {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'Maps',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Maps',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
@@ -33,7 +33,9 @@ class ScalarMembers {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
@@ -33,7 +33,9 @@ class StreamingPayload {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'StreamingPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StreamingPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
+++ b/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
@@ -33,7 +33,9 @@ class SupportsHeaderMaps {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'SupportsHeaderMaps',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'SupportsHeaderMaps',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
@@ -33,7 +33,9 @@ class TimestampMembers {
     String endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
           client: client,
-          service: 'TimestampMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/blob.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/blob.dart
@@ -23,7 +23,9 @@ class Blob {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'Blob',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Blob',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/empty_string.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/empty_string.dart
@@ -23,7 +23,9 @@ class EmptyString {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'EmptyString',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'EmptyString',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/enum.dart
@@ -23,7 +23,9 @@ class Enum {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'Enum',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Enum',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/flattened_list.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/flattened_list.dart
@@ -23,7 +23,9 @@ class FlattenedList {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'FlattenedList',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedList',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/flattened_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/flattened_map.dart
@@ -23,7 +23,9 @@ class FlattenedMap {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'FlattenedMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'FlattenedMap',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/list_with_custom_member_name.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/list_with_custom_member_name.dart
@@ -23,7 +23,9 @@ class ListWithCustomMemberName {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'ListWithCustomMemberName',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ListWithCustomMemberName',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/lists.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/lists.dart
@@ -23,7 +23,9 @@ class Lists {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'Lists',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'Lists',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/named_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/named_map.dart
@@ -23,7 +23,9 @@ class NamedMap {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'NamedMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NamedMap',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/normal_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/normal_map.dart
@@ -23,7 +23,9 @@ class NormalMap {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'NormalMap',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'NormalMap',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/scalar_members.dart
@@ -23,7 +23,9 @@ class ScalarMembers {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'ScalarMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/scalar_members_in_headers.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/scalar_members_in_headers.dart
@@ -23,7 +23,9 @@ class ScalarMembersInHeaders {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'ScalarMembersInHeaders',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'ScalarMembersInHeaders',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/streaming_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/streaming_payload.dart
@@ -23,7 +23,9 @@ class StreamingPayload {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'StreamingPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'StreamingPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
@@ -23,7 +23,9 @@ class TimestampMembers {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'TimestampMembers',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'TimestampMembers',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
@@ -23,7 +23,9 @@ class XMLAttributes {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'XMLAttributes',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'XMLAttributes',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/generated/output/rest-xml/xml_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_payload.dart
@@ -23,7 +23,9 @@ class XMLPayload {
     String endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
           client: client,
-          service: 'XMLPayload',
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'XMLPayload',
+          ),
           region: region,
           credentials: credentials,
           endpointUrl: endpointUrl,

--- a/shared_aws_api/test/protocol/endpoint_test.dart
+++ b/shared_aws_api/test/protocol/endpoint_test.dart
@@ -5,27 +5,30 @@ void main() {
   group('Endpoint.fromConfig', () {
     test('Create url for service', () {
       expect(
-        Endpoint.fromConfig('s3', region: 'eu-west-1'),
+        Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 's3'),
+            region: 'eu-west-1'),
         Endpoint(
-          service: 's3',
+          service: ServiceMetadata(endpointPrefix: 's3'),
           url: 'https://s3.eu-west-1.amazonaws.com',
           signingRegion: 'eu-west-1',
           signatureVersion: 's3',
         ),
       );
       expect(
-        Endpoint.fromConfig('a4b', region: 'af-south-1'),
+        Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 'a4b'),
+            region: 'af-south-1'),
         Endpoint(
-          service: 'a4b',
+          service: ServiceMetadata(endpointPrefix: 'a4b'),
           url: 'https://a4b.af-south-1.amazonaws.com',
           signingRegion: 'af-south-1',
           signatureVersion: 'v4',
         ),
       );
       expect(
-        Endpoint.fromConfig('lambda', region: 'us-west-2'),
+        Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 'lambda'),
+            region: 'us-west-2'),
         Endpoint(
-          service: 'lambda',
+          service: ServiceMetadata(endpointPrefix: 'lambda'),
           url: 'https://lambda.us-west-2.amazonaws.com',
           signingRegion: 'us-west-2',
           signatureVersion: 'v4',
@@ -35,16 +38,16 @@ void main() {
 
     test('Throw if region is not provided when required', () {
       expect(
-        () => Endpoint.fromConfig('s3'),
+        () => Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 's3')),
         throwsA(isA<ArgumentError>()),
       );
     });
 
     test('Infer signing region for global services', () {
       expect(
-        Endpoint.fromConfig('iam'),
+        Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 'iam')),
         Endpoint(
-          service: 'iam',
+          service: ServiceMetadata(endpointPrefix: 'iam'),
           url: 'https://iam.amazonaws.com',
           signingRegion: 'us-east-1',
           signatureVersion: 'v4',
@@ -54,9 +57,10 @@ void main() {
 
     test('Use correct signing region for global services', () {
       expect(
-        Endpoint.fromConfig('iam', region: 'eu-west-1'),
+        Endpoint.fromConfig(ServiceMetadata(endpointPrefix: 'iam'),
+            region: 'eu-west-1'),
         Endpoint(
-          service: 'iam',
+          service: ServiceMetadata(endpointPrefix: 'iam'),
           url: 'https://iam.amazonaws.com',
           signingRegion: 'us-east-1',
           signatureVersion: 'v4',
@@ -67,9 +71,9 @@ void main() {
   group('Endpoint.forProtocol', () {
     test('Infer endpoint', () {
       expect(
-        Endpoint.forProtocol(service: 'iam'),
+        Endpoint.forProtocol(service: ServiceMetadata(endpointPrefix: 'iam')),
         Endpoint(
-          service: 'iam',
+          service: ServiceMetadata(endpointPrefix: 'iam'),
           url: 'https://iam.amazonaws.com',
           signingRegion: 'us-east-1',
           signatureVersion: 'v4',
@@ -79,11 +83,11 @@ void main() {
     test('Custom endpointUrl', () {
       expect(
         Endpoint.forProtocol(
-            service: 'iam',
+            service: ServiceMetadata(endpointPrefix: 'iam'),
             endpointUrl: 'https://test.com',
             region: 'us-gov-1'),
         Endpoint(
-          service: 'iam',
+          service: ServiceMetadata(endpointPrefix: 'iam'),
           url: 'https://test.com',
           signingRegion: 'us-gov-1',
           signatureVersion: 'v4',


### PR DESCRIPTION
Use the field `signingName` from api.metadata to sign the request (fallback to `endpointPrefix` if not present).

First commit is the code change to review and the second is the re-generated apis.

Fixes #272 