### PR TITLE
Add request.query to the signature

### DIFF
--- a/shared_aws_api/lib/src/protocol/_sign.dart
+++ b/shared_aws_api/lib/src/protocol/_sign.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart';
 import 'package:meta/meta.dart';
 
 import '../credentials.dart';
+import '../utils/query_string.dart';
 import 'endpoint.dart' show ServiceMetadata;
 
 void signAws4HmacSha256({
@@ -32,7 +33,7 @@ void signAws4HmacSha256({
   final canonical = [
     rq.method.toUpperCase(),
     Uri.encodeFull(rq.url.path),
-    '',
+    canonicalQueryParametersAll(rq.url.queryParametersAll),
     ...canonicalHeaders,
     '',
     headerKeys.join(';'),

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -7,6 +7,7 @@ import 'package:shared_aws_api/src/model/shape.dart';
 import 'package:xml/xml.dart';
 
 import '../credentials.dart';
+import '../utils/query_string.dart';
 
 import '_sign.dart';
 import 'endpoint.dart';
@@ -82,7 +83,8 @@ class QueryProtocol {
     String action,
   ) {
     final rq = Request(method, Uri.parse('${_endpoint.url}$requestUri'));
-    rq.body = canonical(flatQueryParams(data, shape, shapes, version, action));
+    rq.body = canonicalQueryParameters(
+        flatQueryParams(data, shape, shapes, version, action));
     rq.headers['Content-Type'] = 'application/x-www-form-urlencoded';
     // TODO: handle if the API is using different signing
     signAws4HmacSha256(
@@ -257,13 +259,4 @@ Iterable<MapEntry<String, String>> _flatten(
 
   throw ArgumentError(
       'Unknown type at "${prefixes.join('.')}": ${data.runtimeType} ($data)');
-}
-
-String canonical(Map<String, String> data) {
-  final list = data.entries
-      .map((e) =>
-          '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
-      .toList();
-  list.sort();
-  return list.join('&');
 }

--- a/shared_aws_api/lib/src/utils/query_string.dart
+++ b/shared_aws_api/lib/src/utils/query_string.dart
@@ -1,0 +1,16 @@
+String canonicalQueryParameters(Map<String, String> query) {
+  return canonicalQueryParametersAll(
+      query.map((key, value) => MapEntry(key, [value])));
+}
+
+String canonicalQueryParametersAll(Map<String, List<String>> query) {
+  final items = <String>[];
+  for (var key in query.keys) {
+    for (var value in query[key]) {
+      items.add(
+          '${Uri.encodeQueryComponent(key)}=${Uri.encodeQueryComponent(value)}');
+    }
+  }
+  items.sort();
+  return items.join('&');
+}

--- a/shared_aws_api/test/utils.dart
+++ b/shared_aws_api/test/utils.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
+import 'package:shared_aws_api/src/utils/query_string.dart';
 import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 
 String pathAndQuery(Uri uri) {
   if (uri.hasQuery && uri.query.isNotEmpty) {
-    return '${uri.path}?${uri.query}';
+    return '${uri.path}?${canonicalQueryParametersAll(uri.queryParametersAll)}';
   }
   return uri.path;
 }
@@ -120,10 +121,13 @@ class _QueryEqual extends _FeatureMatcher<String> {
 
   _QueryEqual(this._expected);
 
+  static String _canonical(String query) {
+    return canonicalQueryParametersAll(Uri(query: query).queryParametersAll);
+  }
+
   @override
   bool typedMatches(String item, Map matchState) {
-    return unorderedEquals(_expected.split('&'))
-        .matches(item.split('&'), matchState);
+    return equals(_canonical(_expected)).matches(_canonical(item), matchState);
   }
 
   @override


### PR DESCRIPTION
Some endpoint with query in the requestUri fails with:
`The request signature we calculated does not match the signature you provided. Check your key and signing method`