### PR TITLE
Resolve credentials from AWS IDMS

### DIFF
--- a/generated/aws_ssm_api/pubspec.yaml
+++ b/generated/aws_ssm_api/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  shared_aws_api: ^1.1.0
+  shared_aws_api:
+    path: ../../shared_aws_api
 
 

--- a/generated/aws_ssm_api/pubspec.yaml
+++ b/generated/aws_ssm_api/pubspec.yaml
@@ -10,7 +10,6 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  shared_aws_api:
-    path: ../../shared_aws_api
+  shared_aws_api: ^1.1.0
 
 

--- a/shared_aws_api/lib/src/credentials.dart
+++ b/shared_aws_api/lib/src/credentials.dart
@@ -39,5 +39,6 @@ class AwsClientCredentials {
     this.expiration,
   });
 
-  static AwsClientCredentials? resolve() => CredentialsUtil.resolve();
+  static Future<AwsClientCredentials?> resolve(Client? client) =>
+      CredentialsUtil.resolve(client);
 }

--- a/shared_aws_api/lib/src/credentials/credentials_io.dart
+++ b/shared_aws_api/lib/src/credentials/credentials_io.dart
@@ -1,11 +1,18 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:http/http.dart';
 import 'package:shared_aws_api/src/credentials.dart';
 import 'package:shared_aws_api/src/credentials/ini_config.dart';
 
 class CredentialsUtil {
-  static AwsClientCredentials? resolve() {
-    return fromEnvironment ?? fromProfileFile;
+  static Future<AwsClientCredentials?> resolve(Client? client) {
+    final localCredentials = fromEnvironment ?? fromProfileFile;
+    if (localCredentials != null) {
+      return Future.value(localCredentials);
+    }
+
+    return fromInstanceMetaDataService(client);
   }
 
   static AwsClientCredentials? get fromEnvironment {
@@ -70,5 +77,54 @@ class CredentialsUtil {
     }
 
     return AwsClientCredentials(accessKey: accessKey, secretKey: secretKey);
+  }
+
+  static const _imdsV1BaseSecurityCredentialsUrl =
+      'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
+  static Future<AwsClientCredentials?> fromInstanceMetaDataService(
+      Client? client) async {
+    // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
+    //   - IMDSv1
+    //   Sample response from IMDSv1:
+    //   http://169.254.169.254/latest/meta-data/iam/security-credentials/<profile-name>
+    // {
+    //   "Code" : "Success",
+    //   "LastUpdated" : "2022-01-22T17:42:11Z",
+    //   "Type" : "AWS-HMAC",
+    //   "AccessKeyId" : "ASIXXXXXXXXX",
+    //   "SecretAccessKey" : "<...>",
+    //   "Token" : "xxxxxxxx",
+    //   "Expiration" : "2022-01-22T23:53:55Z"
+    // }
+    if (client == null) {
+      return null;
+    }
+
+    // Profile response
+    final profileResult =
+        await client.get(Uri.parse(_imdsV1BaseSecurityCredentialsUrl));
+    if (profileResult.statusCode > 299) {
+      print(
+          'Could not get profile from instance metadata service - status code: ${profileResult.statusCode}');
+      return null;
+    }
+
+    final profileName = profileResult.body;
+
+    final credsResult = await client
+        .get(Uri.parse('$_imdsV1BaseSecurityCredentialsUrl$profileName'));
+    if (credsResult.statusCode > 299) {
+      print(
+          'Could not get credentials from instance metadata service - status code: ${credsResult.statusCode}');
+      return null;
+    }
+
+    final creds = jsonDecode(credsResult.body);
+    return AwsClientCredentials(
+      accessKey: creds['AccessKeyId'] as String,
+      secretKey: creds['SecretAccessKey'] as String,
+      sessionToken: creds['Token'] as String,
+      expiration: DateTime.parse(creds['Expiration'] as String),
+    );
   }
 }

--- a/shared_aws_api/lib/src/protocol/json.dart
+++ b/shared_aws_api/lib/src/protocol/json.dart
@@ -40,7 +40,7 @@ class JsonProtocol {
       credentialsProvider = ({Client? client}) => Future.value(credentials);
     } else {
       credentialsProvider ??=
-          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+          ({Client? client}) => AwsClientCredentials.resolve(client);
     }
 
     return JsonProtocol._(client, endpoint, credentialsProvider, requestSigner);

--- a/shared_aws_api/lib/src/protocol/query.dart
+++ b/shared_aws_api/lib/src/protocol/query.dart
@@ -43,7 +43,7 @@ class QueryProtocol {
       credentialsProvider = ({Client? client}) => Future.value(credentials);
     } else {
       credentialsProvider ??=
-          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+          ({Client? client}) => AwsClientCredentials.resolve(client);
     }
 
     return QueryProtocol._(

--- a/shared_aws_api/lib/src/protocol/rest-json.dart
+++ b/shared_aws_api/lib/src/protocol/rest-json.dart
@@ -38,7 +38,7 @@ class RestJsonProtocol {
       credentialsProvider = ({Client? client}) => Future.value(credentials);
     } else {
       credentialsProvider ??=
-          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+          ({Client? client}) => AwsClientCredentials.resolve(client);
     }
 
     return RestJsonProtocol._(

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -39,7 +39,7 @@ class RestXmlProtocol {
       credentialsProvider = ({Client? client}) => Future.value(credentials);
     } else {
       credentialsProvider ??=
-          ({Client? client}) => Future.value(AwsClientCredentials.resolve());
+          ({Client? client}) => AwsClientCredentials.resolve(client);
     }
 
     return RestXmlProtocol._(


### PR DESCRIPTION
For use when running on EC2 instances. It is the last fallback in the chain. Local credentials are attempted first.