### PR TITLE
Release shared_aws_api with new functionality

### DIFF
--- a/shared_aws_api/CHANGELOG.md
+++ b/shared_aws_api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add `credentialsProvider` and `requestSigner` to protocol classes.
+
 ## 1.0.1
 
 - Remove string parameter pattern validation due to regex incompatibility.

--- a/shared_aws_api/pubspec.yaml
+++ b/shared_aws_api/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shared_aws_api
 description: Shared protocol implementation and utilities for generated AWS API clients.
-version: 1.0.1
+version: 1.1.0
 
 homepage: https://github.com/agilord/aws_client/tree/master/shared_aws_api
 


### PR DESCRIPTION
In order to close #316, shared package needs to be published.
Services will be bumped in a later PR.