### PR TITLE
Add option to pass credentialsProvider in generated services

### DIFF
--- a/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
+++ b/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
@@ -35,6 +35,7 @@ class AccessAnalyzer {
   AccessAnalyzer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -45,6 +46,7 @@ class AccessAnalyzer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_acm_api/lib/acm-2015-12-08.dart
+++ b/generated/aws_acm_api/lib/acm-2015-12-08.dart
@@ -24,6 +24,7 @@ class ACM {
   ACM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class ACM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
+++ b/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
@@ -39,6 +39,7 @@ class ACMPCA {
   ACMPCA({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -48,6 +49,7 @@ class ACMPCA {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
+++ b/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
@@ -33,6 +33,7 @@ class AlexaForBusiness {
   AlexaForBusiness({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -42,6 +43,7 @@ class AlexaForBusiness {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
+++ b/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
@@ -31,6 +31,7 @@ class Amplify {
   Amplify({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -41,6 +42,7 @@ class Amplify {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -28,6 +28,7 @@ class APIGateway {
   APIGateway({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class APIGateway {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
+++ b/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
@@ -29,6 +29,7 @@ class ApiGatewayManagementApi {
   ApiGatewayManagementApi({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class ApiGatewayManagementApi {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -24,6 +24,7 @@ class ApiGatewayV2 {
   ApiGatewayV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class ApiGatewayV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -29,6 +29,7 @@ class AppConfig {
   AppConfig({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class AppConfig {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
+++ b/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
@@ -96,6 +96,7 @@ class ApplicationAutoScaling {
   ApplicationAutoScaling({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -106,6 +107,7 @@ class ApplicationAutoScaling {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
+++ b/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
@@ -28,6 +28,7 @@ class ApplicationInsights {
   ApplicationInsights({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class ApplicationInsights {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -55,6 +55,7 @@ class AppMesh {
   AppMesh({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -65,6 +66,7 @@ class AppMesh {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -42,6 +42,7 @@ class AppMesh {
   AppMesh({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -52,6 +53,7 @@ class AppMesh {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
+++ b/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
@@ -38,6 +38,7 @@ class AppStream {
   AppStream({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -48,6 +49,7 @@ class AppStream {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -25,6 +25,7 @@ class AppSync {
   AppSync({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -35,6 +36,7 @@ class AppSync {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_athena_api/lib/athena-2017-05-18.dart
+++ b/generated/aws_athena_api/lib/athena-2017-05-18.dart
@@ -42,6 +42,7 @@ class Athena {
   Athena({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -51,6 +52,7 @@ class Athena {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -30,6 +30,7 @@ class AutoScaling {
   AutoScaling({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -38,6 +39,7 @@ class AutoScaling {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
+++ b/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
@@ -28,6 +28,7 @@ class AutoScalingPlans {
   AutoScalingPlans({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class AutoScalingPlans {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_backup_api/lib/backup-2018-11-15.dart
+++ b/generated/aws_backup_api/lib/backup-2018-11-15.dart
@@ -27,6 +27,7 @@ class Backup {
   Backup({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class Backup {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_batch_api/lib/batch-2016-08-10.dart
+++ b/generated/aws_batch_api/lib/batch-2016-08-10.dart
@@ -39,6 +39,7 @@ class Batch {
   Batch({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -48,6 +49,7 @@ class Batch {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
+++ b/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
@@ -81,6 +81,7 @@ class Budgets {
   Budgets({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -90,6 +91,7 @@ class Budgets {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ce_api/lib/ce-2017-10-25.dart
+++ b/generated/aws_ce_api/lib/ce-2017-10-25.dart
@@ -41,6 +41,7 @@ class CostExplorer {
   CostExplorer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -51,6 +52,7 @@ class CostExplorer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_chime_api/lib/chime-2018-05-01.dart
+++ b/generated/aws_chime_api/lib/chime-2018-05-01.dart
@@ -66,6 +66,7 @@ class Chime {
   Chime({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -75,6 +76,7 @@ class Chime {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
+++ b/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
@@ -25,6 +25,7 @@ class Cloud9 {
   Cloud9({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class Cloud9 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
@@ -32,6 +32,7 @@ class CloudDirectory {
   CloudDirectory({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -42,6 +43,7 @@ class CloudDirectory {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
@@ -32,6 +32,7 @@ class CloudDirectory {
   CloudDirectory({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -42,6 +43,7 @@ class CloudDirectory {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -33,6 +33,7 @@ class CloudFormation {
   CloudFormation({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -41,6 +42,7 @@ class CloudFormation {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
@@ -28,6 +28,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -37,6 +38,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
@@ -27,6 +27,7 @@ class CloudFront {
   CloudFront({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -36,6 +37,7 @@ class CloudFront {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
+++ b/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
@@ -30,6 +30,7 @@ class CloudHSM {
   CloudHSM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class CloudHSM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
+++ b/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
@@ -27,6 +27,7 @@ class CloudHSMV2 {
   CloudHSMV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class CloudHSMV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -30,6 +30,7 @@ class CloudSearch {
   CloudSearch({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -38,6 +39,7 @@ class CloudSearch {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -30,6 +30,7 @@ class CloudSearch {
   CloudSearch({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -38,6 +39,7 @@ class CloudSearch {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
+++ b/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
@@ -36,6 +36,7 @@ class CloudSearchDomain {
   CloudSearchDomain({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -46,6 +47,7 @@ class CloudSearchDomain {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
+++ b/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
@@ -25,6 +25,7 @@ class CloudTrail {
   CloudTrail({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class CloudTrail {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -42,6 +42,7 @@ class CloudWatch {
   CloudWatch({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -50,6 +51,7 @@ class CloudWatch {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
+++ b/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
@@ -34,6 +34,7 @@ class CodeBuild {
   CodeBuild({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -43,6 +44,7 @@ class CodeBuild {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
+++ b/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
@@ -26,6 +26,7 @@ class CodeCommit {
   CodeCommit({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class CodeCommit {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
+++ b/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
@@ -41,6 +41,7 @@ class CodeGuruReviewer {
   CodeGuruReviewer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -51,6 +52,7 @@ class CodeGuruReviewer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -43,6 +43,7 @@ class CodeGuruProfiler {
   CodeGuruProfiler({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -53,6 +54,7 @@ class CodeGuruProfiler {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
+++ b/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
@@ -29,6 +29,7 @@ class CodePipeline {
   CodePipeline({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class CodePipeline {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
+++ b/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
@@ -26,6 +26,7 @@ class CodeStar {
   CodeStar({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class CodeStar {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
+++ b/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
@@ -27,6 +27,7 @@ class CodeStarconnections {
   CodeStarconnections({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class CodeStarconnections {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
+++ b/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
@@ -95,6 +95,7 @@ class CodeStarNotifications {
   CodeStarNotifications({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -105,6 +106,7 @@ class CodeStarNotifications {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
+++ b/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
@@ -27,6 +27,7 @@ class CognitoIdentity {
   CognitoIdentity({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class CognitoIdentity {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
+++ b/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
@@ -31,6 +31,7 @@ class CognitoIdentityProvider {
   CognitoIdentityProvider({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -40,6 +41,7 @@ class CognitoIdentityProvider {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
+++ b/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
@@ -32,6 +32,7 @@ class CognitoSync {
   CognitoSync({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -41,6 +42,7 @@ class CognitoSync {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
+++ b/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
@@ -27,6 +27,7 @@ class Comprehend {
   Comprehend({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class Comprehend {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
+++ b/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
@@ -25,6 +25,7 @@ class ComprehendMedical {
   ComprehendMedical({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class ComprehendMedical {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
+++ b/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
@@ -38,6 +38,7 @@ class ComputeOptimizer {
   ComputeOptimizer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -48,6 +49,7 @@ class ComputeOptimizer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_configservice_api/lib/config-2014-11-12.dart
+++ b/generated/aws_configservice_api/lib/config-2014-11-12.dart
@@ -33,6 +33,7 @@ class ConfigService {
   ConfigService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -42,6 +43,7 @@ class ConfigService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_connect_api/lib/connect-2017-08-08.dart
+++ b/generated/aws_connect_api/lib/connect-2017-08-08.dart
@@ -46,6 +46,7 @@ class Connect {
   Connect({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -56,6 +57,7 @@ class Connect {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
+++ b/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
@@ -31,6 +31,7 @@ class ConnectParticipant {
   ConnectParticipant({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -41,6 +42,7 @@ class ConnectParticipant {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_cur_api/lib/cur-2017-01-06.dart
+++ b/generated/aws_cur_api/lib/cur-2017-01-06.dart
@@ -41,6 +41,7 @@ class CostandUsageReportService {
   CostandUsageReportService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -51,6 +52,7 @@ class CostandUsageReportService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
+++ b/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
@@ -44,6 +44,7 @@ class DataExchange {
   DataExchange({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -54,6 +55,7 @@ class DataExchange {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
+++ b/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
@@ -45,6 +45,7 @@ class DataPipeline {
   DataPipeline({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -54,6 +55,7 @@ class DataPipeline {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
+++ b/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
@@ -26,6 +26,7 @@ class DataSync {
   DataSync({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class DataSync {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dax_api/lib/dax-2017-04-19.dart
+++ b/generated/aws_dax_api/lib/dax-2017-04-19.dart
@@ -30,6 +30,7 @@ class DAX {
   DAX({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class DAX {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
+++ b/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
@@ -27,6 +27,7 @@ class CodeDeploy {
   CodeDeploy({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class CodeDeploy {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_detective_api/lib/detective-2018-10-26.dart
+++ b/generated/aws_detective_api/lib/detective-2018-10-26.dart
@@ -74,6 +74,7 @@ class Detective {
   Detective({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -84,6 +85,7 @@ class Detective {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
+++ b/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
@@ -44,6 +44,7 @@ class DeviceFarm {
   DeviceFarm({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -53,6 +54,7 @@ class DeviceFarm {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
+++ b/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
@@ -32,6 +32,7 @@ class DirectConnect {
   DirectConnect({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -41,6 +42,7 @@ class DirectConnect {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
+++ b/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
@@ -30,6 +30,7 @@ class ApplicationDiscoveryService {
   ApplicationDiscoveryService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class ApplicationDiscoveryService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
+++ b/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
@@ -26,6 +26,7 @@ class DLM {
   DLM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class DLM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dms_api/lib/dms-2016-01-01.dart
+++ b/generated/aws_dms_api/lib/dms-2016-01-01.dart
@@ -30,6 +30,7 @@ class DatabaseMigrationService {
   DatabaseMigrationService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class DatabaseMigrationService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -27,6 +27,7 @@ class DocDB {
   DocDB({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -36,6 +37,7 @@ class DocDB {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_ds_api/lib/ds-2015-04-16.dart
+++ b/generated/aws_ds_api/lib/ds-2015-04-16.dart
@@ -40,6 +40,7 @@ class DirectoryService {
   DirectoryService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -49,6 +50,7 @@ class DirectoryService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
@@ -28,6 +28,7 @@ class DynamoDB {
   DynamoDB({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class DynamoDB {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
@@ -28,6 +28,7 @@ class DynamoDB {
   DynamoDB({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class DynamoDB {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
@@ -29,6 +29,7 @@ class DynamoDBStreams {
   DynamoDBStreams({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class DynamoDBStreams {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
+++ b/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
@@ -51,6 +51,7 @@ class EBS {
   EBS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -60,6 +61,7 @@ class EBS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
+++ b/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
@@ -27,6 +27,7 @@ class EC2InstanceConnect {
   EC2InstanceConnect({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class EC2InstanceConnect {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
+++ b/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
@@ -30,6 +30,7 @@ class ECR {
   ECR({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -40,6 +41,7 @@ class ECR {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
+++ b/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
@@ -33,6 +33,7 @@ class ECS {
   ECS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -42,6 +43,7 @@ class ECS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
+++ b/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
@@ -30,6 +30,7 @@ class EFS {
   EFS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class EFS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_eks_api/lib/eks-2017-11-01.dart
+++ b/generated/aws_eks_api/lib/eks-2017-11-01.dart
@@ -36,6 +36,7 @@ class EKS {
   EKS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -46,6 +47,7 @@ class EKS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
+++ b/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
@@ -24,6 +24,7 @@ class ElasticInference {
   ElasticInference({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class ElasticInference {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -28,6 +28,7 @@ class ElastiCache {
   ElastiCache({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -36,6 +37,7 @@ class ElastiCache {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -29,6 +29,7 @@ class ElasticBeanstalk {
   ElasticBeanstalk({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -37,6 +38,7 @@ class ElasticBeanstalk {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
+++ b/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
@@ -24,6 +24,7 @@ class ElasticTranscoder {
   ElasticTranscoder({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class ElasticTranscoder {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
+++ b/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
@@ -34,6 +34,7 @@ class ElasticLoadBalancing {
   ElasticLoadBalancing({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -42,6 +43,7 @@ class ElasticLoadBalancing {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -36,6 +36,7 @@ class ElasticLoadBalancingv2 {
   ElasticLoadBalancingv2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -44,6 +45,7 @@ class ElasticLoadBalancingv2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
+++ b/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
@@ -28,6 +28,7 @@ class EMR {
   EMR({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class EMR {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_es_api/lib/es-2015-01-01.dart
+++ b/generated/aws_es_api/lib/es-2015-01-01.dart
@@ -25,6 +25,7 @@ class ElasticsearchService {
   ElasticsearchService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class ElasticsearchService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
+++ b/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
@@ -47,6 +47,7 @@ class EventBridge {
   EventBridge({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -56,6 +57,7 @@ class EventBridge {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_events_api/lib/events-2015-10-07.dart
+++ b/generated/aws_events_api/lib/events-2015-10-07.dart
@@ -47,6 +47,7 @@ class CloudWatchEvents {
   CloudWatchEvents({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -56,6 +57,7 @@ class CloudWatchEvents {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
+++ b/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
@@ -27,6 +27,7 @@ class Firehose {
   Firehose({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class Firehose {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_fms_api/lib/fms-2018-01-01.dart
+++ b/generated/aws_fms_api/lib/fms-2018-01-01.dart
@@ -29,6 +29,7 @@ class FMS {
   FMS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class FMS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
+++ b/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
@@ -24,6 +24,7 @@ class ForecastService {
   ForecastService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class ForecastService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
+++ b/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
@@ -24,6 +24,7 @@ class ForecastQueryService {
   ForecastQueryService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class ForecastQueryService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
+++ b/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
@@ -29,6 +29,7 @@ class FraudDetector {
   FraudDetector({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class FraudDetector {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
+++ b/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
@@ -25,6 +25,7 @@ class FSx {
   FSx({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class FSx {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
+++ b/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
@@ -28,6 +28,7 @@ class GameLift {
   GameLift({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class GameLift {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
+++ b/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
@@ -62,6 +62,7 @@ class Glacier {
   Glacier({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -71,6 +72,7 @@ class Glacier {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
+++ b/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
@@ -29,6 +29,7 @@ class GlobalAccelerator {
   GlobalAccelerator({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class GlobalAccelerator {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_glue_api/lib/glue-2017-03-31.dart
+++ b/generated/aws_glue_api/lib/glue-2017-03-31.dart
@@ -24,6 +24,7 @@ class Glue {
   Glue({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Glue {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
+++ b/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
@@ -30,6 +30,7 @@ class Greengrass {
   Greengrass({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -40,6 +41,7 @@ class Greengrass {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
+++ b/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
@@ -41,6 +41,7 @@ class GreengrassV2 {
   GreengrassV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -50,6 +51,7 @@ class GreengrassV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
+++ b/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
@@ -28,6 +28,7 @@ class GroundStation {
   GroundStation({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class GroundStation {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
+++ b/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
@@ -43,6 +43,7 @@ class GuardDuty {
   GuardDuty({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -53,6 +54,7 @@ class GuardDuty {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_health_api/lib/health-2016-08-04.dart
+++ b/generated/aws_health_api/lib/health-2016-08-04.dart
@@ -37,6 +37,7 @@ class Health {
   Health({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -46,6 +47,7 @@ class Health {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -34,6 +34,7 @@ class IAM {
   IAM({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -42,6 +43,7 @@ class IAM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
+++ b/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
@@ -27,6 +27,7 @@ class Imagebuilder {
   Imagebuilder({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class Imagebuilder {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -32,6 +32,7 @@ class ImportExport {
   ImportExport({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -40,6 +41,7 @@ class ImportExport {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
+++ b/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
@@ -27,6 +27,7 @@ class Inspector {
   Inspector({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -36,6 +37,7 @@ class Inspector {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
+++ b/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
@@ -28,6 +28,7 @@ class IoT1ClickDevicesService {
   IoT1ClickDevicesService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class IoT1ClickDevicesService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
+++ b/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
@@ -24,6 +24,7 @@ class IoT1ClickProjects {
   IoT1ClickProjects({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class IoT1ClickProjects {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iot_api/lib/iot-2015-05-28.dart
+++ b/generated/aws_iot_api/lib/iot-2015-05-28.dart
@@ -30,6 +30,7 @@ class IoT {
   IoT({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -40,6 +41,7 @@ class IoT {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
+++ b/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
@@ -29,6 +29,7 @@ class IoTDataPlane {
   IoTDataPlane({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class IoTDataPlane {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
+++ b/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
@@ -39,6 +39,7 @@ class IoTJobsDataPlane {
   IoTJobsDataPlane({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -49,6 +50,7 @@ class IoTJobsDataPlane {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
+++ b/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
@@ -47,6 +47,7 @@ class IoTAnalytics {
   IoTAnalytics({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -57,6 +58,7 @@ class IoTAnalytics {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
+++ b/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
@@ -27,6 +27,7 @@ class IoTEvents {
   IoTEvents({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class IoTEvents {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
+++ b/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
@@ -27,6 +27,7 @@ class IoTEventsData {
   IoTEventsData({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class IoTEventsData {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
+++ b/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
@@ -25,6 +25,7 @@ class IoTSecureTunneling {
   IoTSecureTunneling({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class IoTSecureTunneling {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
+++ b/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
@@ -29,6 +29,7 @@ class IoTThingsGraph {
   IoTThingsGraph({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class IoTThingsGraph {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
+++ b/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
@@ -26,6 +26,7 @@ class Kafka {
   Kafka({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class Kafka {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
+++ b/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
@@ -24,6 +24,7 @@ class Kendra {
   Kendra({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class Kendra {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
+++ b/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
@@ -25,6 +25,7 @@ class Kinesis {
   Kinesis({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class Kinesis {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -24,6 +24,7 @@ class KinesisVideoArchivedMedia {
   KinesisVideoArchivedMedia({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class KinesisVideoArchivedMedia {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -24,6 +24,7 @@ class KinesisVideoMedia {
   KinesisVideoMedia({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class KinesisVideoMedia {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
+++ b/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
@@ -27,6 +27,7 @@ class KinesisVideoSignalingChannels {
   KinesisVideoSignalingChannels({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class KinesisVideoSignalingChannels {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
+++ b/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
@@ -32,6 +32,7 @@ class KinesisAnalytics {
   KinesisAnalytics({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -41,6 +42,7 @@ class KinesisAnalytics {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
+++ b/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
@@ -28,6 +28,7 @@ class KinesisAnalyticsV2 {
   KinesisAnalyticsV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class KinesisAnalyticsV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
+++ b/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
@@ -24,6 +24,7 @@ class KinesisVideo {
   KinesisVideo({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class KinesisVideo {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_kms_api/lib/kms-2014-11-01.dart
+++ b/generated/aws_kms_api/lib/kms-2014-11-01.dart
@@ -40,6 +40,7 @@ class KMS {
   KMS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -49,6 +50,7 @@ class KMS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
+++ b/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
@@ -24,6 +24,7 @@ class LakeFormation {
   LakeFormation({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class LakeFormation {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
+++ b/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
@@ -29,6 +29,7 @@ class Lambda {
   Lambda({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class Lambda {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -29,6 +29,7 @@ class Lambda {
   Lambda({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class Lambda {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
+++ b/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
@@ -26,6 +26,7 @@ class LexModelBuildingService {
   LexModelBuildingService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class LexModelBuildingService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -34,6 +34,7 @@ class LexRuntimeService {
   LexRuntimeService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -44,6 +45,7 @@ class LexRuntimeService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
+++ b/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
@@ -25,6 +25,7 @@ class LicenseManager {
   LicenseManager({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class LicenseManager {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
+++ b/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
@@ -43,6 +43,7 @@ class Lightsail {
   Lightsail({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -52,6 +53,7 @@ class Lightsail {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_logs_api/lib/logs-2014-03-28.dart
+++ b/generated/aws_logs_api/lib/logs-2014-03-28.dart
@@ -59,6 +59,7 @@ class CloudWatchLogs {
   CloudWatchLogs({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -68,6 +69,7 @@ class CloudWatchLogs {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
+++ b/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
@@ -24,6 +24,7 @@ class MachineLearning {
   MachineLearning({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class MachineLearning {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_macie_api/lib/macie-2017-12-19.dart
+++ b/generated/aws_macie_api/lib/macie-2017-12-19.dart
@@ -31,6 +31,7 @@ class Macie {
   Macie({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -40,6 +41,7 @@ class Macie {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
+++ b/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
@@ -40,6 +40,7 @@ class ManagedBlockchain {
   ManagedBlockchain({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -50,6 +51,7 @@ class ManagedBlockchain {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
+++ b/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
@@ -31,6 +31,7 @@ class MarketplaceCatalog {
   MarketplaceCatalog({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -41,6 +42,7 @@ class MarketplaceCatalog {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
+++ b/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
@@ -25,6 +25,7 @@ class MarketplaceEntitlementService {
   MarketplaceEntitlementService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class MarketplaceEntitlementService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
@@ -24,6 +24,7 @@ class MarketplaceCommerceAnalytics {
   MarketplaceCommerceAnalytics({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class MarketplaceCommerceAnalytics {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
+++ b/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
@@ -24,6 +24,7 @@ class MediaConnect {
   MediaConnect({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class MediaConnect {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
+++ b/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
@@ -24,6 +24,7 @@ class MediaConvert {
   MediaConvert({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class MediaConvert {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
+++ b/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
@@ -24,6 +24,7 @@ class MediaLive {
   MediaLive({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class MediaLive {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -24,6 +24,7 @@ class MediaPackage {
   MediaPackage({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class MediaPackage {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -24,6 +24,7 @@ class MediaPackageVod {
   MediaPackageVod({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class MediaPackageVod {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
+++ b/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
@@ -25,6 +25,7 @@ class MediaStore {
   MediaStore({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class MediaStore {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
+++ b/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
@@ -26,6 +26,7 @@ class MediaStoreData {
   MediaStoreData({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class MediaStoreData {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
+++ b/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
@@ -33,6 +33,7 @@ class MediaTailor {
   MediaTailor({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -43,6 +44,7 @@ class MediaTailor {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
+++ b/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
@@ -25,6 +25,7 @@ class MarketplaceMetering {
   MarketplaceMetering({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class MarketplaceMetering {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
+++ b/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
@@ -31,6 +31,7 @@ class MigrationHub {
   MigrationHub({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -40,6 +41,7 @@ class MigrationHub {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
+++ b/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
@@ -49,6 +49,7 @@ class MigrationHubConfig {
   MigrationHubConfig({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -59,6 +60,7 @@ class MigrationHubConfig {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
+++ b/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
@@ -27,6 +27,7 @@ class Mobile {
   Mobile({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class Mobile {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mq_api/lib/mq-2017-11-27.dart
+++ b/generated/aws_mq_api/lib/mq-2017-11-27.dart
@@ -28,6 +28,7 @@ class MQ {
   MQ({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class MQ {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
+++ b/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
@@ -23,6 +23,7 @@ class MTurk {
   MTurk({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -32,6 +33,7 @@ class MTurk {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -37,6 +37,7 @@ class Neptune {
   Neptune({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -46,6 +47,7 @@ class Neptune {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
+++ b/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
@@ -30,6 +30,7 @@ class NetworkManager {
   NetworkManager({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -40,6 +41,7 @@ class NetworkManager {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
+++ b/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
@@ -26,6 +26,7 @@ class OpsWorks {
   OpsWorks({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class OpsWorks {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
+++ b/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
@@ -27,6 +27,7 @@ class OpsWorksCM {
   OpsWorksCM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class OpsWorksCM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
+++ b/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
@@ -23,6 +23,7 @@ class Organizations {
   Organizations({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -32,6 +33,7 @@ class Organizations {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
+++ b/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
@@ -29,6 +29,7 @@ class Outposts {
   Outposts({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class Outposts {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
+++ b/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
@@ -25,6 +25,7 @@ class Personalize {
   Personalize({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class Personalize {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
+++ b/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
@@ -27,6 +27,7 @@ class PersonalizeEvents {
   PersonalizeEvents({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -37,6 +38,7 @@ class PersonalizeEvents {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
+++ b/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
@@ -24,6 +24,7 @@ class PersonalizeRuntime {
   PersonalizeRuntime({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class PersonalizeRuntime {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_pi_api/lib/pi-2018-02-27.dart
+++ b/generated/aws_pi_api/lib/pi-2018-02-27.dart
@@ -27,6 +27,7 @@ class PI {
   PI({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class PI {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -24,6 +24,7 @@ class Pinpoint {
   Pinpoint({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class Pinpoint {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
+++ b/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
@@ -26,6 +26,7 @@ class PinpointEmail {
   PinpointEmail({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class PinpointEmail {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
+++ b/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
@@ -24,6 +24,7 @@ class PinpointSMSVoice {
   PinpointSMSVoice({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class PinpointSMSVoice {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -30,6 +30,7 @@ class Polly {
   Polly({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -39,6 +40,7 @@ class Polly {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
+++ b/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
@@ -55,6 +55,7 @@ class Pricing {
   Pricing({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -65,6 +66,7 @@ class Pricing {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
+++ b/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
@@ -24,6 +24,7 @@ class QLDB {
   QLDB({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class QLDB {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
+++ b/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
@@ -45,6 +45,7 @@ class QLDBSession {
   QLDBSession({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -55,6 +56,7 @@ class QLDBSession {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
+++ b/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
@@ -27,6 +27,7 @@ class QuickSight {
   QuickSight({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class QuickSight {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ram_api/lib/ram-2018-01-04.dart
+++ b/generated/aws_ram_api/lib/ram-2018-01-04.dart
@@ -33,6 +33,7 @@ class RAM {
   RAM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -42,6 +43,7 @@ class RAM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -26,6 +26,7 @@ class RDS {
   RDS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -34,6 +35,7 @@ class RDS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -26,6 +26,7 @@ class RDS {
   RDS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -34,6 +35,7 @@ class RDS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -26,6 +26,7 @@ class RDS {
   RDS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -34,6 +35,7 @@ class RDS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -26,6 +26,7 @@ class RDS {
   RDS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -34,6 +35,7 @@ class RDS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -32,6 +32,7 @@ class RDS {
   RDS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -40,6 +41,7 @@ class RDS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
+++ b/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
@@ -26,6 +26,7 @@ class RDSDataService {
   RDSDataService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class RDSDataService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -37,6 +37,7 @@ class Redshift {
   Redshift({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -45,6 +46,7 @@ class Redshift {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
+++ b/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
@@ -24,6 +24,7 @@ class Rekognition {
   Rekognition({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Rekognition {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
+++ b/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
@@ -35,6 +35,7 @@ class ResourceGroups {
   ResourceGroups({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -45,6 +46,7 @@ class ResourceGroups {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
@@ -24,6 +24,7 @@ class ResourceGroupsTaggingAPI {
   ResourceGroupsTaggingAPI({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class ResourceGroupsTaggingAPI {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
+++ b/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
@@ -24,6 +24,7 @@ class RoboMaker {
   RoboMaker({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class RoboMaker {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -25,6 +25,7 @@ class Route53 {
   Route53({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -34,6 +35,7 @@ class Route53 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
+++ b/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
@@ -25,6 +25,7 @@ class Route53Domains {
   Route53Domains({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class Route53Domains {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
+++ b/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
@@ -62,6 +62,7 @@ class Route53Resolver {
   Route53Resolver({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -71,6 +72,7 @@ class Route53Resolver {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -24,6 +24,7 @@ class S3 {
   S3({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class S3 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -24,6 +24,7 @@ class S3Control {
   S3Control({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -34,6 +35,7 @@ class S3Control {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
@@ -68,6 +68,7 @@ class AugmentedAIRuntime {
   AugmentedAIRuntime({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -78,6 +79,7 @@ class AugmentedAIRuntime {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
+++ b/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
@@ -39,6 +39,7 @@ class SageMaker {
   SageMaker({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -49,6 +50,7 @@ class SageMaker {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
+++ b/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
@@ -24,6 +24,7 @@ class SageMakerRuntime {
   SageMakerRuntime({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class SageMakerRuntime {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
+++ b/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
@@ -29,6 +29,7 @@ class SavingsPlans {
   SavingsPlans({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -38,6 +39,7 @@ class SavingsPlans {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -24,6 +24,7 @@ class Schemas {
   Schemas({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class Schemas {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
+++ b/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
@@ -43,6 +43,7 @@ class SimpleDB {
   SimpleDB({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -51,6 +52,7 @@ class SimpleDB {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
+++ b/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
@@ -25,6 +25,7 @@ class SecretsManager {
   SecretsManager({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class SecretsManager {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
+++ b/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
@@ -70,6 +70,7 @@ class SecurityHub {
   SecurityHub({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -80,6 +81,7 @@ class SecurityHub {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
+++ b/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
@@ -72,6 +72,7 @@ class ServerlessApplicationRepository {
   ServerlessApplicationRepository({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -82,6 +83,7 @@ class ServerlessApplicationRepository {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
+++ b/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
@@ -29,6 +29,7 @@ class ServiceQuotas {
   ServiceQuotas({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class ServiceQuotas {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
+++ b/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
@@ -29,6 +29,7 @@ class ServiceCatalog {
   ServiceCatalog({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class ServiceCatalog {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
+++ b/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
@@ -30,6 +30,7 @@ class ServiceDiscovery {
   ServiceDiscovery({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class ServiceDiscovery {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -39,6 +39,7 @@ class SES {
   SES({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -48,6 +49,7 @@ class SES {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
+++ b/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
@@ -26,6 +26,7 @@ class SESV2 {
   SESV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -36,6 +37,7 @@ class SESV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sfn_api/lib/states-2016-11-23.dart
+++ b/generated/aws_sfn_api/lib/states-2016-11-23.dart
@@ -25,6 +25,7 @@ class SFN {
   SFN({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class SFN {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_shield_api/lib/shield-2016-06-02.dart
+++ b/generated/aws_shield_api/lib/shield-2016-06-02.dart
@@ -30,6 +30,7 @@ class Shield {
   Shield({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -39,6 +40,7 @@ class Shield {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_signer_api/lib/signer-2017-08-25.dart
+++ b/generated/aws_signer_api/lib/signer-2017-08-25.dart
@@ -48,6 +48,7 @@ class Signer {
   Signer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -58,6 +59,7 @@ class Signer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sms_api/lib/sms-2016-10-24.dart
+++ b/generated/aws_sms_api/lib/sms-2016-10-24.dart
@@ -26,6 +26,7 @@ class SMS {
   SMS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class SMS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
+++ b/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
@@ -33,6 +33,7 @@ class Snowball {
   Snowball({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -42,6 +43,7 @@ class Snowball {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sns_api/lib/sns-2010-03-31.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.dart
@@ -35,6 +35,7 @@ class SNS {
   SNS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -43,6 +44,7 @@ class SNS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -95,6 +95,7 @@ class SQS {
   SQS({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -103,6 +104,7 @@ class SQS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
+++ b/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
@@ -32,6 +32,7 @@ class SSM {
   SSM({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -41,6 +42,7 @@ class SSM {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sso_api/lib/sso-2019-06-10.dart
+++ b/generated/aws_sso_api/lib/sso-2019-06-10.dart
@@ -43,6 +43,7 @@ class SSO {
   SSO({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -53,6 +54,7 @@ class SSO {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
+++ b/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
@@ -23,6 +23,7 @@ class SSOAdmin {
   SSOAdmin({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class SSOAdmin {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
+++ b/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
@@ -46,6 +46,7 @@ class SSOOIDC {
   SSOOIDC({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -56,6 +57,7 @@ class SSOOIDC {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
+++ b/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
@@ -28,6 +28,7 @@ class StorageGateway {
   StorageGateway({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -37,6 +38,7 @@ class StorageGateway {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_sts_api/lib/sts-2011-06-15.dart
+++ b/generated/aws_sts_api/lib/sts-2011-06-15.dart
@@ -33,6 +33,7 @@ class STS {
   STS({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -41,6 +42,7 @@ class STS {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_support_api/lib/support-2013-04-15.dart
+++ b/generated/aws_support_api/lib/support-2013-04-15.dart
@@ -46,6 +46,7 @@ class Support {
   Support({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -55,6 +56,7 @@ class Support {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_swf_api/lib/swf-2012-01-25.dart
+++ b/generated/aws_swf_api/lib/swf-2012-01-25.dart
@@ -29,6 +29,7 @@ class SWF {
   SWF({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -38,6 +39,7 @@ class SWF {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_textract_api/lib/textract-2018-06-27.dart
+++ b/generated/aws_textract_api/lib/textract-2018-06-27.dart
@@ -26,6 +26,7 @@ class Textract {
   Textract({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class Textract {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
+++ b/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
@@ -24,6 +24,7 @@ class TranscribeService {
   TranscribeService({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class TranscribeService {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
+++ b/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
@@ -34,6 +34,7 @@ class Transfer {
   Transfer({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -44,6 +45,7 @@ class Transfer {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_translate_api/lib/translate-2017-07-01.dart
+++ b/generated/aws_translate_api/lib/translate-2017-07-01.dart
@@ -25,6 +25,7 @@ class Translate {
   Translate({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -35,6 +36,7 @@ class Translate {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_waf_api/lib/waf-2015-08-24.dart
+++ b/generated/aws_waf_api/lib/waf-2015-08-24.dart
@@ -44,6 +44,7 @@ class WAF {
   WAF({
     String? region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -53,6 +54,7 @@ class WAF {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
+++ b/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
@@ -48,6 +48,7 @@ class WAFRegional {
   WAFRegional({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -57,6 +58,7 @@ class WAFRegional {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
+++ b/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
@@ -99,6 +99,7 @@ class WAFV2 {
   WAFV2({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -108,6 +109,7 @@ class WAFV2 {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
+++ b/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
@@ -58,6 +58,7 @@ class WorkDocs {
   WorkDocs({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -67,6 +68,7 @@ class WorkDocs {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
+++ b/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
@@ -32,6 +32,7 @@ class WorkLink {
   WorkLink({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -42,6 +43,7 @@ class WorkLink {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
+++ b/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
@@ -62,6 +62,7 @@ class WorkMail {
   WorkMail({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -71,6 +72,7 @@ class WorkMail {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
+++ b/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
@@ -25,6 +25,7 @@ class WorkMailMessageFlow {
   WorkMailMessageFlow({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class WorkMailMessageFlow {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
+++ b/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
@@ -25,6 +25,7 @@ class WorkSpaces {
   WorkSpaces({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -34,6 +35,7 @@ class WorkSpaces {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generated/aws_xray_api/lib/xray-2016-04-12.dart
+++ b/generated/aws_xray_api/lib/xray-2016-04-12.dart
@@ -25,6 +25,7 @@ class XRay {
   XRay({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -34,6 +35,7 @@ class XRay {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/generator/lib/builders/protocols/json_builder.dart
+++ b/generator/lib/builders/protocols/json_builder.dart
@@ -14,8 +14,20 @@ class JsonServiceBuilder extends ServiceBuilder {
     final isRegionRequired = !api.isGlobalService;
     return '''
   final _s.JsonProtocol _protocol;
-  ${api.metadata.className}({${isRegionRequired ? 'required' : ''} String${isRegionRequired ? '' : '?'} region, _s.AwsClientCredentials? credentials, _s.Client? client, String? endpointUrl,})
-  : _protocol = _s.JsonProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
+  ${api.metadata.className}({
+    ${isRegionRequired ? 'required String' : 'String?'} region,
+      _s.AwsClientCredentials? credentials,
+      _s.AwsClientCredentialsProvider? credentialsProvider,
+      _s.Client? client, String? endpointUrl,
+    })
+  : _protocol = _s.JsonProtocol(
+      client: client,
+      service: ${buildServiceMetadata(api)},
+      region: region,
+      credentials: credentials,
+      credentialsProvider: credentialsProvider,
+      endpointUrl: endpointUrl,
+    );
   ''';
   }
 

--- a/generator/lib/builders/protocols/query_builder.dart
+++ b/generator/lib/builders/protocols/query_builder.dart
@@ -16,8 +16,19 @@ class QueryServiceBuilder extends ServiceBuilder {
   final _s.QueryProtocol _protocol;
   final Map<String, _s.Shape> shapes;
 
-  ${api.metadata.className}({${isRegionRequired ? 'required' : ''} String${isRegionRequired ? '' : '?'} region, _s.AwsClientCredentials? credentials, _s.Client? client,})
-  : _protocol = _s.QueryProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials,),
+  ${api.metadata.className}({
+    ${isRegionRequired ? 'required String' : 'String?'} region,
+    _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
+    _s.Client? client,
+    })
+  : _protocol = _s.QueryProtocol(
+      client: client,
+      service: ${buildServiceMetadata(api)},
+      region: region,
+      credentials: credentials,
+      credentialsProvider: credentialsProvider,
+    ),
   shapes = shapesJson.map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));
   ''';
   }

--- a/generator/lib/builders/protocols/rest_json_builder.dart
+++ b/generator/lib/builders/protocols/rest_json_builder.dart
@@ -15,8 +15,21 @@ class RestJsonServiceBuilder extends ServiceBuilder {
     final isRegionRequired = !api.isGlobalService;
     return '''
   final _s.RestJsonProtocol _protocol;
-  ${api.metadata.className}({${isRegionRequired ? 'required' : ''} String${isRegionRequired ? '' : '?'} region, _s.AwsClientCredentials? credentials, _s.Client? client, String? endpointUrl,})
-  : _protocol = _s.RestJsonProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
+  ${api.metadata.className}({
+      ${isRegionRequired ? 'required String' : 'String?'} region,
+      _s.AwsClientCredentials? credentials,
+      _s.AwsClientCredentialsProvider? credentialsProvider,
+      _s.Client? client, 
+      String? endpointUrl,
+    })
+  : _protocol = _s.RestJsonProtocol(
+      client: client,
+      service: ${buildServiceMetadata(api)},
+      region: region,
+      credentials: credentials,
+      credentialsProvider: credentialsProvider,
+      endpointUrl: endpointUrl,
+    );
   ''';
   }
 

--- a/generator/lib/builders/protocols/rest_xml_builder.dart
+++ b/generator/lib/builders/protocols/rest_xml_builder.dart
@@ -17,8 +17,21 @@ class RestXmlServiceBuilder extends ServiceBuilder {
     final isRegionRequired = !api.isGlobalService;
     return '''
     final _s.RestXmlProtocol _protocol;
-    ${api.metadata.className}({${isRegionRequired ? 'required' : ''} String${isRegionRequired ? '' : '?'} region, _s.AwsClientCredentials? credentials, _s.Client? client, String? endpointUrl,})
-        : _protocol = _s.RestXmlProtocol(client: client, service: ${buildServiceMetadata(api)}, region: region, credentials: credentials, endpointUrl: endpointUrl,);
+    ${api.metadata.className}({
+      ${isRegionRequired ? 'required String' : 'String?'} region,
+      _s.AwsClientCredentials? credentials,
+      _s.AwsClientCredentialsProvider? credentialsProvider,
+      _s.Client? client,
+      String? endpointUrl,
+    })
+    : _protocol = _s.RestXmlProtocol(
+        client: client, 
+        service: ${buildServiceMetadata(api)}, 
+        region: region, 
+        credentials: credentials, 
+        credentialsProvider: credentialsProvider, 
+        endpointUrl: endpointUrl,
+      );
     ''';
   }
 

--- a/shared_aws_api/test/generated/input/json/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/json/base64_encoded_blobs.dart
@@ -24,6 +24,7 @@ class Base64EncodedBlobs {
   Base64EncodedBlobs({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Base64EncodedBlobs {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/empty_maps.dart
+++ b/shared_aws_api/test/generated/input/json/empty_maps.dart
@@ -24,6 +24,7 @@ class EmptyMaps {
   EmptyMaps({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class EmptyMaps {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/endpoint_host_trait_static_prefix.dart
+++ b/shared_aws_api/test/generated/input/json/endpoint_host_trait_static_prefix.dart
@@ -24,6 +24,7 @@ class EndpointHostTraitStaticPrefix {
   EndpointHostTraitStaticPrefix({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class EndpointHostTraitStaticPrefix {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/enum.dart
+++ b/shared_aws_api/test/generated/input/json/enum.dart
@@ -24,6 +24,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/json/idempotency_token_auto_fill.dart
@@ -24,6 +24,7 @@ class IdempotencyTokenAutoFill {
   IdempotencyTokenAutoFill({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class IdempotencyTokenAutoFill {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/nested_blobs.dart
+++ b/shared_aws_api/test/generated/input/json/nested_blobs.dart
@@ -24,6 +24,7 @@ class NestedBlobs {
   NestedBlobs({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class NestedBlobs {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/json/recursive_shapes.dart
@@ -24,6 +24,7 @@ class RecursiveShapes {
   RecursiveShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class RecursiveShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/scalar_members.dart
+++ b/shared_aws_api/test/generated/input/json/scalar_members.dart
@@ -24,6 +24,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/json/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/json/timestamp_values.dart
@@ -24,6 +24,7 @@ class TimestampValues {
   TimestampValues({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class TimestampValues {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
@@ -27,6 +27,7 @@ class Base64EncodedBlobs {
   Base64EncodedBlobs({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class Base64EncodedBlobs {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
@@ -27,6 +27,7 @@ class Base64EncodedBlobsNested {
   Base64EncodedBlobsNested({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class Base64EncodedBlobsNested {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
@@ -27,6 +27,7 @@ class EndpointHostTrait {
   EndpointHostTrait({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class EndpointHostTrait {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/enum.dart
+++ b/shared_aws_api/test/generated/input/query/enum.dart
@@ -27,6 +27,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list.dart
@@ -27,6 +27,7 @@ class FlattenedList {
   FlattenedList({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedList {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
@@ -27,6 +27,7 @@ class FlattenedListWithLocationName {
   FlattenedListWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedListWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
@@ -27,6 +27,7 @@ class IdempotencyTokenAutoFill {
   IdempotencyTokenAutoFill({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class IdempotencyTokenAutoFill {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/list_types.dart
+++ b/shared_aws_api/test/generated/input/query/list_types.dart
@@ -27,6 +27,7 @@ class ListTypes {
   ListTypes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class ListTypes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/nested_structure_members.dart
+++ b/shared_aws_api/test/generated/input/query/nested_structure_members.dart
@@ -27,6 +27,7 @@ class NestedStructureMembers {
   NestedStructureMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class NestedStructureMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
@@ -27,6 +27,7 @@ class NonFlattenedListWithLocationName {
   NonFlattenedListWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class NonFlattenedListWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/query/recursive_shapes.dart
@@ -27,6 +27,7 @@ class RecursiveShapes {
   RecursiveShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class RecursiveShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/input/query/scalar_members.dart
@@ -27,6 +27,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
@@ -27,6 +27,7 @@ class SerializeFlattenedMapType {
   SerializeFlattenedMapType({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class SerializeFlattenedMapType {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type.dart
@@ -27,6 +27,7 @@ class SerializeMapType {
   SerializeMapType({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class SerializeMapType {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
@@ -27,6 +27,7 @@ class SerializeMapTypeWithLocationName {
   SerializeMapTypeWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class SerializeMapTypeWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/query/timestamp_values.dart
@@ -27,6 +27,7 @@ class TimestampValues {
   TimestampValues({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class TimestampValues {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/rest-json/blob_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/blob_payload.dart
@@ -24,6 +24,7 @@ class BlobPayload {
   BlobPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class BlobPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/boolean_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/boolean_in_querystring.dart
@@ -24,6 +24,7 @@ class BooleanInQuerystring {
   BooleanInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class BooleanInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-json/endpoint_host_trait.dart
@@ -24,6 +24,7 @@ class EndpointHostTrait {
   EndpointHostTrait({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class EndpointHostTrait {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-json/enum.dart
@@ -24,6 +24,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/rest-json/idempotency_token_auto_fill.dart
@@ -24,6 +24,7 @@ class IdempotencyTokenAutoFill {
   IdempotencyTokenAutoFill({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class IdempotencyTokenAutoFill {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/json_value_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-json/json_value_trait.dart
@@ -24,6 +24,7 @@ class JSONValueTrait {
   JSONValueTrait({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class JSONValueTrait {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/named_locations_in_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/named_locations_in_json_body.dart
@@ -24,6 +24,7 @@ class NamedLocationsInJSONBody {
   NamedLocationsInJSONBody({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class NamedLocationsInJSONBody {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/no_parameters.dart
+++ b/shared_aws_api/test/generated/input/rest-json/no_parameters.dart
@@ -24,6 +24,7 @@ class NoParameters {
   NoParameters({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class NoParameters {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/omits_null_query_params_but_serializes_empty_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-json/omits_null_query_params_but_serializes_empty_strings.dart
@@ -24,6 +24,7 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
   OmitsNullQueryParamsButSerializesEmptyStrings({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/querystring_list_of_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-json/querystring_list_of_strings.dart
@@ -24,6 +24,7 @@ class QuerystringListOfStrings {
   QuerystringListOfStrings({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class QuerystringListOfStrings {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-json/recursive_shapes.dart
@@ -24,6 +24,7 @@ class RecursiveShapes {
   RecursiveShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class RecursiveShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
@@ -24,6 +24,7 @@ class SerializeBlobsInBody {
   SerializeBlobsInBody({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class SerializeBlobsInBody {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
@@ -24,6 +24,7 @@ class StreamingPayload {
   StreamingPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StreamingPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/string_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_payload.dart
@@ -24,6 +24,7 @@ class StringPayload {
   StringPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StringPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
@@ -24,6 +24,7 @@ class StringToStringListMapsInQuerystring {
   StringToStringListMapsInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StringToStringListMapsInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
@@ -24,6 +24,7 @@ class StringToStringMapsInQuerystring {
   StringToStringMapsInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StringToStringMapsInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/structure_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/structure_payload.dart
@@ -24,6 +24,7 @@ class StructurePayload {
   StructurePayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StructurePayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/rest-json/timestamp_values.dart
@@ -24,6 +24,7 @@ class TimestampValues {
   TimestampValues({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class TimestampValues {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
@@ -24,6 +24,7 @@ class URIParameterAndQuerystringParams {
   URIParameterAndQuerystringParams({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class URIParameterAndQuerystringParams {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
@@ -24,6 +24,7 @@ class URIParameterOnlyWithLocationName {
   URIParameterOnlyWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class URIParameterOnlyWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
@@ -24,6 +24,7 @@ class URIParameterOnlyWithNoLocationName {
   URIParameterOnlyWithNoLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class URIParameterOnlyWithNoLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_and_json_body.dart
@@ -24,6 +24,7 @@ class URIParameterQuerystringParamsAndJSONBody {
   URIParameterQuerystringParamsAndJSONBody({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class URIParameterQuerystringParamsAndJSONBody {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body.dart
@@ -24,6 +24,7 @@ class URIParameterQuerystringParamsHeadersAndJSONBody {
   URIParameterQuerystringParamsHeadersAndJSONBody({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class URIParameterQuerystringParamsHeadersAndJSONBody {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/basic_xml_serialization.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/basic_xml_serialization.dart
@@ -24,6 +24,7 @@ class BasicXMLSerialization {
   BasicXMLSerialization({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class BasicXMLSerialization {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/blob_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/blob_payload.dart
@@ -24,6 +24,7 @@ class BlobPayload {
   BlobPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class BlobPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/blob_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/blob_shapes.dart
@@ -24,6 +24,7 @@ class BlobShapes {
   BlobShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class BlobShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/boolean_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/boolean_in_querystring.dart
@@ -24,6 +24,7 @@ class BooleanInQuerystring {
   BooleanInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class BooleanInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/endpoint_host_trait.dart
@@ -24,6 +24,7 @@ class EndpointHostTrait {
   EndpointHostTrait({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class EndpointHostTrait {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -24,6 +24,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/flattened_lists.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/flattened_lists.dart
@@ -24,6 +24,7 @@ class FlattenedLists {
   FlattenedLists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class FlattenedLists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/flattened_lists_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/flattened_lists_with_locationname.dart
@@ -24,6 +24,7 @@ class FlattenedListsWithLocationName {
   FlattenedListsWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class FlattenedListsWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
@@ -24,6 +24,7 @@ class GreedyKeys {
   GreedyKeys({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class GreedyKeys {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/header_maps.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/header_maps.dart
@@ -24,6 +24,7 @@ class HeaderMaps {
   HeaderMaps({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class HeaderMaps {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/idempotency_token_auto_fill.dart
@@ -24,6 +24,7 @@ class IdempotencyTokenAutoFill {
   IdempotencyTokenAutoFill({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class IdempotencyTokenAutoFill {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/list_of_structures.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/list_of_structures.dart
@@ -24,6 +24,7 @@ class ListOfStructures {
   ListOfStructures({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class ListOfStructures {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/nested_structures.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/nested_structures.dart
@@ -24,6 +24,7 @@ class NestedStructures {
   NestedStructures({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class NestedStructures {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists.dart
@@ -24,6 +24,7 @@ class NonFlattenedLists {
   NonFlattenedLists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class NonFlattenedLists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/non_flattened_lists_with_locationname.dart
@@ -24,6 +24,7 @@ class NonFlattenedListsWithLocationName {
   NonFlattenedListsWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class NonFlattenedListsWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/omits_null_query_params_but_serializes_empty_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/omits_null_query_params_but_serializes_empty_strings.dart
@@ -24,6 +24,7 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
   OmitsNullQueryParamsButSerializesEmptyStrings({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class OmitsNullQueryParamsButSerializesEmptyStrings {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/querystring_list_of_strings.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/querystring_list_of_strings.dart
@@ -24,6 +24,7 @@ class QuerystringListOfStrings {
   QuerystringListOfStrings({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class QuerystringListOfStrings {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/recursive_shapes.dart
@@ -24,6 +24,7 @@ class RecursiveShapes {
   RecursiveShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class RecursiveShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/serialize_other_scalar_types.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/serialize_other_scalar_types.dart
@@ -24,6 +24,7 @@ class SerializeOtherScalarTypes {
   SerializeOtherScalarTypes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class SerializeOtherScalarTypes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/string_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_payload.dart
@@ -24,6 +24,7 @@ class StringPayload {
   StringPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class StringPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
@@ -24,6 +24,7 @@ class StringToStringListMapsInQuerystring {
   StringToStringListMapsInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class StringToStringListMapsInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
@@ -24,6 +24,7 @@ class StringToStringMapsInQuerystring {
   StringToStringMapsInQuerystring({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class StringToStringMapsInQuerystring {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/structure_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/structure_payload.dart
@@ -24,6 +24,7 @@ class StructurePayload {
   StructurePayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class StructurePayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/timestamp_shapes.dart
@@ -24,6 +24,7 @@ class TimestampShapes {
   TimestampShapes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class TimestampShapes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/input/rest-xml/xml_attribute.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/xml_attribute.dart
@@ -24,6 +24,7 @@ class XMLAttribute {
   XMLAttribute({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class XMLAttribute {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/blob_members.dart
+++ b/shared_aws_api/test/generated/output/json/blob_members.dart
@@ -24,6 +24,7 @@ class BlobMembers {
   BlobMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class BlobMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/enum_output.dart
+++ b/shared_aws_api/test/generated/output/json/enum_output.dart
@@ -24,6 +24,7 @@ class EnumOutput {
   EnumOutput({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class EnumOutput {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/ignores_extra_data.dart
+++ b/shared_aws_api/test/generated/output/json/ignores_extra_data.dart
@@ -24,6 +24,7 @@ class IgnoresExtraData {
   IgnoresExtraData({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class IgnoresExtraData {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/lists.dart
+++ b/shared_aws_api/test/generated/output/json/lists.dart
@@ -24,6 +24,7 @@ class Lists {
   Lists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Lists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/maps.dart
+++ b/shared_aws_api/test/generated/output/json/maps.dart
@@ -24,6 +24,7 @@ class Maps {
   Maps({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class Maps {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/json/scalar_members.dart
@@ -24,6 +24,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/json/timestamp_members.dart
@@ -24,6 +24,7 @@ class TimestampMembers {
   TimestampMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.JsonProtocol(
@@ -33,6 +34,7 @@ class TimestampMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/query/blob.dart
+++ b/shared_aws_api/test/generated/output/query/blob.dart
@@ -27,6 +27,7 @@ class Blob {
   Blob({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class Blob {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/empty_string.dart
+++ b/shared_aws_api/test/generated/output/query/empty_string.dart
@@ -27,6 +27,7 @@ class EmptyString {
   EmptyString({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class EmptyString {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/enum_output.dart
+++ b/shared_aws_api/test/generated/output/query/enum_output.dart
@@ -27,6 +27,7 @@ class EnumOutput {
   EnumOutput({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class EnumOutput {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list.dart
@@ -27,6 +27,7 @@ class FlattenedList {
   FlattenedList({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedList {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
@@ -27,6 +27,7 @@ class FlattenedListOfStructures {
   FlattenedListOfStructures({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedListOfStructures {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
@@ -27,6 +27,7 @@ class FlattenedListWithLocationName {
   FlattenedListWithLocationName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedListWithLocationName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_map.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map.dart
@@ -27,6 +27,7 @@ class FlattenedMap {
   FlattenedMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
@@ -27,6 +27,7 @@ class FlattenedMapInShapeDefinition {
   FlattenedMapInShapeDefinition({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedMapInShapeDefinition {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
@@ -27,6 +27,7 @@ class FlattenedSingleElementList {
   FlattenedSingleElementList({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class FlattenedSingleElementList {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/list_of_structures.dart
@@ -27,6 +27,7 @@ class ListOfStructures {
   ListOfStructures({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class ListOfStructures {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
+++ b/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
@@ -27,6 +27,7 @@ class ListWithCustomMemberName {
   ListWithCustomMemberName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class ListWithCustomMemberName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/lists.dart
+++ b/shared_aws_api/test/generated/output/query/lists.dart
@@ -27,6 +27,7 @@ class Lists {
   Lists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class Lists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/named_map.dart
+++ b/shared_aws_api/test/generated/output/query/named_map.dart
@@ -27,6 +27,7 @@ class NamedMap {
   NamedMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class NamedMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/normal_map.dart
+++ b/shared_aws_api/test/generated/output/query/normal_map.dart
@@ -27,6 +27,7 @@ class NormalMap {
   NormalMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class NormalMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
+++ b/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
@@ -27,6 +27,7 @@ class NotAllMembersInResponse {
   NotAllMembersInResponse({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class NotAllMembersInResponse {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/query/scalar_members.dart
@@ -27,6 +27,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/query/timestamp_members.dart
@@ -27,6 +27,7 @@ class TimestampMembers {
   TimestampMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
   })  : _protocol = _s.QueryProtocol(
           client: client,
@@ -35,6 +36,7 @@ class TimestampMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/rest-json/blob_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/blob_members.dart
@@ -24,6 +24,7 @@ class BlobMembers {
   BlobMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class BlobMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/complex_list_values.dart
+++ b/shared_aws_api/test/generated/output/rest-json/complex_list_values.dart
@@ -24,6 +24,7 @@ class ComplexListValues {
   ComplexListValues({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class ComplexListValues {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-json/enum.dart
@@ -24,6 +24,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/ignores_extra_data.dart
+++ b/shared_aws_api/test/generated/output/rest-json/ignores_extra_data.dart
@@ -24,6 +24,7 @@ class IgnoresExtraData {
   IgnoresExtraData({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class IgnoresExtraData {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/ignores_undefined_output.dart
+++ b/shared_aws_api/test/generated/output/rest-json/ignores_undefined_output.dart
@@ -24,6 +24,7 @@ class IgnoresUndefinedOutput {
   IgnoresUndefinedOutput({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class IgnoresUndefinedOutput {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/json_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_payload.dart
@@ -24,6 +24,7 @@ class JSONPayload {
   JSONPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class JSONPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
+++ b/shared_aws_api/test/generated/output/rest-json/json_value_trait.dart
@@ -24,6 +24,7 @@ class JSONValueTrait {
   JSONValueTrait({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class JSONValueTrait {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/lists.dart
+++ b/shared_aws_api/test/generated/output/rest-json/lists.dart
@@ -24,6 +24,7 @@ class Lists {
   Lists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class Lists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/lists_with_structure_member.dart
+++ b/shared_aws_api/test/generated/output/rest-json/lists_with_structure_member.dart
@@ -24,6 +24,7 @@ class ListsWithStructureMember {
   ListsWithStructureMember({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class ListsWithStructureMember {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/maps.dart
+++ b/shared_aws_api/test/generated/output/rest-json/maps.dart
@@ -24,6 +24,7 @@ class Maps {
   Maps({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class Maps {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/scalar_members.dart
@@ -24,6 +24,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-json/streaming_payload.dart
@@ -24,6 +24,7 @@ class StreamingPayload {
   StreamingPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class StreamingPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
+++ b/shared_aws_api/test/generated/output/rest-json/supports_header_maps.dart
@@ -24,6 +24,7 @@ class SupportsHeaderMaps {
   SupportsHeaderMaps({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class SupportsHeaderMaps {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-json/timestamp_members.dart
@@ -24,6 +24,7 @@ class TimestampMembers {
   TimestampMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestJsonProtocol(
@@ -33,6 +34,7 @@ class TimestampMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/blob.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/blob.dart
@@ -24,6 +24,7 @@ class Blob {
   Blob({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class Blob {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/empty_string.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/empty_string.dart
@@ -24,6 +24,7 @@ class EmptyString {
   EmptyString({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class EmptyString {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/enum.dart
@@ -24,6 +24,7 @@ class Enum {
   Enum({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class Enum {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/flattened_list.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/flattened_list.dart
@@ -24,6 +24,7 @@ class FlattenedList {
   FlattenedList({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class FlattenedList {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/flattened_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/flattened_map.dart
@@ -24,6 +24,7 @@ class FlattenedMap {
   FlattenedMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class FlattenedMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/list_with_custom_member_name.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/list_with_custom_member_name.dart
@@ -24,6 +24,7 @@ class ListWithCustomMemberName {
   ListWithCustomMemberName({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class ListWithCustomMemberName {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/lists.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/lists.dart
@@ -24,6 +24,7 @@ class Lists {
   Lists({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class Lists {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/named_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/named_map.dart
@@ -24,6 +24,7 @@ class NamedMap {
   NamedMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class NamedMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/normal_map.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/normal_map.dart
@@ -24,6 +24,7 @@ class NormalMap {
   NormalMap({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class NormalMap {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/scalar_members.dart
@@ -24,6 +24,7 @@ class ScalarMembers {
   ScalarMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class ScalarMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/scalar_members_in_headers.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/scalar_members_in_headers.dart
@@ -24,6 +24,7 @@ class ScalarMembersInHeaders {
   ScalarMembersInHeaders({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class ScalarMembersInHeaders {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/streaming_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/streaming_payload.dart
@@ -24,6 +24,7 @@ class StreamingPayload {
   StreamingPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class StreamingPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/timestamp_members.dart
@@ -24,6 +24,7 @@ class TimestampMembers {
   TimestampMembers({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class TimestampMembers {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
@@ -24,6 +24,7 @@ class XMLAttributes {
   XMLAttributes({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class XMLAttributes {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 

--- a/shared_aws_api/test/generated/output/rest-xml/xml_payload.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_payload.dart
@@ -24,6 +24,7 @@ class XMLPayload {
   XMLPayload({
     required String region,
     _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
     String? endpointUrl,
   }) : _protocol = _s.RestXmlProtocol(
@@ -33,6 +34,7 @@ class XMLPayload {
           ),
           region: region,
           credentials: credentials,
+          credentialsProvider: credentialsProvider,
           endpointUrl: endpointUrl,
         );
 


### PR DESCRIPTION
This adds the `credentialsProvider` argument to generated services and passes it on to the protocol classes.