### PR TITLE
Remove string parameter pattern validation due to regex incompatibility.

### DIFF
--- a/shared_aws_api/CHANGELOG.md
+++ b/shared_aws_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Remove string parameter pattern validation due to regex incompatibility.
+
 ## 1.0.0
 
 - Null safety

--- a/shared_aws_api/lib/src/validation/utils.dart
+++ b/shared_aws_api/lib/src/validation/utils.dart
@@ -1,10 +1,14 @@
+/// This function returns immediately without doing any checks.
+/// The regexes in the API definitions are PCRE regexes which are either
+/// invalid or produce incorrect results in an ECMA compliant regex engine.
 void validateStringPattern(
   String name,
   String? value,
   String pattern, {
   bool isRequired = false,
 }) {
-  if (value == null) {
+  return;
+  /*if (value == null) {
     if (isRequired) {
       throw ArgumentError.notNull(name);
     } else {
@@ -18,7 +22,7 @@ void validateStringPattern(
       name,
       'Argument does not conform to $pattern',
     );
-  }
+  }*/
 }
 
 void validateStringLength(

--- a/shared_aws_api/pubspec.yaml
+++ b/shared_aws_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_aws_api
 description: Shared protocol implementation and utilities for generated AWS API clients.
-version: 1.0.0
+version: 1.0.1
 
 homepage: https://github.com/agilord/aws_client/tree/master/shared_aws_api
 

--- a/shared_aws_api/test/validation/string_validation_test.dart
+++ b/shared_aws_api/test/validation/string_validation_test.dart
@@ -13,7 +13,7 @@ void main() {
               isRequired: true),
           throwsA(TypeMatcher<ArgumentError>()));
     });
-  });
+  }, skip: 'Pattern validation is inactivated due to faulty regexes in definitions');
 
   group('validate string length', () {
     test('null name is ok', () {


### PR DESCRIPTION
As mentioned in #313 , the regexes in the API definitions are PCRE regexes which are either
invalid or produce incorrect results in an ECMA compliant regex engine.