### PR TITLE
Use Uint8List for blob in query protocol

### DIFF
--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -3716,14 +3716,14 @@ class GetMetricStatisticsOutput {
 
 class GetMetricWidgetImageOutput {
   /// The image of the graph, in the output format specified.
-  final String metricWidgetImage;
+  final Uint8List metricWidgetImage;
 
   GetMetricWidgetImageOutput({
     this.metricWidgetImage,
   });
   factory GetMetricWidgetImageOutput.fromXml(_s.XmlElement elem) {
     return GetMetricWidgetImageOutput(
-      metricWidgetImage: _s.extractXmlStringValue(elem, 'MetricWidgetImage'),
+      metricWidgetImage: _s.extractXmlUint8ListValue(elem, 'MetricWidgetImage'),
     );
   }
 }

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -13255,7 +13255,7 @@ class GetContextKeysForPolicyResponse {
 /// Contains the response to a successful <a>GetCredentialReport</a> request.
 class GetCredentialReportResponse {
   /// Contains the credential report. The report is Base64-encoded.
-  final String content;
+  final Uint8List content;
 
   /// The date and time when the credential report was created, in <a
   /// href="http://www.iso.org/iso/iso8601">ISO 8601 date-time format</a>.
@@ -13271,7 +13271,7 @@ class GetCredentialReportResponse {
   });
   factory GetCredentialReportResponse.fromXml(_s.XmlElement elem) {
     return GetCredentialReportResponse(
-      content: _s.extractXmlStringValue(elem, 'Content'),
+      content: _s.extractXmlUint8ListValue(elem, 'Content'),
       generatedTime: _s.extractXmlDateTimeValue(elem, 'GeneratedTime'),
       reportFormat:
           _s.extractXmlStringValue(elem, 'ReportFormat')?.toReportFormatType(),
@@ -17057,7 +17057,7 @@ class VirtualMFADevice {
   /// The base32 seed defined as specified in <a
   /// href="https://tools.ietf.org/html/rfc3548.txt">RFC3548</a>. The
   /// <code>Base32StringSeed</code> is base64-encoded.
-  final String base32StringSeed;
+  final Uint8List base32StringSeed;
 
   /// The date and time on which the virtual MFA device was enabled.
   final DateTime enableDate;
@@ -17068,7 +17068,7 @@ class VirtualMFADevice {
   /// arguments. <code>AccountName</code> is the user name if set (otherwise, the
   /// account ID otherwise), and <code>Base32String</code> is the seed in base32
   /// format. The <code>Base32String</code> value is base64-encoded.
-  final String qRCodePNG;
+  final Uint8List qRCodePNG;
 
   /// The IAM user associated with this virtual MFA device.
   final User user;
@@ -17083,9 +17083,9 @@ class VirtualMFADevice {
   factory VirtualMFADevice.fromXml(_s.XmlElement elem) {
     return VirtualMFADevice(
       serialNumber: _s.extractXmlStringValue(elem, 'SerialNumber'),
-      base32StringSeed: _s.extractXmlStringValue(elem, 'Base32StringSeed'),
+      base32StringSeed: _s.extractXmlUint8ListValue(elem, 'Base32StringSeed'),
       enableDate: _s.extractXmlDateTimeValue(elem, 'EnableDate'),
-      qRCodePNG: _s.extractXmlStringValue(elem, 'QRCodePNG'),
+      qRCodePNG: _s.extractXmlUint8ListValue(elem, 'QRCodePNG'),
       user: _s.extractXmlChild(elem, 'User')?.let((e) => User.fromXml(e)),
     );
   }

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -5910,8 +5910,9 @@ class RawMessage {
   /// For more information, go to the <a
   /// href="https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-raw.html">Amazon
   /// SES Developer Guide</a>.
+  @Uint8ListConverter()
   @_s.JsonKey(name: 'Data')
-  final String data;
+  final Uint8List data;
 
   RawMessage({
     @_s.required this.data,

--- a/generated/aws_ses_api/lib/email-2010-12-01.g.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.g.dart
@@ -327,7 +327,7 @@ Map<String, dynamic> _$RawMessageToJson(RawMessage instance) {
     }
   }
 
-  writeNotNull('Data', instance.data);
+  writeNotNull('Data', const Uint8ListConverter().toJson(instance.data));
   return val;
 }
 

--- a/generated/aws_sns_api/lib/sns-2010-03-31.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.dart
@@ -2490,8 +2490,9 @@ class MessageAttributeValue {
 
   /// Binary type attributes can store any binary data, for example, compressed
   /// data, encrypted data, or images.
+  @Uint8ListConverter()
   @_s.JsonKey(name: 'BinaryValue')
-  final String binaryValue;
+  final Uint8List binaryValue;
 
   /// Strings are Unicode with UTF8 binary encoding. For a list of code values,
   /// see <a

--- a/generated/aws_sns_api/lib/sns-2010-03-31.g.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.g.dart
@@ -17,7 +17,8 @@ Map<String, dynamic> _$MessageAttributeValueToJson(
   }
 
   writeNotNull('DataType', instance.dataType);
-  writeNotNull('BinaryValue', instance.binaryValue);
+  writeNotNull(
+      'BinaryValue', const Uint8ListConverter().toJson(instance.binaryValue));
   writeNotNull('StringValue', instance.stringValue);
   return val;
 }

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -2550,13 +2550,15 @@ class MessageAttributeValue {
   final String dataType;
 
   /// Not implemented. Reserved for future use.
+  @Uint8ListListConverter()
   @_s.JsonKey(name: 'BinaryListValue')
-  final List<String> binaryListValues;
+  final List<Uint8List> binaryListValues;
 
   /// Binary type attributes can store any binary data, such as compressed data,
   /// encrypted data, or images.
+  @Uint8ListConverter()
   @_s.JsonKey(name: 'BinaryValue')
-  final String binaryValue;
+  final Uint8List binaryValue;
 
   /// Not implemented. Reserved for future use.
   @_s.JsonKey(name: 'StringListValue')
@@ -2579,8 +2581,9 @@ class MessageAttributeValue {
   factory MessageAttributeValue.fromXml(_s.XmlElement elem) {
     return MessageAttributeValue(
       dataType: _s.extractXmlStringValue(elem, 'DataType'),
-      binaryListValues: _s.extractXmlStringListValues(elem, 'BinaryListValue'),
-      binaryValue: _s.extractXmlStringValue(elem, 'BinaryValue'),
+      binaryListValues:
+          _s.extractXmlUint8ListListValues(elem, 'BinaryListValue'),
+      binaryValue: _s.extractXmlUint8ListValue(elem, 'BinaryValue'),
       stringListValues: _s.extractXmlStringListValues(elem, 'StringListValue'),
       stringValue: _s.extractXmlStringValue(elem, 'StringValue'),
     );
@@ -2672,13 +2675,15 @@ class MessageSystemAttributeValue {
   final String dataType;
 
   /// Not implemented. Reserved for future use.
+  @Uint8ListListConverter()
   @_s.JsonKey(name: 'BinaryListValue')
-  final List<String> binaryListValues;
+  final List<Uint8List> binaryListValues;
 
   /// Binary type attributes can store any binary data, such as compressed data,
   /// encrypted data, or images.
+  @Uint8ListConverter()
   @_s.JsonKey(name: 'BinaryValue')
-  final String binaryValue;
+  final Uint8List binaryValue;
 
   /// Not implemented. Reserved for future use.
   @_s.JsonKey(name: 'StringListValue')

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.g.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.g.dart
@@ -48,8 +48,10 @@ Map<String, dynamic> _$MessageAttributeValueToJson(
   }
 
   writeNotNull('DataType', instance.dataType);
-  writeNotNull('BinaryListValue', instance.binaryListValues);
-  writeNotNull('BinaryValue', instance.binaryValue);
+  writeNotNull('BinaryListValue',
+      const Uint8ListListConverter().toJson(instance.binaryListValues));
+  writeNotNull(
+      'BinaryValue', const Uint8ListConverter().toJson(instance.binaryValue));
   writeNotNull('StringListValue', instance.stringListValues);
   writeNotNull('StringValue', instance.stringValue);
   return val;
@@ -66,8 +68,10 @@ Map<String, dynamic> _$MessageSystemAttributeValueToJson(
   }
 
   writeNotNull('DataType', instance.dataType);
-  writeNotNull('BinaryListValue', instance.binaryListValues);
-  writeNotNull('BinaryValue', instance.binaryValue);
+  writeNotNull('BinaryListValue',
+      const Uint8ListListConverter().toJson(instance.binaryListValues));
+  writeNotNull(
+      'BinaryValue', const Uint8ListConverter().toJson(instance.binaryValue));
   writeNotNull('StringListValue', instance.stringListValues);
   writeNotNull('StringValue', instance.stringValue);
   return val;

--- a/generator/lib/builders/test_suite_builder.dart
+++ b/generator/lib/builders/test_suite_builder.dart
@@ -209,9 +209,7 @@ String _buildParameters(Shape shape, Member member, Object params,
     if (shape.enumeration != null) {
       if (params is String && params.isEmpty) return 'null';
       return '${shape.className}.${toEnumerationFieldName('$params')}';
-    } else if (shape.type == 'blob' &&
-        params is String &&
-        !shape.api.usesQueryProtocol) {
+    } else if (shape.type == 'blob' && params is String) {
       return "Uint8List.fromList('$params'.codeUnits)";
     } else if (shape.type == 'timestamp') {
       return 'DateTime.fromMillisecondsSinceEpoch($params * 1000)';

--- a/generator/lib/model/dart_type.dart
+++ b/generator/lib/model/dart_type.dart
@@ -48,7 +48,6 @@ extension StringStuff on String {
       case 'long':
         return 'int';
       case 'blob':
-        if (api.usesQueryProtocol) return 'String';
         return 'Uint8List';
       case 'timestamp':
         return 'DateTime';

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:meta/meta.dart';
@@ -160,13 +161,18 @@ Iterable<MapEntry<String, String>> _flatten(
     return;
   }
 
+  if (data is Uint8List) {
+    yield MapEntry(prefixes.join('.'), base64Encode(data));
+    return;
+  }
+
   if (data is List) {
     if (data.isEmpty) {
       final key = prefixes.join('.');
       yield MapEntry(key, '');
     } else {
       final member = shapes[shape.member?.shape];
-      final name = shape.member?.locationName ?? member.locationName;
+      final name = shape.member?.locationName ?? member?.locationName;
 
       if (shape.flattened && name != null) {
         prefixes.removeLast();

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
@@ -43,7 +43,7 @@ class Base64EncodedBlobs {
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));
 
   Future<void> operationName0({
-    String blobArg,
+    Uint8List blobArg,
   }) async {
     final $request = <String, dynamic>{};
     blobArg?.also((arg) => $request['BlobArg'] = arg);

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
@@ -43,7 +43,7 @@ class Base64EncodedBlobsNested {
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));
 
   Future<void> operationName0({
-    List<String> blobArgs,
+    List<Uint8List> blobArgs,
   }) async {
     final $request = <String, dynamic>{};
     blobArgs?.also((arg) => $request['BlobArgs'] = arg);

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested_test.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested_test.dart
@@ -25,7 +25,7 @@ void main() {
         credentials: AwsClientCredentials(accessKey: '', secretKey: ''));
 
     await service.operationName0(
-      blobArgs: ["foo"],
+      blobArgs: [Uint8List.fromList('foo'.codeUnits)],
     );
 /*
 {

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_test.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_test.dart
@@ -25,7 +25,7 @@ void main() {
         credentials: AwsClientCredentials(accessKey: '', secretKey: ''));
 
     await service.operationName0(
-      blobArg: "foo",
+      blobArg: Uint8List.fromList('foo'.codeUnits),
     );
 /*
 {

--- a/shared_aws_api/test/generated/output/query/blob.dart
+++ b/shared_aws_api/test/generated/output/query/blob.dart
@@ -59,14 +59,14 @@ class Blob {
 }
 
 class OutputShape {
-  final String blob;
+  final Uint8List blob;
 
   OutputShape({
     this.blob,
   });
   factory OutputShape.fromXml(_s.XmlElement elem) {
     return OutputShape(
-      blob: _s.extractXmlStringValue(elem, 'Blob'),
+      blob: _s.extractXmlUint8ListValue(elem, 'Blob'),
     );
   }
 }


### PR DESCRIPTION
I was wondering why `blob` are generated as `String` in the query protocol instead of `Uint8List`?

So I decided to ask with this pull request :-)