### PR TITLE
Add accept header in Rest-Json protocol

### DIFF
--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -60,6 +60,7 @@ class RestJsonProtocol {
         rq.body = json.encode(payload);
       }
     }
+    rq.headers['accept'] = 'application/json';
     if (headers != null) {
       rq.headers.addAll(headers);
     }


### PR DESCRIPTION
The `rest-json` protocol respond differently if the `Accept` header is present or not.

For instance, with the `apigateway-2015-07-09`
```dart
  final apigateway = APIGateway(region: 'eu-west-1');
  final api = await apigateway.getRestApi(restApiId: 'xx');
```

Without Accept: application/json
```json
{
    "_links": "....",
    "apiKeySource": "HEADER",
    "createdDate": "2019-12-05T12:47:19Z",
    "disableExecuteApiEndpoint": false,
    "endpointConfiguration": {
      "vpcEndpointIds": null,
      "types": "EDGE",
      "ipv6": false
    },
    "id": "xxx",
    "..."
  }
```

With Accept: application/json
```json
  {
    "apiKeySource": "HEADER",
    "createdDate": 1575550039,
    "disableExecuteApiEndpoint": false,
    "endpointConfiguration": {
      "ipv6": false,
      "types": [
        "EDGE"
      ]
    },
    "id": "xxx",
    "..."
  }
```

- The date is in the correct format (fixes #288)
- The "types" entry is now (correctly) a json list (previously would fail with a CastError).
