### PR TITLE
Introduce asynchronous credentials

### DIFF
--- a/shared_aws_api/lib/src/credentials.dart
+++ b/shared_aws_api/lib/src/credentials.dart
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
+import 'package:http/http.dart';
 import 'credentials/credentials_io.dart'
     if (dart.library.html) 'credentials/credentials_html.dart';
+
+typedef AwsClientCredentialsProvider = Future<AwsClientCredentials?> Function(
+    {Client? client});
 
 /// AWS credentials.
 class AwsClientCredentials {
@@ -16,11 +20,15 @@ class AwsClientCredentials {
   /// AWS temporary credentials session token
   final String? sessionToken;
 
+  // If applicable, e.g. when credentials are fetched from STS or Cognito
+  final DateTime? expiration;
+
   /// AWS credentials.
   AwsClientCredentials({
     required this.accessKey,
     required this.secretKey,
     this.sessionToken,
+    this.expiration,
   });
 
   static AwsClientCredentials? resolve() => CredentialsUtil.resolve();

--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -1,4 +1,5 @@
 // ignore_for_file: unused_field
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart';
@@ -11,12 +12,12 @@ import 'shared.dart';
 class JsonProtocol {
   final Client _client;
   final Endpoint _endpoint;
-  final AwsClientCredentials _credentials;
+  final AwsClientCredentialsProvider? _credentialsProvider;
 
   JsonProtocol._(
     this._client,
     this._endpoint,
-    this._credentials,
+    this._credentialsProvider,
   );
 
   factory JsonProtocol({
@@ -25,13 +26,21 @@ class JsonProtocol {
     String? region,
     String? endpointUrl,
     AwsClientCredentials? credentials,
+    AwsClientCredentialsProvider? credentialsProvider,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
         service: service, region: region, endpointUrl: endpointUrl);
-    credentials ??= AwsClientCredentials.resolve();
-    ArgumentError.checkNotNull(credentials, 'credentials');
-    return JsonProtocol._(client, endpoint, credentials!);
+
+    // If credentials are provided, override credentials provider
+    if (credentials != null) {
+      credentialsProvider = ({Client? client}) => Future.value(credentials);
+    } else {
+      credentialsProvider ??=
+          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+    }
+
+    return JsonProtocol._(client, endpoint, credentialsProvider);
   }
 
   Future<JsonResponse> send({
@@ -58,11 +67,17 @@ class JsonProtocol {
     }
 
     if (signed) {
+      final credentials = await _credentialsProvider?.call(client: _client);
+
+      if (credentials == null) {
+        throw Exception('credentials for signing request is null');
+      }
+
       signAws4HmacSha256(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,
-        credentials: _credentials,
+        credentials: credentials,
       );
     }
 

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -15,12 +15,12 @@ import 'shared.dart';
 class QueryProtocol {
   final Client _client;
   final Endpoint _endpoint;
-  final AwsClientCredentials _credentials;
+  final AwsClientCredentialsProvider? _credentialsProvider;
 
   QueryProtocol._(
     this._client,
     this._endpoint,
-    this._credentials,
+    this._credentialsProvider,
   );
 
   factory QueryProtocol({
@@ -29,13 +29,21 @@ class QueryProtocol {
     String? region,
     String? endpointUrl,
     AwsClientCredentials? credentials,
+    AwsClientCredentialsProvider? credentialsProvider,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
         service: service, region: region, endpointUrl: endpointUrl);
-    credentials ??= AwsClientCredentials.resolve();
-    ArgumentError.checkNotNull(credentials, 'credentials');
-    return QueryProtocol._(client, endpoint, credentials!);
+
+    // If credentials are provided, override credentials provider
+    if (credentials != null) {
+      credentialsProvider = ({Client? client}) => Future.value(credentials);
+    } else {
+      credentialsProvider ??=
+          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+    }
+
+    return QueryProtocol._(client, endpoint, credentialsProvider);
   }
 
   Future<XmlElement> send(
@@ -50,12 +58,22 @@ class QueryProtocol {
     required String action,
     String? resultWrapper,
   }) async {
-    final rq = _buildRequest(
-        data, method, requestUri, signed, shape, shapes, version, action);
+    final rq = await _buildRequest(
+      data,
+      method,
+      requestUri,
+      signed,
+      shape,
+      shapes,
+      version,
+      action,
+    );
+
     final rs = await _client.send(rq);
     final body = await rs.stream.bytesToString();
     final root = XmlDocument.parse(body);
     var elem = root.rootElement;
+
     if (elem.name.local == 'ErrorResponse') {
       final error = elem.findElements('Error').first;
       final type = error.findElements('Type').first.text;
@@ -67,13 +85,15 @@ class QueryProtocol {
           : GenericAwsException(type: type, code: code, message: message);
       throw exception;
     }
+
     if (resultWrapper != null) {
       elem = elem.findElements(resultWrapper).first;
     }
+
     return elem;
   }
 
-  Request _buildRequest(
+  Future<Request> _buildRequest(
     Map<String, dynamic> data,
     String method,
     String requestUri,
@@ -82,18 +102,25 @@ class QueryProtocol {
     Map<String, Shape> shapes,
     String version,
     String action,
-  ) {
+  ) async {
     final rq = Request(method, Uri.parse('${_endpoint.url}$requestUri'));
     rq.body = canonicalQueryParameters(
         flatQueryParams(data, shape, shapes, version, action));
     rq.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+
     if (signed) {
+      final credentials = await _credentialsProvider?.call(client: _client);
+
+      if (credentials == null) {
+        throw Exception('credentials for signing request is null');
+      }
+
       // TODO: handle if the API is using different signing
       signAws4HmacSha256(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,
-        credentials: _credentials,
+        credentials: credentials,
       );
     }
     return rq;

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -10,12 +10,12 @@ import 'shared.dart';
 class RestJsonProtocol {
   final Client _client;
   final Endpoint _endpoint;
-  final AwsClientCredentials _credentials;
+  final AwsClientCredentialsProvider? _credentialsProvider;
 
   RestJsonProtocol._(
     this._client,
     this._endpoint,
-    this._credentials,
+    this._credentialsProvider,
   );
 
   factory RestJsonProtocol({
@@ -24,13 +24,21 @@ class RestJsonProtocol {
     String? region,
     String? endpointUrl,
     AwsClientCredentials? credentials,
+    AwsClientCredentialsProvider? credentialsProvider,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
         service: service, region: region, endpointUrl: endpointUrl);
-    credentials ??= AwsClientCredentials.resolve();
-    ArgumentError.checkNotNull(credentials, 'credentials');
-    return RestJsonProtocol._(client, endpoint, credentials!);
+
+    // If credentials are provided, override credentials provider
+    if (credentials != null) {
+      credentialsProvider = ({Client? client}) => Future.value(credentials);
+    } else {
+      credentialsProvider ??=
+          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+    }
+
+    return RestJsonProtocol._(client, endpoint, credentialsProvider);
   }
 
   Future<StreamedResponse> sendRaw({
@@ -66,11 +74,17 @@ class RestJsonProtocol {
     }
 
     if (signed) {
+      final credentials = await _credentialsProvider?.call(client: _client);
+
+      if (credentials == null) {
+        throw Exception('credentials for signing request is null');
+      }
+
       signAws4HmacSha256(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,
-        credentials: _credentials,
+        credentials: credentials,
       );
     }
 


### PR DESCRIPTION
I'm splitting up #328 since the activity has been low, perhaps because of PR size.
This is introducing the ability to provide an asynchronous credentials provider to the protocol classes, which evaluates only when requests need to be signed.
This improves a number of use cases:
- When there is no need to provide credentials e.g. in
  - aws_sso_oidc_api
  - aws_sso_api
  - aws_cognito_idp_api
  - aws_cognito_identity_api
- When credentials need to be fetched asynchronously, and updated when they expire (e.g. from assumed roles in STS/logged in users in Cognito).
- Provide all the ways to fetch credentials as separate features split from the shared package (due to circular dependency issues):
  - Cognito
  - STS
  - EC2
  - Web Identity
  - SSO

Adding the `credentialsProvider` to the generated service constructors will come in later PRs