### PR TITLE
Pave way for different signing algorithms

### DIFF
--- a/shared_aws_api/lib/src/credentials.dart
+++ b/shared_aws_api/lib/src/credentials.dart
@@ -5,9 +5,17 @@
 import 'package:http/http.dart';
 import 'credentials/credentials_io.dart'
     if (dart.library.html) 'credentials/credentials_html.dart';
+import 'protocol/endpoint.dart';
 
 typedef AwsClientCredentialsProvider = Future<AwsClientCredentials?> Function(
     {Client? client});
+
+typedef RequestSigner = void Function({
+  required Request rq,
+  required ServiceMetadata service,
+  required String region,
+  required AwsClientCredentials credentials,
+});
 
 /// AWS credentials.
 class AwsClientCredentials {

--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -13,11 +13,13 @@ class JsonProtocol {
   final Client _client;
   final Endpoint _endpoint;
   final AwsClientCredentialsProvider? _credentialsProvider;
+  final RequestSigner _requestSigner;
 
   JsonProtocol._(
     this._client,
     this._endpoint,
     this._credentialsProvider,
+    this._requestSigner,
   );
 
   factory JsonProtocol({
@@ -27,6 +29,7 @@ class JsonProtocol {
     String? endpointUrl,
     AwsClientCredentials? credentials,
     AwsClientCredentialsProvider? credentialsProvider,
+    RequestSigner requestSigner = signAws4HmacSha256,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
@@ -40,7 +43,7 @@ class JsonProtocol {
           ({Client? client}) => Future.value(AwsClientCredentials.resolve());
     }
 
-    return JsonProtocol._(client, endpoint, credentialsProvider);
+    return JsonProtocol._(client, endpoint, credentialsProvider, requestSigner);
   }
 
   Future<JsonResponse> send({
@@ -73,7 +76,7 @@ class JsonProtocol {
         throw Exception('credentials for signing request is null');
       }
 
-      signAws4HmacSha256(
+      _requestSigner(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -16,11 +16,13 @@ class QueryProtocol {
   final Client _client;
   final Endpoint _endpoint;
   final AwsClientCredentialsProvider? _credentialsProvider;
+  final RequestSigner _requestSigner;
 
   QueryProtocol._(
     this._client,
     this._endpoint,
     this._credentialsProvider,
+    this._requestSigner,
   );
 
   factory QueryProtocol({
@@ -30,6 +32,7 @@ class QueryProtocol {
     String? endpointUrl,
     AwsClientCredentials? credentials,
     AwsClientCredentialsProvider? credentialsProvider,
+    RequestSigner requestSigner = signAws4HmacSha256,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
@@ -43,7 +46,8 @@ class QueryProtocol {
           ({Client? client}) => Future.value(AwsClientCredentials.resolve());
     }
 
-    return QueryProtocol._(client, endpoint, credentialsProvider);
+    return QueryProtocol._(
+        client, endpoint, credentialsProvider, requestSigner);
   }
 
   Future<XmlElement> send(
@@ -115,8 +119,7 @@ class QueryProtocol {
         throw Exception('credentials for signing request is null');
       }
 
-      // TODO: handle if the API is using different signing
-      signAws4HmacSha256(
+      _requestSigner(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -11,11 +11,13 @@ class RestJsonProtocol {
   final Client _client;
   final Endpoint _endpoint;
   final AwsClientCredentialsProvider? _credentialsProvider;
+  final RequestSigner _requestSigner;
 
   RestJsonProtocol._(
     this._client,
     this._endpoint,
     this._credentialsProvider,
+    this._requestSigner,
   );
 
   factory RestJsonProtocol({
@@ -25,6 +27,7 @@ class RestJsonProtocol {
     String? endpointUrl,
     AwsClientCredentials? credentials,
     AwsClientCredentialsProvider? credentialsProvider,
+    RequestSigner requestSigner = signAws4HmacSha256,
   }) {
     client ??= Client();
     final endpoint = Endpoint.forProtocol(
@@ -38,7 +41,8 @@ class RestJsonProtocol {
           ({Client? client}) => Future.value(AwsClientCredentials.resolve());
     }
 
-    return RestJsonProtocol._(client, endpoint, credentialsProvider);
+    return RestJsonProtocol._(
+        client, endpoint, credentialsProvider, requestSigner);
   }
 
   Future<StreamedResponse> sendRaw({
@@ -80,7 +84,7 @@ class RestJsonProtocol {
         throw Exception('credentials for signing request is null');
       }
 
-      signAws4HmacSha256(
+      _requestSigner(
         rq: rq,
         service: _endpoint.service,
         region: _endpoint.signingRegion,

--- a/shared_aws_api/test/validation/string_validation_test.dart
+++ b/shared_aws_api/test/validation/string_validation_test.dart
@@ -13,7 +13,9 @@ void main() {
               isRequired: true),
           throwsA(TypeMatcher<ArgumentError>()));
     });
-  }, skip: 'Pattern validation is inactivated due to faulty regexes in definitions');
+  },
+      skip:
+          'Pattern validation is inactivated due to faulty regexes in definitions');
 
   group('validate string length', () {
     test('null name is ok', () {


### PR DESCRIPTION
As per #241, the signing protocols needs to be a little more flexible.
This is making it possible for individual services to pass a different signing function if needed.