### PR TITLE
Update deps in generator.

### DIFF
--- a/generator/lib/download_command.dart
+++ b/generator/lib/download_command.dart
@@ -37,8 +37,8 @@ class DownloadCommand extends Command {
 }
 
 Future<void> _fetchApiDefinitions(String reference) async {
-  final response = await http
-      .get('https://api.github.com/repos/aws/aws-sdk-js/zipball/$reference');
+  final response = await http.get(
+      Uri.https('api.github.com', '/repos/aws/aws-sdk-js/zipball/$reference'));
   final archive = ZipDecoder().decodeBytes(response.bodyBytes);
   // Extract the contents of the Zip archive to disk.
   for (final file in archive) {

--- a/generator/lib/generate_command.dart
+++ b/generator/lib/generate_command.dart
@@ -9,8 +9,8 @@ import 'package:aws_client.generator/model/api.dart';
 import 'package:aws_client.generator/model_thin/api.dart' as thin;
 import 'package:dart_style/dart_style.dart';
 import 'package:json_annotation/json_annotation.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:path/path.dart' as p;
+import 'package:pedantic/pedantic.dart';
 import 'package:pool/pool.dart';
 import 'package:version/version.dart';
 import 'package:yaml/yaml.dart';
@@ -430,7 +430,8 @@ const Map<String, Map<String, dynamic>> shapesJson = ${jsonEncode(thinApi.toJson
         .listSync(recursive: true)
         .whereType<File>()
         .where((f) => f.path.endsWith('_test.dart'))
-        .map((file) => p.relative(file.path, from: root.path))
+        .map((file) =>
+            p.relative(file.path, from: root.path).replaceAll(p.separator, '/'))
         .toList();
     allFiles.sort();
 

--- a/generator/lib/package_command.dart
+++ b/generator/lib/package_command.dart
@@ -284,7 +284,7 @@ class PublishCommand extends Command {
   }
 
   Future<String> _currentPublishedVersion(Client client, String package) async {
-    final rs = await client.get('https://pub.dev/api/packages/$package');
+    final rs = await client.get(Uri.https('pub.dev', '/api/packages/$package'));
     if (rs.statusCode == 404) return null;
     if (rs.statusCode == 200) {
       final body = json.decode(rs.body);

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -7,21 +7,21 @@ environment:
   sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
-  archive: ^2.0.11
+  archive: ^3.0.0
   args: ^1.5.2
   html: ^0.14.0
   http: ^0.12.0
-  json_annotation: ^3.0.0
+  json_annotation: ^4.0.0
   path: ^1.7.0
   pool: ^1.4.0
-  process_runner: ^3.1.1
+  process_runner: ^4.0.0
 
 dev_dependencies:
   pedantic: ^1.8.0+1
   build_runner: ^1.7.2
   build_verify: ^1.1.1
-  json_serializable: ^3.2.0
+  json_serializable: ^4.1.0
   test: ^1.0.0
   version: ^1.2.0
-  dart_style: ^1.3.3
-  yaml: ^2.2.0
+  dart_style: ^2.0.0
+  yaml: ^3.0.0

--- a/generator/pubspec.yaml
+++ b/generator/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 
 dependencies:
   archive: ^3.0.0
-  args: ^1.5.2
-  html: ^0.14.0
-  http: ^0.12.0
+  args: ^2.2.0
+  html: ^0.15.0
+  http: ^0.13.3
   json_annotation: ^4.0.0
   path: ^1.7.0
   pool: ^1.4.0
@@ -18,10 +18,10 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.8.0+1
-  build_runner: ^1.7.2
-  build_verify: ^1.1.1
-  json_serializable: ^4.1.0
+  build_runner: ^2.1.1
+  build_verify: ^2.0.0
+  json_serializable: ^5.0.0
   test: ^1.0.0
-  version: ^1.2.0
+  version: ^2.0.0
   dart_style: ^2.0.0
   yaml: ^3.0.0


### PR DESCRIPTION
Ran into dependency conflicts in `generator` on a clean checkout (shouldn't the `pubspec.lock` be committed?) so updated everything.

Shockingly, not much needed to be changed for all the major version changes here. Builds cleanly and doesn't generate any diffs in `generated` after `dart run bin/generate.dart generate --download` which seems encouraging, though!

Threw in a fix where the test_all.dart file would be generated with `import 'foo\bar.dart' as ...` on windows.