### PR TITLE
Update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
-[![Build Status](https://travis-ci.com/agilord/aws_client.svg?branch=master)](https://travis-ci.com/agilord/aws_client)
 # High-level APIs for Amazon Web Services (AWS) in Dart
+
+## Development
+
+### Generate Dart APIs
+
+Generated sources are checked into the repository. To generate the sources, run the following command at the root of the [`generator`](/generator) folder:
+```bash
+dart bin/generate.dart generate
+```
+
+All commands in `generate.dart` has the `--help` command available for more information on usage.
 
 - [Shared API utilities](https://github.com/agilord/aws_client/tree/master/shared_aws_api)
 - [Generated API packages directory](https://github.com/agilord/aws_client/tree/master/generated)
-- [DocumentClient for DynamoDB](https://github.com/agilord/aws_client/tree/master/document_client)
-- [Code generator](https://github.com/agilord/aws_client/tree/master/generator)
-- [Original Dart package](https://github.com/agilord/aws_client/tree/master/aws_client)
+- [DocumentClient for DynamoDB](/document_client)
+- [Code generator](/generator)
+- [Original Dart package](/aws_client)
 
 ## Published generated packages
 
@@ -53,7 +63,6 @@
 - [AWS Elemental MediaStore Data Plane](https://pub.dev/packages/aws_mediastore_data_api)
 - [AWS Global Accelerator](https://pub.dev/packages/aws_globalaccelerator_api)
 - [AWS Glue](https://pub.dev/packages/aws_glue_api)
-- [AWS Greengrass](https://pub.dev/packages/aws_greengrass_api)
 - [AWS Ground Station](https://pub.dev/packages/aws_groundstation_api)
 - [AWS Health APIs and Notifications](https://pub.dev/packages/aws_health_api)
 - [AWS Identity and Access Management](https://pub.dev/packages/aws_iam_api)
@@ -65,6 +74,7 @@
 - [AWS IoT Data Plane](https://pub.dev/packages/aws_iot_data_api)
 - [AWS IoT Events](https://pub.dev/packages/aws_iotevents_api)
 - [AWS IoT Events Data](https://pub.dev/packages/aws_iotevents_data_api)
+- [AWS IoT Greengrass V2](https://pub.dev/packages/aws_greengrass_api)
 - [AWS IoT Jobs Data Plane](https://pub.dev/packages/aws_iot_jobs_data_api)
 - [AWS IoT Secure Tunneling](https://pub.dev/packages/aws_iotsecuretunneling_api)
 - [AWS IoT Things Graph](https://pub.dev/packages/aws_iotthingsgraph_api)
@@ -102,10 +112,11 @@
 - [AWS Service Catalog](https://pub.dev/packages/aws_servicecatalog_api)
 - [AWS Shield](https://pub.dev/packages/aws_shield_api)
 - [AWS Signer](https://pub.dev/packages/aws_signer_api)
-- [AWS Single Sign-On](https://pub.dev/packages/aws_sso_api)
+- [AWS Single Sign-On Admin](https://pub.dev/packages/aws_sso_api)
+- [AWS Step Functions](https://pub.dev/packages/aws_sfn_api)
 - [AWS Storage Gateway](https://pub.dev/packages/aws_storagegateway_api)
 - [AWS Support](https://pub.dev/packages/aws_support_api)
-- [AWS Transfer for SFTP](https://pub.dev/packages/aws_transfer_api)
+- [AWS Transfer Family](https://pub.dev/packages/aws_transfer_api)
 - [AWS WAF](https://pub.dev/packages/aws_waf_api)
 - [AWS WAF Regional](https://pub.dev/packages/aws_waf_regional_api)
 - [AWS WAFV2](https://pub.dev/packages/aws_wafv2_api)
@@ -149,6 +160,7 @@
 - [Amazon ElastiCache](https://pub.dev/packages/aws_elasticache_api)
 - [Amazon Elastic  Inference](https://pub.dev/packages/aws_elastic_inference_api)
 - [Amazon Elastic Block Store](https://pub.dev/packages/aws_ebs_api)
+- [Amazon Elastic Compute Cloud](https://pub.dev/packages/aws_ec2_api)
 - [Amazon Elastic File System](https://pub.dev/packages/aws_efs_api)
 - [Amazon Elastic Kubernetes Service](https://pub.dev/packages/aws_eks_api)
 - [Amazon Elastic MapReduce](https://pub.dev/packages/aws_emr_api)
@@ -230,14 +242,4 @@
 
 - Implement EC2 protocol
 
-## Maintenance
 
-### Update travis config:
-
-```bash
-# run only once:
-# pub global activate mono_repo
-
-# if there is an update in mono_pkg.yaml
-pub global run mono_repo travis
-```

--- a/generated/aws_accessanalyzer_api/README.md
+++ b/generated/aws_accessanalyzer_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Access Analyzer
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IAM Access Analyzer helps identify potential resource-access risks by
@@ -21,9 +21,3 @@ To start using Access Analyzer, you first need to create an analyzer.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_accessanalyzer_api/example/README.md
+++ b/generated/aws_accessanalyzer_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_accessanalyzer_api/accessanalyzer-2019-11-01.dart';
 
 void main() {
   final service = AccessAnalyzer(region: 'eu-west-1');
-  // See documentation on how to use AccessAnalyzer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_accessanalyzer_api/latest/accessanalyzer-2019-11-01/AccessAnalyzer-class.html) on how to use AccessAnalyzer

--- a/generated/aws_acm_api/README.md
+++ b/generated/aws_acm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Certificate Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the AWS Certificate Manager (ACM) API documentation.
@@ -10,9 +10,3 @@ Welcome to the AWS Certificate Manager (ACM) API documentation.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_acm_api/example/README.md
+++ b/generated/aws_acm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_acm_api/acm-2015-12-08.dart';
 
 void main() {
   final service = ACM(region: 'eu-west-1');
-  // See documentation on how to use ACM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_acm_api/latest/acm-2015-12-08/ACM-class.html) on how to use ACM

--- a/generated/aws_acm_pca_api/README.md
+++ b/generated/aws_acm_pca_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Certificate Manager Private Certificate Authority
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>ACM Private CA API Reference</i>. It provides descriptions,
@@ -25,9 +25,3 @@ Rate Quotas in ACM Private CA</a> in the ACM Private CA user guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_acm_pca_api/example/README.md
+++ b/generated/aws_acm_pca_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_acm_pca_api/acm-pca-2017-08-22.dart';
 
 void main() {
   final service = ACMPCA(region: 'eu-west-1');
-  // See documentation on how to use ACMPCA
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_acm_pca_api/latest/acm-pca-2017-08-22/ACMPCA-class.html) on how to use ACMPCA

--- a/generated/aws_alexaforbusiness_api/README.md
+++ b/generated/aws_alexaforbusiness_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Alexa For Business
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Alexa for Business helps you use Alexa in your organization. Alexa for
@@ -19,9 +19,3 @@ for Business, and manage them as shared devices in their organization.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_alexaforbusiness_api/example/README.md
+++ b/generated/aws_alexaforbusiness_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_alexaforbusiness_api/alexaforbusiness-2017-11-09.dart';
 
 void main() {
   final service = AlexaForBusiness(region: 'eu-west-1');
-  // See documentation on how to use AlexaForBusiness
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_alexaforbusiness_api/latest/alexaforbusiness-2017-11-09/AlexaForBusiness-class.html) on how to use AlexaForBusiness

--- a/generated/aws_amplify_api/README.md
+++ b/generated/aws_amplify_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Amplify
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amplify enables developers to develop and deploy cloud-powered mobile and
@@ -17,9 +17,3 @@ Framework.</a>
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_amplify_api/example/README.md
+++ b/generated/aws_amplify_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_amplify_api/amplify-2017-07-25.dart';
 
 void main() {
   final service = Amplify(region: 'eu-west-1');
-  // See documentation on how to use Amplify
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_amplify_api/latest/amplify-2017-07-25/Amplify-class.html) on how to use Amplify

--- a/generated/aws_apigateway_api/README.md
+++ b/generated/aws_apigateway_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon API Gateway
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon API Gateway helps developers deliver robust, secure, and scalable
@@ -14,9 +14,3 @@ outside of AWS.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_apigateway_api/example/README.md
+++ b/generated/aws_apigateway_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_apigateway_api/apigateway-2015-07-09.dart';
 
 void main() {
   final service = APIGateway(region: 'eu-west-1');
-  // See documentation on how to use APIGateway
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_apigateway_api/latest/apigateway-2015-07-09/APIGateway-class.html) on how to use APIGateway

--- a/generated/aws_apigatewaymanagementapi_api/README.md
+++ b/generated/aws_apigatewaymanagementapi_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AmazonApiGatewayManagementApi
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The Amazon API Gateway Management API allows you to directly manage runtime
@@ -15,9 +15,3 @@ path, if applicable.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_apigatewaymanagementapi_api/example/README.md
+++ b/generated/aws_apigatewaymanagementapi_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_apigatewaymanagementapi_api/apigatewaymanagementapi-2018-11-
 
 void main() {
   final service = ApiGatewayManagementApi(region: 'eu-west-1');
-  // See documentation on how to use ApiGatewayManagementApi
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_apigatewaymanagementapi_api/latest/apigatewaymanagementapi-2018-11-29/ApiGatewayManagementApi-class.html) on how to use ApiGatewayManagementApi

--- a/generated/aws_apigatewayv2_api/README.md
+++ b/generated/aws_apigatewayv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AmazonApiGatewayV2
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon API Gateway V2
@@ -10,9 +10,3 @@ Amazon API Gateway V2
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_apigatewayv2_api/example/README.md
+++ b/generated/aws_apigatewayv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_apigatewayv2_api/apigatewayv2-2018-11-29.dart';
 
 void main() {
   final service = ApiGatewayV2(region: 'eu-west-1');
-  // See documentation on how to use ApiGatewayV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_apigatewayv2_api/latest/apigatewayv2-2018-11-29/ApiGatewayV2-class.html) on how to use ApiGatewayV2

--- a/generated/aws_appconfig_api/README.md
+++ b/generated/aws_appconfig_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon AppConfig
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Use AWS AppConfig, a capability of AWS Systems Manager, to create, manage,
@@ -15,9 +15,3 @@ devices.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_appconfig_api/example/README.md
+++ b/generated/aws_appconfig_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_appconfig_api/appconfig-2019-10-09.dart';
 
 void main() {
   final service = AppConfig(region: 'eu-west-1');
-  // See documentation on how to use AppConfig
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_appconfig_api/latest/appconfig-2019-10-09/AppConfig-class.html) on how to use AppConfig

--- a/generated/aws_application_autoscaling_api/README.md
+++ b/generated/aws_application_autoscaling_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Application Auto Scaling
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 With Application Auto Scaling, you can configure automatic scaling for the
@@ -82,9 +82,3 @@ Auto Scaling User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_application_autoscaling_api/example/README.md
+++ b/generated/aws_application_autoscaling_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_application_autoscaling_api/application-autoscaling-2016-02-
 
 void main() {
   final service = ApplicationAutoScaling(region: 'eu-west-1');
-  // See documentation on how to use ApplicationAutoScaling
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_application_autoscaling_api/latest/application-autoscaling-2016-02-06/ApplicationAutoScaling-class.html) on how to use ApplicationAutoScaling

--- a/generated/aws_application_insights_api/README.md
+++ b/generated/aws_application_insights_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudWatch Application Insights
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon CloudWatch Application Insights is a service that helps you detect
@@ -14,9 +14,3 @@ into detected problems.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_application_insights_api/example/README.md
+++ b/generated/aws_application_insights_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_application_insights_api/application-insights-2018-11-25.dar
 
 void main() {
   final service = ApplicationInsights(region: 'eu-west-1');
-  // See documentation on how to use ApplicationInsights
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_application_insights_api/latest/application-insights-2018-11-25/ApplicationInsights-class.html) on how to use ApplicationInsights

--- a/generated/aws_appmesh_api/README.md
+++ b/generated/aws_appmesh_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS App Mesh
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS App Mesh is a service mesh based on the Envoy proxy that makes it easy
@@ -28,9 +28,3 @@ for Services and Pods</a> in the Kubernetes documentation.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_appmesh_api/example/README.md
+++ b/generated/aws_appmesh_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_appmesh_api/appmesh-2019-01-25.dart';
 
 void main() {
   final service = AppMesh(region: 'eu-west-1');
-  // See documentation on how to use AppMesh
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_appmesh_api/latest/appmesh-2019-01-25/AppMesh-class.html) on how to use AppMesh

--- a/generated/aws_appstream_api/README.md
+++ b/generated/aws_appstream_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon AppStream
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>Amazon AppStream 2.0 API Reference</i>. This documentation
@@ -24,9 +24,3 @@ To learn more about AppStream 2.0, see the following resources:
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_appstream_api/example/README.md
+++ b/generated/aws_appstream_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_appstream_api/appstream-2016-12-01.dart';
 
 void main() {
   final service = AppStream(region: 'eu-west-1');
-  // See documentation on how to use AppStream
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_appstream_api/latest/appstream-2016-12-01/AppStream-class.html) on how to use AppStream

--- a/generated/aws_appsync_api/README.md
+++ b/generated/aws_appsync_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS AppSync
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS AppSync provides API actions for creating and interacting with data
@@ -11,9 +11,3 @@ sources using GraphQL from your application.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_appsync_api/example/README.md
+++ b/generated/aws_appsync_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_appsync_api/appsync-2017-07-25.dart';
 
 void main() {
   final service = AppSync(region: 'eu-west-1');
-  // See documentation on how to use AppSync
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_appsync_api/latest/appsync-2017-07-25/AppSync-class.html) on how to use AppSync

--- a/generated/aws_athena_api/README.md
+++ b/generated/aws_athena_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Athena
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Athena is an interactive query service that lets you use standard SQL
@@ -28,9 +28,3 @@ and Code Samples</a> in the <i>Amazon Athena User Guide</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_athena_api/example/README.md
+++ b/generated/aws_athena_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_athena_api/athena-2017-05-18.dart';
 
 void main() {
   final service = Athena(region: 'eu-west-1');
-  // See documentation on how to use Athena
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_athena_api/latest/athena-2017-05-18/Athena-class.html) on how to use Athena

--- a/generated/aws_autoscaling_api/README.md
+++ b/generated/aws_autoscaling_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Auto Scaling
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon EC2 Auto Scaling is designed to automatically launch or terminate EC2
@@ -13,9 +13,3 @@ and Elastic Load Balancing.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_autoscaling_api/example/README.md
+++ b/generated/aws_autoscaling_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_autoscaling_api/autoscaling-2011-01-01.dart';
 
 void main() {
   final service = AutoScaling(region: 'eu-west-1');
-  // See documentation on how to use AutoScaling
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_autoscaling_api/latest/autoscaling-2011-01-01/AutoScaling-class.html) on how to use AutoScaling

--- a/generated/aws_autoscaling_plans_api/README.md
+++ b/generated/aws_autoscaling_plans_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Auto Scaling Plans
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Use AWS Auto Scaling to quickly discover all the scalable AWS resources for
@@ -14,9 +14,3 @@ AWS CloudFormation services.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_autoscaling_plans_api/example/README.md
+++ b/generated/aws_autoscaling_plans_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_autoscaling_plans_api/autoscaling-plans-2018-01-06.dart';
 
 void main() {
   final service = AutoScalingPlans(region: 'eu-west-1');
-  // See documentation on how to use AutoScalingPlans
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_autoscaling_plans_api/latest/autoscaling-plans-2018-01-06/AutoScalingPlans-class.html) on how to use AutoScalingPlans

--- a/generated/aws_backup_api/README.md
+++ b/generated/aws_backup_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Backup
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Backup is a unified backup service designed to protect AWS services and
@@ -13,9 +13,3 @@ auditing.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_backup_api/example/README.md
+++ b/generated/aws_backup_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_backup_api/backup-2018-11-15.dart';
 
 void main() {
   final service = Backup(region: 'eu-west-1');
-  // See documentation on how to use Backup
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_backup_api/latest/backup-2018-11-15/Backup-class.html) on how to use Backup

--- a/generated/aws_batch_api/README.md
+++ b/generated/aws_batch_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Batch
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Using AWS Batch, you can run batch computing workloads on the AWS Cloud.
@@ -25,9 +25,3 @@ on analyzing results and solving your specific problems.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_batch_api/example/README.md
+++ b/generated/aws_batch_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_batch_api/batch-2016-08-10.dart';
 
 void main() {
   final service = Batch(region: 'eu-west-1');
-  // See documentation on how to use Batch
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_batch_api/latest/batch-2016-08-10/Batch-class.html) on how to use Batch

--- a/generated/aws_budgets_api/README.md
+++ b/generated/aws_budgets_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Budgets
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Budgets API enables you to use AWS Budgets to plan your service
@@ -67,9 +67,3 @@ Management Pricing</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_budgets_api/example/README.md
+++ b/generated/aws_budgets_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_budgets_api/budgets-2016-10-20.dart';
 
 void main() {
   final service = Budgets(region: 'eu-west-1');
-  // See documentation on how to use Budgets
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_budgets_api/latest/budgets-2016-10-20/Budgets-class.html) on how to use Budgets

--- a/generated/aws_ce_api/README.md
+++ b/generated/aws_ce_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Cost Explorer Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The Cost Explorer API enables you to programmatically query your cost and
@@ -27,9 +27,3 @@ Management Pricing</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ce_api/example/README.md
+++ b/generated/aws_ce_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ce_api/ce-2017-10-25.dart';
 
 void main() {
   final service = CostExplorer(region: 'eu-west-1');
-  // See documentation on how to use CostExplorer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ce_api/latest/ce-2017-10-25/CostExplorer-class.html) on how to use CostExplorer

--- a/generated/aws_chime_api/README.md
+++ b/generated/aws_chime_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Chime
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The Amazon Chime API (application programming interface) is designed for
@@ -52,9 +52,3 @@ Administration Guide</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_chime_api/example/README.md
+++ b/generated/aws_chime_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_chime_api/chime-2018-05-01.dart';
 
 void main() {
   final service = Chime(region: 'eu-west-1');
-  // See documentation on how to use Chime
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_chime_api/latest/chime-2018-05-01/Chime-class.html) on how to use Chime

--- a/generated/aws_cloud9_api/README.md
+++ b/generated/aws_cloud9_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Cloud9
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Cloud9 is a collection of tools that you can use to code, build, run,
@@ -11,9 +11,3 @@ test, debug, and release software in the cloud.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloud9_api/example/README.md
+++ b/generated/aws_cloud9_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloud9_api/cloud9-2017-09-23.dart';
 
 void main() {
   final service = Cloud9(region: 'eu-west-1');
-  // See documentation on how to use Cloud9
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloud9_api/latest/cloud9-2017-09-23/Cloud9-class.html) on how to use Cloud9

--- a/generated/aws_clouddirectory_api/README.md
+++ b/generated/aws_clouddirectory_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudDirectory
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Cloud Directory is a component of the AWS Directory Service that
@@ -18,9 +18,3 @@ Cloud Directory Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_clouddirectory_api/example/README.md
+++ b/generated/aws_clouddirectory_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_clouddirectory_api/clouddirectory-2017-01-11.dart';
 
 void main() {
   final service = CloudDirectory(region: 'eu-west-1');
-  // See documentation on how to use CloudDirectory
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_clouddirectory_api/latest/clouddirectory-2017-01-11/CloudDirectory-class.html) on how to use CloudDirectory

--- a/generated/aws_cloudformation_api/README.md
+++ b/generated/aws_cloudformation_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CloudFormation
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS CloudFormation allows you to create and manage AWS infrastructure
@@ -16,9 +16,3 @@ infrastructure.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudformation_api/example/README.md
+++ b/generated/aws_cloudformation_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudformation_api/cloudformation-2010-05-15.dart';
 
 void main() {
   final service = CloudFormation(region: 'eu-west-1');
-  // See documentation on how to use CloudFormation
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudformation_api/latest/cloudformation-2010-05-15/CloudFormation-class.html) on how to use CloudFormation

--- a/generated/aws_cloudfront_api/README.md
+++ b/generated/aws_cloudfront_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudFront
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>Amazon CloudFront API Reference</i>. This guide is for
@@ -13,9 +13,3 @@ the <i>Amazon CloudFront Developer Guide</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudfront_api/example/README.md
+++ b/generated/aws_cloudfront_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudfront_api/cloudfront-2020-05-31.dart';
 
 void main() {
   final service = CloudFront(region: 'eu-west-1');
-  // See documentation on how to use CloudFront
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudfront_api/latest/cloudfront-2020-05-31/CloudFront-class.html) on how to use CloudFront

--- a/generated/aws_cloudhsm_api/README.md
+++ b/generated/aws_cloudhsm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudHSM
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is documentation for <b>AWS CloudHSM Classic</b>. For more information,
@@ -16,9 +16,3 @@ CloudHSM Classic API Reference</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudhsm_api/example/README.md
+++ b/generated/aws_cloudhsm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudhsm_api/cloudhsm-2014-05-30.dart';
 
 void main() {
   final service = CloudHSM(region: 'eu-west-1');
-  // See documentation on how to use CloudHSM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudhsm_api/latest/cloudhsm-2014-05-30/CloudHSM-class.html) on how to use CloudHSM

--- a/generated/aws_cloudhsmv2_api/README.md
+++ b/generated/aws_cloudhsmv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CloudHSM V2
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 For more information about AWS CloudHSM, see <a
@@ -13,9 +13,3 @@ User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudhsmv2_api/example/README.md
+++ b/generated/aws_cloudhsmv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudhsmv2_api/cloudhsmv2-2017-04-28.dart';
 
 void main() {
   final service = CloudHSMV2(region: 'eu-west-1');
-  // See documentation on how to use CloudHSMV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudhsmv2_api/latest/cloudhsmv2-2017-04-28/CloudHSMV2-class.html) on how to use CloudHSMV2

--- a/generated/aws_cloudsearch_api/README.md
+++ b/generated/aws_cloudsearch_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudSearch
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 You use the Amazon CloudSearch configuration service to create, configure,
@@ -13,9 +13,3 @@ submitted via HTTP GET or POST with a query parameter named Action.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudsearch_api/example/README.md
+++ b/generated/aws_cloudsearch_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudsearch_api/cloudsearch-2013-01-01.dart';
 
 void main() {
   final service = CloudSearch(region: 'eu-west-1');
-  // See documentation on how to use CloudSearch
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudsearch_api/latest/cloudsearch-2013-01-01/CloudSearch-class.html) on how to use CloudSearch

--- a/generated/aws_cloudsearchdomain_api/README.md
+++ b/generated/aws_cloudsearchdomain_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudSearch Domain
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 You use the AmazonCloudSearch2013 API to upload documents to a search domain
@@ -22,9 +22,3 @@ CloudSearch Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudsearchdomain_api/example/README.md
+++ b/generated/aws_cloudsearchdomain_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudsearchdomain_api/cloudsearchdomain-2013-01-01.dart';
 
 void main() {
   final service = CloudSearchDomain(region: 'eu-west-1');
-  // See documentation on how to use CloudSearchDomain
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudsearchdomain_api/latest/cloudsearchdomain-2013-01-01/CloudSearchDomain-class.html) on how to use CloudSearchDomain

--- a/generated/aws_cloudtrail_api/README.md
+++ b/generated/aws_cloudtrail_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CloudTrail
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the CloudTrail API Reference. It provides descriptions of actions,
@@ -11,9 +11,3 @@ data types, common parameters, and common errors for CloudTrail.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudtrail_api/example/README.md
+++ b/generated/aws_cloudtrail_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudtrail_api/cloudtrail-2013-11-01.dart';
 
 void main() {
   final service = CloudTrail(region: 'eu-west-1');
-  // See documentation on how to use CloudTrail
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudtrail_api/latest/cloudtrail-2013-11-01/CloudTrail-class.html) on how to use CloudTrail

--- a/generated/aws_cloudwatch_api/README.md
+++ b/generated/aws_cloudwatch_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudWatch
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon CloudWatch monitors your Amazon Web Services (AWS) resources and the
@@ -25,9 +25,3 @@ operational health.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cloudwatch_api/example/README.md
+++ b/generated/aws_cloudwatch_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cloudwatch_api/monitoring-2010-08-01.dart';
 
 void main() {
   final service = CloudWatch(region: 'eu-west-1');
-  // See documentation on how to use CloudWatch
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cloudwatch_api/latest/monitoring-2010-08-01/CloudWatch-class.html) on how to use CloudWatch

--- a/generated/aws_codebuild_api/README.md
+++ b/generated/aws_codebuild_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeBuild
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS CodeBuild is a fully managed build service in the cloud. AWS CodeBuild
@@ -20,9 +20,3 @@ CodeBuild User Guide</a>.</i>
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codebuild_api/example/README.md
+++ b/generated/aws_codebuild_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codebuild_api/codebuild-2016-10-06.dart';
 
 void main() {
   final service = CodeBuild(region: 'eu-west-1');
-  // See documentation on how to use CodeBuild
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codebuild_api/latest/codebuild-2016-10-06/CodeBuild-class.html) on how to use CodeBuild

--- a/generated/aws_codecommit_api/README.md
+++ b/generated/aws_codecommit_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeCommit
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>AWS CodeCommit API Reference</i>. This reference provides
@@ -12,9 +12,3 @@ with usage examples.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codecommit_api/example/README.md
+++ b/generated/aws_codecommit_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codecommit_api/codecommit-2015-04-13.dart';
 
 void main() {
   final service = CodeCommit(region: 'eu-west-1');
-  // See documentation on how to use CodeCommit
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codecommit_api/latest/codecommit-2015-04-13/CodeCommit-class.html) on how to use CodeCommit

--- a/generated/aws_codeguru_reviewer_api/README.md
+++ b/generated/aws_codeguru_reviewer_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CodeGuru Reviewer
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This section provides documentation for the Amazon CodeGuru Reviewer API
@@ -27,9 +27,3 @@ CodeGuru Reviewer User Guide</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codeguru_reviewer_api/example/README.md
+++ b/generated/aws_codeguru_reviewer_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codeguru_reviewer_api/codeguru-reviewer-2019-09-19.dart';
 
 void main() {
   final service = CodeGuruReviewer(region: 'eu-west-1');
-  // See documentation on how to use CodeGuruReviewer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codeguru_reviewer_api/latest/codeguru-reviewer-2019-09-19/CodeGuruReviewer-class.html) on how to use CodeGuruReviewer

--- a/generated/aws_codeguruprofiler_api/README.md
+++ b/generated/aws_codeguruprofiler_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CodeGuru Profiler
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This section provides documentation for the Amazon CodeGuru Profiler API
@@ -29,9 +29,3 @@ Profiler User Guide&lt;/i&gt;. &lt;/p&gt; </code></pre>
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codeguruprofiler_api/example/README.md
+++ b/generated/aws_codeguruprofiler_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codeguruprofiler_api/codeguruprofiler-2019-07-18.dart';
 
 void main() {
   final service = CodeGuruProfiler(region: 'eu-west-1');
-  // See documentation on how to use CodeGuruProfiler
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codeguruprofiler_api/latest/codeguruprofiler-2019-07-18/CodeGuruProfiler-class.html) on how to use CodeGuruProfiler

--- a/generated/aws_codepipeline_api/README.md
+++ b/generated/aws_codepipeline_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodePipeline
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the AWS CodePipeline API Reference. This guide provides descriptions
@@ -15,9 +15,3 @@ CodePipeline User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codepipeline_api/example/README.md
+++ b/generated/aws_codepipeline_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codepipeline_api/codepipeline-2015-07-09.dart';
 
 void main() {
   final service = CodePipeline(region: 'eu-west-1');
-  // See documentation on how to use CodePipeline
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codepipeline_api/latest/codepipeline-2015-07-09/CodePipeline-class.html) on how to use CodePipeline

--- a/generated/aws_codestar_api/README.md
+++ b/generated/aws_codestar_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeStar
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the API reference for AWS CodeStar. This reference provides
@@ -12,9 +12,3 @@ with usage examples.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codestar_api/example/README.md
+++ b/generated/aws_codestar_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codestar_api/codestar-2017-04-19.dart';
 
 void main() {
   final service = CodeStar(region: 'eu-west-1');
-  // See documentation on how to use CodeStar
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codestar_api/latest/codestar-2017-04-19/CodeStar-class.html) on how to use CodeStar

--- a/generated/aws_codestar_connections_api/README.md
+++ b/generated/aws_codestar_connections_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeStar connections
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This AWS CodeStar Connections API Reference provides descriptions and usage
@@ -13,9 +13,3 @@ installations.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codestar_connections_api/example/README.md
+++ b/generated/aws_codestar_connections_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codestar_connections_api/codestar-connections-2019-12-01.dar
 
 void main() {
   final service = CodeStarconnections(region: 'eu-west-1');
-  // See documentation on how to use CodeStarconnections
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codestar_connections_api/latest/codestar-connections-2019-12-01/CodeStarconnections-class.html) on how to use CodeStarconnections

--- a/generated/aws_codestar_notifications_api/README.md
+++ b/generated/aws_codestar_notifications_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeStar Notifications
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This AWS CodeStar Notifications API Reference provides descriptions and
@@ -81,9 +81,3 @@ CodeStarNotifications User Guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_codestar_notifications_api/example/README.md
+++ b/generated/aws_codestar_notifications_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_codestar_notifications_api/codestar-notifications-2019-10-15
 
 void main() {
   final service = CodeStarNotifications(region: 'eu-west-1');
-  // See documentation on how to use CodeStarNotifications
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_codestar_notifications_api/latest/codestar-notifications-2019-10-15/CodeStarNotifications-class.html) on how to use CodeStarNotifications

--- a/generated/aws_cognito_identity_api/README.md
+++ b/generated/aws_cognito_identity_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Cognito Identity
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Cognito Federated Identities is a web service that delivers scoped
@@ -13,9 +13,3 @@ identity over the lifetime of an application.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cognito_identity_api/example/README.md
+++ b/generated/aws_cognito_identity_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cognito_identity_api/cognito-identity-2014-06-30.dart';
 
 void main() {
   final service = CognitoIdentity(region: 'eu-west-1');
-  // See documentation on how to use CognitoIdentity
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cognito_identity_api/latest/cognito-identity-2014-06-30/CognitoIdentity-class.html) on how to use CognitoIdentity

--- a/generated/aws_cognito_idp_api/README.md
+++ b/generated/aws_cognito_idp_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Cognito Identity Provider
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Using the Amazon Cognito User Pools API, you can create a user pool to
@@ -17,9 +17,3 @@ For more information, see the Amazon Cognito Documentation.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cognito_idp_api/example/README.md
+++ b/generated/aws_cognito_idp_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cognito_idp_api/cognito-idp-2016-04-18.dart';
 
 void main() {
   final service = CognitoIdentityProvider(region: 'eu-west-1');
-  // See documentation on how to use CognitoIdentityProvider
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cognito_idp_api/latest/cognito-idp-2016-04-18/CognitoIdentityProvider-class.html) on how to use CognitoIdentityProvider

--- a/generated/aws_cognito_sync_api/README.md
+++ b/generated/aws_cognito_sync_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Cognito Sync
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Cognito Sync provides an AWS service and client library that enable
@@ -18,9 +18,3 @@ per user identity.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cognito_sync_api/example/README.md
+++ b/generated/aws_cognito_sync_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cognito_sync_api/cognito-sync-2014-06-30.dart';
 
 void main() {
   final service = CognitoSync(region: 'eu-west-1');
-  // See documentation on how to use CognitoSync
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cognito_sync_api/latest/cognito-sync-2014-06-30/CognitoSync-class.html) on how to use CognitoSync

--- a/generated/aws_comprehend_api/README.md
+++ b/generated/aws_comprehend_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Comprehend
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Comprehend is an AWS service for gaining insight into the content of
@@ -13,9 +13,3 @@ them, the predominant language used, and more.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_comprehend_api/example/README.md
+++ b/generated/aws_comprehend_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_comprehend_api/comprehend-2017-11-27.dart';
 
 void main() {
   final service = Comprehend(region: 'eu-west-1');
-  // See documentation on how to use Comprehend
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_comprehend_api/latest/comprehend-2017-11-27/Comprehend-class.html) on how to use Comprehend

--- a/generated/aws_comprehendmedical_api/README.md
+++ b/generated/aws_comprehendmedical_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Comprehend Medical
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Comprehend Medical extracts structured information from unstructured
@@ -11,9 +11,3 @@ clinical text. Use these actions to gain insight in your documents.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_comprehendmedical_api/example/README.md
+++ b/generated/aws_comprehendmedical_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_comprehendmedical_api/comprehendmedical-2018-10-30.dart';
 
 void main() {
   final service = ComprehendMedical(region: 'eu-west-1');
-  // See documentation on how to use ComprehendMedical
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_comprehendmedical_api/latest/comprehendmedical-2018-10-30/ComprehendMedical-class.html) on how to use ComprehendMedical

--- a/generated/aws_compute_optimizer_api/README.md
+++ b/generated/aws_compute_optimizer_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Compute Optimizer
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Compute Optimizer is a service that analyzes the configuration and
@@ -24,9 +24,3 @@ Optimizer User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_compute_optimizer_api/example/README.md
+++ b/generated/aws_compute_optimizer_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_compute_optimizer_api/compute-optimizer-2019-11-01.dart';
 
 void main() {
   final service = ComputeOptimizer(region: 'eu-west-1');
-  // See documentation on how to use ComputeOptimizer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_compute_optimizer_api/latest/compute-optimizer-2019-11-01/ComputeOptimizer-class.html) on how to use ComputeOptimizer

--- a/generated/aws_configservice_api/README.md
+++ b/generated/aws_configservice_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Config
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Config provides a way to keep track of the configurations of all the AWS
@@ -19,9 +19,3 @@ AWS Resources</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_configservice_api/example/README.md
+++ b/generated/aws_configservice_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_configservice_api/config-2014-11-12.dart';
 
 void main() {
   final service = ConfigService(region: 'eu-west-1');
-  // See documentation on how to use ConfigService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_configservice_api/latest/config-2014-11-12/ConfigService-class.html) on how to use ConfigService

--- a/generated/aws_connect_api/README.md
+++ b/generated/aws_connect_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Connect Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Connect is a cloud-based contact center solution that makes it easy
@@ -32,9 +32,3 @@ Connect Flow language</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_connect_api/example/README.md
+++ b/generated/aws_connect_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_connect_api/connect-2017-08-08.dart';
 
 void main() {
   final service = Connect(region: 'eu-west-1');
-  // See documentation on how to use Connect
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_connect_api/latest/connect-2017-08-08/Connect-class.html) on how to use Connect

--- a/generated/aws_connectparticipant_api/README.md
+++ b/generated/aws_connectparticipant_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Connect Participant Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Connect is a cloud-based contact center solution that makes it easy
@@ -17,9 +17,3 @@ customers.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_connectparticipant_api/example/README.md
+++ b/generated/aws_connectparticipant_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_connectparticipant_api/connectparticipant-2018-09-07.dart';
 
 void main() {
   final service = ConnectParticipant(region: 'eu-west-1');
-  // See documentation on how to use ConnectParticipant
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_connectparticipant_api/latest/connectparticipant-2018-09-07/ConnectParticipant-class.html) on how to use ConnectParticipant

--- a/generated/aws_cur_api/README.md
+++ b/generated/aws_cur_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Cost and Usage Report Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Cost and Usage Report API enables you to programmatically create,
@@ -27,9 +27,3 @@ cur.us-east-1.amazonaws.com
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_cur_api/example/README.md
+++ b/generated/aws_cur_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_cur_api/cur-2017-01-06.dart';
 
 void main() {
   final service = CostandUsageReportService(region: 'eu-west-1');
-  // See documentation on how to use CostandUsageReportService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_cur_api/latest/cur-2017-01-06/CostandUsageReportService-class.html) on how to use CostandUsageReportService

--- a/generated/aws_dataexchange_api/README.md
+++ b/generated/aws_dataexchange_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Data Exchange
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Data Exchange is a service that makes it easy for AWS customers to
@@ -30,9 +30,3 @@ to create or copy assets.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dataexchange_api/example/README.md
+++ b/generated/aws_dataexchange_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dataexchange_api/dataexchange-2017-07-25.dart';
 
 void main() {
   final service = DataExchange(region: 'eu-west-1');
-  // See documentation on how to use DataExchange
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dataexchange_api/latest/dataexchange-2017-07-25/DataExchange-class.html) on how to use DataExchange

--- a/generated/aws_datapipeline_api/README.md
+++ b/generated/aws_datapipeline_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Data Pipeline
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Data Pipeline configures and manages a data-driven workflow called a
@@ -31,9 +31,3 @@ the task to the web service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_datapipeline_api/example/README.md
+++ b/generated/aws_datapipeline_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_datapipeline_api/datapipeline-2012-10-29.dart';
 
 void main() {
   final service = DataPipeline(region: 'eu-west-1');
-  // See documentation on how to use DataPipeline
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_datapipeline_api/latest/datapipeline-2012-10-29/DataPipeline-class.html) on how to use DataPipeline

--- a/generated/aws_datasync_api/README.md
+++ b/generated/aws_datasync_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS DataSync
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS DataSync is a managed data transfer service that makes it simpler for
@@ -12,9 +12,3 @@ Storage Service (Amazon S3) or Amazon Elastic File System (Amazon EFS).
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_datasync_api/example/README.md
+++ b/generated/aws_datasync_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_datasync_api/datasync-2018-11-09.dart';
 
 void main() {
   final service = DataSync(region: 'eu-west-1');
-  // See documentation on how to use DataSync
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_datasync_api/latest/datasync-2018-11-09/DataSync-class.html) on how to use DataSync

--- a/generated/aws_dax_api/README.md
+++ b/generated/aws_dax_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon DynamoDB Accelerator (DAX)
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 DAX is a managed caching service engineered for Amazon DynamoDB. DAX
@@ -16,9 +16,3 @@ improvements in read performance.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dax_api/example/README.md
+++ b/generated/aws_dax_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dax_api/dax-2017-04-19.dart';
 
 void main() {
   final service = DAX(region: 'eu-west-1');
-  // See documentation on how to use DAX
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dax_api/latest/dax-2017-04-19/DAX-class.html) on how to use DAX

--- a/generated/aws_deploy_api/README.md
+++ b/generated/aws_deploy_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS CodeDeploy
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS CodeDeploy is a deployment service that automates application
@@ -13,9 +13,3 @@ ECS service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_deploy_api/example/README.md
+++ b/generated/aws_deploy_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_deploy_api/codedeploy-2014-10-06.dart';
 
 void main() {
   final service = CodeDeploy(region: 'eu-west-1');
-  // See documentation on how to use CodeDeploy
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_deploy_api/latest/codedeploy-2014-10-06/CodeDeploy-class.html) on how to use CodeDeploy

--- a/generated/aws_detective_api/README.md
+++ b/generated/aws_detective_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Detective
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Detective uses machine learning and purpose-built visualizations to help you
@@ -60,9 +60,3 @@ Detective API Calls with CloudTrail</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_detective_api/example/README.md
+++ b/generated/aws_detective_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_detective_api/detective-2018-10-26.dart';
 
 void main() {
   final service = Detective(region: 'eu-west-1');
-  // See documentation on how to use Detective
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_detective_api/latest/detective-2018-10-26/Detective-class.html) on how to use Detective

--- a/generated/aws_devicefarm_api/README.md
+++ b/generated/aws_devicefarm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Device Farm
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the AWS Device Farm API documentation, which contains APIs for:
@@ -30,9 +30,3 @@ Farm Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_devicefarm_api/example/README.md
+++ b/generated/aws_devicefarm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_devicefarm_api/devicefarm-2015-06-23.dart';
 
 void main() {
   final service = DeviceFarm(region: 'eu-west-1');
-  // See documentation on how to use DeviceFarm
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_devicefarm_api/latest/devicefarm-2015-06-23/DeviceFarm-class.html) on how to use DeviceFarm

--- a/generated/aws_directconnect_api/README.md
+++ b/generated/aws_directconnect_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Direct Connect
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Direct Connect links your internal network to an AWS Direct Connect
@@ -18,9 +18,3 @@ through locations associated with those Regions.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_directconnect_api/example/README.md
+++ b/generated/aws_directconnect_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_directconnect_api/directconnect-2012-10-25.dart';
 
 void main() {
   final service = DirectConnect(region: 'eu-west-1');
-  // See documentation on how to use DirectConnect
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_directconnect_api/latest/directconnect-2012-10-25/DirectConnect-class.html) on how to use DirectConnect

--- a/generated/aws_discovery_api/README.md
+++ b/generated/aws_discovery_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Application Discovery Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Application Discovery Service helps you plan application migration
@@ -16,9 +16,3 @@ on-premises servers:
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_discovery_api/example/README.md
+++ b/generated/aws_discovery_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_discovery_api/discovery-2015-11-01.dart';
 
 void main() {
   final service = ApplicationDiscoveryService(region: 'eu-west-1');
-  // See documentation on how to use ApplicationDiscoveryService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_discovery_api/latest/discovery-2015-11-01/ApplicationDiscoveryService-class.html) on how to use ApplicationDiscoveryService

--- a/generated/aws_dlm_api/README.md
+++ b/generated/aws_dlm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Data Lifecycle Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 With Amazon Data Lifecycle Manager, you can manage the lifecycle of your AWS
@@ -12,9 +12,3 @@ operations on the specified resources.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dlm_api/example/README.md
+++ b/generated/aws_dlm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dlm_api/dlm-2018-01-12.dart';
 
 void main() {
   final service = DLM(region: 'eu-west-1');
-  // See documentation on how to use DLM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dlm_api/latest/dlm-2018-01-12/DLM-class.html) on how to use DLM

--- a/generated/aws_dms_api/README.md
+++ b/generated/aws_dms_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Database Migration Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Database Migration Service (AWS DMS) can migrate your data to and from
@@ -16,9 +16,3 @@ SQL Server to PostgreSQL.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dms_api/example/README.md
+++ b/generated/aws_dms_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dms_api/dms-2016-01-01.dart';
 
 void main() {
   final service = DatabaseMigrationService(region: 'eu-west-1');
-  // See documentation on how to use DatabaseMigrationService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dms_api/latest/dms-2016-01-01/DatabaseMigrationService-class.html) on how to use DatabaseMigrationService

--- a/generated/aws_docdb_api/README.md
+++ b/generated/aws_docdb_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon DocumentDB with MongoDB compatibility
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon DocumentDB API documentation
@@ -10,9 +10,3 @@ Amazon DocumentDB API documentation
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_docdb_api/example/README.md
+++ b/generated/aws_docdb_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_docdb_api/docdb-2014-10-31.dart';
 
 void main() {
   final service = DocDB(region: 'eu-west-1');
-  // See documentation on how to use DocDB
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_docdb_api/latest/docdb-2014-10-31/DocDB-class.html) on how to use DocDB

--- a/generated/aws_ds_api/README.md
+++ b/generated/aws_ds_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Directory Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Directory Service is a web service that makes it easy for you to setup
@@ -26,9 +26,3 @@ href="https://aws.amazon.com/tools/">Tools for Amazon Web Services</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ds_api/example/README.md
+++ b/generated/aws_ds_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ds_api/ds-2015-04-16.dart';
 
 void main() {
   final service = DirectoryService(region: 'eu-west-1');
-  // See documentation on how to use DirectoryService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ds_api/latest/ds-2015-04-16/DirectoryService-class.html) on how to use DirectoryService

--- a/generated/aws_dynamodb_api/README.md
+++ b/generated/aws_dynamodb_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon DynamoDB
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon DynamoDB is a fully managed NoSQL database service that provides fast
@@ -14,9 +14,3 @@ and configuration, replication, software patching, or cluster scaling.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dynamodb_api/example/README.md
+++ b/generated/aws_dynamodb_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dynamodb_api/dynamodb-2012-08-10.dart';
 
 void main() {
   final service = DynamoDB(region: 'eu-west-1');
-  // See documentation on how to use DynamoDB
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dynamodb_api/latest/dynamodb-2012-08-10/DynamoDB-class.html) on how to use DynamoDB

--- a/generated/aws_dynamodbstreams_api/README.md
+++ b/generated/aws_dynamodbstreams_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon DynamoDB Streams
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon DynamoDB Streams provides API actions for accessing streams and
@@ -15,9 +15,3 @@ Guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_dynamodbstreams_api/example/README.md
+++ b/generated/aws_dynamodbstreams_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_dynamodbstreams_api/streams-dynamodb-2012-08-10.dart';
 
 void main() {
   final service = DynamoDBStreams(region: 'eu-west-1');
-  // See documentation on how to use DynamoDBStreams
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_dynamodbstreams_api/latest/streams-dynamodb-2012-08-10/DynamoDBStreams-class.html) on how to use DynamoDBStreams

--- a/generated/aws_ebs_api/README.md
+++ b/generated/aws_ebs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic Block Store
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 You can use the Amazon Elastic Block Store (Amazon EBS) direct APIs to
@@ -37,9 +37,3 @@ Reference</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ebs_api/example/README.md
+++ b/generated/aws_ebs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ebs_api/ebs-2019-11-02.dart';
 
 void main() {
   final service = EBS(region: 'eu-west-1');
-  // See documentation on how to use EBS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ebs_api/latest/ebs-2019-11-02/EBS-class.html) on how to use EBS

--- a/generated/aws_ec2_api/README.md
+++ b/generated/aws_ec2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic Compute Cloud
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Elastic Compute Cloud (Amazon EC2) provides secure and resizable
@@ -13,9 +13,3 @@ faster.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ec2_api/example/README.md
+++ b/generated/aws_ec2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ec2_api/ec2-2016-11-15.dart';
 
 void main() {
   final service = EC2(region: 'eu-west-1');
-  // See documentation on how to use EC2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ec2_api/latest/ec2-2016-11-15/EC2-class.html) on how to use EC2

--- a/generated/aws_ec2_instance_connect_api/README.md
+++ b/generated/aws_ec2_instance_connect_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS EC2 Instance Connect
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS EC2 Connect Service is a service that enables system administrators to
@@ -13,9 +13,3 @@ option.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ec2_instance_connect_api/example/README.md
+++ b/generated/aws_ec2_instance_connect_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ec2_instance_connect_api/ec2-instance-connect-2018-04-02.dar
 
 void main() {
   final service = EC2InstanceConnect(region: 'eu-west-1');
-  // See documentation on how to use EC2InstanceConnect
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ec2_instance_connect_api/latest/ec2-instance-connect-2018-04-02/EC2InstanceConnect-class.html) on how to use EC2InstanceConnect

--- a/generated/aws_ecr_api/README.md
+++ b/generated/aws_ecr_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon EC2 Container Registry
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Elastic Container Registry (Amazon ECR) is a managed container image
@@ -16,9 +16,3 @@ instances can access repositories and images.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ecr_api/example/README.md
+++ b/generated/aws_ecr_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ecr_api/ecr-2015-09-21.dart';
 
 void main() {
   final service = ECR(region: 'eu-west-1');
-  // See documentation on how to use ECR
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ecr_api/latest/ecr-2015-09-21/ECR-class.html) on how to use ECR

--- a/generated/aws_ecs_api/README.md
+++ b/generated/aws_ecs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon EC2 Container Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Elastic Container Service (Amazon ECS) is a highly scalable, fast,
@@ -19,9 +19,3 @@ ECS Launch Types</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ecs_api/example/README.md
+++ b/generated/aws_ecs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ecs_api/ecs-2014-11-13.dart';
 
 void main() {
   final service = ECS(region: 'eu-west-1');
-  // See documentation on how to use ECS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ecs_api/latest/ecs-2014-11-13/ECS-class.html) on how to use ECS

--- a/generated/aws_efs_api/README.md
+++ b/generated/aws_efs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic File System
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Elastic File System (Amazon EFS) provides simple, scalable file
@@ -16,9 +16,3 @@ Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_efs_api/example/README.md
+++ b/generated/aws_efs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_efs_api/elasticfilesystem-2015-02-01.dart';
 
 void main() {
   final service = EFS(region: 'eu-west-1');
-  // See documentation on how to use EFS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_efs_api/latest/elasticfilesystem-2015-02-01/EFS-class.html) on how to use EFS

--- a/generated/aws_eks_api/README.md
+++ b/generated/aws_eks_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic Kubernetes Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Elastic Kubernetes Service (Amazon EKS) is a managed service that
@@ -22,9 +22,3 @@ modification required.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_eks_api/example/README.md
+++ b/generated/aws_eks_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_eks_api/eks-2017-11-01.dart';
 
 void main() {
   final service = EKS(region: 'eu-west-1');
-  // See documentation on how to use EKS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_eks_api/latest/eks-2017-11-01/EKS-class.html) on how to use EKS

--- a/generated/aws_elastic_inference_api/README.md
+++ b/generated/aws_elastic_inference_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic  Inference
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Elastic Inference public APIs.
@@ -10,9 +10,3 @@ Elastic Inference public APIs.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elastic_inference_api/example/README.md
+++ b/generated/aws_elastic_inference_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elastic_inference_api/elastic-inference-2017-07-25.dart';
 
 void main() {
   final service = ElasticInference(region: 'eu-west-1');
-  // See documentation on how to use ElasticInference
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elastic_inference_api/latest/elastic-inference-2017-07-25/ElasticInference-class.html) on how to use ElasticInference

--- a/generated/aws_elasticache_api/README.md
+++ b/generated/aws_elasticache_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon ElastiCache
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon ElastiCache is a web service that makes it easier to set up, operate,
@@ -11,9 +11,3 @@ and scale a distributed cache in the cloud.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elasticache_api/example/README.md
+++ b/generated/aws_elasticache_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elasticache_api/elasticache-2015-02-02.dart';
 
 void main() {
   final service = ElastiCache(region: 'eu-west-1');
-  // See documentation on how to use ElastiCache
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elasticache_api/latest/elasticache-2015-02-02/ElastiCache-class.html) on how to use ElastiCache

--- a/generated/aws_elasticbeanstalk_api/README.md
+++ b/generated/aws_elasticbeanstalk_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elastic Beanstalk
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Elastic Beanstalk makes it easy for you to create, deploy, and manage
@@ -12,9 +12,3 @@ cloud.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elasticbeanstalk_api/example/README.md
+++ b/generated/aws_elasticbeanstalk_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elasticbeanstalk_api/elasticbeanstalk-2010-12-01.dart';
 
 void main() {
   final service = ElasticBeanstalk(region: 'eu-west-1');
-  // See documentation on how to use ElasticBeanstalk
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elasticbeanstalk_api/latest/elasticbeanstalk-2010-12-01/ElasticBeanstalk-class.html) on how to use ElasticBeanstalk

--- a/generated/aws_elastictranscoder_api/README.md
+++ b/generated/aws_elastictranscoder_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic Transcoder
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Elastic Transcoder Service.
@@ -10,9 +10,3 @@ The AWS Elastic Transcoder Service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elastictranscoder_api/example/README.md
+++ b/generated/aws_elastictranscoder_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elastictranscoder_api/elastictranscoder-2012-09-25.dart';
 
 void main() {
   final service = ElasticTranscoder(region: 'eu-west-1');
-  // See documentation on how to use ElasticTranscoder
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elastictranscoder_api/latest/elastictranscoder-2012-09-25/ElasticTranscoder-class.html) on how to use ElasticTranscoder

--- a/generated/aws_elb_api/README.md
+++ b/generated/aws_elb_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Elastic Load Balancing
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 A load balancer can distribute incoming traffic across your EC2 instances.
@@ -17,9 +17,3 @@ from the load balancer to the instances.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elb_api/example/README.md
+++ b/generated/aws_elb_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elb_api/elasticloadbalancing-2012-06-01.dart';
 
 void main() {
   final service = ElasticLoadBalancing(region: 'eu-west-1');
-  // See documentation on how to use ElasticLoadBalancing
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elb_api/latest/elasticloadbalancing-2012-06-01/ElasticLoadBalancing-class.html) on how to use ElasticLoadBalancing

--- a/generated/aws_elbv2_api/README.md
+++ b/generated/aws_elbv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Elastic Load Balancing
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 A load balancer distributes incoming traffic across targets, such as your
@@ -19,9 +19,3 @@ health status of the targets.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_elbv2_api/example/README.md
+++ b/generated/aws_elbv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_elbv2_api/elasticloadbalancingv2-2015-12-01.dart';
 
 void main() {
   final service = ElasticLoadBalancingv2(region: 'eu-west-1');
-  // See documentation on how to use ElasticLoadBalancingv2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_elbv2_api/latest/elasticloadbalancingv2-2015-12-01/ElasticLoadBalancingv2-class.html) on how to use ElasticLoadBalancingv2

--- a/generated/aws_emr_api/README.md
+++ b/generated/aws_emr_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elastic MapReduce
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon EMR is a web service that makes it easier to process large amounts of
@@ -14,9 +14,3 @@ management.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_emr_api/example/README.md
+++ b/generated/aws_emr_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_emr_api/elasticmapreduce-2009-03-31.dart';
 
 void main() {
   final service = EMR(region: 'eu-west-1');
-  // See documentation on how to use EMR
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_emr_api/latest/elasticmapreduce-2009-03-31/EMR-class.html) on how to use EMR

--- a/generated/aws_es_api/README.md
+++ b/generated/aws_es_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Elasticsearch Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Use the Amazon Elasticsearch Configuration API to create, configure, and
@@ -11,9 +11,3 @@ manage Elasticsearch domains.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_es_api/example/README.md
+++ b/generated/aws_es_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_es_api/es-2015-01-01.dart';
 
 void main() {
   final service = ElasticsearchService(region: 'eu-west-1');
-  // See documentation on how to use ElasticsearchService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_es_api/latest/es-2015-01-01/ElasticsearchService-class.html) on how to use ElasticsearchService

--- a/generated/aws_events_api/README.md
+++ b/generated/aws_events_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudWatch Events
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon EventBridge helps you to respond to state changes in your AWS
@@ -33,9 +33,3 @@ EventBridge User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_events_api/example/README.md
+++ b/generated/aws_events_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_events_api/events-2015-10-07.dart';
 
 void main() {
   final service = CloudWatchEvents(region: 'eu-west-1');
-  // See documentation on how to use CloudWatchEvents
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_events_api/latest/events-2015-10-07/CloudWatchEvents-class.html) on how to use CloudWatchEvents

--- a/generated/aws_firehose_api/README.md
+++ b/generated/aws_firehose_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Firehose
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Kinesis Data Firehose is a fully managed service that delivers
@@ -13,9 +13,3 @@ Redshift, and Splunk.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_firehose_api/example/README.md
+++ b/generated/aws_firehose_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_firehose_api/firehose-2015-08-04.dart';
 
 void main() {
   final service = Firehose(region: 'eu-west-1');
-  // See documentation on how to use Firehose
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_firehose_api/latest/firehose-2015-08-04/Firehose-class.html) on how to use Firehose

--- a/generated/aws_fms_api/README.md
+++ b/generated/aws_fms_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Firewall Management Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>AWS Firewall Manager API Reference</i>. This guide is for
@@ -15,9 +15,3 @@ Firewall Manager Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_fms_api/example/README.md
+++ b/generated/aws_fms_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_fms_api/fms-2018-01-01.dart';
 
 void main() {
   final service = FMS(region: 'eu-west-1');
-  // See documentation on how to use FMS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_fms_api/latest/fms-2018-01-01/FMS-class.html) on how to use FMS

--- a/generated/aws_forecast_api/README.md
+++ b/generated/aws_forecast_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Forecast Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Provides APIs for creating and managing Amazon Forecast resources.
@@ -10,9 +10,3 @@ Provides APIs for creating and managing Amazon Forecast resources.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_forecast_api/example/README.md
+++ b/generated/aws_forecast_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_forecast_api/forecast-2018-06-26.dart';
 
 void main() {
   final service = ForecastService(region: 'eu-west-1');
-  // See documentation on how to use ForecastService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_forecast_api/latest/forecast-2018-06-26/ForecastService-class.html) on how to use ForecastService

--- a/generated/aws_forecastquery_api/README.md
+++ b/generated/aws_forecastquery_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Forecast Query Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Provides APIs for creating and managing Amazon Forecast resources.
@@ -10,9 +10,3 @@ Provides APIs for creating and managing Amazon Forecast resources.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_forecastquery_api/example/README.md
+++ b/generated/aws_forecastquery_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_forecastquery_api/forecastquery-2018-06-26.dart';
 
 void main() {
   final service = ForecastQueryService(region: 'eu-west-1');
-  // See documentation on how to use ForecastQueryService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_forecastquery_api/latest/forecastquery-2018-06-26/ForecastQueryService-class.html) on how to use ForecastQueryService

--- a/generated/aws_frauddetector_api/README.md
+++ b/generated/aws_frauddetector_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Fraud Detector
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the Amazon Fraud Detector API Reference. This guide is for
@@ -15,9 +15,3 @@ Detector User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_frauddetector_api/example/README.md
+++ b/generated/aws_frauddetector_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_frauddetector_api/frauddetector-2019-11-15.dart';
 
 void main() {
   final service = FraudDetector(region: 'eu-west-1');
-  // See documentation on how to use FraudDetector
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_frauddetector_api/latest/frauddetector-2019-11-15/FraudDetector-class.html) on how to use FraudDetector

--- a/generated/aws_fsx_api/README.md
+++ b/generated/aws_fsx_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon FSx
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon FSx is a fully managed service that makes it easy for storage and
@@ -11,9 +11,3 @@ application administrators to launch and use shared file storage.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_fsx_api/example/README.md
+++ b/generated/aws_fsx_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_fsx_api/fsx-2018-03-01.dart';
 
 void main() {
   final service = FSx(region: 'eu-west-1');
-  // See documentation on how to use FSx
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_fsx_api/latest/fsx-2018-03-01/FSx-class.html) on how to use FSx

--- a/generated/aws_gamelift_api/README.md
+++ b/generated/aws_gamelift_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon GameLift
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 GameLift provides solutions for hosting session-based multiplayer game
@@ -14,9 +14,3 @@ dynamically scaling your resource usage to meet player demand.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_gamelift_api/example/README.md
+++ b/generated/aws_gamelift_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_gamelift_api/gamelift-2015-10-01.dart';
 
 void main() {
   final service = GameLift(region: 'eu-west-1');
-  // See documentation on how to use GameLift
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_gamelift_api/latest/gamelift-2015-10-01/GameLift-class.html) on how to use GameLift

--- a/generated/aws_glacier_api/README.md
+++ b/generated/aws_glacier_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Glacier
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon S3 Glacier (Glacier) is a storage solution for "cold data."
@@ -48,9 +48,3 @@ to download archives, retrieving the job output, and deleting archives.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_glacier_api/example/README.md
+++ b/generated/aws_glacier_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_glacier_api/glacier-2012-06-01.dart';
 
 void main() {
   final service = Glacier(region: 'eu-west-1');
-  // See documentation on how to use Glacier
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_glacier_api/latest/glacier-2012-06-01/Glacier-class.html) on how to use Glacier

--- a/generated/aws_globalaccelerator_api/README.md
+++ b/generated/aws_globalaccelerator_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Global Accelerator
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>AWS Global Accelerator API Reference</i>. This guide is for
@@ -15,9 +15,3 @@ Global Accelerator Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_globalaccelerator_api/example/README.md
+++ b/generated/aws_globalaccelerator_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_globalaccelerator_api/globalaccelerator-2018-08-08.dart';
 
 void main() {
   final service = GlobalAccelerator(region: 'eu-west-1');
-  // See documentation on how to use GlobalAccelerator
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_globalaccelerator_api/latest/globalaccelerator-2018-08-08/GlobalAccelerator-class.html) on how to use GlobalAccelerator

--- a/generated/aws_glue_api/README.md
+++ b/generated/aws_glue_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Glue
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Defines the public endpoint for the AWS Glue service.
@@ -10,9 +10,3 @@ Defines the public endpoint for the AWS Glue service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_glue_api/example/README.md
+++ b/generated/aws_glue_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_glue_api/glue-2017-03-31.dart';
 
 void main() {
   final service = Glue(region: 'eu-west-1');
-  // See documentation on how to use Glue
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_glue_api/latest/glue-2017-03-31/Glue-class.html) on how to use Glue

--- a/generated/aws_greengrass_api/README.md
+++ b/generated/aws_greengrass_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Greengrass V2
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Greengrass brings local compute, messaging, data management, sync,
@@ -27,9 +27,3 @@ Guide</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_greengrass_api/example/README.md
+++ b/generated/aws_greengrass_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_greengrass_api/greengrassv2-2020-11-30.dart';
 
 void main() {
   final service = GreengrassV2(region: 'eu-west-1');
-  // See documentation on how to use GreengrassV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_greengrass_api/latest/greengrassv2-2020-11-30/GreengrassV2-class.html) on how to use GreengrassV2

--- a/generated/aws_groundstation_api/README.md
+++ b/generated/aws_groundstation_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Ground Station
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the AWS Ground Station API Reference. AWS Ground Station is a
@@ -14,9 +14,3 @@ ground station infrastructure.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_groundstation_api/example/README.md
+++ b/generated/aws_groundstation_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_groundstation_api/groundstation-2019-05-23.dart';
 
 void main() {
   final service = GroundStation(region: 'eu-west-1');
-  // See documentation on how to use GroundStation
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_groundstation_api/latest/groundstation-2019-05-23/GroundStation-class.html) on how to use GroundStation

--- a/generated/aws_guardduty_api/README.md
+++ b/generated/aws_guardduty_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon GuardDuty
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon GuardDuty is a continuous security monitoring service that analyzes
@@ -29,9 +29,3 @@ GuardDuty User Guide</a> </i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_guardduty_api/example/README.md
+++ b/generated/aws_guardduty_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_guardduty_api/guardduty-2017-11-28.dart';
 
 void main() {
   final service = GuardDuty(region: 'eu-west-1');
-  // See documentation on how to use GuardDuty
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_guardduty_api/latest/guardduty-2017-11-28/GuardDuty-class.html) on how to use GuardDuty

--- a/generated/aws_health_api/README.md
+++ b/generated/aws_health_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Health APIs and Notifications
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Health API provides programmatic access to the AWS Health
@@ -23,9 +23,3 @@ Use this endpoint to call the AWS Health API operations.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_health_api/example/README.md
+++ b/generated/aws_health_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_health_api/health-2016-08-04.dart';
 
 void main() {
   final service = Health(region: 'eu-west-1');
-  // See documentation on how to use Health
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_health_api/latest/health-2016-08-04/Health-class.html) on how to use Health

--- a/generated/aws_iam_api/README.md
+++ b/generated/aws_iam_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Identity and Access Management
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Identity and Access Management (IAM) is a web service for securely
@@ -17,9 +17,3 @@ Access Management User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iam_api/example/README.md
+++ b/generated/aws_iam_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iam_api/iam-2010-05-08.dart';
 
 void main() {
   final service = IAM(region: 'eu-west-1');
-  // See documentation on how to use IAM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iam_api/latest/iam-2010-05-08/IAM-class.html) on how to use IAM

--- a/generated/aws_imagebuilder_api/README.md
+++ b/generated/aws_imagebuilder_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for EC2 Image Builder
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 EC2 Image Builder is a fully managed AWS service that makes it easier to
@@ -13,9 +13,3 @@ with software and settings to meet specific IT standards.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_imagebuilder_api/example/README.md
+++ b/generated/aws_imagebuilder_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_imagebuilder_api/imagebuilder-2019-12-02.dart';
 
 void main() {
   final service = Imagebuilder(region: 'eu-west-1');
-  // See documentation on how to use Imagebuilder
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_imagebuilder_api/latest/imagebuilder-2019-12-02/Imagebuilder-class.html) on how to use Imagebuilder

--- a/generated/aws_importexport_api/README.md
+++ b/generated/aws_importexport_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Import/Export
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 transferring large amounts of data between the AWS cloud and portable
@@ -15,9 +15,3 @@ than upgrading your connectivity.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_importexport_api/example/README.md
+++ b/generated/aws_importexport_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_importexport_api/importexport-2010-06-01.dart';
 
 void main() {
   final service = ImportExport(region: 'eu-west-1');
-  // See documentation on how to use ImportExport
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_importexport_api/latest/importexport-2010-06-01/ImportExport-class.html) on how to use ImportExport

--- a/generated/aws_inspector_api/README.md
+++ b/generated/aws_inspector_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Inspector
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Inspector enables you to analyze the behavior of your AWS resources
@@ -13,9 +13,3 @@ Amazon Inspector User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_inspector_api/example/README.md
+++ b/generated/aws_inspector_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_inspector_api/inspector-2016-02-16.dart';
 
 void main() {
   final service = Inspector(region: 'eu-west-1');
-  // See documentation on how to use Inspector
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_inspector_api/latest/inspector-2016-02-16/Inspector-class.html) on how to use Inspector

--- a/generated/aws_iot1click_devices_api/README.md
+++ b/generated/aws_iot1click_devices_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT 1-Click Devices Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Describes all of the AWS IoT 1-Click device-related API operations for the
@@ -14,9 +14,3 @@ protocols.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iot1click_devices_api/example/README.md
+++ b/generated/aws_iot1click_devices_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iot1click_devices_api/devices-2018-05-14.dart';
 
 void main() {
   final service = IoT1ClickDevicesService(region: 'eu-west-1');
-  // See documentation on how to use IoT1ClickDevicesService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iot1click_devices_api/latest/devices-2018-05-14/IoT1ClickDevicesService-class.html) on how to use IoT1ClickDevicesService

--- a/generated/aws_iot1click_projects_api/README.md
+++ b/generated/aws_iot1click_projects_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT 1-Click Projects Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS IoT 1-Click Projects API Reference
@@ -10,9 +10,3 @@ The AWS IoT 1-Click Projects API Reference
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iot1click_projects_api/example/README.md
+++ b/generated/aws_iot1click_projects_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iot1click_projects_api/iot1click-projects-2018-05-14.dart';
 
 void main() {
   final service = IoT1ClickProjects(region: 'eu-west-1');
-  // See documentation on how to use IoT1ClickProjects
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iot1click_projects_api/latest/iot1click-projects-2018-05-14/IoT1ClickProjects-class.html) on how to use IoT1ClickProjects

--- a/generated/aws_iot_api/README.md
+++ b/generated/aws_iot_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT provides secure, bi-directional communication between
@@ -16,9 +16,3 @@ credentials to authenticate devices.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iot_api/example/README.md
+++ b/generated/aws_iot_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iot_api/iot-2015-05-28.dart';
 
 void main() {
   final service = IoT(region: 'eu-west-1');
-  // See documentation on how to use IoT
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iot_api/latest/iot-2015-05-28/IoT-class.html) on how to use IoT

--- a/generated/aws_iot_data_api/README.md
+++ b/generated/aws_iot_data_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Data Plane
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT-Data enables secure, bi-directional communication between
@@ -15,9 +15,3 @@ their state in the AWS cloud.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iot_data_api/example/README.md
+++ b/generated/aws_iot_data_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iot_data_api/iot-data-2015-05-28.dart';
 
 void main() {
   final service = IoTDataPlane(region: 'eu-west-1');
-  // See documentation on how to use IoTDataPlane
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iot_data_api/latest/iot-data-2015-05-28/IoTDataPlane-class.html) on how to use IoTDataPlane

--- a/generated/aws_iot_jobs_data_api/README.md
+++ b/generated/aws_iot_jobs_data_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Jobs Data Plane
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Jobs is a service that allows you to define a set of jobs — remote
@@ -25,9 +25,3 @@ specific target and for all the targets of the job
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iot_jobs_data_api/example/README.md
+++ b/generated/aws_iot_jobs_data_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iot_jobs_data_api/iot-jobs-data-2017-09-29.dart';
 
 void main() {
   final service = IoTJobsDataPlane(region: 'eu-west-1');
-  // See documentation on how to use IoTJobsDataPlane
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iot_jobs_data_api/latest/iot-jobs-data-2017-09-29/IoTJobsDataPlane-class.html) on how to use IoTJobsDataPlane

--- a/generated/aws_iotanalytics_api/README.md
+++ b/generated/aws_iotanalytics_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Analytics
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Analytics allows you to collect large amounts of device data,
@@ -33,9 +33,3 @@ which customers are at risk of abandoning their wearable devices.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iotanalytics_api/example/README.md
+++ b/generated/aws_iotanalytics_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iotanalytics_api/iotanalytics-2017-11-27.dart';
 
 void main() {
   final service = IoTAnalytics(region: 'eu-west-1');
-  // See documentation on how to use IoTAnalytics
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iotanalytics_api/latest/iotanalytics-2017-11-27/IoTAnalytics-class.html) on how to use IoTAnalytics

--- a/generated/aws_iotevents_api/README.md
+++ b/generated/aws_iotevents_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Events
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Events monitors your equipment or device fleets for failures or
@@ -13,9 +13,3 @@ and detector models, and to list their versions.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iotevents_api/example/README.md
+++ b/generated/aws_iotevents_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iotevents_api/iotevents-2018-07-27.dart';
 
 void main() {
   final service = IoTEvents(region: 'eu-west-1');
-  // See documentation on how to use IoTEvents
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iotevents_api/latest/iotevents-2018-07-27/IoTEvents-class.html) on how to use IoTEvents

--- a/generated/aws_iotevents_data_api/README.md
+++ b/generated/aws_iotevents_data_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Events Data
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Events monitors your equipment or device fleets for failures or
@@ -13,9 +13,3 @@ detectors, and view or update a detector's status.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iotevents_data_api/example/README.md
+++ b/generated/aws_iotevents_data_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iotevents_data_api/iotevents-data-2018-10-23.dart';
 
 void main() {
   final service = IoTEventsData(region: 'eu-west-1');
-  // See documentation on how to use IoTEventsData
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iotevents_data_api/latest/iotevents-data-2018-10-23/IoTEventsData-class.html) on how to use IoTEventsData

--- a/generated/aws_iotsecuretunneling_api/README.md
+++ b/generated/aws_iotsecuretunneling_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Secure Tunneling
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Secure Tunnling enables you to create remote connections to devices
@@ -11,9 +11,3 @@ deployed in the field.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iotsecuretunneling_api/example/README.md
+++ b/generated/aws_iotsecuretunneling_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iotsecuretunneling_api/iotsecuretunneling-2018-10-05.dart';
 
 void main() {
   final service = IoTSecureTunneling(region: 'eu-west-1');
-  // See documentation on how to use IoTSecureTunneling
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iotsecuretunneling_api/latest/iotsecuretunneling-2018-10-05/IoTSecureTunneling-class.html) on how to use IoTSecureTunneling

--- a/generated/aws_iotthingsgraph_api/README.md
+++ b/generated/aws_iotthingsgraph_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS IoT Things Graph
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS IoT Things Graph provides an integrated set of tools that enable
@@ -15,9 +15,3 @@ abstract level.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_iotthingsgraph_api/example/README.md
+++ b/generated/aws_iotthingsgraph_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_iotthingsgraph_api/iotthingsgraph-2018-09-06.dart';
 
 void main() {
   final service = IoTThingsGraph(region: 'eu-west-1');
-  // See documentation on how to use IoTThingsGraph
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_iotthingsgraph_api/latest/iotthingsgraph-2018-09-06/IoTThingsGraph-class.html) on how to use IoTThingsGraph

--- a/generated/aws_kafka_api/README.md
+++ b/generated/aws_kafka_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Managed Streaming for Kafka
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 
@@ -12,9 +12,3 @@ The operations for managing an Amazon MSK cluster.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kafka_api/example/README.md
+++ b/generated/aws_kafka_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kafka_api/kafka-2018-11-14.dart';
 
 void main() {
   final service = Kafka(region: 'eu-west-1');
-  // See documentation on how to use Kafka
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kafka_api/latest/kafka-2018-11-14/Kafka-class.html) on how to use Kafka

--- a/generated/aws_kendra_api/README.md
+++ b/generated/aws_kendra_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWSKendraFrontendService
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Kendra is a service for indexing large document sets.
@@ -10,9 +10,3 @@ Amazon Kendra is a service for indexing large document sets.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kendra_api/example/README.md
+++ b/generated/aws_kendra_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kendra_api/kendra-2019-02-03.dart';
 
 void main() {
   final service = Kendra(region: 'eu-west-1');
-  // See documentation on how to use Kendra
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kendra_api/latest/kendra-2019-02-03/Kendra-class.html) on how to use Kendra

--- a/generated/aws_kinesis_api/README.md
+++ b/generated/aws_kinesis_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Kinesis Data Streams is a managed service that scales elastically for
@@ -11,9 +11,3 @@ real-time processing of streaming big data.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesis_api/example/README.md
+++ b/generated/aws_kinesis_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesis_api/kinesis-2013-12-02.dart';
 
 void main() {
   final service = Kinesis(region: 'eu-west-1');
-  // See documentation on how to use Kinesis
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesis_api/latest/kinesis-2013-12-02/Kinesis-class.html) on how to use Kinesis

--- a/generated/aws_kinesis_video_archived_media_api/README.md
+++ b/generated/aws_kinesis_video_archived_media_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Video Streams Archived Media
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -10,9 +10,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesis_video_archived_media_api/example/README.md
+++ b/generated/aws_kinesis_video_archived_media_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesis_video_archived_media_api/kinesis-video-archived-medi
 
 void main() {
   final service = KinesisVideoArchivedMedia(region: 'eu-west-1');
-  // See documentation on how to use KinesisVideoArchivedMedia
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesis_video_archived_media_api/latest/kinesis-video-archived-media-2017-09-30/KinesisVideoArchivedMedia-class.html) on how to use KinesisVideoArchivedMedia

--- a/generated/aws_kinesis_video_media_api/README.md
+++ b/generated/aws_kinesis_video_media_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Video Streams Media
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -10,9 +10,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesis_video_media_api/example/README.md
+++ b/generated/aws_kinesis_video_media_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesis_video_media_api/kinesis-video-media-2017-09-30.dart'
 
 void main() {
   final service = KinesisVideoMedia(region: 'eu-west-1');
-  // See documentation on how to use KinesisVideoMedia
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesis_video_media_api/latest/kinesis-video-media-2017-09-30/KinesisVideoMedia-class.html) on how to use KinesisVideoMedia

--- a/generated/aws_kinesis_video_signaling_api/README.md
+++ b/generated/aws_kinesis_video_signaling_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Video Signaling Channels
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Kinesis Video Streams Signaling Service is a intermediate service that
@@ -13,9 +13,3 @@ technology.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesis_video_signaling_api/example/README.md
+++ b/generated/aws_kinesis_video_signaling_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesis_video_signaling_api/kinesis-video-signaling-2019-12-
 
 void main() {
   final service = KinesisVideoSignalingChannels(region: 'eu-west-1');
-  // See documentation on how to use KinesisVideoSignalingChannels
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesis_video_signaling_api/latest/kinesis-video-signaling-2019-12-04/KinesisVideoSignalingChannels-class.html) on how to use KinesisVideoSignalingChannels

--- a/generated/aws_kinesisanalytics_api/README.md
+++ b/generated/aws_kinesisanalytics_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Analytics
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <note>
@@ -18,9 +18,3 @@ Kinesis Analytics Developer Guide provides additional information.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesisanalytics_api/example/README.md
+++ b/generated/aws_kinesisanalytics_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesisanalytics_api/kinesisanalytics-2015-08-14.dart';
 
 void main() {
   final service = KinesisAnalytics(region: 'eu-west-1');
-  // See documentation on how to use KinesisAnalytics
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesisanalytics_api/latest/kinesisanalytics-2015-08-14/KinesisAnalytics-class.html) on how to use KinesisAnalytics

--- a/generated/aws_kinesisanalyticsv2_api/README.md
+++ b/generated/aws_kinesisanalyticsv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Analytics
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Kinesis Data Analytics is a fully managed service that you can use to
@@ -14,9 +14,3 @@ dashboards, and create real-time metrics.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesisanalyticsv2_api/example/README.md
+++ b/generated/aws_kinesisanalyticsv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesisanalyticsv2_api/kinesisanalyticsv2-2018-05-23.dart';
 
 void main() {
   final service = KinesisAnalyticsV2(region: 'eu-west-1');
-  // See documentation on how to use KinesisAnalyticsV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesisanalyticsv2_api/latest/kinesisanalyticsv2-2018-05-23/KinesisAnalyticsV2-class.html) on how to use KinesisAnalyticsV2

--- a/generated/aws_kinesisvideo_api/README.md
+++ b/generated/aws_kinesisvideo_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Kinesis Video Streams
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -10,9 +10,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kinesisvideo_api/example/README.md
+++ b/generated/aws_kinesisvideo_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kinesisvideo_api/kinesisvideo-2017-09-30.dart';
 
 void main() {
   final service = KinesisVideo(region: 'eu-west-1');
-  // See documentation on how to use KinesisVideo
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kinesisvideo_api/latest/kinesisvideo-2017-09-30/KinesisVideo-class.html) on how to use KinesisVideo

--- a/generated/aws_kms_api/README.md
+++ b/generated/aws_kms_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Key Management Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Key Management Service (AWS KMS) is an encryption and key management web
@@ -26,9 +26,3 @@ KMS.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_kms_api/example/README.md
+++ b/generated/aws_kms_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_kms_api/kms-2014-11-01.dart';
 
 void main() {
   final service = KMS(region: 'eu-west-1');
-  // See documentation on how to use KMS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_kms_api/latest/kms-2014-11-01/KMS-class.html) on how to use KMS

--- a/generated/aws_lakeformation_api/README.md
+++ b/generated/aws_lakeformation_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Lake Formation
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Defines the public endpoint for the AWS Lake Formation service.
@@ -10,9 +10,3 @@ Defines the public endpoint for the AWS Lake Formation service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_lakeformation_api/example/README.md
+++ b/generated/aws_lakeformation_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_lakeformation_api/lakeformation-2017-03-31.dart';
 
 void main() {
   final service = LakeFormation(region: 'eu-west-1');
-  // See documentation on how to use LakeFormation
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_lakeformation_api/latest/lakeformation-2017-03-31/LakeFormation-class.html) on how to use LakeFormation

--- a/generated/aws_lambda_api/README.md
+++ b/generated/aws_lambda_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Lambda
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>AWS Lambda API Reference</i>. The AWS Lambda Developer Guide
@@ -15,9 +15,3 @@ Lambda: How it Works</a> in the <b>AWS Lambda Developer Guide</b>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_lambda_api/example/README.md
+++ b/generated/aws_lambda_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_lambda_api/lambda-2015-03-31.dart';
 
 void main() {
   final service = Lambda(region: 'eu-west-1');
-  // See documentation on how to use Lambda
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_lambda_api/latest/lambda-2015-03-31/Lambda-class.html) on how to use Lambda

--- a/generated/aws_lex_models_api/README.md
+++ b/generated/aws_lex_models_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Lex Model Building Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Lex is an AWS service for building conversational voice and text
@@ -12,9 +12,3 @@ bots for new and existing client applications.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_lex_models_api/example/README.md
+++ b/generated/aws_lex_models_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_lex_models_api/lex-models-2017-04-19.dart';
 
 void main() {
   final service = LexModelBuildingService(region: 'eu-west-1');
-  // See documentation on how to use LexModelBuildingService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_lex_models_api/latest/lex-models-2017-04-19/LexModelBuildingService-class.html) on how to use LexModelBuildingService

--- a/generated/aws_lex_runtime_api/README.md
+++ b/generated/aws_lex_runtime_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Lex Runtime Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Lex provides both build and runtime endpoints. Each endpoint provides
@@ -20,9 +20,3 @@ For a list of build-time operations, see the build-time API, .
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_lex_runtime_api/example/README.md
+++ b/generated/aws_lex_runtime_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_lex_runtime_api/runtime.lex-2016-11-28.dart';
 
 void main() {
   final service = LexRuntimeService(region: 'eu-west-1');
-  // See documentation on how to use LexRuntimeService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_lex_runtime_api/latest/runtime.lex-2016-11-28/LexRuntimeService-class.html) on how to use LexRuntimeService

--- a/generated/aws_license_manager_api/README.md
+++ b/generated/aws_license_manager_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS License Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS License Manager makes it easier to manage licenses from software vendors
@@ -11,9 +11,3 @@ across multiple AWS accounts and on-premises servers.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_license_manager_api/example/README.md
+++ b/generated/aws_license_manager_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_license_manager_api/license-manager-2018-08-01.dart';
 
 void main() {
   final service = LicenseManager(region: 'eu-west-1');
-  // See documentation on how to use LicenseManager
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_license_manager_api/latest/license-manager-2018-08-01/LicenseManager-class.html) on how to use LicenseManager

--- a/generated/aws_lightsail_api/README.md
+++ b/generated/aws_lightsail_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Lightsail
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Lightsail is the easiest way to get started with Amazon Web Services
@@ -29,9 +29,3 @@ Lightsail Endpoints and Quotas</a> in the <i>AWS General Reference</i>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_lightsail_api/example/README.md
+++ b/generated/aws_lightsail_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_lightsail_api/lightsail-2016-11-28.dart';
 
 void main() {
   final service = Lightsail(region: 'eu-west-1');
-  // See documentation on how to use Lightsail
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_lightsail_api/latest/lightsail-2016-11-28/Lightsail-class.html) on how to use Lightsail

--- a/generated/aws_logs_api/README.md
+++ b/generated/aws_logs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon CloudWatch Logs
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 You can use Amazon CloudWatch Logs to monitor, store, and access your log
@@ -45,9 +45,3 @@ access the raw log data when you need it.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_logs_api/example/README.md
+++ b/generated/aws_logs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_logs_api/logs-2014-03-28.dart';
 
 void main() {
   final service = CloudWatchLogs(region: 'eu-west-1');
-  // See documentation on how to use CloudWatchLogs
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_logs_api/latest/logs-2014-03-28/CloudWatchLogs-class.html) on how to use CloudWatchLogs

--- a/generated/aws_machinelearning_api/README.md
+++ b/generated/aws_machinelearning_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Machine Learning
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Definition of the public APIs exposed by Amazon Machine Learning
@@ -10,9 +10,3 @@ Definition of the public APIs exposed by Amazon Machine Learning
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_machinelearning_api/example/README.md
+++ b/generated/aws_machinelearning_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_machinelearning_api/machinelearning-2014-12-12.dart';
 
 void main() {
   final service = MachineLearning(region: 'eu-west-1');
-  // See documentation on how to use MachineLearning
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_machinelearning_api/latest/machinelearning-2014-12-12/MachineLearning-class.html) on how to use MachineLearning

--- a/generated/aws_macie_api/README.md
+++ b/generated/aws_macie_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Macie
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Macie Classic is a security service that uses machine learning to
@@ -17,9 +17,3 @@ Macie Classic User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_macie_api/example/README.md
+++ b/generated/aws_macie_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_macie_api/macie-2017-12-19.dart';
 
 void main() {
   final service = Macie(region: 'eu-west-1');
-  // See documentation on how to use Macie
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_macie_api/latest/macie-2017-12-19/Macie-class.html) on how to use Macie

--- a/generated/aws_managedblockchain_api/README.md
+++ b/generated/aws_managedblockchain_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Managed Blockchain
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -26,9 +26,3 @@ of a particular framework are similarly indicated.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_managedblockchain_api/example/README.md
+++ b/generated/aws_managedblockchain_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_managedblockchain_api/managedblockchain-2018-09-24.dart';
 
 void main() {
   final service = ManagedBlockchain(region: 'eu-west-1');
-  // See documentation on how to use ManagedBlockchain
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_managedblockchain_api/latest/managedblockchain-2018-09-24/ManagedBlockchain-class.html) on how to use ManagedBlockchain

--- a/generated/aws_marketplace_catalog_api/README.md
+++ b/generated/aws_marketplace_catalog_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Marketplace Catalog Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Catalog API actions allow you to manage your entities through list,
@@ -17,9 +17,3 @@ the Catalog API to manage your products on AWS Marketplace.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_marketplace_catalog_api/example/README.md
+++ b/generated/aws_marketplace_catalog_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_marketplace_catalog_api/marketplace-catalog-2018-09-17.dart'
 
 void main() {
   final service = MarketplaceCatalog(region: 'eu-west-1');
-  // See documentation on how to use MarketplaceCatalog
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_marketplace_catalog_api/latest/marketplace-catalog-2018-09-17/MarketplaceCatalog-class.html) on how to use MarketplaceCatalog

--- a/generated/aws_marketplace_entitlement_api/README.md
+++ b/generated/aws_marketplace_entitlement_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Marketplace Entitlement Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This reference provides descriptions of the AWS Marketplace Entitlement
@@ -11,9 +11,3 @@ Service API.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_marketplace_entitlement_api/example/README.md
+++ b/generated/aws_marketplace_entitlement_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_marketplace_entitlement_api/entitlement.marketplace-2017-01-
 
 void main() {
   final service = MarketplaceEntitlementService(region: 'eu-west-1');
-  // See documentation on how to use MarketplaceEntitlementService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_marketplace_entitlement_api/latest/entitlement.marketplace-2017-01-11/MarketplaceEntitlementService-class.html) on how to use MarketplaceEntitlementService

--- a/generated/aws_marketplacecommerceanalytics_api/README.md
+++ b/generated/aws_marketplacecommerceanalytics_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Marketplace Commerce Analytics
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Provides AWS Marketplace business intelligence data on-demand.
@@ -10,9 +10,3 @@ Provides AWS Marketplace business intelligence data on-demand.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_marketplacecommerceanalytics_api/example/README.md
+++ b/generated/aws_marketplacecommerceanalytics_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_marketplacecommerceanalytics_api/marketplacecommerceanalytic
 
 void main() {
   final service = MarketplaceCommerceAnalytics(region: 'eu-west-1');
-  // See documentation on how to use MarketplaceCommerceAnalytics
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_marketplacecommerceanalytics_api/latest/marketplacecommerceanalytics-2015-07-01/MarketplaceCommerceAnalytics-class.html) on how to use MarketplaceCommerceAnalytics

--- a/generated/aws_mediaconnect_api/README.md
+++ b/generated/aws_mediaconnect_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS MediaConnect
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 API for AWS Elemental MediaConnect
@@ -10,9 +10,3 @@ API for AWS Elemental MediaConnect
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediaconnect_api/example/README.md
+++ b/generated/aws_mediaconnect_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediaconnect_api/mediaconnect-2018-11-14.dart';
 
 void main() {
   final service = MediaConnect(region: 'eu-west-1');
-  // See documentation on how to use MediaConnect
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediaconnect_api/latest/mediaconnect-2018-11-14/MediaConnect-class.html) on how to use MediaConnect

--- a/generated/aws_mediaconvert_api/README.md
+++ b/generated/aws_mediaconvert_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaConvert
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Elemental MediaConvert
@@ -10,9 +10,3 @@ AWS Elemental MediaConvert
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediaconvert_api/example/README.md
+++ b/generated/aws_mediaconvert_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediaconvert_api/mediaconvert-2017-08-29.dart';
 
 void main() {
   final service = MediaConvert(region: 'eu-west-1');
-  // See documentation on how to use MediaConvert
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediaconvert_api/latest/mediaconvert-2017-08-29/MediaConvert-class.html) on how to use MediaConvert

--- a/generated/aws_medialive_api/README.md
+++ b/generated/aws_medialive_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaLive
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 API for AWS Elemental MediaLive
@@ -10,9 +10,3 @@ API for AWS Elemental MediaLive
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_medialive_api/example/README.md
+++ b/generated/aws_medialive_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_medialive_api/medialive-2017-10-14.dart';
 
 void main() {
   final service = MediaLive(region: 'eu-west-1');
-  // See documentation on how to use MediaLive
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_medialive_api/latest/medialive-2017-10-14/MediaLive-class.html) on how to use MediaLive

--- a/generated/aws_mediapackage_api/README.md
+++ b/generated/aws_mediapackage_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaPackage
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Elemental MediaPackage
@@ -10,9 +10,3 @@ AWS Elemental MediaPackage
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediapackage_api/example/README.md
+++ b/generated/aws_mediapackage_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediapackage_api/mediapackage-2017-10-12.dart';
 
 void main() {
   final service = MediaPackage(region: 'eu-west-1');
-  // See documentation on how to use MediaPackage
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediapackage_api/latest/mediapackage-2017-10-12/MediaPackage-class.html) on how to use MediaPackage

--- a/generated/aws_mediapackage_vod_api/README.md
+++ b/generated/aws_mediapackage_vod_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaPackage VOD
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Elemental MediaPackage VOD
@@ -10,9 +10,3 @@ AWS Elemental MediaPackage VOD
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediapackage_vod_api/example/README.md
+++ b/generated/aws_mediapackage_vod_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediapackage_vod_api/mediapackage-vod-2018-11-07.dart';
 
 void main() {
   final service = MediaPackageVod(region: 'eu-west-1');
-  // See documentation on how to use MediaPackageVod
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediapackage_vod_api/latest/mediapackage-vod-2018-11-07/MediaPackageVod-class.html) on how to use MediaPackageVod

--- a/generated/aws_mediastore_api/README.md
+++ b/generated/aws_mediastore_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaStore
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 An AWS Elemental MediaStore container is a namespace that holds folders and
@@ -11,9 +11,3 @@ objects. You use a container endpoint to create, read, and delete objects.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediastore_api/example/README.md
+++ b/generated/aws_mediastore_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediastore_api/mediastore-2017-09-01.dart';
 
 void main() {
   final service = MediaStore(region: 'eu-west-1');
-  // See documentation on how to use MediaStore
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediastore_api/latest/mediastore-2017-09-01/MediaStore-class.html) on how to use MediaStore

--- a/generated/aws_mediastore_data_api/README.md
+++ b/generated/aws_mediastore_data_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Elemental MediaStore Data Plane
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 An AWS Elemental MediaStore asset is an object, similar to an object in the
@@ -12,9 +12,3 @@ AWS Elemental MediaStore.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediastore_data_api/example/README.md
+++ b/generated/aws_mediastore_data_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediastore_data_api/mediastore-data-2017-09-01.dart';
 
 void main() {
   final service = MediaStoreData(region: 'eu-west-1');
-  // See documentation on how to use MediaStoreData
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediastore_data_api/latest/mediastore-data-2017-09-01/MediaStoreData-class.html) on how to use MediaStoreData

--- a/generated/aws_mediatailor_api/README.md
+++ b/generated/aws_mediatailor_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS MediaTailor
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Use the AWS Elemental MediaTailor SDK to configure scalable ad insertion for
@@ -19,9 +19,3 @@ server (ADS).
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mediatailor_api/example/README.md
+++ b/generated/aws_mediatailor_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mediatailor_api/mediatailor-2018-04-23.dart';
 
 void main() {
   final service = MediaTailor(region: 'eu-west-1');
-  // See documentation on how to use MediaTailor
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mediatailor_api/latest/mediatailor-2018-04-23/MediaTailor-class.html) on how to use MediaTailor

--- a/generated/aws_meteringmarketplace_api/README.md
+++ b/generated/aws_meteringmarketplace_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWSMarketplace Metering
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This reference provides descriptions of the low-level AWS Marketplace
@@ -11,9 +11,3 @@ Metering Service API.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_meteringmarketplace_api/example/README.md
+++ b/generated/aws_meteringmarketplace_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_meteringmarketplace_api/meteringmarketplace-2016-01-14.dart'
 
 void main() {
   final service = MarketplaceMetering(region: 'eu-west-1');
-  // See documentation on how to use MarketplaceMetering
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_meteringmarketplace_api/latest/meteringmarketplace-2016-01-14/MarketplaceMetering-class.html) on how to use MarketplaceMetering

--- a/generated/aws_mgh_api/README.md
+++ b/generated/aws_mgh_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Migration Hub
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Migration Hub API methods help to obtain server and application
@@ -17,9 +17,3 @@ region.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mgh_api/example/README.md
+++ b/generated/aws_mgh_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mgh_api/AWSMigrationHub-2017-05-31.dart';
 
 void main() {
   final service = MigrationHub(region: 'eu-west-1');
-  // See documentation on how to use MigrationHub
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mgh_api/latest/AWSMigrationHub-2017-05-31/MigrationHub-class.html) on how to use MigrationHub

--- a/generated/aws_migrationhub_config_api/README.md
+++ b/generated/aws_migrationhub_config_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Migration Hub Config
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Migration Hub home region APIs are available specifically for
@@ -35,9 +35,3 @@ Hub Home Region API reference.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_migrationhub_config_api/example/README.md
+++ b/generated/aws_migrationhub_config_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_migrationhub_config_api/migrationhub-config-2019-06-30.dart'
 
 void main() {
   final service = MigrationHubConfig(region: 'eu-west-1');
-  // See documentation on how to use MigrationHubConfig
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_migrationhub_config_api/latest/migrationhub-config-2019-06-30/MigrationHubConfig-class.html) on how to use MigrationHubConfig

--- a/generated/aws_mobile_api/README.md
+++ b/generated/aws_mobile_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Mobile
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Mobile Service provides mobile app and website developers with
@@ -13,9 +13,3 @@ samples to make use of those resources.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mobile_api/example/README.md
+++ b/generated/aws_mobile_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mobile_api/mobile-2017-07-01.dart';
 
 void main() {
   final service = Mobile(region: 'eu-west-1');
-  // See documentation on how to use Mobile
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mobile_api/latest/mobile-2017-07-01/Mobile-class.html) on how to use Mobile

--- a/generated/aws_mq_api/README.md
+++ b/generated/aws_mq_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AmazonMQ
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon MQ is a managed message broker service for Apache ActiveMQ and
@@ -14,9 +14,3 @@ formal messaging protocols.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mq_api/example/README.md
+++ b/generated/aws_mq_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mq_api/mq-2017-11-27.dart';
 
 void main() {
   final service = MQ(region: 'eu-west-1');
-  // See documentation on how to use MQ
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mq_api/latest/mq-2017-11-27/MQ-class.html) on how to use MQ

--- a/generated/aws_mturk_api/README.md
+++ b/generated/aws_mturk_api/README.md
@@ -1,8 +1,7 @@
 # AWS API client for Amazon Mechanical Turk
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
-*About the service:*
 
 
 ## Links
@@ -10,9 +9,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_mturk_api/example/README.md
+++ b/generated/aws_mturk_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_mturk_api/mturk-requester-2017-01-17.dart';
 
 void main() {
   final service = MTurk(region: 'eu-west-1');
-  // See documentation on how to use MTurk
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_mturk_api/latest/mturk-requester-2017-01-17/MTurk-class.html) on how to use MTurk

--- a/generated/aws_neptune_api/README.md
+++ b/generated/aws_neptune_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Neptune
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Neptune is a fast, reliable, fully-managed graph database service
@@ -20,9 +20,3 @@ security.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_neptune_api/example/README.md
+++ b/generated/aws_neptune_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_neptune_api/neptune-2014-10-31.dart';
 
 void main() {
   final service = Neptune(region: 'eu-west-1');
-  // See documentation on how to use Neptune
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_neptune_api/latest/neptune-2014-10-31/Neptune-class.html) on how to use Neptune

--- a/generated/aws_networkmanager_api/README.md
+++ b/generated/aws_networkmanager_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Network Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Transit Gateway Network Manager (Network Manager) enables you to create a
@@ -16,9 +16,3 @@ Network Manager.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_networkmanager_api/example/README.md
+++ b/generated/aws_networkmanager_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_networkmanager_api/networkmanager-2019-07-05.dart';
 
 void main() {
   final service = NetworkManager(region: 'eu-west-1');
-  // See documentation on how to use NetworkManager
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_networkmanager_api/latest/networkmanager-2019-07-05/NetworkManager-class.html) on how to use NetworkManager

--- a/generated/aws_opsworks_api/README.md
+++ b/generated/aws_opsworks_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS OpsWorks
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the <i>AWS OpsWorks Stacks API Reference</i>. This guide provides
@@ -12,9 +12,3 @@ data types, including common parameters and error codes.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_opsworks_api/example/README.md
+++ b/generated/aws_opsworks_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_opsworks_api/opsworks-2013-02-18.dart';
 
 void main() {
   final service = OpsWorks(region: 'eu-west-1');
-  // See documentation on how to use OpsWorks
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_opsworks_api/latest/opsworks-2013-02-18/OpsWorks-class.html) on how to use OpsWorks

--- a/generated/aws_opsworks_cm_api/README.md
+++ b/generated/aws_opsworks_cm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS OpsWorks CM
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS OpsWorks for configuration management (CM) is a service that runs and
@@ -13,9 +13,3 @@ Enterprise servers, and add or remove nodes for the servers to manage.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_opsworks_cm_api/example/README.md
+++ b/generated/aws_opsworks_cm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_opsworks_cm_api/opsworkscm-2016-11-01.dart';
 
 void main() {
   final service = OpsWorksCM(region: 'eu-west-1');
-  // See documentation on how to use OpsWorksCM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_opsworks_cm_api/latest/opsworkscm-2016-11-01/OpsWorksCM-class.html) on how to use OpsWorksCM

--- a/generated/aws_organizations_api/README.md
+++ b/generated/aws_organizations_api/README.md
@@ -1,8 +1,7 @@
 # AWS API client for AWS Organizations
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
-*About the service:*
 
 
 ## Links
@@ -10,9 +9,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_organizations_api/example/README.md
+++ b/generated/aws_organizations_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_organizations_api/organizations-2016-11-28.dart';
 
 void main() {
   final service = Organizations(region: 'eu-west-1');
-  // See documentation on how to use Organizations
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_organizations_api/latest/organizations-2016-11-28/Organizations-class.html) on how to use Organizations

--- a/generated/aws_outposts_api/README.md
+++ b/generated/aws_outposts_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Outposts
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Outposts is a fully managed service that extends AWS infrastructure,
@@ -15,9 +15,3 @@ and local data processing needs.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_outposts_api/example/README.md
+++ b/generated/aws_outposts_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_outposts_api/outposts-2019-12-03.dart';
 
 void main() {
   final service = Outposts(region: 'eu-west-1');
-  // See documentation on how to use Outposts
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_outposts_api/latest/outposts-2019-12-03/Outposts-class.html) on how to use Outposts

--- a/generated/aws_personalize_api/README.md
+++ b/generated/aws_personalize_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Personalize
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Personalize is a machine learning service that makes it easy to add
@@ -11,9 +11,3 @@ individualized recommendations to customers.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_personalize_api/example/README.md
+++ b/generated/aws_personalize_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_personalize_api/personalize-2018-05-22.dart';
 
 void main() {
   final service = Personalize(region: 'eu-west-1');
-  // See documentation on how to use Personalize
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_personalize_api/latest/personalize-2018-05-22/Personalize-class.html) on how to use Personalize

--- a/generated/aws_personalize_events_api/README.md
+++ b/generated/aws_personalize_events_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Personalize Events
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Personalize can consume real-time user event data, such as
@@ -13,9 +13,3 @@ alone or combined with historical data. For more information see
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_personalize_events_api/example/README.md
+++ b/generated/aws_personalize_events_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_personalize_events_api/personalize-events-2018-03-22.dart';
 
 void main() {
   final service = PersonalizeEvents(region: 'eu-west-1');
-  // See documentation on how to use PersonalizeEvents
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_personalize_events_api/latest/personalize-events-2018-03-22/PersonalizeEvents-class.html) on how to use PersonalizeEvents

--- a/generated/aws_personalize_runtime_api/README.md
+++ b/generated/aws_personalize_runtime_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Personalize Runtime
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -10,9 +10,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_personalize_runtime_api/example/README.md
+++ b/generated/aws_personalize_runtime_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_personalize_runtime_api/personalize-runtime-2018-05-22.dart'
 
 void main() {
   final service = PersonalizeRuntime(region: 'eu-west-1');
-  // See documentation on how to use PersonalizeRuntime
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_personalize_runtime_api/latest/personalize-runtime-2018-05-22/PersonalizeRuntime-class.html) on how to use PersonalizeRuntime

--- a/generated/aws_pi_api/README.md
+++ b/generated/aws_pi_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Performance Insights
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon RDS Performance Insights enables you to monitor and explore different
@@ -13,9 +13,3 @@ data types, parameters and errors.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_pi_api/example/README.md
+++ b/generated/aws_pi_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_pi_api/pi-2018-02-27.dart';
 
 void main() {
   final service = PI(region: 'eu-west-1');
-  // See documentation on how to use PI
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_pi_api/latest/pi-2018-02-27/PI-class.html) on how to use PI

--- a/generated/aws_pinpoint_api/README.md
+++ b/generated/aws_pinpoint_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Pinpoint
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Doc Engage API - Amazon Pinpoint API
@@ -10,9 +10,3 @@ Doc Engage API - Amazon Pinpoint API
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_pinpoint_api/example/README.md
+++ b/generated/aws_pinpoint_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_pinpoint_api/pinpoint-2016-12-01.dart';
 
 void main() {
   final service = Pinpoint(region: 'eu-west-1');
-  // See documentation on how to use Pinpoint
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_pinpoint_api/latest/pinpoint-2016-12-01/Pinpoint-class.html) on how to use Pinpoint

--- a/generated/aws_pinpoint_email_api/README.md
+++ b/generated/aws_pinpoint_email_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Pinpoint Email Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the <i>Amazon Pinpoint Email API Reference</i>. This guide
@@ -12,9 +12,3 @@ including supported operations, data types, parameters, and schemas.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_pinpoint_email_api/example/README.md
+++ b/generated/aws_pinpoint_email_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_pinpoint_email_api/pinpoint-email-2018-07-26.dart';
 
 void main() {
   final service = PinpointEmail(region: 'eu-west-1');
-  // See documentation on how to use PinpointEmail
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_pinpoint_email_api/latest/pinpoint-email-2018-07-26/PinpointEmail-class.html) on how to use PinpointEmail

--- a/generated/aws_pinpoint_sms_voice_api/README.md
+++ b/generated/aws_pinpoint_sms_voice_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Pinpoint SMS and Voice Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Pinpoint SMS and Voice Messaging public facing APIs
@@ -10,9 +10,3 @@ Pinpoint SMS and Voice Messaging public facing APIs
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_pinpoint_sms_voice_api/example/README.md
+++ b/generated/aws_pinpoint_sms_voice_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_pinpoint_sms_voice_api/pinpoint-sms-voice-2018-09-05.dart';
 
 void main() {
   final service = PinpointSMSVoice(region: 'eu-west-1');
-  // See documentation on how to use PinpointSMSVoice
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_pinpoint_sms_voice_api/latest/pinpoint-sms-voice-2018-09-05/PinpointSMSVoice-class.html) on how to use PinpointSMSVoice

--- a/generated/aws_polly_api/README.md
+++ b/generated/aws_polly_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Polly
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Polly is a web service that makes it easy to synthesize speech from
@@ -16,9 +16,3 @@ the best results for your application domain.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_polly_api/example/README.md
+++ b/generated/aws_polly_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_polly_api/polly-2016-06-10.dart';
 
 void main() {
   final service = Polly(region: 'eu-west-1');
-  // See documentation on how to use Polly
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_polly_api/latest/polly-2016-06-10/Polly-class.html) on how to use Polly

--- a/generated/aws_pricing_api/README.md
+++ b/generated/aws_pricing_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Price List Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Price List Service API (AWS Price List Service) is a centralized and
@@ -41,9 +41,3 @@ https://api.pricing.ap-south-1.amazonaws.com
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_pricing_api/example/README.md
+++ b/generated/aws_pricing_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_pricing_api/pricing-2017-10-15.dart';
 
 void main() {
   final service = Pricing(region: 'eu-west-1');
-  // See documentation on how to use Pricing
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_pricing_api/latest/pricing-2017-10-15/Pricing-class.html) on how to use Pricing

--- a/generated/aws_qldb_api/README.md
+++ b/generated/aws_qldb_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon QLDB
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The control plane for Amazon QLDB
@@ -10,9 +10,3 @@ The control plane for Amazon QLDB
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_qldb_api/example/README.md
+++ b/generated/aws_qldb_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_qldb_api/qldb-2019-01-02.dart';
 
 void main() {
   final service = QLDB(region: 'eu-west-1');
-  // See documentation on how to use QLDB
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_qldb_api/latest/qldb-2019-01-02/QLDB-class.html) on how to use QLDB

--- a/generated/aws_qldb_session_api/README.md
+++ b/generated/aws_qldb_session_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon QLDB Session
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The transactional data APIs for Amazon QLDB
@@ -31,9 +31,3 @@ Amazon QLDB using the QLDB shell</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_qldb_session_api/example/README.md
+++ b/generated/aws_qldb_session_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_qldb_session_api/qldb-session-2019-07-11.dart';
 
 void main() {
   final service = QLDBSession(region: 'eu-west-1');
-  // See documentation on how to use QLDBSession
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_qldb_session_api/latest/qldb-session-2019-07-11/QLDBSession-class.html) on how to use QLDBSession

--- a/generated/aws_quicksight_api/README.md
+++ b/generated/aws_quicksight_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon QuickSight
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon QuickSight is a fully managed, serverless business intelligence
@@ -13,9 +13,3 @@ for a programming interface that you can use to manage Amazon QuickSight.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_quicksight_api/example/README.md
+++ b/generated/aws_quicksight_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_quicksight_api/quicksight-2018-04-01.dart';
 
 void main() {
   final service = QuickSight(region: 'eu-west-1');
-  // See documentation on how to use QuickSight
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_quicksight_api/latest/quicksight-2018-04-01/QuickSight-class.html) on how to use QuickSight

--- a/generated/aws_ram_api/README.md
+++ b/generated/aws_ram_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Resource Access Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Use AWS Resource Access Manager to share AWS resources between AWS accounts.
@@ -19,9 +19,3 @@ Manager User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ram_api/example/README.md
+++ b/generated/aws_ram_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ram_api/ram-2018-01-04.dart';
 
 void main() {
   final service = RAM(region: 'eu-west-1');
-  // See documentation on how to use RAM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ram_api/latest/ram-2018-01-04/RAM-class.html) on how to use RAM

--- a/generated/aws_rds_api/README.md
+++ b/generated/aws_rds_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Relational Database Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Relational Database Service (Amazon RDS) is a web service that makes
@@ -15,9 +15,3 @@ businesses unique.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_rds_api/example/README.md
+++ b/generated/aws_rds_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_rds_api/rds-2014-10-31.dart';
 
 void main() {
   final service = RDS(region: 'eu-west-1');
-  // See documentation on how to use RDS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_rds_api/latest/rds-2014-10-31/RDS-class.html) on how to use RDS

--- a/generated/aws_rds_data_api/README.md
+++ b/generated/aws_rds_data_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS RDS DataService
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon RDS provides an HTTP endpoint to run SQL statements on an Amazon
@@ -12,9 +12,3 @@ Data Service API.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_rds_data_api/example/README.md
+++ b/generated/aws_rds_data_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_rds_data_api/rds-data-2018-08-01.dart';
 
 void main() {
   final service = RDSDataService(region: 'eu-west-1');
-  // See documentation on how to use RDSDataService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_rds_data_api/latest/rds-data-2018-08-01/RDSDataService-class.html) on how to use RDSDataService

--- a/generated/aws_redshift_api/README.md
+++ b/generated/aws_redshift_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Redshift
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is an interface reference for Amazon Redshift. It contains
@@ -20,9 +20,3 @@ the Amazon Redshift Management Interfaces</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_redshift_api/example/README.md
+++ b/generated/aws_redshift_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_redshift_api/redshift-2012-12-01.dart';
 
 void main() {
   final service = Redshift(region: 'eu-west-1');
-  // See documentation on how to use Redshift
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_redshift_api/latest/redshift-2012-12-01/Redshift-class.html) on how to use Redshift

--- a/generated/aws_rekognition_api/README.md
+++ b/generated/aws_rekognition_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Rekognition
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the Amazon Rekognition API reference.
@@ -10,9 +10,3 @@ This is the Amazon Rekognition API reference.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_rekognition_api/example/README.md
+++ b/generated/aws_rekognition_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_rekognition_api/rekognition-2016-06-27.dart';
 
 void main() {
   final service = Rekognition(region: 'eu-west-1');
-  // See documentation on how to use Rekognition
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_rekognition_api/latest/rekognition-2016-06-27/Rekognition-class.html) on how to use Rekognition

--- a/generated/aws_resource_groups_api/README.md
+++ b/generated/aws_resource_groups_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Resource Groups
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Resource Groups lets you organize AWS resources such as Amazon EC2
@@ -21,9 +21,3 @@ other monitoring data about member resources.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_resource_groups_api/example/README.md
+++ b/generated/aws_resource_groups_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_resource_groups_api/resource-groups-2017-11-27.dart';
 
 void main() {
   final service = ResourceGroups(region: 'eu-west-1');
-  // See documentation on how to use ResourceGroups
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_resource_groups_api/latest/resource-groups-2017-11-27/ResourceGroups-class.html) on how to use ResourceGroups

--- a/generated/aws_resourcegroupstaggingapi_api/README.md
+++ b/generated/aws_resourcegroupstaggingapi_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Resource Groups Tagging API
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This guide describes the API operations for the resource groups tagging.
@@ -10,9 +10,3 @@ This guide describes the API operations for the resource groups tagging.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_resourcegroupstaggingapi_api/example/README.md
+++ b/generated/aws_resourcegroupstaggingapi_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_resourcegroupstaggingapi_api/resourcegroupstaggingapi-2017-0
 
 void main() {
   final service = ResourceGroupsTaggingAPI(region: 'eu-west-1');
-  // See documentation on how to use ResourceGroupsTaggingAPI
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_resourcegroupstaggingapi_api/latest/resourcegroupstaggingapi-2017-01-26/ResourceGroupsTaggingAPI-class.html) on how to use ResourceGroupsTaggingAPI

--- a/generated/aws_robomaker_api/README.md
+++ b/generated/aws_robomaker_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS RoboMaker
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This section provides documentation for the AWS RoboMaker API operations.
@@ -10,9 +10,3 @@ This section provides documentation for the AWS RoboMaker API operations.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_robomaker_api/example/README.md
+++ b/generated/aws_robomaker_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_robomaker_api/robomaker-2018-06-29.dart';
 
 void main() {
   final service = RoboMaker(region: 'eu-west-1');
-  // See documentation on how to use RoboMaker
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_robomaker_api/latest/robomaker-2018-06-29/RoboMaker-class.html) on how to use RoboMaker

--- a/generated/aws_route53_api/README.md
+++ b/generated/aws_route53_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Route 53
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Route 53 is a highly available and scalable Domain Name System (DNS)
@@ -11,9 +11,3 @@ web service.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_route53_api/example/README.md
+++ b/generated/aws_route53_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_route53_api/route53-2013-04-01.dart';
 
 void main() {
   final service = Route53(region: 'eu-west-1');
-  // See documentation on how to use Route53
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_route53_api/latest/route53-2013-04-01/Route53-class.html) on how to use Route53

--- a/generated/aws_route53domains_api/README.md
+++ b/generated/aws_route53domains_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Route 53 Domains
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Route 53 API actions let you register domain names and perform
@@ -11,9 +11,3 @@ related operations.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_route53domains_api/example/README.md
+++ b/generated/aws_route53domains_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_route53domains_api/route53domains-2014-05-15.dart';
 
 void main() {
   final service = Route53Domains(region: 'eu-west-1');
-  // See documentation on how to use Route53Domains
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_route53domains_api/latest/route53domains-2014-05-15/Route53Domains-class.html) on how to use Route53Domains

--- a/generated/aws_route53resolver_api/README.md
+++ b/generated/aws_route53resolver_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Route 53 Resolver
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 When you create a VPC using Amazon VPC, you automatically get DNS resolution
@@ -48,9 +48,3 @@ both.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_route53resolver_api/example/README.md
+++ b/generated/aws_route53resolver_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_route53resolver_api/route53resolver-2018-04-01.dart';
 
 void main() {
   final service = Route53Resolver(region: 'eu-west-1');
-  // See documentation on how to use Route53Resolver
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_route53resolver_api/latest/route53resolver-2018-04-01/Route53Resolver-class.html) on how to use Route53Resolver

--- a/generated/aws_s3_api/README.md
+++ b/generated/aws_s3_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Storage Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <p/>
@@ -10,9 +10,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_s3_api/example/README.md
+++ b/generated/aws_s3_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_s3_api/s3-2006-03-01.dart';
 
 void main() {
   final service = S3(region: 'eu-west-1');
-  // See documentation on how to use S3
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_s3_api/latest/s3-2006-03-01/S3-class.html) on how to use S3

--- a/generated/aws_s3control_api/README.md
+++ b/generated/aws_s3control_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS S3 Control
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS S3 Control provides access to Amazon S3 control plane operations.
@@ -10,9 +10,3 @@ AWS S3 Control provides access to Amazon S3 control plane operations.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_s3control_api/example/README.md
+++ b/generated/aws_s3control_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_s3control_api/s3control-2018-08-20.dart';
 
 void main() {
   final service = S3Control(region: 'eu-west-1');
-  // See documentation on how to use S3Control
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_s3control_api/latest/s3control-2018-08-20/S3Control-class.html) on how to use S3Control

--- a/generated/aws_sagemaker_a2i_runtime_api/README.md
+++ b/generated/aws_sagemaker_a2i_runtime_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Augmented AI Runtime
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <important>
@@ -54,9 +54,3 @@ APIs in Amazon A2I</a> in the Amazon SageMaker Developer Guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sagemaker_a2i_runtime_api/example/README.md
+++ b/generated/aws_sagemaker_a2i_runtime_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sagemaker_a2i_runtime_api/sagemaker-a2i-runtime-2019-11-07.d
 
 void main() {
   final service = AugmentedAIRuntime(region: 'eu-west-1');
-  // See documentation on how to use AugmentedAIRuntime
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sagemaker_a2i_runtime_api/latest/sagemaker-a2i-runtime-2019-11-07/AugmentedAIRuntime-class.html) on how to use AugmentedAIRuntime

--- a/generated/aws_sagemaker_api/README.md
+++ b/generated/aws_sagemaker_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon SageMaker Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Provides APIs for creating and managing Amazon SageMaker resources.
@@ -25,9 +25,3 @@ Augmented AI Runtime API Reference</a>
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sagemaker_api/example/README.md
+++ b/generated/aws_sagemaker_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sagemaker_api/sagemaker-2017-07-24.dart';
 
 void main() {
   final service = SageMaker(region: 'eu-west-1');
-  // See documentation on how to use SageMaker
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sagemaker_api/latest/sagemaker-2017-07-24/SageMaker-class.html) on how to use SageMaker

--- a/generated/aws_sagemaker_runtime_api/README.md
+++ b/generated/aws_sagemaker_runtime_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon SageMaker Runtime
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The Amazon SageMaker runtime API.
@@ -10,9 +10,3 @@ The Amazon SageMaker runtime API.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sagemaker_runtime_api/example/README.md
+++ b/generated/aws_sagemaker_runtime_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sagemaker_runtime_api/runtime.sagemaker-2017-05-13.dart';
 
 void main() {
   final service = SageMakerRuntime(region: 'eu-west-1');
-  // See documentation on how to use SageMakerRuntime
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sagemaker_runtime_api/latest/runtime.sagemaker-2017-05-13/SageMakerRuntime-class.html) on how to use SageMakerRuntime

--- a/generated/aws_savingsplans_api/README.md
+++ b/generated/aws_savingsplans_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Savings Plans
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Savings Plans are a pricing model that offer significant savings on AWS
@@ -15,9 +15,3 @@ Savings Plans User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_savingsplans_api/example/README.md
+++ b/generated/aws_savingsplans_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_savingsplans_api/savingsplans-2019-06-28.dart';
 
 void main() {
   final service = SavingsPlans(region: 'eu-west-1');
-  // See documentation on how to use SavingsPlans
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_savingsplans_api/latest/savingsplans-2019-06-28/SavingsPlans-class.html) on how to use SavingsPlans

--- a/generated/aws_schemas_api/README.md
+++ b/generated/aws_schemas_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Schemas
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon EventBridge Schema Registry
@@ -10,9 +10,3 @@ Amazon EventBridge Schema Registry
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_schemas_api/example/README.md
+++ b/generated/aws_schemas_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_schemas_api/schemas-2019-12-02.dart';
 
 void main() {
   final service = Schemas(region: 'eu-west-1');
-  // See documentation on how to use Schemas
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_schemas_api/latest/schemas-2019-12-02/Schemas-class.html) on how to use Schemas

--- a/generated/aws_sdb_api/README.md
+++ b/generated/aws_sdb_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon SimpleDB
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon SimpleDB is a web service providing the core database functions of
@@ -26,9 +26,3 @@ for more information.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sdb_api/example/README.md
+++ b/generated/aws_sdb_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sdb_api/sdb-2009-04-15.dart';
 
 void main() {
   final service = SimpleDB(region: 'eu-west-1');
-  // See documentation on how to use SimpleDB
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sdb_api/latest/sdb-2009-04-15/SimpleDB-class.html) on how to use SimpleDB

--- a/generated/aws_secretsmanager_api/README.md
+++ b/generated/aws_secretsmanager_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Secrets Manager
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Secrets Manager provides a service to enable you to store, manage, and
@@ -11,9 +11,3 @@ retrieve, secrets.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_secretsmanager_api/example/README.md
+++ b/generated/aws_secretsmanager_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_secretsmanager_api/secretsmanager-2017-10-17.dart';
 
 void main() {
   final service = SecretsManager(region: 'eu-west-1');
-  // See documentation on how to use SecretsManager
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_secretsmanager_api/latest/secretsmanager-2017-10-17/SecretsManager-class.html) on how to use SecretsManager

--- a/generated/aws_securityhub_api/README.md
+++ b/generated/aws_securityhub_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS SecurityHub
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Security Hub provides you with a comprehensive view of the security state of
@@ -56,9 +56,3 @@ All other operations - <code>RateLimit</code> of 10 requests per second.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_securityhub_api/example/README.md
+++ b/generated/aws_securityhub_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_securityhub_api/securityhub-2018-10-26.dart';
 
 void main() {
   final service = SecurityHub(region: 'eu-west-1');
-  // See documentation on how to use SecurityHub
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_securityhub_api/latest/securityhub-2018-10-26/SecurityHub-class.html) on how to use SecurityHub

--- a/generated/aws_serverlessrepo_api/README.md
+++ b/generated/aws_serverlessrepo_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWSServerlessApplicationRepository
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Serverless Application Repository makes it easy for developers and
@@ -58,9 +58,3 @@ developers, and publish new versions of applications.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_serverlessrepo_api/example/README.md
+++ b/generated/aws_serverlessrepo_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_serverlessrepo_api/serverlessrepo-2017-09-08.dart';
 
 void main() {
   final service = ServerlessApplicationRepository(region: 'eu-west-1');
-  // See documentation on how to use ServerlessApplicationRepository
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_serverlessrepo_api/latest/serverlessrepo-2017-09-08/ServerlessApplicationRepository-class.html) on how to use ServerlessApplicationRepository

--- a/generated/aws_service_quotas_api/README.md
+++ b/generated/aws_service_quotas_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Service Quotas
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 With Service Quotas, you can view and manage your quotas easily as your AWS
@@ -15,9 +15,3 @@ Quotas User Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_service_quotas_api/example/README.md
+++ b/generated/aws_service_quotas_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_service_quotas_api/service-quotas-2019-06-24.dart';
 
 void main() {
   final service = ServiceQuotas(region: 'eu-west-1');
-  // See documentation on how to use ServiceQuotas
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_service_quotas_api/latest/service-quotas-2019-06-24/ServiceQuotas-class.html) on how to use ServiceQuotas

--- a/generated/aws_servicecatalog_api/README.md
+++ b/generated/aws_servicecatalog_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Service Catalog
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <a href="https://aws.amazon.com/servicecatalog/">AWS Service Catalog</a>
@@ -15,9 +15,3 @@ Service Catalog Concepts</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_servicecatalog_api/example/README.md
+++ b/generated/aws_servicecatalog_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_servicecatalog_api/servicecatalog-2015-12-10.dart';
 
 void main() {
   final service = ServiceCatalog(region: 'eu-west-1');
-  // See documentation on how to use ServiceCatalog
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_servicecatalog_api/latest/servicecatalog-2015-12-10/ServiceCatalog-class.html) on how to use ServiceCatalog

--- a/generated/aws_servicediscovery_api/README.md
+++ b/generated/aws_servicediscovery_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Cloud Map
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Cloud Map lets you configure public DNS, private DNS, or HTTP namespaces
@@ -16,9 +16,3 @@ receive an answer that contains up to eight healthy records.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_servicediscovery_api/example/README.md
+++ b/generated/aws_servicediscovery_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_servicediscovery_api/servicediscovery-2017-03-14.dart';
 
 void main() {
   final service = ServiceDiscovery(region: 'eu-west-1');
-  // See documentation on how to use ServiceDiscovery
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_servicediscovery_api/latest/servicediscovery-2017-03-14/ServiceDiscovery-class.html) on how to use ServiceDiscovery

--- a/generated/aws_ses_api/README.md
+++ b/generated/aws_ses_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Email Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This document contains reference information for the <a
@@ -22,9 +22,3 @@ SES Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ses_api/example/README.md
+++ b/generated/aws_ses_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ses_api/email-2010-12-01.dart';
 
 void main() {
   final service = SES(region: 'eu-west-1');
-  // See documentation on how to use SES
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ses_api/latest/email-2010-12-01/SES-class.html) on how to use SES

--- a/generated/aws_sesv2_api/README.md
+++ b/generated/aws_sesv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Email Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the Amazon SES API v2 Reference. This guide provides information
@@ -12,9 +12,3 @@ parameters, and schemas.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sesv2_api/example/README.md
+++ b/generated/aws_sesv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sesv2_api/sesv2-2019-09-27.dart';
 
 void main() {
   final service = SESV2(region: 'eu-west-1');
-  // See documentation on how to use SESV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sesv2_api/latest/sesv2-2019-09-27/SESV2-class.html) on how to use SESV2

--- a/generated/aws_sfn_api/README.md
+++ b/generated/aws_sfn_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Step Functions
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Step Functions is a service that lets you coordinate the components of
@@ -11,9 +11,3 @@ distributed applications and microservices using visual workflows.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sfn_api/example/README.md
+++ b/generated/aws_sfn_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sfn_api/states-2016-11-23.dart';
 
 void main() {
   final service = SFN(region: 'eu-west-1');
-  // See documentation on how to use SFN
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sfn_api/latest/states-2016-11-23/SFN-class.html) on how to use SFN

--- a/generated/aws_shield_api/README.md
+++ b/generated/aws_shield_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Shield
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 This is the <i>AWS Shield Advanced API Reference</i>. This guide is for
@@ -16,9 +16,3 @@ AWS Shield Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_shield_api/example/README.md
+++ b/generated/aws_shield_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_shield_api/shield-2016-06-02.dart';
 
 void main() {
   final service = Shield(region: 'eu-west-1');
-  // See documentation on how to use Shield
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_shield_api/latest/shield-2016-06-02/Shield-class.html) on how to use Shield

--- a/generated/aws_signer_api/README.md
+++ b/generated/aws_signer_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Signer
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Signer is a fully managed code signing service to help you ensure the
@@ -34,9 +34,3 @@ Signer Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_signer_api/example/README.md
+++ b/generated/aws_signer_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_signer_api/signer-2017-08-25.dart';
 
 void main() {
   final service = Signer(region: 'eu-west-1');
-  // See documentation on how to use Signer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_signer_api/latest/signer-2017-08-25/Signer-class.html) on how to use Signer

--- a/generated/aws_sms_api/README.md
+++ b/generated/aws_sms_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Server Migration Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Server Migration Service (AWS SMS) makes it easier and faster for you to
@@ -12,9 +12,3 @@ the following resources:
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sms_api/example/README.md
+++ b/generated/aws_sms_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sms_api/sms-2016-10-24.dart';
 
 void main() {
   final service = SMS(region: 'eu-west-1');
-  // See documentation on how to use SMS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sms_api/latest/sms-2016-10-24/SMS-class.html) on how to use SMS

--- a/generated/aws_snowball_api/README.md
+++ b/generated/aws_snowball_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Import/Export Snowball
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Snow Family is a petabyte-scale data transport solution that uses secure
@@ -19,9 +19,3 @@ Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_snowball_api/example/README.md
+++ b/generated/aws_snowball_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_snowball_api/snowball-2016-06-30.dart';
 
 void main() {
   final service = Snowball(region: 'eu-west-1');
-  // See documentation on how to use Snowball
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_snowball_api/latest/snowball-2016-06-30/Snowball-class.html) on how to use Snowball

--- a/generated/aws_sns_api/README.md
+++ b/generated/aws_sns_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Notification Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Simple Notification Service (Amazon SNS) is a web service that
@@ -18,9 +18,3 @@ SNS Developer Guide</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sns_api/example/README.md
+++ b/generated/aws_sns_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sns_api/sns-2010-03-31.dart';
 
 void main() {
   final service = SNS(region: 'eu-west-1');
-  // See documentation on how to use SNS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sns_api/latest/sns-2010-03-31/SNS-class.html) on how to use SNS

--- a/generated/aws_sqs_api/README.md
+++ b/generated/aws_sqs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Queue Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Welcome to the <i>Amazon Simple Queue Service API Reference</i>.
@@ -78,9 +78,3 @@ and Endpoints</a>
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sqs_api/example/README.md
+++ b/generated/aws_sqs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sqs_api/sqs-2012-11-05.dart';
 
 void main() {
   final service = SQS(region: 'eu-west-1');
-  // See documentation on how to use SQS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sqs_api/latest/sqs-2012-11-05/SQS-class.html) on how to use SQS

--- a/generated/aws_ssm_api/README.md
+++ b/generated/aws_ssm_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Systems Manager (SSM)
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Systems Manager is a collection of capabilities that helps you automate
@@ -18,9 +18,3 @@ Manager.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_ssm_api/example/README.md
+++ b/generated/aws_ssm_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_ssm_api/ssm-2014-11-06.dart';
 
 void main() {
   final service = SSM(region: 'eu-west-1');
-  // See documentation on how to use SSM
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_ssm_api/latest/ssm-2014-11-06/SSM-class.html) on how to use SSM

--- a/generated/aws_sso_api/README.md
+++ b/generated/aws_sso_api/README.md
@@ -1,8 +1,7 @@
 # AWS API client for AWS Single Sign-On Admin
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
-*About the service:*
 
 
 ## Links
@@ -10,9 +9,3 @@
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sso_api/example/README.md
+++ b/generated/aws_sso_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sso_api/sso-admin-2020-07-20.dart';
 
 void main() {
   final service = SSOAdmin(region: 'eu-west-1');
-  // See documentation on how to use SSOAdmin
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sso_api/latest/sso-admin-2020-07-20/SSOAdmin-class.html) on how to use SSOAdmin

--- a/generated/aws_sso_oidc_api/README.md
+++ b/generated/aws_sso_oidc_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS SSO OIDC
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Single Sign-On (SSO) OpenID Connect (OIDC) is a web service that enables
@@ -32,9 +32,3 @@ href="https://aws.amazon.com/tools/">Tools for Amazon Web Services</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sso_oidc_api/example/README.md
+++ b/generated/aws_sso_oidc_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sso_oidc_api/sso-oidc-2019-06-10.dart';
 
 void main() {
   final service = SSOOIDC(region: 'eu-west-1');
-  // See documentation on how to use SSOOIDC
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sso_oidc_api/latest/sso-oidc-2019-06-10/SSOOIDC-class.html) on how to use SSOOIDC

--- a/generated/aws_storagegateway_api/README.md
+++ b/generated/aws_storagegateway_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Storage Gateway
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Storage Gateway is the service that connects an on-premises software
@@ -14,9 +14,3 @@ the AWS Cloud for cost effective backup and rapid disaster recovery.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_storagegateway_api/example/README.md
+++ b/generated/aws_storagegateway_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_storagegateway_api/storagegateway-2013-06-30.dart';
 
 void main() {
   final service = StorageGateway(region: 'eu-west-1');
-  // See documentation on how to use StorageGateway
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_storagegateway_api/latest/storagegateway-2013-06-30/StorageGateway-class.html) on how to use StorageGateway

--- a/generated/aws_sts_api/README.md
+++ b/generated/aws_sts_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Security Token Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Security Token Service (STS) enables you to request temporary,
@@ -16,9 +16,3 @@ Security Credentials</a>.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_sts_api/example/README.md
+++ b/generated/aws_sts_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_sts_api/sts-2011-06-15.dart';
 
 void main() {
   final service = STS(region: 'eu-west-1');
-  // See documentation on how to use STS
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_sts_api/latest/sts-2011-06-15/STS-class.html) on how to use STS

--- a/generated/aws_support_api/README.md
+++ b/generated/aws_support_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Support
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The AWS Support API reference is intended for programmers who need detailed
@@ -32,9 +32,3 @@ refresh status of checks.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_support_api/example/README.md
+++ b/generated/aws_support_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_support_api/support-2013-04-15.dart';
 
 void main() {
   final service = Support(region: 'eu-west-1');
-  // See documentation on how to use Support
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_support_api/latest/support-2013-04-15/Support-class.html) on how to use Support

--- a/generated/aws_swf_api/README.md
+++ b/generated/aws_swf_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Simple Workflow Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The Amazon Simple Workflow Service (Amazon SWF) makes it easy to build
@@ -15,9 +15,3 @@ concurrency in accordance with the logical flow of the application.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_swf_api/example/README.md
+++ b/generated/aws_swf_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_swf_api/swf-2012-01-25.dart';
 
 void main() {
   final service = SWF(region: 'eu-west-1');
-  // See documentation on how to use SWF
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_swf_api/latest/swf-2012-01-25/SWF-class.html) on how to use SWF

--- a/generated/aws_textract_api/README.md
+++ b/generated/aws_textract_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Textract
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon Textract detects and analyzes text in documents and converts it into
@@ -12,9 +12,3 @@ Textract.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_textract_api/example/README.md
+++ b/generated/aws_textract_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_textract_api/textract-2018-06-27.dart';
 
 void main() {
   final service = Textract(region: 'eu-west-1');
-  // See documentation on how to use Textract
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_textract_api/latest/textract-2018-06-27/Textract-class.html) on how to use Textract

--- a/generated/aws_transcribe_api/README.md
+++ b/generated/aws_transcribe_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Transcribe Service
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Operations and objects for transcribing speech to text.
@@ -10,9 +10,3 @@ Operations and objects for transcribing speech to text.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_transcribe_api/example/README.md
+++ b/generated/aws_transcribe_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_transcribe_api/transcribe-2017-10-26.dart';
 
 void main() {
   final service = TranscribeService(region: 'eu-west-1');
-  // See documentation on how to use TranscribeService
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_transcribe_api/latest/transcribe-2017-10-26/TranscribeService-class.html) on how to use TranscribeService

--- a/generated/aws_transfer_api/README.md
+++ b/generated/aws_transfer_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS Transfer Family
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS Transfer Family is a fully managed service that enables the transfer of
@@ -20,9 +20,3 @@ buy and set up.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_transfer_api/example/README.md
+++ b/generated/aws_transfer_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_transfer_api/transfer-2018-11-05.dart';
 
 void main() {
   final service = Transfer(region: 'eu-west-1');
-  // See documentation on how to use Transfer
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_transfer_api/latest/transfer-2018-11-05/Transfer-class.html) on how to use Transfer

--- a/generated/aws_translate_api/README.md
+++ b/generated/aws_translate_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon Translate
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Provides translation between one source language and another of the same set
@@ -11,9 +11,3 @@ of languages.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_translate_api/example/README.md
+++ b/generated/aws_translate_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_translate_api/translate-2017-07-01.dart';
 
 void main() {
   final service = Translate(region: 'eu-west-1');
-  // See documentation on how to use Translate
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_translate_api/latest/translate-2017-07-01/Translate-class.html) on how to use Translate

--- a/generated/aws_waf_api/README.md
+++ b/generated/aws_waf_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS WAF
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <note>
@@ -30,9 +30,3 @@ WAF Classic</a> in the developer guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_waf_api/example/README.md
+++ b/generated/aws_waf_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_waf_api/waf-2015-08-24.dart';
 
 void main() {
   final service = WAF(region: 'eu-west-1');
-  // See documentation on how to use WAF
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_waf_api/latest/waf-2015-08-24/WAF-class.html) on how to use WAF

--- a/generated/aws_waf_regional_api/README.md
+++ b/generated/aws_waf_regional_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS WAF Regional
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <note>
@@ -34,9 +34,3 @@ WAF Classic</a> in the developer guide.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_waf_regional_api/example/README.md
+++ b/generated/aws_waf_regional_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_waf_regional_api/waf-regional-2016-11-28.dart';
 
 void main() {
   final service = WAFRegional(region: 'eu-west-1');
-  // See documentation on how to use WAFRegional
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_waf_regional_api/latest/waf-regional-2016-11-28/WAFRegional-class.html) on how to use WAFRegional

--- a/generated/aws_wafv2_api/README.md
+++ b/generated/aws_wafv2_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS WAFV2
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 <note>
@@ -85,9 +85,3 @@ know the maximum cost of a rule group when you use it.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_wafv2_api/example/README.md
+++ b/generated/aws_wafv2_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_wafv2_api/wafv2-2019-07-29.dart';
 
 void main() {
   final service = WAFV2(region: 'eu-west-1');
-  // See documentation on how to use WAFV2
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_wafv2_api/latest/wafv2-2019-07-29/WAFV2-class.html) on how to use WAFV2

--- a/generated/aws_workdocs_api/README.md
+++ b/generated/aws_workdocs_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon WorkDocs
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The WorkDocs API is designed for the following use cases:
@@ -44,9 +44,3 @@ grant access on a selective basis using the IAM model.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_workdocs_api/example/README.md
+++ b/generated/aws_workdocs_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_workdocs_api/workdocs-2016-05-01.dart';
 
 void main() {
   final service = WorkDocs(region: 'eu-west-1');
-  // See documentation on how to use WorkDocs
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_workdocs_api/latest/workdocs-2016-05-01/WorkDocs-class.html) on how to use WorkDocs

--- a/generated/aws_worklink_api/README.md
+++ b/generated/aws_worklink_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon WorkLink
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon WorkLink is a cloud-based service that provides secure access to
@@ -18,9 +18,3 @@ mobile devices.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_worklink_api/example/README.md
+++ b/generated/aws_worklink_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_worklink_api/worklink-2018-09-25.dart';
 
 void main() {
   final service = WorkLink(region: 'eu-west-1');
-  // See documentation on how to use WorkLink
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_worklink_api/latest/worklink-2018-09-25/WorkLink-class.html) on how to use WorkLink

--- a/generated/aws_workmail_api/README.md
+++ b/generated/aws_workmail_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon WorkMail
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon WorkMail is a secure, managed business email and calendaring service
@@ -48,9 +48,3 @@ ability to grant access on a selective basis using the IAM model.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_workmail_api/example/README.md
+++ b/generated/aws_workmail_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_workmail_api/workmail-2017-10-01.dart';
 
 void main() {
   final service = WorkMail(region: 'eu-west-1');
-  // See documentation on how to use WorkMail
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_workmail_api/latest/workmail-2017-10-01/WorkMail-class.html) on how to use WorkMail

--- a/generated/aws_workmailmessageflow_api/README.md
+++ b/generated/aws_workmailmessageflow_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon WorkMail Message Flow
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 The WorkMail Message Flow API provides access to email messages as they are
@@ -11,9 +11,3 @@ being sent and received by a WorkMail organization.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_workmailmessageflow_api/example/README.md
+++ b/generated/aws_workmailmessageflow_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_workmailmessageflow_api/workmailmessageflow-2019-05-01.dart'
 
 void main() {
   final service = WorkMailMessageFlow(region: 'eu-west-1');
-  // See documentation on how to use WorkMailMessageFlow
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_workmailmessageflow_api/latest/workmailmessageflow-2019-05-01/WorkMailMessageFlow-class.html) on how to use WorkMailMessageFlow

--- a/generated/aws_workspaces_api/README.md
+++ b/generated/aws_workspaces_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for Amazon WorkSpaces
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 Amazon WorkSpaces enables you to provision virtual, cloud-based Microsoft
@@ -11,9 +11,3 @@ Windows and Amazon Linux desktops for your users.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_workspaces_api/example/README.md
+++ b/generated/aws_workspaces_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_workspaces_api/workspaces-2015-04-08.dart';
 
 void main() {
   final service = WorkSpaces(region: 'eu-west-1');
-  // See documentation on how to use WorkSpaces
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_workspaces_api/latest/workspaces-2015-04-08/WorkSpaces-class.html) on how to use WorkSpaces

--- a/generated/aws_xray_api/README.md
+++ b/generated/aws_xray_api/README.md
@@ -1,6 +1,6 @@
 # AWS API client for AWS X-Ray
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
 *About the service:*
 AWS X-Ray provides APIs for managing debug traces and retrieving service
@@ -11,9 +11,3 @@ maps and other data created by processing those traces.
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-

--- a/generated/aws_xray_api/example/README.md
+++ b/generated/aws_xray_api/example/README.md
@@ -3,6 +3,7 @@ import 'package:aws_xray_api/xray-2016-04-12.dart';
 
 void main() {
   final service = XRay(region: 'eu-west-1');
-  // See documentation on how to use XRay
 }
 ```
+
+See [API reference](https://pub.dev/documentation/aws_xray_api/latest/xray-2016-04-12/XRay-class.html) on how to use XRay

--- a/generator/README.md
+++ b/generator/README.md
@@ -3,18 +3,18 @@
 In order to generate the SDK from scratch, run the `generate.dart` file, while the working directory is `generator/`.
 
 ```bash
-dart bin/generate.dart generate --download
+dart bin/generate.dart generate
 ```
 
-This will download the JSON definitions first from Github at 
-https://api.github.com/repos/aws/aws-sdk-js/zipball/master 
+This will download the JSON definitions automatically, if needed, from Github at 
+`https://api.github.com/repos/aws/aws-sdk-js/zipball/<version>`
 , then generate all the services.
+The version is specified in the [config file](/generator/config.yaml) as `awsSdkJsReference`.
 
-If you are developing the [library_builder.dart](bin/library_builder.dart), it is unnecessary to download the definitions every time. 
-To skip the download, omit the `--download` argument:
+To force the download, add the `--download` argument:
 
 ```bash
-dart bin/generate.dart generate
+dart bin/generate.dart generate --download
 ```
 
 If you just want to download the definitions, then run:

--- a/generator/lib/builders/example_builder.dart
+++ b/generator/lib/builders/example_builder.dart
@@ -6,7 +6,8 @@ import 'package:${api.packageName}/${api.fileBasename}.dart';
 
 void main() {
   final service = ${api.metadata.className}(region: 'eu-west-1');
-  // See documentation on how to use ${api.metadata.className}
 }
 ```
+
+See [API reference](https://pub.dev/documentation/${api.packageName}/latest/${api.fileBasename}/${api.metadata.className}-class.html) on how to use ${api.metadata.className}
 ''';

--- a/generator/lib/builders/readme_builder.dart
+++ b/generator/lib/builders/readme_builder.dart
@@ -6,9 +6,8 @@ String buildReadmeMd(Api api) {
   return '''
 # AWS API client for ${api.metadata.serviceFullName}
 
-**Warning: This is a generated library, some operations may not work.**
+**Generated Dart library from API specification**
 
-*About the service:*
 ${_prepareDocumentation(api)}
 
 ## Links
@@ -16,17 +15,15 @@ ${_prepareDocumentation(api)}
 - [Other AWS libraries](https://github.com/agilord/aws_client/tree/master/generated).
 - [Issue tracker](https://github.com/agilord/aws_client/issues).
 - [AWS API definitions](https://github.com/aws/aws-sdk-js/tree/master/apis).
-
-## Contributors
-
-- [Jonathan Böcker](https://github.com/Schwusch)
-- [Istvan Soós](https://github.com/isoos)
-
 ''';
 }
 
 String _prepareDocumentation(Api api) {
   var doc = markdownText(api.documentation);
   doc = doc.replaceAll('http://', 'https://');
-  return doc;
+
+  return [
+    if (doc.isNotEmpty) '*About the service:*',
+    doc,
+  ].join('\n');
 }


### PR DESCRIPTION
I'd like to suggest some updates to all READMEs:
- Some more info on the main readme.
- Remove Travis/mono_repo stuff, since it's not used anymore
- Adjust generator readme to current functionality
- A direct link to the main class API reference in the generated service readme
- Remove warnings and contributors in generated readmes, we're more than just 2 contributors now and warnings don't add value at this point.

If there is more that I should add, give a commment.