### PR TITLE
[Rest-Json] Support blob payload and non-string headers

### DIFF
--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -2375,7 +2375,7 @@ class APIGateway {
     _query = '?${[
       if (parameters != null) _s.toQueryParam(null, parameters),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       headers: headers,
       method: 'GET',
@@ -2383,7 +2383,13 @@ class APIGateway {
           '/restapis/${Uri.encodeComponent(restApiId.toString())}/stages/${Uri.encodeComponent(stageName.toString())}/exports/${Uri.encodeComponent(exportType.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return ExportResponse.fromJson({...response, 'body': response});
+    return ExportResponse(
+      body: await response.stream.toBytes(),
+      contentDisposition:
+          _s.extractHeaderStringValue(response.headers, 'Content-Disposition'),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+    );
   }
 
   /// Gets a <a>GatewayResponse</a> of a specified response type on the given
@@ -2986,14 +2992,20 @@ class APIGateway {
     _query = '?${[
       if (parameters != null) _s.toQueryParam(null, parameters),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/restapis/${Uri.encodeComponent(restApiId.toString())}/stages/${Uri.encodeComponent(stageName.toString())}/sdks/${Uri.encodeComponent(sdkType.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return SdkResponse.fromJson({...response, 'body': response});
+    return SdkResponse(
+      body: await response.stream.toBytes(),
+      contentDisposition:
+          _s.extractHeaderStringValue(response.headers, 'Content-Disposition'),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+    );
   }
 
   ///

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -1446,14 +1446,16 @@ class ApiGatewayV2 {
         _s.toQueryParam('includeExtensions', includeExtensions),
       if (stageName != null) _s.toQueryParam('stageName', stageName),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v2/apis/${Uri.encodeComponent(apiId.toString())}/exports/${Uri.encodeComponent(specification.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return ExportApiResponse.fromJson({...response, 'body': response});
+    return ExportApiResponse(
+      body: await response.stream.toBytes(),
+    );
   }
 
   /// Gets an Api resource.

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -679,14 +679,20 @@ class AppConfig {
         _s.toQueryParam(
             'client_configuration_version', clientConfigurationVersion),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/applications/${Uri.encodeComponent(application.toString())}/environments/${Uri.encodeComponent(environment.toString())}/configurations/${Uri.encodeComponent(configuration.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return Configuration.fromJson({...response, 'Content': response});
+    return Configuration(
+      content: await response.stream.toBytes(),
+      configurationVersion: _s.extractHeaderStringValue(
+          response.headers, 'Configuration-Version'),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+    );
   }
 
   /// Retrieve information about a configuration profile.

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -114,13 +114,16 @@ class AppMesh {
       'meshName': meshName,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri: '/meshes',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Creates a new route that is associated with a virtual router.
@@ -200,14 +203,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Creates a new virtual node within a service mesh.
@@ -299,15 +305,17 @@ class AppMesh {
       'virtualNodeName': virtualNodeName,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Creates a new virtual router within a service mesh.
@@ -369,15 +377,17 @@ class AppMesh {
       'virtualRouterName': virtualRouterName,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Deletes an existing service mesh.
@@ -409,13 +419,16 @@ class AppMesh {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri: '/meshes/${Uri.encodeComponent(meshName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Deletes an existing route.
@@ -466,14 +479,17 @@ class AppMesh {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Deletes an existing virtual node.
@@ -512,15 +528,17 @@ class AppMesh {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Deletes an existing virtual router.
@@ -564,15 +582,17 @@ class AppMesh {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Describes an existing service mesh.
@@ -597,13 +617,16 @@ class AppMesh {
       255,
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/meshes/${Uri.encodeComponent(meshName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Describes an existing route.
@@ -652,14 +675,17 @@ class AppMesh {
       255,
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Describes an existing virtual node.
@@ -696,15 +722,17 @@ class AppMesh {
       255,
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Describes an existing virtual router.
@@ -741,15 +769,17 @@ class AppMesh {
       255,
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Returns a list of existing service meshes.
@@ -1089,14 +1119,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Updates an existing virtual node in a specified service mesh.
@@ -1151,15 +1184,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Updates an existing virtual router in a specified service mesh.
@@ -1214,15 +1249,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 }
 

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -129,13 +129,16 @@ class AppMesh {
       if (spec != null) 'spec': spec,
       if (tags != null) 'tags': tags,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri: '/v20190125/meshes',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Creates a route that is associated with a virtual router.
@@ -253,14 +256,17 @@ class AppMesh {
       if (clientToken != null) 'clientToken': clientToken,
       if (tags != null) 'tags': tags,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Creates a virtual node within a service mesh.
@@ -388,15 +394,17 @@ class AppMesh {
       if (clientToken != null) 'clientToken': clientToken,
       if (tags != null) 'tags': tags,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Creates a virtual router within a service mesh.
@@ -500,15 +508,17 @@ class AppMesh {
       if (clientToken != null) 'clientToken': clientToken,
       if (tags != null) 'tags': tags,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Creates a virtual service within a service mesh.
@@ -603,15 +613,17 @@ class AppMesh {
       if (clientToken != null) 'clientToken': clientToken,
       if (tags != null) 'tags': tags,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualServices$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVirtualServiceOutput.fromJson(
-        {...response, 'virtualService': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVirtualServiceOutput(
+      virtualService: VirtualServiceData.fromJson($json),
+    );
   }
 
   /// Deletes an existing service mesh.
@@ -643,14 +655,17 @@ class AppMesh {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Deletes an existing route.
@@ -720,14 +735,17 @@ class AppMesh {
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Deletes an existing virtual node.
@@ -790,15 +808,17 @@ class AppMesh {
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Deletes an existing virtual router.
@@ -861,15 +881,17 @@ class AppMesh {
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Deletes an existing virtual service.
@@ -919,15 +941,17 @@ class AppMesh {
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualServices/${Uri.encodeComponent(virtualServiceName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVirtualServiceOutput.fromJson(
-        {...response, 'virtualService': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVirtualServiceOutput(
+      virtualService: VirtualServiceData.fromJson($json),
+    );
   }
 
   /// Describes an existing service mesh.
@@ -971,14 +995,17 @@ class AppMesh {
     _query = '?${[
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Describes an existing route.
@@ -1046,14 +1073,17 @@ class AppMesh {
     _query = '?${[
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Describes an existing virtual node.
@@ -1109,15 +1139,17 @@ class AppMesh {
     _query = '?${[
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Describes an existing virtual router.
@@ -1173,15 +1205,17 @@ class AppMesh {
     _query = '?${[
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Describes an existing virtual service.
@@ -1230,15 +1264,17 @@ class AppMesh {
     _query = '?${[
       if (meshOwner != null) _s.toQueryParam('meshOwner', meshOwner),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualServices/${Uri.encodeComponent(virtualServiceName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeVirtualServiceOutput.fromJson(
-        {...response, 'virtualService': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeVirtualServiceOutput(
+      virtualService: VirtualServiceData.fromJson($json),
+    );
   }
 
   /// Returns a list of existing service meshes.
@@ -1832,14 +1868,17 @@ class AppMesh {
       if (clientToken != null) 'clientToken': clientToken,
       if (spec != null) 'spec': spec,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateMeshOutput.fromJson({...response, 'mesh': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateMeshOutput(
+      mesh: MeshData.fromJson($json),
+    );
   }
 
   /// Updates an existing route for a specified service mesh and virtual router.
@@ -1924,14 +1963,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouter/${Uri.encodeComponent(virtualRouterName.toString())}/routes/${Uri.encodeComponent(routeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateRouteOutput.fromJson({...response, 'route': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateRouteOutput(
+      route: RouteData.fromJson($json),
+    );
   }
 
   /// Updates an existing virtual node in a specified service mesh.
@@ -2005,15 +2047,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualNodes/${Uri.encodeComponent(virtualNodeName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVirtualNodeOutput.fromJson(
-        {...response, 'virtualNode': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVirtualNodeOutput(
+      virtualNode: VirtualNodeData.fromJson($json),
+    );
   }
 
   /// Updates an existing virtual router in a specified service mesh.
@@ -2087,15 +2131,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualRouters/${Uri.encodeComponent(virtualRouterName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVirtualRouterOutput.fromJson(
-        {...response, 'virtualRouter': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVirtualRouterOutput(
+      virtualRouter: VirtualRouterData.fromJson($json),
+    );
   }
 
   /// Updates an existing virtual service in a specified service mesh.
@@ -2163,15 +2209,17 @@ class AppMesh {
       'spec': spec,
       if (clientToken != null) 'clientToken': clientToken,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/v20190125/meshes/${Uri.encodeComponent(meshName.toString())}/virtualServices/${Uri.encodeComponent(virtualServiceName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVirtualServiceOutput.fromJson(
-        {...response, 'virtualService': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVirtualServiceOutput(
+      virtualService: VirtualServiceData.fromJson($json),
+    );
   }
 }
 

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -1074,15 +1074,16 @@ class AppSync {
       if (includeDirectives != null)
         _s.toQueryParam('includeDirectives', includeDirectives),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apis/${Uri.encodeComponent(apiId.toString())}/schema$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetIntrospectionSchemaResponse.fromJson(
-        {...response, 'schema': response});
+    return GetIntrospectionSchemaResponse(
+      schema: await response.stream.toBytes(),
+    );
   }
 
   /// Retrieves a <code>Resolver</code> object.

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -87,15 +87,17 @@ class CodeGuruProfiler {
     final $payload = <String, dynamic>{
       if (fleetInstanceId != null) 'fleetInstanceId': fleetInstanceId,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'POST',
       requestUri:
           '/profilingGroups/${Uri.encodeComponent(profilingGroupName.toString())}/configureAgent',
       exceptionFnMap: _exceptionFns,
     );
-    return ConfigureAgentResponse.fromJson(
-        {...response, 'configuration': response});
+    final $json = await _s.jsonFromResponse(response);
+    return ConfigureAgentResponse(
+      configuration: AgentConfiguration.fromJson($json),
+    );
   }
 
   /// Creates a profiling group.
@@ -160,14 +162,16 @@ class CodeGuruProfiler {
       if (agentOrchestrationConfig != null)
         'agentOrchestrationConfig': agentOrchestrationConfig,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'POST',
       requestUri: '/profilingGroups$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateProfilingGroupResponse.fromJson(
-        {...response, 'profilingGroup': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateProfilingGroupResponse(
+      profilingGroup: ProfilingGroupDescription.fromJson($json),
+    );
   }
 
   /// Deletes a profiling group.
@@ -233,15 +237,17 @@ class CodeGuruProfiler {
       r'''^[\w-]+$''',
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/profilingGroups/${Uri.encodeComponent(profilingGroupName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DescribeProfilingGroupResponse.fromJson(
-        {...response, 'profilingGroup': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DescribeProfilingGroupResponse(
+      profilingGroup: ProfilingGroupDescription.fromJson($json),
+    );
   }
 
   /// Gets the profiling group policy.
@@ -369,7 +375,7 @@ class CodeGuruProfiler {
       if (period != null) _s.toQueryParam('period', period),
       if (startTime != null) _s.toQueryParam('startTime', startTime),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       headers: headers,
       method: 'GET',
@@ -377,7 +383,13 @@ class CodeGuruProfiler {
           '/profilingGroups/${Uri.encodeComponent(profilingGroupName.toString())}/profile$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetProfileResponse.fromJson({...response, 'profile': response});
+    return GetProfileResponse(
+      profile: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+      contentEncoding:
+          _s.extractHeaderStringValue(response.headers, 'Content-Encoding'),
+    );
   }
 
   /// List the start times of the available aggregated profiles of a profiling
@@ -779,15 +791,17 @@ class CodeGuruProfiler {
     final $payload = <String, dynamic>{
       'agentOrchestrationConfig': agentOrchestrationConfig,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'PUT',
       requestUri:
           '/profilingGroups/${Uri.encodeComponent(profilingGroupName.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateProfilingGroupResponse.fromJson(
-        {...response, 'profilingGroup': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateProfilingGroupResponse(
+      profilingGroup: ProfilingGroupDescription.fromJson($json),
+    );
   }
 }
 

--- a/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
+++ b/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
@@ -82,14 +82,15 @@ class IoTDataPlane {
       isRequired: true,
     );
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri: '/things/${Uri.encodeComponent(thingName.toString())}/shadow',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteThingShadowResponse.fromJson(
-        {...response, 'payload': response});
+    return DeleteThingShadowResponse(
+      payload: await response.stream.toBytes(),
+    );
   }
 
   /// Gets the thing shadow for the specified thing.
@@ -126,13 +127,15 @@ class IoTDataPlane {
       r'''[a-zA-Z0-9_-]+''',
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/things/${Uri.encodeComponent(thingName.toString())}/shadow',
       exceptionFnMap: _exceptionFns,
     );
-    return GetThingShadowResponse.fromJson({...response, 'payload': response});
+    return GetThingShadowResponse(
+      payload: await response.stream.toBytes(),
+    );
   }
 
   /// Publishes state information.
@@ -218,14 +221,15 @@ class IoTDataPlane {
       r'''[a-zA-Z0-9_-]+''',
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: payload,
       method: 'POST',
       requestUri: '/things/${Uri.encodeComponent(thingName.toString())}/shadow',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateThingShadowResponse.fromJson(
-        {...response, 'payload': response});
+    return UpdateThingShadowResponse(
+      payload: await response.stream.toBytes(),
+    );
   }
 }
 

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -1001,14 +1001,17 @@ class KinesisVideoArchivedMedia {
       'Fragments': fragments,
       'StreamName': streamName,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'POST',
       requestUri: '/getMediaForFragmentList',
       exceptionFnMap: _exceptionFns,
     );
-    return GetMediaForFragmentListOutput.fromJson(
-        {...response, 'Payload': response});
+    return GetMediaForFragmentListOutput(
+      payload: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+    );
   }
 
   /// Returns a list of <a>Fragment</a> objects from the specified stream and

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -150,13 +150,17 @@ class KinesisVideoMedia {
       if (streamARN != null) 'StreamARN': streamARN,
       if (streamName != null) 'StreamName': streamName,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'POST',
       requestUri: '/getMedia',
       exceptionFnMap: _exceptionFns,
     );
-    return GetMediaOutput.fromJson({...response, 'Payload': response});
+    return GetMediaOutput(
+      payload: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+    );
   }
 }
 

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -2237,7 +2237,7 @@ class Lambda {
     _query = '?${[
       if (qualifier != null) _s.toQueryParam('Qualifier', qualifier),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: payload,
       headers: headers,
       method: 'POST',
@@ -2245,7 +2245,16 @@ class Lambda {
           '/2015-03-31/functions/${Uri.encodeComponent(functionName.toString())}/invocations$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return InvocationResponse.fromJson({...response, 'Payload': response});
+    return InvocationResponse(
+      payload: await response.stream.toBytes(),
+      executedVersion: _s.extractHeaderStringValue(
+          response.headers, 'X-Amz-Executed-Version'),
+      functionError:
+          _s.extractHeaderStringValue(response.headers, 'X-Amz-Function-Error'),
+      logResult:
+          _s.extractHeaderStringValue(response.headers, 'X-Amz-Log-Result'),
+      statusCode: response.statusCode,
+    );
   }
 
   /// <important>

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -457,7 +457,7 @@ class LexRuntimeService {
         ?.let((v) => headers['x-amz-lex-request-attributes'] = v.toString());
     sessionAttributes
         ?.let((v) => headers['x-amz-lex-session-attributes'] = v.toString());
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: inputStream,
       headers: headers,
       method: 'POST',
@@ -465,7 +465,33 @@ class LexRuntimeService {
           '/bot/${Uri.encodeComponent(botName.toString())}/alias/${Uri.encodeComponent(botAlias.toString())}/user/${Uri.encodeComponent(userId.toString())}/content',
       exceptionFnMap: _exceptionFns,
     );
-    return PostContentResponse.fromJson({...response, 'audioStream': response});
+    return PostContentResponse(
+      audioStream: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+      dialogState: _s
+          .extractHeaderStringValue(response.headers, 'x-amz-lex-dialog-state')
+          ?.toDialogState(),
+      inputTranscript: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-input-transcript'),
+      intentName: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-intent-name'),
+      message:
+          _s.extractHeaderStringValue(response.headers, 'x-amz-lex-message'),
+      messageFormat: _s
+          .extractHeaderStringValue(
+              response.headers, 'x-amz-lex-message-format')
+          ?.toMessageFormatType(),
+      sentimentResponse:
+          _s.extractHeaderStringValue(response.headers, 'x-amz-lex-sentiment'),
+      sessionAttributes: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-session-attributes'),
+      sessionId:
+          _s.extractHeaderStringValue(response.headers, 'x-amz-lex-session-id'),
+      slotToElicit: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-slot-to-elicit'),
+      slots: _s.extractHeaderStringValue(response.headers, 'x-amz-lex-slots'),
+    );
   }
 
   /// Sends user input to Amazon Lex. Client applications can use this API to
@@ -792,7 +818,7 @@ class LexRuntimeService {
         'recentIntentSummaryView': recentIntentSummaryView,
       if (sessionAttributes != null) 'sessionAttributes': sessionAttributes,
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       headers: headers,
       method: 'POST',
@@ -800,7 +826,29 @@ class LexRuntimeService {
           '/bot/${Uri.encodeComponent(botName.toString())}/alias/${Uri.encodeComponent(botAlias.toString())}/user/${Uri.encodeComponent(userId.toString())}/session',
       exceptionFnMap: _exceptionFns,
     );
-    return PutSessionResponse.fromJson({...response, 'audioStream': response});
+    return PutSessionResponse(
+      audioStream: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+      dialogState: _s
+          .extractHeaderStringValue(response.headers, 'x-amz-lex-dialog-state')
+          ?.toDialogState(),
+      intentName: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-intent-name'),
+      message:
+          _s.extractHeaderStringValue(response.headers, 'x-amz-lex-message'),
+      messageFormat: _s
+          .extractHeaderStringValue(
+              response.headers, 'x-amz-lex-message-format')
+          ?.toMessageFormatType(),
+      sessionAttributes: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-session-attributes'),
+      sessionId:
+          _s.extractHeaderStringValue(response.headers, 'x-amz-lex-session-id'),
+      slotToElicit: _s.extractHeaderStringValue(
+          response.headers, 'x-amz-lex-slot-to-elicit'),
+      slots: _s.extractHeaderStringValue(response.headers, 'x-amz-lex-slots'),
+    );
   }
 }
 
@@ -1015,6 +1063,26 @@ enum DialogState {
   failed,
 }
 
+extension on String {
+  DialogState toDialogState() {
+    switch (this) {
+      case 'ElicitIntent':
+        return DialogState.elicitIntent;
+      case 'ConfirmIntent':
+        return DialogState.confirmIntent;
+      case 'ElicitSlot':
+        return DialogState.elicitSlot;
+      case 'Fulfilled':
+        return DialogState.fulfilled;
+      case 'ReadyForFulfillment':
+        return DialogState.readyForFulfillment;
+      case 'Failed':
+        return DialogState.failed;
+    }
+    throw Exception('Unknown enum value: $this');
+  }
+}
+
 enum FulfillmentState {
   @_s.JsonValue('Fulfilled')
   fulfilled,
@@ -1227,6 +1295,22 @@ enum MessageFormatType {
   ssml,
   @_s.JsonValue('Composite')
   composite,
+}
+
+extension on String {
+  MessageFormatType toMessageFormatType() {
+    switch (this) {
+      case 'PlainText':
+        return MessageFormatType.plainText;
+      case 'CustomPayload':
+        return MessageFormatType.customPayload;
+      case 'SSML':
+        return MessageFormatType.ssml;
+      case 'Composite':
+        return MessageFormatType.composite;
+    }
+    throw Exception('Unknown enum value: $this');
+  }
 }
 
 @_s.JsonSerializable(

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -1105,7 +1105,7 @@ class DashEncryption {
     createToJson: true)
 class DashPackage {
   @_s.JsonKey(name: 'adTriggers')
-  final List<__AdTriggersElement> adTriggers;
+  final List<AdTriggersElement> adTriggers;
   @_s.JsonKey(name: 'adsOnDeliveryRestrictions')
   final AdsOnDeliveryRestrictions adsOnDeliveryRestrictions;
   @_s.JsonKey(name: 'encryption')
@@ -1140,7 +1140,7 @@ class DashPackage {
   /// periods will be created where
   /// the Channel source contains SCTE-35 ad markers.
   @_s.JsonKey(name: 'periodTriggers')
-  final List<__PeriodTriggersElement> periodTriggers;
+  final List<PeriodTriggersElement> periodTriggers;
 
   /// The Dynamic Adaptive Streaming over HTTP (DASH) profile type.  When set to
   /// "HBBTV_1_5", HbbTV 1.5 compliant output is enabled.
@@ -1618,7 +1618,7 @@ class HlsManifestCreateOrUpdateParameters {
   @_s.JsonKey(name: 'adMarkers')
   final AdMarkers adMarkers;
   @_s.JsonKey(name: 'adTriggers')
-  final List<__AdTriggersElement> adTriggers;
+  final List<AdTriggersElement> adTriggers;
   @_s.JsonKey(name: 'adsOnDeliveryRestrictions')
   final AdsOnDeliveryRestrictions adsOnDeliveryRestrictions;
 
@@ -1688,7 +1688,7 @@ class HlsPackage {
   @_s.JsonKey(name: 'adMarkers')
   final AdMarkers adMarkers;
   @_s.JsonKey(name: 'adTriggers')
-  final List<__AdTriggersElement> adTriggers;
+  final List<AdTriggersElement> adTriggers;
   @_s.JsonKey(name: 'adsOnDeliveryRestrictions')
   final AdsOnDeliveryRestrictions adsOnDeliveryRestrictions;
   @_s.JsonKey(name: 'encryption')
@@ -2380,7 +2380,7 @@ class UpdateOriginEndpointResponse {
       _$UpdateOriginEndpointResponseFromJson(json);
 }
 
-enum __AdTriggersElement {
+enum AdTriggersElement {
   @_s.JsonValue('SPLICE_INSERT')
   spliceInsert,
   @_s.JsonValue('BREAK')
@@ -2399,7 +2399,7 @@ enum __AdTriggersElement {
   distributorOverlayPlacementOpportunity,
 }
 
-enum __PeriodTriggersElement {
+enum PeriodTriggersElement {
   @_s.JsonValue('ADS')
   ads,
 }

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.g.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.g.dart
@@ -241,7 +241,7 @@ Map<String, dynamic> _$DashEncryptionToJson(DashEncryption instance) {
 DashPackage _$DashPackageFromJson(Map<String, dynamic> json) {
   return DashPackage(
     adTriggers: (json['adTriggers'] as List)
-        ?.map((e) => _$enumDecodeNullable(_$__AdTriggersElementEnumMap, e))
+        ?.map((e) => _$enumDecodeNullable(_$AdTriggersElementEnumMap, e))
         ?.toList(),
     adsOnDeliveryRestrictions: _$enumDecodeNullable(
         _$AdsOnDeliveryRestrictionsEnumMap, json['adsOnDeliveryRestrictions']),
@@ -254,7 +254,7 @@ DashPackage _$DashPackageFromJson(Map<String, dynamic> json) {
     minBufferTimeSeconds: json['minBufferTimeSeconds'] as int,
     minUpdatePeriodSeconds: json['minUpdatePeriodSeconds'] as int,
     periodTriggers: (json['periodTriggers'] as List)
-        ?.map((e) => _$enumDecodeNullable(_$__PeriodTriggersElementEnumMap, e))
+        ?.map((e) => _$enumDecodeNullable(_$PeriodTriggersElementEnumMap, e))
         ?.toList(),
     profile: _$enumDecodeNullable(_$ProfileEnumMap, json['profile']),
     segmentDurationSeconds: json['segmentDurationSeconds'] as int,
@@ -278,11 +278,8 @@ Map<String, dynamic> _$DashPackageToJson(DashPackage instance) {
     }
   }
 
-  writeNotNull(
-      'adTriggers',
-      instance.adTriggers
-          ?.map((e) => _$__AdTriggersElementEnumMap[e])
-          ?.toList());
+  writeNotNull('adTriggers',
+      instance.adTriggers?.map((e) => _$AdTriggersElementEnumMap[e])?.toList());
   writeNotNull('adsOnDeliveryRestrictions',
       _$AdsOnDeliveryRestrictionsEnumMap[instance.adsOnDeliveryRestrictions]);
   writeNotNull('encryption', instance.encryption?.toJson());
@@ -294,7 +291,7 @@ Map<String, dynamic> _$DashPackageToJson(DashPackage instance) {
   writeNotNull(
       'periodTriggers',
       instance.periodTriggers
-          ?.map((e) => _$__PeriodTriggersElementEnumMap[e])
+          ?.map((e) => _$PeriodTriggersElementEnumMap[e])
           ?.toList());
   writeNotNull('profile', _$ProfileEnumMap[instance.profile]);
   writeNotNull('segmentDurationSeconds', instance.segmentDurationSeconds);
@@ -306,18 +303,18 @@ Map<String, dynamic> _$DashPackageToJson(DashPackage instance) {
   return val;
 }
 
-const _$__AdTriggersElementEnumMap = {
-  __AdTriggersElement.spliceInsert: 'SPLICE_INSERT',
-  __AdTriggersElement.$break: 'BREAK',
-  __AdTriggersElement.providerAdvertisement: 'PROVIDER_ADVERTISEMENT',
-  __AdTriggersElement.distributorAdvertisement: 'DISTRIBUTOR_ADVERTISEMENT',
-  __AdTriggersElement.providerPlacementOpportunity:
+const _$AdTriggersElementEnumMap = {
+  AdTriggersElement.spliceInsert: 'SPLICE_INSERT',
+  AdTriggersElement.$break: 'BREAK',
+  AdTriggersElement.providerAdvertisement: 'PROVIDER_ADVERTISEMENT',
+  AdTriggersElement.distributorAdvertisement: 'DISTRIBUTOR_ADVERTISEMENT',
+  AdTriggersElement.providerPlacementOpportunity:
       'PROVIDER_PLACEMENT_OPPORTUNITY',
-  __AdTriggersElement.distributorPlacementOpportunity:
+  AdTriggersElement.distributorPlacementOpportunity:
       'DISTRIBUTOR_PLACEMENT_OPPORTUNITY',
-  __AdTriggersElement.providerOverlayPlacementOpportunity:
+  AdTriggersElement.providerOverlayPlacementOpportunity:
       'PROVIDER_OVERLAY_PLACEMENT_OPPORTUNITY',
-  __AdTriggersElement.distributorOverlayPlacementOpportunity:
+  AdTriggersElement.distributorOverlayPlacementOpportunity:
       'DISTRIBUTOR_OVERLAY_PLACEMENT_OPPORTUNITY',
 };
 
@@ -333,8 +330,8 @@ const _$ManifestLayoutEnumMap = {
   ManifestLayout.compact: 'COMPACT',
 };
 
-const _$__PeriodTriggersElementEnumMap = {
-  __PeriodTriggersElement.ads: 'ADS',
+const _$PeriodTriggersElementEnumMap = {
+  PeriodTriggersElement.ads: 'ADS',
 };
 
 const _$ProfileEnumMap = {
@@ -530,11 +527,8 @@ Map<String, dynamic> _$HlsManifestCreateOrUpdateParametersToJson(
 
   writeNotNull('id', instance.id);
   writeNotNull('adMarkers', _$AdMarkersEnumMap[instance.adMarkers]);
-  writeNotNull(
-      'adTriggers',
-      instance.adTriggers
-          ?.map((e) => _$__AdTriggersElementEnumMap[e])
-          ?.toList());
+  writeNotNull('adTriggers',
+      instance.adTriggers?.map((e) => _$AdTriggersElementEnumMap[e])?.toList());
   writeNotNull('adsOnDeliveryRestrictions',
       _$AdsOnDeliveryRestrictionsEnumMap[instance.adsOnDeliveryRestrictions]);
   writeNotNull('includeIframeOnlyStream', instance.includeIframeOnlyStream);
@@ -550,7 +544,7 @@ HlsPackage _$HlsPackageFromJson(Map<String, dynamic> json) {
   return HlsPackage(
     adMarkers: _$enumDecodeNullable(_$AdMarkersEnumMap, json['adMarkers']),
     adTriggers: (json['adTriggers'] as List)
-        ?.map((e) => _$enumDecodeNullable(_$__AdTriggersElementEnumMap, e))
+        ?.map((e) => _$enumDecodeNullable(_$AdTriggersElementEnumMap, e))
         ?.toList(),
     adsOnDeliveryRestrictions: _$enumDecodeNullable(
         _$AdsOnDeliveryRestrictionsEnumMap, json['adsOnDeliveryRestrictions']),
@@ -582,11 +576,8 @@ Map<String, dynamic> _$HlsPackageToJson(HlsPackage instance) {
   }
 
   writeNotNull('adMarkers', _$AdMarkersEnumMap[instance.adMarkers]);
-  writeNotNull(
-      'adTriggers',
-      instance.adTriggers
-          ?.map((e) => _$__AdTriggersElementEnumMap[e])
-          ?.toList());
+  writeNotNull('adTriggers',
+      instance.adTriggers?.map((e) => _$AdTriggersElementEnumMap[e])?.toList());
   writeNotNull('adsOnDeliveryRestrictions',
       _$AdsOnDeliveryRestrictionsEnumMap[instance.adsOnDeliveryRestrictions]);
   writeNotNull('encryption', instance.encryption?.toJson());

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -746,7 +746,7 @@ class DashPackage {
   /// periods will be created where
   /// the Asset contains SCTE-35 ad markers.
   @_s.JsonKey(name: 'periodTriggers')
-  final List<__PeriodTriggersElement> periodTriggers;
+  final List<PeriodTriggersElement> periodTriggers;
 
   /// Duration (in seconds) of each segment. Actual segments will be
   /// rounded to the nearest multiple of the source segment duration.
@@ -1384,7 +1384,7 @@ class StreamSelection {
   Map<String, dynamic> toJson() => _$StreamSelectionToJson(this);
 }
 
-enum __PeriodTriggersElement {
+enum PeriodTriggersElement {
   @_s.JsonValue('ADS')
   ads,
 }

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.g.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.g.dart
@@ -222,7 +222,7 @@ DashPackage _$DashPackageFromJson(Map<String, dynamic> json) {
         ? null
         : DashEncryption.fromJson(json['encryption'] as Map<String, dynamic>),
     periodTriggers: (json['periodTriggers'] as List)
-        ?.map((e) => _$enumDecodeNullable(_$__PeriodTriggersElementEnumMap, e))
+        ?.map((e) => _$enumDecodeNullable(_$PeriodTriggersElementEnumMap, e))
         ?.toList(),
     segmentDurationSeconds: json['segmentDurationSeconds'] as int,
     segmentTemplateFormat: _$enumDecodeNullable(
@@ -245,7 +245,7 @@ Map<String, dynamic> _$DashPackageToJson(DashPackage instance) {
   writeNotNull(
       'periodTriggers',
       instance.periodTriggers
-          ?.map((e) => _$__PeriodTriggersElementEnumMap[e])
+          ?.map((e) => _$PeriodTriggersElementEnumMap[e])
           ?.toList());
   writeNotNull('segmentDurationSeconds', instance.segmentDurationSeconds);
   writeNotNull('segmentTemplateFormat',
@@ -253,8 +253,8 @@ Map<String, dynamic> _$DashPackageToJson(DashPackage instance) {
   return val;
 }
 
-const _$__PeriodTriggersElementEnumMap = {
-  __PeriodTriggersElement.ads: 'ADS',
+const _$PeriodTriggersElementEnumMap = {
+  PeriodTriggersElement.ads: 'ADS',
 };
 
 const _$SegmentTemplateFormatEnumMap = {

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -56,14 +56,16 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(
         createApplicationRequest, 'createApplicationRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: createApplicationRequest,
       method: 'POST',
       requestUri: '/v1/apps',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateAppResponse.fromJson(
-        {...response, 'ApplicationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateAppResponse(
+      applicationResponse: ApplicationResponse.fromJson($json),
+    );
   }
 
   /// Creates a new campaign for an application or updates the settings of an
@@ -86,15 +88,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(writeCampaignRequest, 'writeCampaignRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeCampaignRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateCampaignResponse.fromJson(
-        {...response, 'CampaignResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateCampaignResponse(
+      campaignResponse: CampaignResponse.fromJson($json),
+    );
   }
 
   /// Creates a message template for messages that are sent through the email
@@ -117,15 +121,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(emailTemplateRequest, 'emailTemplateRequest');
     ArgumentError.checkNotNull(templateName, 'templateName');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: emailTemplateRequest,
       method: 'POST',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/email',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateEmailTemplateResponse.fromJson(
-        {...response, 'CreateTemplateMessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateEmailTemplateResponse(
+      createTemplateMessageBody: CreateTemplateMessageBody.fromJson($json),
+    );
   }
 
   /// Creates an export job for an application.
@@ -147,15 +153,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(exportJobRequest, 'exportJobRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: exportJobRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/export',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateExportJobResponse.fromJson(
-        {...response, 'ExportJobResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateExportJobResponse(
+      exportJobResponse: ExportJobResponse.fromJson($json),
+    );
   }
 
   /// Creates an import job for an application.
@@ -177,15 +185,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(importJobRequest, 'importJobRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: importJobRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/import',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateImportJobResponse.fromJson(
-        {...response, 'ImportJobResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateImportJobResponse(
+      importJobResponse: ImportJobResponse.fromJson($json),
+    );
   }
 
   /// Creates a journey for an application.
@@ -207,15 +217,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(writeJourneyRequest, 'writeJourneyRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeJourneyRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateJourneyResponse.fromJson(
-        {...response, 'JourneyResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateJourneyResponse(
+      journeyResponse: JourneyResponse.fromJson($json),
+    );
   }
 
   /// Creates a message template for messages that are sent through a push
@@ -240,15 +252,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(
         pushNotificationTemplateRequest, 'pushNotificationTemplateRequest');
     ArgumentError.checkNotNull(templateName, 'templateName');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: pushNotificationTemplateRequest,
       method: 'POST',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/push',
       exceptionFnMap: _exceptionFns,
     );
-    return CreatePushTemplateResponse.fromJson(
-        {...response, 'CreateTemplateMessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreatePushTemplateResponse(
+      createTemplateMessageBody: CreateTemplateMessageBody.fromJson($json),
+    );
   }
 
   /// Creates an Amazon Pinpoint configuration for a recommender model.
@@ -266,14 +280,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(
         createRecommenderConfiguration, 'createRecommenderConfiguration');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: createRecommenderConfiguration,
       method: 'POST',
       requestUri: '/v1/recommenders',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateRecommenderConfigurationResponse.fromJson(
-        {...response, 'RecommenderConfigurationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateRecommenderConfigurationResponse(
+      recommenderConfigurationResponse:
+          RecommenderConfigurationResponse.fromJson($json),
+    );
   }
 
   /// Creates a new segment for an application or updates the configuration,
@@ -297,15 +314,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(writeSegmentRequest, 'writeSegmentRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeSegmentRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateSegmentResponse.fromJson(
-        {...response, 'SegmentResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateSegmentResponse(
+      segmentResponse: SegmentResponse.fromJson($json),
+    );
   }
 
   /// Creates a message template for messages that are sent through the SMS
@@ -328,15 +347,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(sMSTemplateRequest, 'sMSTemplateRequest');
     ArgumentError.checkNotNull(templateName, 'templateName');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: sMSTemplateRequest,
       method: 'POST',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/sms',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateSmsTemplateResponse.fromJson(
-        {...response, 'CreateTemplateMessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateSmsTemplateResponse(
+      createTemplateMessageBody: CreateTemplateMessageBody.fromJson($json),
+    );
   }
 
   /// Creates a message template for messages that are sent through the voice
@@ -359,15 +380,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(templateName, 'templateName');
     ArgumentError.checkNotNull(voiceTemplateRequest, 'voiceTemplateRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: voiceTemplateRequest,
       method: 'POST',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/voice',
       exceptionFnMap: _exceptionFns,
     );
-    return CreateVoiceTemplateResponse.fromJson(
-        {...response, 'CreateTemplateMessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return CreateVoiceTemplateResponse(
+      createTemplateMessageBody: CreateTemplateMessageBody.fromJson($json),
+    );
   }
 
   /// Disables the ADM channel for an application and deletes any existing
@@ -389,15 +412,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/adm',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteAdmChannelResponse.fromJson(
-        {...response, 'ADMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteAdmChannelResponse(
+      aDMChannelResponse: ADMChannelResponse.fromJson($json),
+    );
   }
 
   /// Disables the APNs channel for an application and deletes any existing
@@ -419,15 +444,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteApnsChannelResponse.fromJson(
-        {...response, 'APNSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteApnsChannelResponse(
+      aPNSChannelResponse: APNSChannelResponse.fromJson($json),
+    );
   }
 
   /// Disables the APNs sandbox channel for an application and deletes any
@@ -449,15 +476,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteApnsSandboxChannelResponse.fromJson(
-        {...response, 'APNSSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteApnsSandboxChannelResponse(
+      aPNSSandboxChannelResponse: APNSSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Disables the APNs VoIP channel for an application and deletes any existing
@@ -479,15 +508,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteApnsVoipChannelResponse.fromJson(
-        {...response, 'APNSVoipChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteApnsVoipChannelResponse(
+      aPNSVoipChannelResponse: APNSVoipChannelResponse.fromJson($json),
+    );
   }
 
   /// Disables the APNs VoIP sandbox channel for an application and deletes any
@@ -509,15 +540,18 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteApnsVoipSandboxChannelResponse.fromJson(
-        {...response, 'APNSVoipSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteApnsVoipSandboxChannelResponse(
+      aPNSVoipSandboxChannelResponse:
+          APNSVoipSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes an application.
@@ -538,14 +572,16 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri: '/v1/apps/${Uri.encodeComponent(applicationId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteAppResponse.fromJson(
-        {...response, 'ApplicationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteAppResponse(
+      applicationResponse: ApplicationResponse.fromJson($json),
+    );
   }
 
   /// Disables the Baidu channel for an application and deletes any existing
@@ -567,15 +603,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/baidu',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteBaiduChannelResponse.fromJson(
-        {...response, 'BaiduChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteBaiduChannelResponse(
+      baiduChannelResponse: BaiduChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes a campaign from an application.
@@ -601,15 +639,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(campaignId, 'campaignId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteCampaignResponse.fromJson(
-        {...response, 'CampaignResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteCampaignResponse(
+      campaignResponse: CampaignResponse.fromJson($json),
+    );
   }
 
   /// Disables the email channel for an application and deletes any existing
@@ -631,15 +671,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/email',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteEmailChannelResponse.fromJson(
-        {...response, 'EmailChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteEmailChannelResponse(
+      emailChannelResponse: EmailChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes a message template for messages that were sent through the email
@@ -699,15 +741,17 @@ class Pinpoint {
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/email$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteEmailTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteEmailTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Deletes an endpoint from an application.
@@ -733,15 +777,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(endpointId, 'endpointId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/endpoints/${Uri.encodeComponent(endpointId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteEndpointResponse.fromJson(
-        {...response, 'EndpointResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteEndpointResponse(
+      endpointResponse: EndpointResponse.fromJson($json),
+    );
   }
 
   /// Deletes the event stream for an application.
@@ -762,15 +808,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/eventstream',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteEventStreamResponse.fromJson(
-        {...response, 'EventStream': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteEventStreamResponse(
+      eventStream: EventStream.fromJson($json),
+    );
   }
 
   /// Disables the GCM channel for an application and deletes any existing
@@ -792,15 +840,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/gcm',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteGcmChannelResponse.fromJson(
-        {...response, 'GCMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteGcmChannelResponse(
+      gCMChannelResponse: GCMChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes a journey from an application.
@@ -826,15 +876,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(journeyId, 'journeyId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteJourneyResponse.fromJson(
-        {...response, 'JourneyResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteJourneyResponse(
+      journeyResponse: JourneyResponse.fromJson($json),
+    );
   }
 
   /// Deletes a message template for messages that were sent through a push
@@ -894,15 +946,17 @@ class Pinpoint {
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/push$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeletePushTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeletePushTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Deletes an Amazon Pinpoint configuration for a recommender model.
@@ -925,15 +979,18 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(recommenderId, 'recommenderId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/recommenders/${Uri.encodeComponent(recommenderId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteRecommenderConfigurationResponse.fromJson(
-        {...response, 'RecommenderConfigurationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteRecommenderConfigurationResponse(
+      recommenderConfigurationResponse:
+          RecommenderConfigurationResponse.fromJson($json),
+    );
   }
 
   /// Deletes a segment from an application.
@@ -959,15 +1016,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(segmentId, 'segmentId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteSegmentResponse.fromJson(
-        {...response, 'SegmentResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteSegmentResponse(
+      segmentResponse: SegmentResponse.fromJson($json),
+    );
   }
 
   /// Disables the SMS channel for an application and deletes any existing
@@ -989,15 +1048,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/sms',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteSmsChannelResponse.fromJson(
-        {...response, 'SMSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteSmsChannelResponse(
+      sMSChannelResponse: SMSChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes a message template for messages that were sent through the SMS
@@ -1057,15 +1118,17 @@ class Pinpoint {
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/sms$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteSmsTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteSmsTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Deletes all the endpoints that are associated with a specific user ID.
@@ -1091,15 +1154,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/users/${Uri.encodeComponent(userId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteUserEndpointsResponse.fromJson(
-        {...response, 'EndpointsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteUserEndpointsResponse(
+      endpointsResponse: EndpointsResponse.fromJson($json),
+    );
   }
 
   /// Disables the voice channel for an application and deletes any existing
@@ -1121,15 +1186,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/voice',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVoiceChannelResponse.fromJson(
-        {...response, 'VoiceChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVoiceChannelResponse(
+      voiceChannelResponse: VoiceChannelResponse.fromJson($json),
+    );
   }
 
   /// Deletes a message template for messages that were sent through the voice
@@ -1189,15 +1256,17 @@ class Pinpoint {
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
     final $payload = <String, dynamic>{};
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'DELETE',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/voice$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return DeleteVoiceTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return DeleteVoiceTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the ADM channel for
@@ -1218,15 +1287,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/adm',
       exceptionFnMap: _exceptionFns,
     );
-    return GetAdmChannelResponse.fromJson(
-        {...response, 'ADMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetAdmChannelResponse(
+      aDMChannelResponse: ADMChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the APNs channel
@@ -1247,15 +1318,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApnsChannelResponse.fromJson(
-        {...response, 'APNSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApnsChannelResponse(
+      aPNSChannelResponse: APNSChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the APNs sandbox
@@ -1276,15 +1349,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApnsSandboxChannelResponse.fromJson(
-        {...response, 'APNSSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApnsSandboxChannelResponse(
+      aPNSSandboxChannelResponse: APNSSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the APNs VoIP
@@ -1305,15 +1380,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApnsVoipChannelResponse.fromJson(
-        {...response, 'APNSVoipChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApnsVoipChannelResponse(
+      aPNSVoipChannelResponse: APNSVoipChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the APNs VoIP
@@ -1334,15 +1411,18 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApnsVoipSandboxChannelResponse.fromJson(
-        {...response, 'APNSVoipSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApnsVoipSandboxChannelResponse(
+      aPNSVoipSandboxChannelResponse:
+          APNSVoipSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about an application.
@@ -1362,14 +1442,16 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/v1/apps/${Uri.encodeComponent(applicationId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetAppResponse.fromJson(
-        {...response, 'ApplicationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetAppResponse(
+      applicationResponse: ApplicationResponse.fromJson($json),
+    );
   }
 
   /// Retrieves (queries) pre-aggregated data for a standard metric that applies
@@ -1436,15 +1518,18 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (startTime != null) _s.toQueryParam('start-time', startTime),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/kpis/daterange/${Uri.encodeComponent(kpiName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApplicationDateRangeKpiResponse.fromJson(
-        {...response, 'ApplicationDateRangeKpiResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApplicationDateRangeKpiResponse(
+      applicationDateRangeKpiResponse:
+          ApplicationDateRangeKpiResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the settings for an application.
@@ -1464,15 +1549,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/settings',
       exceptionFnMap: _exceptionFns,
     );
-    return GetApplicationSettingsResponse.fromJson(
-        {...response, 'ApplicationSettingsResource': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetApplicationSettingsResponse(
+      applicationSettingsResource: ApplicationSettingsResource.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the applications that are associated with
@@ -1503,14 +1590,16 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/v1/apps$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetAppsResponse.fromJson(
-        {...response, 'ApplicationsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetAppsResponse(
+      applicationsResponse: ApplicationsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the Baidu channel
@@ -1531,15 +1620,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/baidu',
       exceptionFnMap: _exceptionFns,
     );
-    return GetBaiduChannelResponse.fromJson(
-        {...response, 'BaiduChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetBaiduChannelResponse(
+      baiduChannelResponse: BaiduChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -1565,15 +1656,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(campaignId, 'campaignId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignResponse.fromJson(
-        {...response, 'CampaignResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignResponse(
+      campaignResponse: CampaignResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the activities for a campaign.
@@ -1614,15 +1707,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}/activities$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignActivitiesResponse.fromJson(
-        {...response, 'ActivitiesResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignActivitiesResponse(
+      activitiesResponse: ActivitiesResponse.fromJson($json),
+    );
   }
 
   /// Retrieves (queries) pre-aggregated data for a standard metric that applies
@@ -1694,15 +1789,18 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (startTime != null) _s.toQueryParam('start-time', startTime),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}/kpis/daterange/${Uri.encodeComponent(kpiName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignDateRangeKpiResponse.fromJson(
-        {...response, 'CampaignDateRangeKpiResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignDateRangeKpiResponse(
+      campaignDateRangeKpiResponse:
+          CampaignDateRangeKpiResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -1733,15 +1831,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(campaignId, 'campaignId');
     ArgumentError.checkNotNull(version, 'version');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}/versions/${Uri.encodeComponent(version.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignVersionResponse.fromJson(
-        {...response, 'CampaignResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignVersionResponse(
+      campaignResponse: CampaignResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -1783,15 +1883,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}/versions$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignVersionsResponse.fromJson(
-        {...response, 'CampaignsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignVersionsResponse(
+      campaignsResponse: CampaignsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -1828,15 +1930,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCampaignsResponse.fromJson(
-        {...response, 'CampaignsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetCampaignsResponse(
+      campaignsResponse: CampaignsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the history and status of each channel for an
@@ -1857,15 +1961,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels',
       exceptionFnMap: _exceptionFns,
     );
-    return GetChannelsResponse.fromJson(
-        {...response, 'ChannelsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetChannelsResponse(
+      channelsResponse: ChannelsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the email channel
@@ -1886,15 +1992,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/email',
       exceptionFnMap: _exceptionFns,
     );
-    return GetEmailChannelResponse.fromJson(
-        {...response, 'EmailChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetEmailChannelResponse(
+      emailChannelResponse: EmailChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves the content and settings of a message template for messages that
@@ -1953,15 +2061,17 @@ class Pinpoint {
     _query = '?${[
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/email$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetEmailTemplateResponse.fromJson(
-        {...response, 'EmailTemplateResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetEmailTemplateResponse(
+      emailTemplateResponse: EmailTemplateResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the settings and attributes of a specific
@@ -1987,15 +2097,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(endpointId, 'endpointId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/endpoints/${Uri.encodeComponent(endpointId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetEndpointResponse.fromJson(
-        {...response, 'EndpointResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetEndpointResponse(
+      endpointResponse: EndpointResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the event stream settings for an application.
@@ -2015,15 +2127,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/eventstream',
       exceptionFnMap: _exceptionFns,
     );
-    return GetEventStreamResponse.fromJson(
-        {...response, 'EventStream': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetEventStreamResponse(
+      eventStream: EventStream.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of a specific export
@@ -2049,15 +2163,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(jobId, 'jobId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/export/${Uri.encodeComponent(jobId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetExportJobResponse.fromJson(
-        {...response, 'ExportJobResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetExportJobResponse(
+      exportJobResponse: ExportJobResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of all the export jobs
@@ -2094,15 +2210,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/export$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetExportJobsResponse.fromJson(
-        {...response, 'ExportJobsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetExportJobsResponse(
+      exportJobsResponse: ExportJobsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the GCM channel for
@@ -2123,15 +2241,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/gcm',
       exceptionFnMap: _exceptionFns,
     );
-    return GetGcmChannelResponse.fromJson(
-        {...response, 'GCMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetGcmChannelResponse(
+      gCMChannelResponse: GCMChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of a specific import
@@ -2157,15 +2277,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(jobId, 'jobId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/import/${Uri.encodeComponent(jobId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetImportJobResponse.fromJson(
-        {...response, 'ImportJobResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetImportJobResponse(
+      importJobResponse: ImportJobResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of all the import jobs
@@ -2202,15 +2324,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/jobs/import$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetImportJobsResponse.fromJson(
-        {...response, 'ImportJobsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetImportJobsResponse(
+      importJobsResponse: ImportJobsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -2236,15 +2360,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(journeyId, 'journeyId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetJourneyResponse.fromJson(
-        {...response, 'JourneyResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetJourneyResponse(
+      journeyResponse: JourneyResponse.fromJson($json),
+    );
   }
 
   /// Retrieves (queries) pre-aggregated data for a standard engagement metric
@@ -2316,15 +2442,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (startTime != null) _s.toQueryParam('start-time', startTime),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}/kpis/daterange/${Uri.encodeComponent(kpiName.toString())}$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetJourneyDateRangeKpiResponse.fromJson(
-        {...response, 'JourneyDateRangeKpiResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetJourneyDateRangeKpiResponse(
+      journeyDateRangeKpiResponse: JourneyDateRangeKpiResponse.fromJson($json),
+    );
   }
 
   /// Retrieves (queries) pre-aggregated data for a standard execution metric
@@ -2373,15 +2501,18 @@ class Pinpoint {
       if (nextToken != null) _s.toQueryParam('next-token', nextToken),
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}/activities/${Uri.encodeComponent(journeyActivityId.toString())}/execution-metrics$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetJourneyExecutionActivityMetricsResponse.fromJson(
-        {...response, 'JourneyExecutionActivityMetricsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetJourneyExecutionActivityMetricsResponse(
+      journeyExecutionActivityMetricsResponse:
+          JourneyExecutionActivityMetricsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves (queries) pre-aggregated data for a standard execution metric
@@ -2424,15 +2555,18 @@ class Pinpoint {
       if (nextToken != null) _s.toQueryParam('next-token', nextToken),
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}/execution-metrics$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetJourneyExecutionMetricsResponse.fromJson(
-        {...response, 'JourneyExecutionMetricsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetJourneyExecutionMetricsResponse(
+      journeyExecutionMetricsResponse:
+          JourneyExecutionMetricsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves the content and settings of a message template for messages that
@@ -2491,15 +2625,18 @@ class Pinpoint {
     _query = '?${[
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/push$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetPushTemplateResponse.fromJson(
-        {...response, 'PushNotificationTemplateResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetPushTemplateResponse(
+      pushNotificationTemplateResponse:
+          PushNotificationTemplateResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about an Amazon Pinpoint configuration for a
@@ -2521,15 +2658,18 @@ class Pinpoint {
     @_s.required String recommenderId,
   }) async {
     ArgumentError.checkNotNull(recommenderId, 'recommenderId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/recommenders/${Uri.encodeComponent(recommenderId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetRecommenderConfigurationResponse.fromJson(
-        {...response, 'RecommenderConfigurationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetRecommenderConfigurationResponse(
+      recommenderConfigurationResponse:
+          RecommenderConfigurationResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the recommender model configurations that
@@ -2560,14 +2700,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/v1/recommenders$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetRecommenderConfigurationsResponse.fromJson(
-        {...response, 'ListRecommenderConfigurationsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetRecommenderConfigurationsResponse(
+      listRecommenderConfigurationsResponse:
+          ListRecommenderConfigurationsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the configuration, dimension, and other
@@ -2593,15 +2736,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(segmentId, 'segmentId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentResponse.fromJson(
-        {...response, 'SegmentResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentResponse(
+      segmentResponse: SegmentResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the export jobs for
@@ -2643,15 +2788,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}/jobs/export$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentExportJobsResponse.fromJson(
-        {...response, 'ExportJobsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentExportJobsResponse(
+      exportJobsResponse: ExportJobsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the import jobs for
@@ -2693,15 +2840,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}/jobs/import$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentImportJobsResponse.fromJson(
-        {...response, 'ImportJobsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentImportJobsResponse(
+      importJobsResponse: ImportJobsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the configuration, dimension, and other
@@ -2733,15 +2882,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(segmentId, 'segmentId');
     ArgumentError.checkNotNull(version, 'version');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}/versions/${Uri.encodeComponent(version.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentVersionResponse.fromJson(
-        {...response, 'SegmentResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentVersionResponse(
+      segmentResponse: SegmentResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the configuration, dimension, and other
@@ -2784,15 +2935,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}/versions$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentVersionsResponse.fromJson(
-        {...response, 'SegmentsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentVersionsResponse(
+      segmentsResponse: SegmentsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the configuration, dimension, and other
@@ -2829,15 +2982,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSegmentsResponse.fromJson(
-        {...response, 'SegmentsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSegmentsResponse(
+      segmentsResponse: SegmentsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the SMS channel for
@@ -2858,15 +3013,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/sms',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSmsChannelResponse.fromJson(
-        {...response, 'SMSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSmsChannelResponse(
+      sMSChannelResponse: SMSChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves the content and settings of a message template for messages that
@@ -2925,15 +3082,17 @@ class Pinpoint {
     _query = '?${[
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/sms$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetSmsTemplateResponse.fromJson(
-        {...response, 'SMSTemplateResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetSmsTemplateResponse(
+      sMSTemplateResponse: SMSTemplateResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the endpoints that are associated with a
@@ -2959,15 +3118,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(userId, 'userId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/users/${Uri.encodeComponent(userId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetUserEndpointsResponse.fromJson(
-        {...response, 'EndpointsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetUserEndpointsResponse(
+      endpointsResponse: EndpointsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status and settings of the voice channel
@@ -2988,15 +3149,17 @@ class Pinpoint {
     @_s.required String applicationId,
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/voice',
       exceptionFnMap: _exceptionFns,
     );
-    return GetVoiceChannelResponse.fromJson(
-        {...response, 'VoiceChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetVoiceChannelResponse(
+      voiceChannelResponse: VoiceChannelResponse.fromJson($json),
+    );
   }
 
   /// Retrieves the content and settings of a message template for messages that
@@ -3055,15 +3218,17 @@ class Pinpoint {
     _query = '?${[
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/voice$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetVoiceTemplateResponse.fromJson(
-        {...response, 'VoiceTemplateResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return GetVoiceTemplateResponse(
+      voiceTemplateResponse: VoiceTemplateResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about the status, configuration, and other settings
@@ -3100,15 +3265,17 @@ class Pinpoint {
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
       if (token != null) _s.toQueryParam('token', token),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return ListJourneysResponse.fromJson(
-        {...response, 'JourneysResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return ListJourneysResponse(
+      journeysResponse: JourneysResponse.fromJson($json),
+    );
   }
 
   /// Retrieves all the tags (keys and values) that are associated with an
@@ -3120,14 +3287,16 @@ class Pinpoint {
     @_s.required String resourceArn,
   }) async {
     ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/v1/tags/${Uri.encodeComponent(resourceArn.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return ListTagsForResourceResponse.fromJson(
-        {...response, 'TagsModel': response});
+    final $json = await _s.jsonFromResponse(response);
+    return ListTagsForResourceResponse(
+      tagsModel: TagsModel.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the versions of a specific message
@@ -3173,15 +3342,17 @@ class Pinpoint {
       if (nextToken != null) _s.toQueryParam('next-token', nextToken),
       if (pageSize != null) _s.toQueryParam('page-size', pageSize),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/${Uri.encodeComponent(templateType.toString())}/versions$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return ListTemplateVersionsResponse.fromJson(
-        {...response, 'TemplateVersionsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return ListTemplateVersionsResponse(
+      templateVersionsResponse: TemplateVersionsResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about all the message templates that are associated
@@ -3225,14 +3396,16 @@ class Pinpoint {
       if (prefix != null) _s.toQueryParam('prefix', prefix),
       if (templateType != null) _s.toQueryParam('template-type', templateType),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/v1/templates$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return ListTemplatesResponse.fromJson(
-        {...response, 'TemplatesResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return ListTemplatesResponse(
+      templatesResponse: TemplatesResponse.fromJson($json),
+    );
   }
 
   /// Retrieves information about a phone number.
@@ -3248,14 +3421,16 @@ class Pinpoint {
     @_s.required NumberValidateRequest numberValidateRequest,
   }) async {
     ArgumentError.checkNotNull(numberValidateRequest, 'numberValidateRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: numberValidateRequest,
       method: 'POST',
       requestUri: '/v1/phone/number/validate',
       exceptionFnMap: _exceptionFns,
     );
-    return PhoneNumberValidateResponse.fromJson(
-        {...response, 'NumberValidateResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return PhoneNumberValidateResponse(
+      numberValidateResponse: NumberValidateResponse.fromJson($json),
+    );
   }
 
   /// Creates a new event stream for an application or updates the settings of
@@ -3278,15 +3453,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(writeEventStream, 'writeEventStream');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeEventStream,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/eventstream',
       exceptionFnMap: _exceptionFns,
     );
-    return PutEventStreamResponse.fromJson(
-        {...response, 'EventStream': response});
+    final $json = await _s.jsonFromResponse(response);
+    return PutEventStreamResponse(
+      eventStream: EventStream.fromJson($json),
+    );
   }
 
   /// Creates a new event to record for endpoints, or creates or updates
@@ -3309,15 +3486,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(eventsRequest, 'eventsRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: eventsRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/events',
       exceptionFnMap: _exceptionFns,
     );
-    return PutEventsResponse.fromJson(
-        {...response, 'EventsResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return PutEventsResponse(
+      eventsResponse: EventsResponse.fromJson($json),
+    );
   }
 
   /// Removes one or more attributes, of the same attribute type, from all the
@@ -3363,15 +3542,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(attributeType, 'attributeType');
     ArgumentError.checkNotNull(
         updateAttributesRequest, 'updateAttributesRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: updateAttributesRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/attributes/${Uri.encodeComponent(attributeType.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return RemoveAttributesResponse.fromJson(
-        {...response, 'AttributesResource': response});
+    final $json = await _s.jsonFromResponse(response);
+    return RemoveAttributesResponse(
+      attributesResource: AttributesResource.fromJson($json),
+    );
   }
 
   /// Creates and sends a direct message.
@@ -3393,15 +3574,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(messageRequest, 'messageRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: messageRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/messages',
       exceptionFnMap: _exceptionFns,
     );
-    return SendMessagesResponse.fromJson(
-        {...response, 'MessageResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return SendMessagesResponse(
+      messageResponse: MessageResponse.fromJson($json),
+    );
   }
 
   /// Creates and sends a message to a list of users.
@@ -3424,15 +3607,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(
         sendUsersMessageRequest, 'sendUsersMessageRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: sendUsersMessageRequest,
       method: 'POST',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/users-messages',
       exceptionFnMap: _exceptionFns,
     );
-    return SendUsersMessagesResponse.fromJson(
-        {...response, 'SendUsersMessageResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return SendUsersMessagesResponse(
+      sendUsersMessageResponse: SendUsersMessageResponse.fromJson($json),
+    );
   }
 
   /// Adds one or more tags (keys and values) to an application, campaign,
@@ -3504,15 +3689,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(aDMChannelRequest, 'aDMChannelRequest');
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: aDMChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/adm',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateAdmChannelResponse.fromJson(
-        {...response, 'ADMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateAdmChannelResponse(
+      aDMChannelResponse: ADMChannelResponse.fromJson($json),
+    );
   }
 
   /// Enables the APNs channel for an application or updates the status and
@@ -3535,15 +3722,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(aPNSChannelRequest, 'aPNSChannelRequest');
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: aPNSChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateApnsChannelResponse.fromJson(
-        {...response, 'APNSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateApnsChannelResponse(
+      aPNSChannelResponse: APNSChannelResponse.fromJson($json),
+    );
   }
 
   /// Enables the APNs sandbox channel for an application or updates the status
@@ -3567,15 +3756,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(
         aPNSSandboxChannelRequest, 'aPNSSandboxChannelRequest');
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: aPNSSandboxChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateApnsSandboxChannelResponse.fromJson(
-        {...response, 'APNSSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateApnsSandboxChannelResponse(
+      aPNSSandboxChannelResponse: APNSSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Enables the APNs VoIP channel for an application or updates the status and
@@ -3599,15 +3790,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(
         aPNSVoipChannelRequest, 'aPNSVoipChannelRequest');
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: aPNSVoipChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateApnsVoipChannelResponse.fromJson(
-        {...response, 'APNSVoipChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateApnsVoipChannelResponse(
+      aPNSVoipChannelResponse: APNSVoipChannelResponse.fromJson($json),
+    );
   }
 
   /// Enables the APNs VoIP sandbox channel for an application or updates the
@@ -3631,15 +3824,18 @@ class Pinpoint {
     ArgumentError.checkNotNull(
         aPNSVoipSandboxChannelRequest, 'aPNSVoipSandboxChannelRequest');
     ArgumentError.checkNotNull(applicationId, 'applicationId');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: aPNSVoipSandboxChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/apns_voip_sandbox',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateApnsVoipSandboxChannelResponse.fromJson(
-        {...response, 'APNSVoipSandboxChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateApnsVoipSandboxChannelResponse(
+      aPNSVoipSandboxChannelResponse:
+          APNSVoipSandboxChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates the settings for an application.
@@ -3663,15 +3859,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(
         writeApplicationSettingsRequest, 'writeApplicationSettingsRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeApplicationSettingsRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/settings',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateApplicationSettingsResponse.fromJson(
-        {...response, 'ApplicationSettingsResource': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateApplicationSettingsResponse(
+      applicationSettingsResource: ApplicationSettingsResource.fromJson($json),
+    );
   }
 
   /// Enables the Baidu channel for an application or updates the status and
@@ -3694,15 +3892,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(baiduChannelRequest, 'baiduChannelRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: baiduChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/baidu',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateBaiduChannelResponse.fromJson(
-        {...response, 'BaiduChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateBaiduChannelResponse(
+      baiduChannelResponse: BaiduChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates the configuration and other settings for a campaign.
@@ -3729,15 +3929,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(campaignId, 'campaignId');
     ArgumentError.checkNotNull(writeCampaignRequest, 'writeCampaignRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeCampaignRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/campaigns/${Uri.encodeComponent(campaignId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateCampaignResponse.fromJson(
-        {...response, 'CampaignResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateCampaignResponse(
+      campaignResponse: CampaignResponse.fromJson($json),
+    );
   }
 
   /// Enables the email channel for an application or updates the status and
@@ -3760,15 +3962,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(emailChannelRequest, 'emailChannelRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: emailChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/email',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateEmailChannelResponse.fromJson(
-        {...response, 'EmailChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateEmailChannelResponse(
+      emailChannelResponse: EmailChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates an existing message template for messages that are sent through
@@ -3843,15 +4047,17 @@ class Pinpoint {
         _s.toQueryParam('create-new-version', createNewVersion),
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: emailTemplateRequest,
       method: 'PUT',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/email$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateEmailTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateEmailTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Creates a new endpoint for an application or updates the settings and
@@ -3881,15 +4087,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(endpointId, 'endpointId');
     ArgumentError.checkNotNull(endpointRequest, 'endpointRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: endpointRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/endpoints/${Uri.encodeComponent(endpointId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateEndpointResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateEndpointResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Creates a new batch of endpoints for an application or updates the
@@ -3915,15 +4123,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(endpointBatchRequest, 'endpointBatchRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: endpointBatchRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/endpoints',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateEndpointsBatchResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateEndpointsBatchResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Enables the GCM channel for an application or updates the status and
@@ -3946,15 +4156,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(gCMChannelRequest, 'gCMChannelRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: gCMChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/gcm',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateGcmChannelResponse.fromJson(
-        {...response, 'GCMChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateGcmChannelResponse(
+      gCMChannelResponse: GCMChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates the configuration and other settings for a journey.
@@ -3981,15 +4193,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(journeyId, 'journeyId');
     ArgumentError.checkNotNull(writeJourneyRequest, 'writeJourneyRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeJourneyRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateJourneyResponse.fromJson(
-        {...response, 'JourneyResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateJourneyResponse(
+      journeyResponse: JourneyResponse.fromJson($json),
+    );
   }
 
   /// Cancels (stops) an active journey.
@@ -4016,15 +4230,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(journeyId, 'journeyId');
     ArgumentError.checkNotNull(journeyStateRequest, 'journeyStateRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: journeyStateRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/journeys/${Uri.encodeComponent(journeyId.toString())}/state',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateJourneyStateResponse.fromJson(
-        {...response, 'JourneyResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateJourneyStateResponse(
+      journeyResponse: JourneyResponse.fromJson($json),
+    );
   }
 
   /// Updates an existing message template for messages that are sent through a
@@ -4101,15 +4317,17 @@ class Pinpoint {
         _s.toQueryParam('create-new-version', createNewVersion),
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: pushNotificationTemplateRequest,
       method: 'PUT',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/push$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdatePushTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdatePushTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Updates an Amazon Pinpoint configuration for a recommender model.
@@ -4134,15 +4352,18 @@ class Pinpoint {
     ArgumentError.checkNotNull(recommenderId, 'recommenderId');
     ArgumentError.checkNotNull(
         updateRecommenderConfiguration, 'updateRecommenderConfiguration');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: updateRecommenderConfiguration,
       method: 'PUT',
       requestUri:
           '/v1/recommenders/${Uri.encodeComponent(recommenderId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateRecommenderConfigurationResponse.fromJson(
-        {...response, 'RecommenderConfigurationResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateRecommenderConfigurationResponse(
+      recommenderConfigurationResponse:
+          RecommenderConfigurationResponse.fromJson($json),
+    );
   }
 
   /// Creates a new segment for an application or updates the configuration,
@@ -4171,15 +4392,17 @@ class Pinpoint {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(segmentId, 'segmentId');
     ArgumentError.checkNotNull(writeSegmentRequest, 'writeSegmentRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: writeSegmentRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/segments/${Uri.encodeComponent(segmentId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateSegmentResponse.fromJson(
-        {...response, 'SegmentResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateSegmentResponse(
+      segmentResponse: SegmentResponse.fromJson($json),
+    );
   }
 
   /// Enables the SMS channel for an application or updates the status and
@@ -4202,15 +4425,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(sMSChannelRequest, 'sMSChannelRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: sMSChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/sms',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateSmsChannelResponse.fromJson(
-        {...response, 'SMSChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateSmsChannelResponse(
+      sMSChannelResponse: SMSChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates an existing message template for messages that are sent through
@@ -4285,15 +4510,17 @@ class Pinpoint {
         _s.toQueryParam('create-new-version', createNewVersion),
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: sMSTemplateRequest,
       method: 'PUT',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/sms$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateSmsTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateSmsTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Changes the status of a specific version of a message template to
@@ -4325,15 +4552,17 @@ class Pinpoint {
         templateActiveVersionRequest, 'templateActiveVersionRequest');
     ArgumentError.checkNotNull(templateName, 'templateName');
     ArgumentError.checkNotNull(templateType, 'templateType');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: templateActiveVersionRequest,
       method: 'PUT',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/${Uri.encodeComponent(templateType.toString())}/active-version',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateTemplateActiveVersionResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateTemplateActiveVersionResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 
   /// Enables the voice channel for an application or updates the status and
@@ -4356,15 +4585,17 @@ class Pinpoint {
   }) async {
     ArgumentError.checkNotNull(applicationId, 'applicationId');
     ArgumentError.checkNotNull(voiceChannelRequest, 'voiceChannelRequest');
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: voiceChannelRequest,
       method: 'PUT',
       requestUri:
           '/v1/apps/${Uri.encodeComponent(applicationId.toString())}/channels/voice',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVoiceChannelResponse.fromJson(
-        {...response, 'VoiceChannelResponse': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVoiceChannelResponse(
+      voiceChannelResponse: VoiceChannelResponse.fromJson($json),
+    );
   }
 
   /// Updates an existing message template for messages that are sent through
@@ -4439,15 +4670,17 @@ class Pinpoint {
         _s.toQueryParam('create-new-version', createNewVersion),
       if (version != null) _s.toQueryParam('version', version),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: voiceTemplateRequest,
       method: 'PUT',
       requestUri:
           '/v1/templates/${Uri.encodeComponent(templateName.toString())}/voice$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return UpdateVoiceTemplateResponse.fromJson(
-        {...response, 'MessageBody': response});
+    final $json = await _s.jsonFromResponse(response);
+    return UpdateVoiceTemplateResponse(
+      messageBody: MessageBody.fromJson($json),
+    );
   }
 }
 

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -590,14 +590,19 @@ class Polly {
       if (speechMarkTypes != null) 'SpeechMarkTypes': speechMarkTypes,
       if (textType != null) 'TextType': textType?.toValue(),
     };
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: $payload,
       method: 'POST',
       requestUri: '/v1/speech',
       exceptionFnMap: _exceptionFns,
     );
-    return SynthesizeSpeechOutput.fromJson(
-        {...response, 'AudioStream': response});
+    return SynthesizeSpeechOutput(
+      audioStream: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+      requestCharacters: _s.extractHeaderIntValue(
+          response.headers, 'x-amzn-RequestCharacters'),
+    );
   }
 }
 

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -4828,8 +4828,6 @@ class AssociateVPCWithHostedZoneRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       vpc?.toXml('VPC'),
       _s.encodeXmlStringValue('Comment', comment),
     ];
@@ -5036,8 +5034,6 @@ class ChangeResourceRecordSetsRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       changeBatch?.toXml('ChangeBatch'),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -5139,10 +5135,6 @@ class ChangeTagsForResourceRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: ResourceType
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: ResourceId
-      if (1 == 1) throw UnimplementedError(),
       if (addTags != null)
         _s.XmlElement(_s.XmlName('AddTags'), [],
             <_s.XmlNode>[...addTags.map((v) => v.toXml('AddTags'))]),
@@ -5895,8 +5887,6 @@ class CreateTrafficPolicyVersionRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Document', document),
       _s.encodeXmlStringValue('Comment', comment),
     ];
@@ -5957,8 +5947,6 @@ class CreateVPCAssociationAuthorizationRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       vpc?.toXml('VPC'),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -6113,8 +6101,6 @@ class DeleteVPCAssociationAuthorizationRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       vpc?.toXml('VPC'),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -6181,8 +6167,6 @@ class DisassociateVPCFromHostedZoneRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       vpc?.toXml('VPC'),
       _s.encodeXmlStringValue('Comment', comment),
     ];
@@ -8001,8 +7985,6 @@ class ListTagsForResourcesRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: ResourceType
-      if (1 == 1) throw UnimplementedError(),
       if (resourceIds != null)
         _s.XmlElement(_s.XmlName('ResourceIds'), [], <_s.XmlNode>[
           ...resourceIds.map((v) => _s.encodeXmlStringValue('ResourceId', v))
@@ -10213,8 +10195,6 @@ class UpdateHealthCheckRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: HealthCheckId
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlIntValue('HealthCheckVersion', healthCheckVersion),
       _s.encodeXmlStringValue('IPAddress', iPAddress),
       _s.encodeXmlIntValue('Port', port),
@@ -10291,8 +10271,6 @@ class UpdateHostedZoneCommentRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Comment', comment),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -10346,10 +10324,6 @@ class UpdateTrafficPolicyCommentRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: Version
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Comment', comment),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -10407,8 +10381,6 @@ class UpdateTrafficPolicyInstanceRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Id
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlIntValue('TTL', ttl),
       _s.encodeXmlStringValue('TrafficPolicyId', trafficPolicyId),
       _s.encodeXmlIntValue('TrafficPolicyVersion', trafficPolicyVersion),

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -18218,16 +18218,6 @@ class SelectObjectContentRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement uri member: Bucket
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: Key
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement header member: x-amz-server-side-encryption-customer-algorithm
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement header member: x-amz-server-side-encryption-customer-key
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement header member: x-amz-server-side-encryption-customer-key-MD5
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Expression', expression),
       _s.encodeXmlStringValue('ExpressionType', expressionType?.toValue()),
       requestProgress?.toXml('RequestProgress'),

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -1107,10 +1107,6 @@ class CreateAccessPointRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-account-id
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: name
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Bucket', bucket),
       vpcConfiguration?.toXml('VpcConfiguration'),
       publicAccessBlockConfiguration?.toXml('PublicAccessBlockConfiguration'),
@@ -1182,8 +1178,6 @@ class CreateJobRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-account-id
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlBoolValue('ConfirmationRequired', confirmationRequired),
       operation?.toXml('Operation'),
       report?.toXml('Report'),
@@ -2327,10 +2321,6 @@ class PutAccessPointPolicyRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-account-id
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: name
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('Policy', policy),
     ];
     final $attributes = <_s.XmlAttribute>[
@@ -2362,10 +2352,6 @@ class PutJobTaggingRequest {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-account-id
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement uri member: id
-      if (1 == 1) throw UnimplementedError(),
       if (tags != null)
         _s.XmlElement(_s.XmlName('Tags'), [],
             <_s.XmlNode>[...tags.map((v) => v.toXml('Tags'))]),

--- a/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
+++ b/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
@@ -187,7 +187,7 @@ class SageMakerRuntime {
         (v) => headers['X-Amzn-SageMaker-Custom-Attributes'] = v.toString());
     targetModel
         ?.let((v) => headers['X-Amzn-SageMaker-Target-Model'] = v.toString());
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: body,
       headers: headers,
       method: 'POST',
@@ -195,7 +195,15 @@ class SageMakerRuntime {
           '/endpoints/${Uri.encodeComponent(endpointName.toString())}/invocations',
       exceptionFnMap: _exceptionFns,
     );
-    return InvokeEndpointOutput.fromJson({...response, 'Body': response});
+    return InvokeEndpointOutput(
+      body: await response.stream.toBytes(),
+      contentType:
+          _s.extractHeaderStringValue(response.headers, 'Content-Type'),
+      customAttributes: _s.extractHeaderStringValue(
+          response.headers, 'X-Amzn-SageMaker-Custom-Attributes'),
+      invokedProductionVariant: _s.extractHeaderStringValue(
+          response.headers, 'x-Amzn-Invoked-Production-Variant'),
+    );
   }
 }
 

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -407,15 +407,16 @@ class Schemas {
       if (schemaVersion != null)
         _s.toQueryParam('schemaVersion', schemaVersion),
     ].where((e) => e != null).join('&')}';
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri:
           '/v1/registries/name/${Uri.encodeComponent(registryName.toString())}/schemas/name/${Uri.encodeComponent(schemaName.toString())}/language/${Uri.encodeComponent(language.toString())}/source$_query',
       exceptionFnMap: _exceptionFns,
     );
-    return GetCodeBindingSourceResponse.fromJson(
-        {...response, 'Body': response});
+    return GetCodeBindingSourceResponse(
+      body: await response.stream.toBytes(),
+    );
   }
 
   /// Get the discovered schema that was generated based on sampled events.

--- a/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
+++ b/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
@@ -65,14 +65,15 @@ class WorkMailMessageFlow {
       r'''[a-z0-9\-]*''',
       isRequired: true,
     );
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
       requestUri: '/messages/${Uri.encodeComponent(messageId.toString())}',
       exceptionFnMap: _exceptionFns,
     );
-    return GetRawMessageContentResponse.fromJson(
-        {...response, 'messageContent': response});
+    return GetRawMessageContentResponse(
+      messageContent: await response.stream.toBytes(),
+    );
   }
 }
 

--- a/generator/lib/builders/test_suite_builder.dart
+++ b/generator/lib/builders/test_suite_builder.dart
@@ -160,11 +160,6 @@ void _visitExpect(StringBuffer code, String memberTrail, Shape shape,
     if (shape.type == 'timestamp') {
       memberTrail += '.millisecondsSinceEpoch ~/ 1000';
     }
-    if ([shape.location, member?.location].contains('statusCode')) {
-      code.writeln('    // Extraction from statusCode is not supported yet');
-      code.write('    // ');
-    }
-
     code.writeln('expect($memberTrail, $match);');
   }
 }

--- a/generator/lib/model/descriptor.dart
+++ b/generator/lib/model/descriptor.dart
@@ -8,6 +8,12 @@ import 'xml_namespace.dart';
 
 part 'descriptor.g.dart';
 
+abstract class MemberOrDescriptor {
+  Shape get shapeClass;
+  String get locationName;
+  String get timestampFormat;
+}
+
 @JsonSerializable(createToJson: false, disallowUnrecognizedKeys: true)
 class Descriptor {
   @JsonKey(ignore: true)

--- a/generator/lib/model/shape.dart
+++ b/generator/lib/model/shape.dart
@@ -19,6 +19,8 @@ class Shape {
   @JsonKey(ignore: true)
   bool isTopLevelInputEnum = false;
   @JsonKey(ignore: true)
+  bool isTopLevelOutputEnum = false;
+  @JsonKey(ignore: true)
   bool isUsedInOutput = false;
   final String type;
   @JsonKey(name: 'enum')
@@ -128,7 +130,7 @@ class Shape {
 
   bool get hasQueryMembers => queryMembers.isNotEmpty;
 
-  bool get hasNoBodyMembers => _members.where((m) => m.isBody).isEmpty;
+  bool get hasBodyMembers => _members.any((m) => m.isBody);
 
   Iterable<Member> get headerMembers => _members.where((m) => m.isHeader);
 
@@ -160,6 +162,9 @@ class Shape {
   String get className {
     var cn = name.substring(0, 1).toUpperCase() + name.substring(1);
     if (cn == 'Function') cn = '\$$cn';
+
+    cn = cn.replaceAll(RegExp(r'^_+'), '');
+
     return cn;
   }
 
@@ -275,7 +280,9 @@ class Member {
 
   bool get isQuery => location == 'querystring';
 
-  bool get isBody => !isHeader && !isUri && !isQuery;
+  bool get isStatusCode => location == 'statusCode';
+
+  bool get isBody => !isHeader && !isUri && !isQuery && !isStatusCode;
 }
 
 extension NameStuff on String {

--- a/generator/lib/utils/string_utils.dart
+++ b/generator/lib/utils/string_utils.dart
@@ -1,0 +1,2 @@
+String uppercaseName(String value) =>
+    value.substring(0, 1).toUpperCase() + value.substring(1);

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -212,8 +212,16 @@ XmlElement encodeXmlDoubleValue(String name, double value) {
   return encodeXmlStringValue(name, value?.toString());
 }
 
-XmlElement encodeXmlDateTimeValue(String name, DateTime value) {
-  return encodeXmlStringValue(name, value?.toUtc()?.toIso8601String());
+XmlElement encodeXmlDateTimeValue(String name, DateTime value,
+    {String Function(DateTime) formatter}) {
+  value = value?.toUtc();
+
+  String output;
+  if (value != null) {
+    output = formatter != null ? formatter(value) : value.toIso8601String();
+  }
+
+  return encodeXmlStringValue(name, output);
 }
 
 XmlElement encodeXmlUint8ListValue(String name, Uint8List value) {
@@ -281,6 +289,13 @@ class JsonResponse {
   final Map<String, dynamic> body;
 
   JsonResponse(this.headers, this.body);
+}
+
+Future<Map<String, dynamic>> jsonFromResponse(StreamedResponse rs) async {
+  final body = await rs.stream.bytesToString();
+  return body.isEmpty
+      ? <String, dynamic>{}
+      : jsonDecode(body) as Map<String, dynamic>;
 }
 
 void throwException(StreamedResponse rs, String body,

--- a/shared_aws_api/test/fixtures/output/rest-json.json
+++ b/shared_aws_api/test/fixtures/output/rest-json.json
@@ -631,7 +631,6 @@
   },
   {
     "description": "Streaming payload",
-    "skip": "Not implemented",
     "metadata": {
       "protocol": "rest-json"
     },

--- a/shared_aws_api/test/fixtures/output/rest-xml.json
+++ b/shared_aws_api/test/fixtures/output/rest-xml.json
@@ -527,7 +527,6 @@
   },
   {
     "description": "Streaming payload",
-    "skip": "Not implemented",
     "metadata": {
       "protocol": "rest-xml"
     },

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -102,18 +102,12 @@ class InputShape {
   });
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-enum
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('FooEnum', fooEnum?.toValue()),
-// TODO: implement uri member: URIEnum
-      if (1 == 1) throw UnimplementedError(),
       if (listEnums != null)
         _s.XmlElement(_s.XmlName('ListEnums'), [], <_s.XmlNode>[
           ...listEnums
               .map((v) => _s.encodeXmlStringValue('ListEnums', v.toValue()))
         ]),
-// TODO: implement querystring member: ListEnums
-      if (1 == 1) throw UnimplementedError(),
     ];
     final $attributes = <_s.XmlAttribute>[
       ...?attributes,

--- a/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
@@ -107,20 +107,8 @@ class InputShape {
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
       _s.encodeXmlDateTimeValue('TimeArg', timeArg),
-// TODO: implement header member: x-amz-timearg
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement querystring member: TimeQuery
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlDateTimeValue('TimeCustom', timeCustom),
-// TODO: implement header member: x-amz-timecustom-header
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement querystring member: TimeCustomQuery
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlDateTimeValue('TimeFormat', timeFormat),
-// TODO: implement header member: x-amz-timeformat-header
-      if (1 == 1) throw UnimplementedError(),
-// TODO: implement querystring member: TimeFormatQuery
-      if (1 == 1) throw UnimplementedError(),
     ];
     final $attributes = <_s.XmlAttribute>[
       ...?attributes,

--- a/shared_aws_api/test/generated/output/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-json/enum.dart
@@ -42,13 +42,22 @@ class Enum {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/path',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      fooEnum: ($json['FooEnum'] as String)?.toRESTJSONEnumType(),
+      listEnums: ($json['ListEnums'] as List)
+          ?.map((e) => (e as String)?.toRESTJSONEnumType())
+          ?.toList(),
+      headerEnum: _s
+          .extractHeaderStringValue(response.headers, 'x-amz-enum')
+          ?.toRESTJSONEnumType(),
+    );
   }
 
   Future<void> operationName1({
@@ -120,6 +129,24 @@ extension on RESTJSONEnumType {
         return '0';
       case RESTJSONEnumType.$1:
         return '1';
+    }
+    throw Exception('Unknown enum value: $this');
+  }
+}
+
+extension on String {
+  RESTJSONEnumType toRESTJSONEnumType() {
+    switch (this) {
+      case 'foo':
+        return RESTJSONEnumType.foo;
+      case 'bar':
+        return RESTJSONEnumType.bar;
+      case 'baz':
+        return RESTJSONEnumType.baz;
+      case '0':
+        return RESTJSONEnumType.$0;
+      case '1':
+        return RESTJSONEnumType.$1;
     }
     throw Exception('Unknown enum value: $this');
   }

--- a/shared_aws_api/test/generated/output/rest-json/json_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_payload.dart
@@ -42,13 +42,17 @@ class JSONPayload {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson({...response, 'Data': response});
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      data: BodyStructure.fromJson($json),
+      header: _s.extractHeaderStringValue(response.headers, 'X-Foo'),
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
@@ -42,23 +42,35 @@ class JSONValueTrait {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      bodyField: $json['BodyField'] as String,
+      bodyListField:
+          ($json['BodyListField'] as List)?.map((e) => e as String)?.toList(),
+      headerField: _s.extractHeaderStringValue(response.headers, 'X-Amz-Foo'),
+    );
   }
 
   Future<OutputShape> operationName1() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      bodyField: $json['BodyField'] as String,
+      bodyListField:
+          ($json['BodyListField'] as List)?.map((e) => e as String)?.toList(),
+      headerField: _s.extractHeaderStringValue(response.headers, 'X-Amz-Foo'),
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
@@ -42,13 +42,26 @@ class ScalarMembers {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      char: $json['Char'] as String,
+      doubleValue: $json['Double'] as double,
+      falseBool: $json['FalseBool'] as bool,
+      float: $json['Float'] as double,
+      long: $json['Long'] as int,
+      num: $json['Num'] as int,
+      str: $json['Str'] as String,
+      trueBool: $json['TrueBool'] as bool,
+      imaHeader: _s.extractHeaderStringValue(response.headers, 'ImaHeader'),
+      imaHeaderLocation: _s.extractHeaderStringValue(response.headers, 'X-Foo'),
+      status: response.statusCode,
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-json/scalar_members_test.dart
+++ b/shared_aws_api/test/generated/output/rest-json/scalar_members_test.dart
@@ -31,8 +31,7 @@ void main() {
     expect(output.imaHeaderLocation, "abc");
     expect(output.long, 200);
     expect(output.num, 123);
-    // Extraction from statusCode is not supported yet
-    // expect(output.status, 200);
+    expect(output.status, 200);
     expect(output.str, "myname");
     expect(output.trueBool, true);
 /*

--- a/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
@@ -42,13 +42,15 @@ class StreamingPayload {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson({...response, 'Stream': response});
+    return OutputShape(
+      stream: await response.stream.toBytes(),
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-json/streaming_payload_test.dart
+++ b/shared_aws_api/test/generated/output/rest-json/streaming_payload_test.dart
@@ -26,5 +26,5 @@ void main() {
   "Stream": "abc"
 }
 */
-  }, skip: r'''Not implemented''');
+  });
 }

--- a/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
+++ b/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
@@ -42,13 +42,17 @@ class SupportsHeaderMaps {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      allHeaders: _s.extractHeaderMapValues(response.headers, 'AllHeaders'),
+      prefixedHeaders: _s.extractHeaderMapValues(response.headers, 'X-'),
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
@@ -42,13 +42,28 @@ class TimestampMembers {
         );
 
   Future<OutputShape> operationName0() async {
-    final response = await _protocol.send(
+    final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
       requestUri: '/',
       exceptionFnMap: _exceptionFns,
     );
-    return OutputShape.fromJson(response);
+    final $json = await _s.jsonFromResponse(response);
+    return OutputShape(
+      structMember:
+          TimeContainer.fromJson($json['StructMember'] as Map<String, dynamic>),
+      timeArg: unixTimestampFromJson($json['TimeArg'] as int),
+      timeCustom: rfc822FromJson($json['TimeCustom'] as String),
+      timeFormat: iso8601FromJson($json['TimeFormat'] as String),
+      timeArgInHeader:
+          _s.extractHeaderDateTimeValue(response.headers, 'x-amz-timearg'),
+      timeCustomInHeader: _s.extractHeaderDateTimeValue(
+          response.headers, 'x-amz-timecustom',
+          parser: _s.unixTimestampFromJson),
+      timeFormatInHeader: _s.extractHeaderDateTimeValue(
+          response.headers, 'x-amz-timeformat',
+          parser: _s.iso8601FromJson),
+    );
   }
 }
 

--- a/shared_aws_api/test/generated/output/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/enum.dart
@@ -87,8 +87,6 @@ class OutputShape {
 
   _s.XmlElement toXml(String elemName, {List<_s.XmlAttribute> attributes}) {
     final $children = <_s.XmlNode>[
-// TODO: implement header member: x-amz-enum
-      if (1 == 1) throw UnimplementedError(),
       _s.encodeXmlStringValue('FooEnum', fooEnum?.toValue()),
       if (listEnums != null)
         _s.XmlElement(_s.XmlName('ListEnums'), [], <_s.XmlNode>[

--- a/shared_aws_api/test/generated/output/rest-xml/streaming_payload_test.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/streaming_payload_test.dart
@@ -26,5 +26,5 @@ void main() {
   "Stream": "abc"
 }
 */
-  }, skip: r'''Not implemented''');
+  });
 }

--- a/shared_aws_api/test/utils.dart
+++ b/shared_aws_api/test/utils.dart
@@ -23,12 +23,12 @@ class _JsonEqual extends _FeatureMatcher<String> {
 
   @override
   bool typedMatches(String item, Map matchState) {
-    if (item == null || item.isEmpty) {
+    if (item == null || item.isEmpty || _expected == null) {
       return equals(_expected).matches(item, matchState);
     }
     final expectedJson = _tryParseJson(_expected);
     if (expectedJson == null) {
-      return equals(_expected).matches(item, matchState);
+      return equals(_expected.codeUnits).matches(item, matchState);
     }
 
     final itemJson = _tryParseJson(item);


### PR DESCRIPTION
This change is to fix 2 things:

### Blob payload in Rest-Json protocol

Some rest-json endpoints have raw bytes in the http response body and thus should not be json decoded.

I expose a `Future<http.Response> sendRaw()` method in the protocol so the generated operation can directly read the bytes of the response.

The Rest-xml protocol has the same problem and will need this change too in the future.

### Headers data in Rest-Json

Before this change, the `response.headers` are merged with the decoded json body. The new map is passed to the fromJson() factory (generated by json_serializable).

This is actually wrong. `response.headers` is a `Map<String, String>`. The values are not encoded in json and only String values would  work (other types throws a cast error).
I couldn't find a simple workaround. I went to generate the full extraction of json keys and headers inside the operation method. This also requires to generate the enum helpers for this cases.

Let me know if you have any concern.
