### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
+++ b/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
@@ -952,7 +952,7 @@ enum AnalyzerStatus {
   failed,
 }
 
-extension on AnalyzerStatus {
+extension AnalyzerStatusValue on AnalyzerStatus {
   String toValue() {
     switch (this) {
       case AnalyzerStatus.active:
@@ -967,7 +967,7 @@ extension on AnalyzerStatus {
   }
 }
 
-extension on String {
+extension AnalyzerStatusFromString on String {
   AnalyzerStatus toAnalyzerStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -1288,7 +1288,7 @@ enum FindingSourceType {
   s3AccessPoint,
 }
 
-extension on FindingSourceType {
+extension FindingSourceTypeValue on FindingSourceType {
   String toValue() {
     switch (this) {
       case FindingSourceType.policy:
@@ -1301,7 +1301,7 @@ extension on FindingSourceType {
   }
 }
 
-extension on String {
+extension FindingSourceTypeFromString on String {
   FindingSourceType toFindingSourceType() {
     switch (this) {
       case 'POLICY':
@@ -1321,7 +1321,7 @@ enum FindingStatus {
   resolved,
 }
 
-extension on FindingStatus {
+extension FindingStatusValue on FindingStatus {
   String toValue() {
     switch (this) {
       case FindingStatus.active:
@@ -1334,7 +1334,7 @@ extension on FindingStatus {
   }
 }
 
-extension on String {
+extension FindingStatusFromString on String {
   FindingStatus toFindingStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -1353,7 +1353,7 @@ enum FindingStatusUpdate {
   archived,
 }
 
-extension on FindingStatusUpdate {
+extension FindingStatusUpdateValue on FindingStatusUpdate {
   String toValue() {
     switch (this) {
       case FindingStatusUpdate.active:
@@ -1364,7 +1364,7 @@ extension on FindingStatusUpdate {
   }
 }
 
-extension on String {
+extension FindingStatusUpdateFromString on String {
   FindingStatusUpdate toFindingStatusUpdate() {
     switch (this) {
       case 'ACTIVE':
@@ -1674,7 +1674,7 @@ enum OrderBy {
   desc,
 }
 
-extension on OrderBy {
+extension OrderByValue on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.asc:
@@ -1685,7 +1685,7 @@ extension on OrderBy {
   }
 }
 
-extension on String {
+extension OrderByFromString on String {
   OrderBy toOrderBy() {
     switch (this) {
       case 'ASC':
@@ -1704,7 +1704,7 @@ enum ReasonCode {
   serviceLinkedRoleCreationFailed,
 }
 
-extension on ReasonCode {
+extension ReasonCodeValue on ReasonCode {
   String toValue() {
     switch (this) {
       case ReasonCode.awsServiceAccessDisabled:
@@ -1719,7 +1719,7 @@ extension on ReasonCode {
   }
 }
 
-extension on String {
+extension ReasonCodeFromString on String {
   ReasonCode toReasonCode() {
     switch (this) {
       case 'AWS_SERVICE_ACCESS_DISABLED':
@@ -1744,7 +1744,7 @@ enum ResourceType {
   awsKmsKey,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.awsS3Bucket:
@@ -1763,7 +1763,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'AWS::S3::Bucket':
@@ -1837,7 +1837,7 @@ enum Type {
   organization,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.account:
@@ -1848,7 +1848,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'ACCOUNT':

--- a/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
+++ b/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
@@ -952,7 +952,7 @@ enum AnalyzerStatus {
   failed,
 }
 
-extension AnalyzerStatusValue on AnalyzerStatus {
+extension AnalyzerStatusValueExtension on AnalyzerStatus {
   String toValue() {
     switch (this) {
       case AnalyzerStatus.active:
@@ -1288,7 +1288,7 @@ enum FindingSourceType {
   s3AccessPoint,
 }
 
-extension FindingSourceTypeValue on FindingSourceType {
+extension FindingSourceTypeValueExtension on FindingSourceType {
   String toValue() {
     switch (this) {
       case FindingSourceType.policy:
@@ -1321,7 +1321,7 @@ enum FindingStatus {
   resolved,
 }
 
-extension FindingStatusValue on FindingStatus {
+extension FindingStatusValueExtension on FindingStatus {
   String toValue() {
     switch (this) {
       case FindingStatus.active:
@@ -1353,7 +1353,7 @@ enum FindingStatusUpdate {
   archived,
 }
 
-extension FindingStatusUpdateValue on FindingStatusUpdate {
+extension FindingStatusUpdateValueExtension on FindingStatusUpdate {
   String toValue() {
     switch (this) {
       case FindingStatusUpdate.active:
@@ -1674,7 +1674,7 @@ enum OrderBy {
   desc,
 }
 
-extension OrderByValue on OrderBy {
+extension OrderByValueExtension on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.asc:
@@ -1704,7 +1704,7 @@ enum ReasonCode {
   serviceLinkedRoleCreationFailed,
 }
 
-extension ReasonCodeValue on ReasonCode {
+extension ReasonCodeValueExtension on ReasonCode {
   String toValue() {
     switch (this) {
       case ReasonCode.awsServiceAccessDisabled:
@@ -1744,7 +1744,7 @@ enum ResourceType {
   awsKmsKey,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.awsS3Bucket:
@@ -1837,7 +1837,7 @@ enum Type {
   organization,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.account:

--- a/generated/aws_acm_api/lib/acm-2015-12-08.dart
+++ b/generated/aws_acm_api/lib/acm-2015-12-08.dart
@@ -1263,7 +1263,7 @@ enum CertificateStatus {
   failed,
 }
 
-extension on CertificateStatus {
+extension CertificateStatusValue on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.pendingValidation:
@@ -1284,7 +1284,7 @@ extension on CertificateStatus {
   }
 }
 
-extension on String {
+extension CertificateStatusFromString on String {
   CertificateStatus toCertificateStatus() {
     switch (this) {
       case 'PENDING_VALIDATION':
@@ -1339,7 +1339,8 @@ enum CertificateTransparencyLoggingPreference {
   disabled,
 }
 
-extension on CertificateTransparencyLoggingPreference {
+extension CertificateTransparencyLoggingPreferenceValue
+    on CertificateTransparencyLoggingPreference {
   String toValue() {
     switch (this) {
       case CertificateTransparencyLoggingPreference.enabled:
@@ -1350,7 +1351,7 @@ extension on CertificateTransparencyLoggingPreference {
   }
 }
 
-extension on String {
+extension CertificateTransparencyLoggingPreferenceFromString on String {
   CertificateTransparencyLoggingPreference
       toCertificateTransparencyLoggingPreference() {
     switch (this) {
@@ -1370,7 +1371,7 @@ enum CertificateType {
   private,
 }
 
-extension on CertificateType {
+extension CertificateTypeValue on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.imported:
@@ -1383,7 +1384,7 @@ extension on CertificateType {
   }
 }
 
-extension on String {
+extension CertificateTypeFromString on String {
   CertificateType toCertificateType() {
     switch (this) {
       case 'IMPORTED':
@@ -1420,7 +1421,7 @@ enum DomainStatus {
   failed,
 }
 
-extension on DomainStatus {
+extension DomainStatusValue on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingValidation:
@@ -1433,7 +1434,7 @@ extension on DomainStatus {
   }
 }
 
-extension on String {
+extension DomainStatusFromString on String {
   DomainStatus toDomainStatus() {
     switch (this) {
       case 'PENDING_VALIDATION':
@@ -1660,7 +1661,7 @@ enum ExtendedKeyUsageName {
   custom,
 }
 
-extension on ExtendedKeyUsageName {
+extension ExtendedKeyUsageNameValue on ExtendedKeyUsageName {
   String toValue() {
     switch (this) {
       case ExtendedKeyUsageName.tlsWebServerAuthentication:
@@ -1691,7 +1692,7 @@ extension on ExtendedKeyUsageName {
   }
 }
 
-extension on String {
+extension ExtendedKeyUsageNameFromString on String {
   ExtendedKeyUsageName toExtendedKeyUsageName() {
     switch (this) {
       case 'TLS_WEB_SERVER_AUTHENTICATION':
@@ -1743,7 +1744,7 @@ enum FailureReason {
   other,
 }
 
-extension on FailureReason {
+extension FailureReasonValue on FailureReason {
   String toValue() {
     switch (this) {
       case FailureReason.noAvailableContacts:
@@ -1784,7 +1785,7 @@ extension on FailureReason {
   }
 }
 
-extension on String {
+extension FailureReasonFromString on String {
   FailureReason toFailureReason() {
     switch (this) {
       case 'NO_AVAILABLE_CONTACTS':
@@ -1910,7 +1911,7 @@ enum KeyAlgorithm {
   ecSecp521r1,
 }
 
-extension on KeyAlgorithm {
+extension KeyAlgorithmValue on KeyAlgorithm {
   String toValue() {
     switch (this) {
       case KeyAlgorithm.rsa_2048:
@@ -1929,7 +1930,7 @@ extension on KeyAlgorithm {
   }
 }
 
-extension on String {
+extension KeyAlgorithmFromString on String {
   KeyAlgorithm toKeyAlgorithm() {
     switch (this) {
       case 'RSA_2048':
@@ -1979,7 +1980,7 @@ enum KeyUsageName {
   custom,
 }
 
-extension on KeyUsageName {
+extension KeyUsageNameValue on KeyUsageName {
   String toValue() {
     switch (this) {
       case KeyUsageName.digitalSignature:
@@ -2008,7 +2009,7 @@ extension on KeyUsageName {
   }
 }
 
-extension on String {
+extension KeyUsageNameFromString on String {
   KeyUsageName toKeyUsageName() {
     switch (this) {
       case 'DIGITAL_SIGNATURE':
@@ -2083,7 +2084,7 @@ enum RecordType {
   cname,
 }
 
-extension on RecordType {
+extension RecordTypeValue on RecordType {
   String toValue() {
     switch (this) {
       case RecordType.cname:
@@ -2092,7 +2093,7 @@ extension on RecordType {
   }
 }
 
-extension on String {
+extension RecordTypeFromString on String {
   RecordType toRecordType() {
     switch (this) {
       case 'CNAME':
@@ -2107,7 +2108,7 @@ enum RenewalEligibility {
   ineligible,
 }
 
-extension on RenewalEligibility {
+extension RenewalEligibilityValue on RenewalEligibility {
   String toValue() {
     switch (this) {
       case RenewalEligibility.eligible:
@@ -2118,7 +2119,7 @@ extension on RenewalEligibility {
   }
 }
 
-extension on String {
+extension RenewalEligibilityFromString on String {
   RenewalEligibility toRenewalEligibility() {
     switch (this) {
       case 'ELIGIBLE':
@@ -2137,7 +2138,7 @@ enum RenewalStatus {
   failed,
 }
 
-extension on RenewalStatus {
+extension RenewalStatusValue on RenewalStatus {
   String toValue() {
     switch (this) {
       case RenewalStatus.pendingAutoRenewal:
@@ -2152,7 +2153,7 @@ extension on RenewalStatus {
   }
 }
 
-extension on String {
+extension RenewalStatusFromString on String {
   RenewalStatus toRenewalStatus() {
     switch (this) {
       case 'PENDING_AUTO_RENEWAL':
@@ -2271,7 +2272,7 @@ enum RevocationReason {
   aACompromise,
 }
 
-extension on RevocationReason {
+extension RevocationReasonValue on RevocationReason {
   String toValue() {
     switch (this) {
       case RevocationReason.unspecified:
@@ -2298,7 +2299,7 @@ extension on RevocationReason {
   }
 }
 
-extension on String {
+extension RevocationReasonFromString on String {
   RevocationReason toRevocationReason() {
     switch (this) {
       case 'UNSPECIFIED':
@@ -2361,7 +2362,7 @@ enum ValidationMethod {
   dns,
 }
 
-extension on ValidationMethod {
+extension ValidationMethodValue on ValidationMethod {
   String toValue() {
     switch (this) {
       case ValidationMethod.email:
@@ -2372,7 +2373,7 @@ extension on ValidationMethod {
   }
 }
 
-extension on String {
+extension ValidationMethodFromString on String {
   ValidationMethod toValidationMethod() {
     switch (this) {
       case 'EMAIL':

--- a/generated/aws_acm_api/lib/acm-2015-12-08.dart
+++ b/generated/aws_acm_api/lib/acm-2015-12-08.dart
@@ -1263,7 +1263,7 @@ enum CertificateStatus {
   failed,
 }
 
-extension CertificateStatusValue on CertificateStatus {
+extension CertificateStatusValueExtension on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.pendingValidation:
@@ -1339,7 +1339,7 @@ enum CertificateTransparencyLoggingPreference {
   disabled,
 }
 
-extension CertificateTransparencyLoggingPreferenceValue
+extension CertificateTransparencyLoggingPreferenceValueExtension
     on CertificateTransparencyLoggingPreference {
   String toValue() {
     switch (this) {
@@ -1371,7 +1371,7 @@ enum CertificateType {
   private,
 }
 
-extension CertificateTypeValue on CertificateType {
+extension CertificateTypeValueExtension on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.imported:
@@ -1421,7 +1421,7 @@ enum DomainStatus {
   failed,
 }
 
-extension DomainStatusValue on DomainStatus {
+extension DomainStatusValueExtension on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingValidation:
@@ -1661,7 +1661,7 @@ enum ExtendedKeyUsageName {
   custom,
 }
 
-extension ExtendedKeyUsageNameValue on ExtendedKeyUsageName {
+extension ExtendedKeyUsageNameValueExtension on ExtendedKeyUsageName {
   String toValue() {
     switch (this) {
       case ExtendedKeyUsageName.tlsWebServerAuthentication:
@@ -1744,7 +1744,7 @@ enum FailureReason {
   other,
 }
 
-extension FailureReasonValue on FailureReason {
+extension FailureReasonValueExtension on FailureReason {
   String toValue() {
     switch (this) {
       case FailureReason.noAvailableContacts:
@@ -1911,7 +1911,7 @@ enum KeyAlgorithm {
   ecSecp521r1,
 }
 
-extension KeyAlgorithmValue on KeyAlgorithm {
+extension KeyAlgorithmValueExtension on KeyAlgorithm {
   String toValue() {
     switch (this) {
       case KeyAlgorithm.rsa_2048:
@@ -1980,7 +1980,7 @@ enum KeyUsageName {
   custom,
 }
 
-extension KeyUsageNameValue on KeyUsageName {
+extension KeyUsageNameValueExtension on KeyUsageName {
   String toValue() {
     switch (this) {
       case KeyUsageName.digitalSignature:
@@ -2084,7 +2084,7 @@ enum RecordType {
   cname,
 }
 
-extension RecordTypeValue on RecordType {
+extension RecordTypeValueExtension on RecordType {
   String toValue() {
     switch (this) {
       case RecordType.cname:
@@ -2108,7 +2108,7 @@ enum RenewalEligibility {
   ineligible,
 }
 
-extension RenewalEligibilityValue on RenewalEligibility {
+extension RenewalEligibilityValueExtension on RenewalEligibility {
   String toValue() {
     switch (this) {
       case RenewalEligibility.eligible:
@@ -2138,7 +2138,7 @@ enum RenewalStatus {
   failed,
 }
 
-extension RenewalStatusValue on RenewalStatus {
+extension RenewalStatusValueExtension on RenewalStatus {
   String toValue() {
     switch (this) {
       case RenewalStatus.pendingAutoRenewal:
@@ -2272,7 +2272,7 @@ enum RevocationReason {
   aACompromise,
 }
 
-extension RevocationReasonValue on RevocationReason {
+extension RevocationReasonValueExtension on RevocationReason {
   String toValue() {
     switch (this) {
       case RevocationReason.unspecified:
@@ -2362,7 +2362,7 @@ enum ValidationMethod {
   dns,
 }
 
-extension ValidationMethodValue on ValidationMethod {
+extension ValidationMethodValueExtension on ValidationMethod {
   String toValue() {
     switch (this) {
       case ValidationMethod.email:

--- a/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
+++ b/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
@@ -2321,7 +2321,7 @@ enum AccessMethodType {
   resourcePkiNotify,
 }
 
-extension AccessMethodTypeValue on AccessMethodType {
+extension AccessMethodTypeValueExtension on AccessMethodType {
   String toValue() {
     switch (this) {
       case AccessMethodType.caRepository:
@@ -2354,7 +2354,7 @@ enum ActionType {
   listPermissions,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.issueCertificate:
@@ -2386,7 +2386,7 @@ enum AuditReportResponseFormat {
   csv,
 }
 
-extension AuditReportResponseFormatValue on AuditReportResponseFormat {
+extension AuditReportResponseFormatValueExtension on AuditReportResponseFormat {
   String toValue() {
     switch (this) {
       case AuditReportResponseFormat.json:
@@ -2415,7 +2415,7 @@ enum AuditReportStatus {
   failed,
 }
 
-extension AuditReportStatusValue on AuditReportStatus {
+extension AuditReportStatusValueExtension on AuditReportStatus {
   String toValue() {
     switch (this) {
       case AuditReportStatus.creating:
@@ -2614,7 +2614,8 @@ enum CertificateAuthorityStatus {
   failed,
 }
 
-extension CertificateAuthorityStatusValue on CertificateAuthorityStatus {
+extension CertificateAuthorityStatusValueExtension
+    on CertificateAuthorityStatus {
   String toValue() {
     switch (this) {
       case CertificateAuthorityStatus.creating:
@@ -2662,7 +2663,7 @@ enum CertificateAuthorityType {
   subordinate,
 }
 
-extension CertificateAuthorityTypeValue on CertificateAuthorityType {
+extension CertificateAuthorityTypeValueExtension on CertificateAuthorityType {
   String toValue() {
     switch (this) {
       case CertificateAuthorityType.root:
@@ -2997,7 +2998,7 @@ enum FailureReason {
   other,
 }
 
-extension FailureReasonValue on FailureReason {
+extension FailureReasonValueExtension on FailureReason {
   String toValue() {
     switch (this) {
       case FailureReason.requestTimedOut:
@@ -3204,7 +3205,7 @@ enum KeyAlgorithm {
   ecSecp384r1,
 }
 
-extension KeyAlgorithmValue on KeyAlgorithm {
+extension KeyAlgorithmValueExtension on KeyAlgorithm {
   String toValue() {
     switch (this) {
       case KeyAlgorithm.rsa_2048:
@@ -3479,7 +3480,7 @@ enum ResourceOwner {
   otherAccounts,
 }
 
-extension ResourceOwnerValue on ResourceOwner {
+extension ResourceOwnerValueExtension on ResourceOwner {
   String toValue() {
     switch (this) {
       case ResourceOwner.self:
@@ -3546,7 +3547,7 @@ enum RevocationReason {
   aACompromise,
 }
 
-extension RevocationReasonValue on RevocationReason {
+extension RevocationReasonValueExtension on RevocationReason {
   String toValue() {
     switch (this) {
       case RevocationReason.unspecified:
@@ -3602,7 +3603,7 @@ enum SigningAlgorithm {
   sha512withrsa,
 }
 
-extension SigningAlgorithmValue on SigningAlgorithm {
+extension SigningAlgorithmValueExtension on SigningAlgorithm {
   String toValue() {
     switch (this) {
       case SigningAlgorithm.sha256withecdsa:
@@ -3763,7 +3764,7 @@ enum ValidityPeriodType {
   years,
 }
 
-extension ValidityPeriodTypeValue on ValidityPeriodType {
+extension ValidityPeriodTypeValueExtension on ValidityPeriodType {
   String toValue() {
     switch (this) {
       case ValidityPeriodType.endDate:

--- a/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
+++ b/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
@@ -2321,7 +2321,7 @@ enum AccessMethodType {
   resourcePkiNotify,
 }
 
-extension on AccessMethodType {
+extension AccessMethodTypeValue on AccessMethodType {
   String toValue() {
     switch (this) {
       case AccessMethodType.caRepository:
@@ -2334,7 +2334,7 @@ extension on AccessMethodType {
   }
 }
 
-extension on String {
+extension AccessMethodTypeFromString on String {
   AccessMethodType toAccessMethodType() {
     switch (this) {
       case 'CA_REPOSITORY':
@@ -2354,7 +2354,7 @@ enum ActionType {
   listPermissions,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.issueCertificate:
@@ -2367,7 +2367,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'IssueCertificate':
@@ -2386,7 +2386,7 @@ enum AuditReportResponseFormat {
   csv,
 }
 
-extension on AuditReportResponseFormat {
+extension AuditReportResponseFormatValue on AuditReportResponseFormat {
   String toValue() {
     switch (this) {
       case AuditReportResponseFormat.json:
@@ -2397,7 +2397,7 @@ extension on AuditReportResponseFormat {
   }
 }
 
-extension on String {
+extension AuditReportResponseFormatFromString on String {
   AuditReportResponseFormat toAuditReportResponseFormat() {
     switch (this) {
       case 'JSON':
@@ -2415,7 +2415,7 @@ enum AuditReportStatus {
   failed,
 }
 
-extension on AuditReportStatus {
+extension AuditReportStatusValue on AuditReportStatus {
   String toValue() {
     switch (this) {
       case AuditReportStatus.creating:
@@ -2428,7 +2428,7 @@ extension on AuditReportStatus {
   }
 }
 
-extension on String {
+extension AuditReportStatusFromString on String {
   AuditReportStatus toAuditReportStatus() {
     switch (this) {
       case 'CREATING':
@@ -2614,7 +2614,7 @@ enum CertificateAuthorityStatus {
   failed,
 }
 
-extension on CertificateAuthorityStatus {
+extension CertificateAuthorityStatusValue on CertificateAuthorityStatus {
   String toValue() {
     switch (this) {
       case CertificateAuthorityStatus.creating:
@@ -2635,7 +2635,7 @@ extension on CertificateAuthorityStatus {
   }
 }
 
-extension on String {
+extension CertificateAuthorityStatusFromString on String {
   CertificateAuthorityStatus toCertificateAuthorityStatus() {
     switch (this) {
       case 'CREATING':
@@ -2662,7 +2662,7 @@ enum CertificateAuthorityType {
   subordinate,
 }
 
-extension on CertificateAuthorityType {
+extension CertificateAuthorityTypeValue on CertificateAuthorityType {
   String toValue() {
     switch (this) {
       case CertificateAuthorityType.root:
@@ -2673,7 +2673,7 @@ extension on CertificateAuthorityType {
   }
 }
 
-extension on String {
+extension CertificateAuthorityTypeFromString on String {
   CertificateAuthorityType toCertificateAuthorityType() {
     switch (this) {
       case 'ROOT':
@@ -2997,7 +2997,7 @@ enum FailureReason {
   other,
 }
 
-extension on FailureReason {
+extension FailureReasonValue on FailureReason {
   String toValue() {
     switch (this) {
       case FailureReason.requestTimedOut:
@@ -3010,7 +3010,7 @@ extension on FailureReason {
   }
 }
 
-extension on String {
+extension FailureReasonFromString on String {
   FailureReason toFailureReason() {
     switch (this) {
       case 'REQUEST_TIMED_OUT':
@@ -3204,7 +3204,7 @@ enum KeyAlgorithm {
   ecSecp384r1,
 }
 
-extension on KeyAlgorithm {
+extension KeyAlgorithmValue on KeyAlgorithm {
   String toValue() {
     switch (this) {
       case KeyAlgorithm.rsa_2048:
@@ -3219,7 +3219,7 @@ extension on KeyAlgorithm {
   }
 }
 
-extension on String {
+extension KeyAlgorithmFromString on String {
   KeyAlgorithm toKeyAlgorithm() {
     switch (this) {
       case 'RSA_2048':
@@ -3479,7 +3479,7 @@ enum ResourceOwner {
   otherAccounts,
 }
 
-extension on ResourceOwner {
+extension ResourceOwnerValue on ResourceOwner {
   String toValue() {
     switch (this) {
       case ResourceOwner.self:
@@ -3490,7 +3490,7 @@ extension on ResourceOwner {
   }
 }
 
-extension on String {
+extension ResourceOwnerFromString on String {
   ResourceOwner toResourceOwner() {
     switch (this) {
       case 'SELF':
@@ -3546,7 +3546,7 @@ enum RevocationReason {
   aACompromise,
 }
 
-extension on RevocationReason {
+extension RevocationReasonValue on RevocationReason {
   String toValue() {
     switch (this) {
       case RevocationReason.unspecified:
@@ -3569,7 +3569,7 @@ extension on RevocationReason {
   }
 }
 
-extension on String {
+extension RevocationReasonFromString on String {
   RevocationReason toRevocationReason() {
     switch (this) {
       case 'UNSPECIFIED':
@@ -3602,7 +3602,7 @@ enum SigningAlgorithm {
   sha512withrsa,
 }
 
-extension on SigningAlgorithm {
+extension SigningAlgorithmValue on SigningAlgorithm {
   String toValue() {
     switch (this) {
       case SigningAlgorithm.sha256withecdsa:
@@ -3621,7 +3621,7 @@ extension on SigningAlgorithm {
   }
 }
 
-extension on String {
+extension SigningAlgorithmFromString on String {
   SigningAlgorithm toSigningAlgorithm() {
     switch (this) {
       case 'SHA256WITHECDSA':
@@ -3763,7 +3763,7 @@ enum ValidityPeriodType {
   years,
 }
 
-extension on ValidityPeriodType {
+extension ValidityPeriodTypeValue on ValidityPeriodType {
   String toValue() {
     switch (this) {
       case ValidityPeriodType.endDate:
@@ -3780,7 +3780,7 @@ extension on ValidityPeriodType {
   }
 }
 
-extension on String {
+extension ValidityPeriodTypeFromString on String {
   ValidityPeriodType toValidityPeriodType() {
     switch (this) {
       case 'END_DATE':

--- a/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
+++ b/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
@@ -4617,7 +4617,7 @@ enum BusinessReportFailureCode {
   internalFailure,
 }
 
-extension on BusinessReportFailureCode {
+extension BusinessReportFailureCodeValue on BusinessReportFailureCode {
   String toValue() {
     switch (this) {
       case BusinessReportFailureCode.accessDenied:
@@ -4630,7 +4630,7 @@ extension on BusinessReportFailureCode {
   }
 }
 
-extension on String {
+extension BusinessReportFailureCodeFromString on String {
   BusinessReportFailureCode toBusinessReportFailureCode() {
     switch (this) {
       case 'ACCESS_DENIED':
@@ -4649,7 +4649,7 @@ enum BusinessReportFormat {
   csvZip,
 }
 
-extension on BusinessReportFormat {
+extension BusinessReportFormatValue on BusinessReportFormat {
   String toValue() {
     switch (this) {
       case BusinessReportFormat.csv:
@@ -4660,7 +4660,7 @@ extension on BusinessReportFormat {
   }
 }
 
-extension on String {
+extension BusinessReportFormatFromString on String {
   BusinessReportFormat toBusinessReportFormat() {
     switch (this) {
       case 'CSV':
@@ -4678,7 +4678,7 @@ enum BusinessReportInterval {
   thirtyDays,
 }
 
-extension on BusinessReportInterval {
+extension BusinessReportIntervalValue on BusinessReportInterval {
   String toValue() {
     switch (this) {
       case BusinessReportInterval.oneDay:
@@ -4691,7 +4691,7 @@ extension on BusinessReportInterval {
   }
 }
 
-extension on String {
+extension BusinessReportIntervalFromString on String {
   BusinessReportInterval toBusinessReportInterval() {
     switch (this) {
       case 'ONE_DAY':
@@ -4814,7 +4814,7 @@ enum BusinessReportStatus {
   failed,
 }
 
-extension on BusinessReportStatus {
+extension BusinessReportStatusValue on BusinessReportStatus {
   String toValue() {
     switch (this) {
       case BusinessReportStatus.running:
@@ -4827,7 +4827,7 @@ extension on BusinessReportStatus {
   }
 }
 
-extension on String {
+extension BusinessReportStatusFromString on String {
   BusinessReportStatus toBusinessReportStatus() {
     switch (this) {
       case 'RUNNING':
@@ -4868,7 +4868,7 @@ enum CommsProtocol {
   h323,
 }
 
-extension on CommsProtocol {
+extension CommsProtocolValue on CommsProtocol {
   String toValue() {
     switch (this) {
       case CommsProtocol.sip:
@@ -4881,7 +4881,7 @@ extension on CommsProtocol {
   }
 }
 
-extension on String {
+extension CommsProtocolFromString on String {
   CommsProtocol toCommsProtocol() {
     switch (this) {
       case 'SIP':
@@ -4983,7 +4983,7 @@ enum ConferenceProviderType {
   custom,
 }
 
-extension on ConferenceProviderType {
+extension ConferenceProviderTypeValue on ConferenceProviderType {
   String toValue() {
     switch (this) {
       case ConferenceProviderType.chime:
@@ -5010,7 +5010,7 @@ extension on ConferenceProviderType {
   }
 }
 
-extension on String {
+extension ConferenceProviderTypeFromString on String {
   ConferenceProviderType toConferenceProviderType() {
     switch (this) {
       case 'CHIME':
@@ -5043,7 +5043,7 @@ enum ConnectionStatus {
   offline,
 }
 
-extension on ConnectionStatus {
+extension ConnectionStatusValue on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.online:
@@ -5054,7 +5054,7 @@ extension on ConnectionStatus {
   }
 }
 
-extension on String {
+extension ConnectionStatusFromString on String {
   ConnectionStatus toConnectionStatus() {
     switch (this) {
       case 'ONLINE':
@@ -5767,7 +5767,7 @@ enum DeviceEventType {
   deviceStatus,
 }
 
-extension on DeviceEventType {
+extension DeviceEventTypeValue on DeviceEventType {
   String toValue() {
     switch (this) {
       case DeviceEventType.connectionStatus:
@@ -5778,7 +5778,7 @@ extension on DeviceEventType {
   }
 }
 
-extension on String {
+extension DeviceEventTypeFromString on String {
   DeviceEventType toDeviceEventType() {
     switch (this) {
       case 'CONNECTION_STATUS':
@@ -5824,7 +5824,7 @@ enum DeviceStatus {
   failed,
 }
 
-extension on DeviceStatus {
+extension DeviceStatusValue on DeviceStatus {
   String toValue() {
     switch (this) {
       case DeviceStatus.ready:
@@ -5841,7 +5841,7 @@ extension on DeviceStatus {
   }
 }
 
-extension on String {
+extension DeviceStatusFromString on String {
   DeviceStatus toDeviceStatus() {
     switch (this) {
       case 'READY':
@@ -5899,7 +5899,7 @@ enum DeviceStatusDetailCode {
   certificateAuthorityAccessDenied,
 }
 
-extension on DeviceStatusDetailCode {
+extension DeviceStatusDetailCodeValue on DeviceStatusDetailCode {
   String toValue() {
     switch (this) {
       case DeviceStatusDetailCode.deviceSoftwareUpdateNeeded:
@@ -5940,7 +5940,7 @@ extension on DeviceStatusDetailCode {
   }
 }
 
-extension on String {
+extension DeviceStatusDetailCodeFromString on String {
   DeviceStatusDetailCode toDeviceStatusDetailCode() {
     switch (this) {
       case 'DEVICE_SOFTWARE_UPDATE_NEEDED':
@@ -6016,7 +6016,7 @@ enum DeviceUsageType {
   voice,
 }
 
-extension on DeviceUsageType {
+extension DeviceUsageTypeValue on DeviceUsageType {
   String toValue() {
     switch (this) {
       case DeviceUsageType.voice:
@@ -6025,7 +6025,7 @@ extension on DeviceUsageType {
   }
 }
 
-extension on String {
+extension DeviceUsageTypeFromString on String {
   DeviceUsageType toDeviceUsageType() {
     switch (this) {
       case 'VOICE':
@@ -6078,7 +6078,7 @@ enum DistanceUnit {
   imperial,
 }
 
-extension on DistanceUnit {
+extension DistanceUnitValue on DistanceUnit {
   String toValue() {
     switch (this) {
       case DistanceUnit.metric:
@@ -6089,7 +6089,7 @@ extension on DistanceUnit {
   }
 }
 
-extension on String {
+extension DistanceUnitFromString on String {
   DistanceUnit toDistanceUnit() {
     switch (this) {
       case 'METRIC':
@@ -6106,7 +6106,7 @@ enum EnablementType {
   pending,
 }
 
-extension on EnablementType {
+extension EnablementTypeValue on EnablementType {
   String toValue() {
     switch (this) {
       case EnablementType.enabled:
@@ -6117,7 +6117,7 @@ extension on EnablementType {
   }
 }
 
-extension on String {
+extension EnablementTypeFromString on String {
   EnablementType toEnablementType() {
     switch (this) {
       case 'ENABLED':
@@ -6134,7 +6134,7 @@ enum EnablementTypeFilter {
   pending,
 }
 
-extension on EnablementTypeFilter {
+extension EnablementTypeFilterValue on EnablementTypeFilter {
   String toValue() {
     switch (this) {
       case EnablementTypeFilter.enabled:
@@ -6145,7 +6145,7 @@ extension on EnablementTypeFilter {
   }
 }
 
-extension on String {
+extension EnablementTypeFilterFromString on String {
   EnablementTypeFilter toEnablementTypeFilter() {
     switch (this) {
       case 'ENABLED':
@@ -6195,7 +6195,7 @@ enum EndOfMeetingReminderType {
   knock,
 }
 
-extension on EndOfMeetingReminderType {
+extension EndOfMeetingReminderTypeValue on EndOfMeetingReminderType {
   String toValue() {
     switch (this) {
       case EndOfMeetingReminderType.announcementTimeCheck:
@@ -6210,7 +6210,7 @@ extension on EndOfMeetingReminderType {
   }
 }
 
-extension on String {
+extension EndOfMeetingReminderTypeFromString on String {
   EndOfMeetingReminderType toEndOfMeetingReminderType() {
     switch (this) {
       case 'ANNOUNCEMENT_TIME_CHECK':
@@ -6234,7 +6234,7 @@ enum EnrollmentStatus {
   deregistering,
 }
 
-extension on EnrollmentStatus {
+extension EnrollmentStatusValue on EnrollmentStatus {
   String toValue() {
     switch (this) {
       case EnrollmentStatus.initialized:
@@ -6251,7 +6251,7 @@ extension on EnrollmentStatus {
   }
 }
 
-extension on String {
+extension EnrollmentStatusFromString on String {
   EnrollmentStatus toEnrollmentStatus() {
     switch (this) {
       case 'INITIALIZED':
@@ -6280,7 +6280,7 @@ enum Feature {
   all,
 }
 
-extension on Feature {
+extension FeatureValue on Feature {
   String toValue() {
     switch (this) {
       case Feature.bluetooth:
@@ -6303,7 +6303,7 @@ extension on Feature {
   }
 }
 
-extension on String {
+extension FeatureFromString on String {
   Feature toFeature() {
     switch (this) {
       case 'BLUETOOTH':
@@ -6985,7 +6985,7 @@ enum Locale {
   enUs,
 }
 
-extension on Locale {
+extension LocaleValue on Locale {
   String toValue() {
     switch (this) {
       case Locale.enUs:
@@ -6994,7 +6994,7 @@ extension on Locale {
   }
 }
 
-extension on String {
+extension LocaleFromString on String {
   Locale toLocale() {
     switch (this) {
       case 'en-US':
@@ -7090,7 +7090,7 @@ enum NetworkEapMethod {
   eapTls,
 }
 
-extension on NetworkEapMethod {
+extension NetworkEapMethodValue on NetworkEapMethod {
   String toValue() {
     switch (this) {
       case NetworkEapMethod.eapTls:
@@ -7099,7 +7099,7 @@ extension on NetworkEapMethod {
   }
 }
 
-extension on String {
+extension NetworkEapMethodFromString on String {
   NetworkEapMethod toNetworkEapMethod() {
     switch (this) {
       case 'EAP_TLS':
@@ -7237,7 +7237,7 @@ enum NetworkSecurityType {
   wpa2Enterprise,
 }
 
-extension on NetworkSecurityType {
+extension NetworkSecurityTypeValue on NetworkSecurityType {
   String toValue() {
     switch (this) {
       case NetworkSecurityType.open:
@@ -7254,7 +7254,7 @@ extension on NetworkSecurityType {
   }
 }
 
-extension on String {
+extension NetworkSecurityTypeFromString on String {
   NetworkSecurityType toNetworkSecurityType() {
     switch (this) {
       case 'OPEN':
@@ -7355,7 +7355,7 @@ enum PhoneNumberType {
   home,
 }
 
-extension on PhoneNumberType {
+extension PhoneNumberTypeValue on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.mobile:
@@ -7368,7 +7368,7 @@ extension on PhoneNumberType {
   }
 }
 
-extension on String {
+extension PhoneNumberTypeFromString on String {
   PhoneNumberType toPhoneNumberType() {
     switch (this) {
       case 'MOBILE':
@@ -7602,7 +7602,7 @@ enum RequirePin {
   optional,
 }
 
-extension on RequirePin {
+extension RequirePinValue on RequirePin {
   String toValue() {
     switch (this) {
       case RequirePin.yes:
@@ -7615,7 +7615,7 @@ extension on RequirePin {
   }
 }
 
-extension on String {
+extension RequirePinFromString on String {
   RequirePin toRequirePin() {
     switch (this) {
       case 'YES':
@@ -8043,7 +8043,7 @@ enum SipType {
   work,
 }
 
-extension on SipType {
+extension SipTypeValue on SipType {
   String toValue() {
     switch (this) {
       case SipType.work:
@@ -8052,7 +8052,7 @@ extension on SipType {
   }
 }
 
-extension on String {
+extension SipTypeFromString on String {
   SipType toSipType() {
     switch (this) {
       case 'WORK':
@@ -8233,7 +8233,7 @@ enum SkillType {
   private,
 }
 
-extension on SkillType {
+extension SkillTypeValue on SkillType {
   String toValue() {
     switch (this) {
       case SkillType.public:
@@ -8244,7 +8244,7 @@ extension on SkillType {
   }
 }
 
-extension on String {
+extension SkillTypeFromString on String {
   SkillType toSkillType() {
     switch (this) {
       case 'PUBLIC':
@@ -8262,7 +8262,7 @@ enum SkillTypeFilter {
   all,
 }
 
-extension on SkillTypeFilter {
+extension SkillTypeFilterValue on SkillTypeFilter {
   String toValue() {
     switch (this) {
       case SkillTypeFilter.public:
@@ -8275,7 +8275,7 @@ extension on SkillTypeFilter {
   }
 }
 
-extension on String {
+extension SkillTypeFilterFromString on String {
   SkillTypeFilter toSkillTypeFilter() {
     switch (this) {
       case 'PUBLIC':
@@ -8392,7 +8392,7 @@ enum SortValue {
   desc,
 }
 
-extension on SortValue {
+extension SortValueValue on SortValue {
   String toValue() {
     switch (this) {
       case SortValue.asc:
@@ -8403,7 +8403,7 @@ extension on SortValue {
   }
 }
 
-extension on String {
+extension SortValueFromString on String {
   SortValue toSortValue() {
     switch (this) {
       case 'ASC':
@@ -8496,7 +8496,7 @@ enum TemperatureUnit {
   celsius,
 }
 
-extension on TemperatureUnit {
+extension TemperatureUnitValue on TemperatureUnit {
   String toValue() {
     switch (this) {
       case TemperatureUnit.fahrenheit:
@@ -8507,7 +8507,7 @@ extension on TemperatureUnit {
   }
 }
 
-extension on String {
+extension TemperatureUnitFromString on String {
   TemperatureUnit toTemperatureUnit() {
     switch (this) {
       case 'FAHRENHEIT':
@@ -8799,7 +8799,7 @@ enum WakeWord {
   computer,
 }
 
-extension on WakeWord {
+extension WakeWordValue on WakeWord {
   String toValue() {
     switch (this) {
       case WakeWord.alexa:
@@ -8814,7 +8814,7 @@ extension on WakeWord {
   }
 }
 
-extension on String {
+extension WakeWordFromString on String {
   WakeWord toWakeWord() {
     switch (this) {
       case 'ALEXA':

--- a/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
+++ b/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
@@ -4617,7 +4617,7 @@ enum BusinessReportFailureCode {
   internalFailure,
 }
 
-extension BusinessReportFailureCodeValue on BusinessReportFailureCode {
+extension BusinessReportFailureCodeValueExtension on BusinessReportFailureCode {
   String toValue() {
     switch (this) {
       case BusinessReportFailureCode.accessDenied:
@@ -4649,7 +4649,7 @@ enum BusinessReportFormat {
   csvZip,
 }
 
-extension BusinessReportFormatValue on BusinessReportFormat {
+extension BusinessReportFormatValueExtension on BusinessReportFormat {
   String toValue() {
     switch (this) {
       case BusinessReportFormat.csv:
@@ -4678,7 +4678,7 @@ enum BusinessReportInterval {
   thirtyDays,
 }
 
-extension BusinessReportIntervalValue on BusinessReportInterval {
+extension BusinessReportIntervalValueExtension on BusinessReportInterval {
   String toValue() {
     switch (this) {
       case BusinessReportInterval.oneDay:
@@ -4814,7 +4814,7 @@ enum BusinessReportStatus {
   failed,
 }
 
-extension BusinessReportStatusValue on BusinessReportStatus {
+extension BusinessReportStatusValueExtension on BusinessReportStatus {
   String toValue() {
     switch (this) {
       case BusinessReportStatus.running:
@@ -4868,7 +4868,7 @@ enum CommsProtocol {
   h323,
 }
 
-extension CommsProtocolValue on CommsProtocol {
+extension CommsProtocolValueExtension on CommsProtocol {
   String toValue() {
     switch (this) {
       case CommsProtocol.sip:
@@ -4983,7 +4983,7 @@ enum ConferenceProviderType {
   custom,
 }
 
-extension ConferenceProviderTypeValue on ConferenceProviderType {
+extension ConferenceProviderTypeValueExtension on ConferenceProviderType {
   String toValue() {
     switch (this) {
       case ConferenceProviderType.chime:
@@ -5043,7 +5043,7 @@ enum ConnectionStatus {
   offline,
 }
 
-extension ConnectionStatusValue on ConnectionStatus {
+extension ConnectionStatusValueExtension on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.online:
@@ -5767,7 +5767,7 @@ enum DeviceEventType {
   deviceStatus,
 }
 
-extension DeviceEventTypeValue on DeviceEventType {
+extension DeviceEventTypeValueExtension on DeviceEventType {
   String toValue() {
     switch (this) {
       case DeviceEventType.connectionStatus:
@@ -5824,7 +5824,7 @@ enum DeviceStatus {
   failed,
 }
 
-extension DeviceStatusValue on DeviceStatus {
+extension DeviceStatusValueExtension on DeviceStatus {
   String toValue() {
     switch (this) {
       case DeviceStatus.ready:
@@ -5899,7 +5899,7 @@ enum DeviceStatusDetailCode {
   certificateAuthorityAccessDenied,
 }
 
-extension DeviceStatusDetailCodeValue on DeviceStatusDetailCode {
+extension DeviceStatusDetailCodeValueExtension on DeviceStatusDetailCode {
   String toValue() {
     switch (this) {
       case DeviceStatusDetailCode.deviceSoftwareUpdateNeeded:
@@ -6016,7 +6016,7 @@ enum DeviceUsageType {
   voice,
 }
 
-extension DeviceUsageTypeValue on DeviceUsageType {
+extension DeviceUsageTypeValueExtension on DeviceUsageType {
   String toValue() {
     switch (this) {
       case DeviceUsageType.voice:
@@ -6078,7 +6078,7 @@ enum DistanceUnit {
   imperial,
 }
 
-extension DistanceUnitValue on DistanceUnit {
+extension DistanceUnitValueExtension on DistanceUnit {
   String toValue() {
     switch (this) {
       case DistanceUnit.metric:
@@ -6106,7 +6106,7 @@ enum EnablementType {
   pending,
 }
 
-extension EnablementTypeValue on EnablementType {
+extension EnablementTypeValueExtension on EnablementType {
   String toValue() {
     switch (this) {
       case EnablementType.enabled:
@@ -6134,7 +6134,7 @@ enum EnablementTypeFilter {
   pending,
 }
 
-extension EnablementTypeFilterValue on EnablementTypeFilter {
+extension EnablementTypeFilterValueExtension on EnablementTypeFilter {
   String toValue() {
     switch (this) {
       case EnablementTypeFilter.enabled:
@@ -6195,7 +6195,7 @@ enum EndOfMeetingReminderType {
   knock,
 }
 
-extension EndOfMeetingReminderTypeValue on EndOfMeetingReminderType {
+extension EndOfMeetingReminderTypeValueExtension on EndOfMeetingReminderType {
   String toValue() {
     switch (this) {
       case EndOfMeetingReminderType.announcementTimeCheck:
@@ -6234,7 +6234,7 @@ enum EnrollmentStatus {
   deregistering,
 }
 
-extension EnrollmentStatusValue on EnrollmentStatus {
+extension EnrollmentStatusValueExtension on EnrollmentStatus {
   String toValue() {
     switch (this) {
       case EnrollmentStatus.initialized:
@@ -6280,7 +6280,7 @@ enum Feature {
   all,
 }
 
-extension FeatureValue on Feature {
+extension FeatureValueExtension on Feature {
   String toValue() {
     switch (this) {
       case Feature.bluetooth:
@@ -6985,7 +6985,7 @@ enum Locale {
   enUs,
 }
 
-extension LocaleValue on Locale {
+extension LocaleValueExtension on Locale {
   String toValue() {
     switch (this) {
       case Locale.enUs:
@@ -7090,7 +7090,7 @@ enum NetworkEapMethod {
   eapTls,
 }
 
-extension NetworkEapMethodValue on NetworkEapMethod {
+extension NetworkEapMethodValueExtension on NetworkEapMethod {
   String toValue() {
     switch (this) {
       case NetworkEapMethod.eapTls:
@@ -7237,7 +7237,7 @@ enum NetworkSecurityType {
   wpa2Enterprise,
 }
 
-extension NetworkSecurityTypeValue on NetworkSecurityType {
+extension NetworkSecurityTypeValueExtension on NetworkSecurityType {
   String toValue() {
     switch (this) {
       case NetworkSecurityType.open:
@@ -7355,7 +7355,7 @@ enum PhoneNumberType {
   home,
 }
 
-extension PhoneNumberTypeValue on PhoneNumberType {
+extension PhoneNumberTypeValueExtension on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.mobile:
@@ -7602,7 +7602,7 @@ enum RequirePin {
   optional,
 }
 
-extension RequirePinValue on RequirePin {
+extension RequirePinValueExtension on RequirePin {
   String toValue() {
     switch (this) {
       case RequirePin.yes:
@@ -8043,7 +8043,7 @@ enum SipType {
   work,
 }
 
-extension SipTypeValue on SipType {
+extension SipTypeValueExtension on SipType {
   String toValue() {
     switch (this) {
       case SipType.work:
@@ -8233,7 +8233,7 @@ enum SkillType {
   private,
 }
 
-extension SkillTypeValue on SkillType {
+extension SkillTypeValueExtension on SkillType {
   String toValue() {
     switch (this) {
       case SkillType.public:
@@ -8262,7 +8262,7 @@ enum SkillTypeFilter {
   all,
 }
 
-extension SkillTypeFilterValue on SkillTypeFilter {
+extension SkillTypeFilterValueExtension on SkillTypeFilter {
   String toValue() {
     switch (this) {
       case SkillTypeFilter.public:
@@ -8392,7 +8392,7 @@ enum SortValue {
   desc,
 }
 
-extension SortValueValue on SortValue {
+extension SortValueValueExtension on SortValue {
   String toValue() {
     switch (this) {
       case SortValue.asc:
@@ -8496,7 +8496,7 @@ enum TemperatureUnit {
   celsius,
 }
 
-extension TemperatureUnitValue on TemperatureUnit {
+extension TemperatureUnitValueExtension on TemperatureUnit {
   String toValue() {
     switch (this) {
       case TemperatureUnit.fahrenheit:
@@ -8799,7 +8799,7 @@ enum WakeWord {
   computer,
 }
 
-extension WakeWordValue on WakeWord {
+extension WakeWordValueExtension on WakeWord {
   String toValue() {
     switch (this) {
       case WakeWord.alexa:

--- a/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
+++ b/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
@@ -3264,7 +3264,7 @@ enum DomainStatus {
   updating,
 }
 
-extension DomainStatusValue on DomainStatus {
+extension DomainStatusValueExtension on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingVerification:
@@ -3466,7 +3466,7 @@ enum JobStatus {
   cancelled,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.pending:
@@ -3575,7 +3575,7 @@ enum JobType {
   webHook,
 }
 
-extension JobTypeValue on JobType {
+extension JobTypeValueExtension on JobType {
   String toValue() {
     switch (this) {
       case JobType.release:
@@ -3795,7 +3795,7 @@ enum Platform {
   web,
 }
 
-extension PlatformValue on Platform {
+extension PlatformValueExtension on Platform {
   String toValue() {
     switch (this) {
       case Platform.web:
@@ -3852,7 +3852,7 @@ enum Stage {
   pullRequest,
 }
 
-extension StageValue on Stage {
+extension StageValueExtension on Stage {
   String toValue() {
     switch (this) {
       case Stage.production:

--- a/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
+++ b/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
@@ -3264,7 +3264,7 @@ enum DomainStatus {
   updating,
 }
 
-extension on DomainStatus {
+extension DomainStatusValue on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingVerification:
@@ -3287,7 +3287,7 @@ extension on DomainStatus {
   }
 }
 
-extension on String {
+extension DomainStatusFromString on String {
   DomainStatus toDomainStatus() {
     switch (this) {
       case 'PENDING_VERIFICATION':
@@ -3466,7 +3466,7 @@ enum JobStatus {
   cancelled,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.pending:
@@ -3487,7 +3487,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'PENDING':
@@ -3575,7 +3575,7 @@ enum JobType {
   webHook,
 }
 
-extension on JobType {
+extension JobTypeValue on JobType {
   String toValue() {
     switch (this) {
       case JobType.release:
@@ -3590,7 +3590,7 @@ extension on JobType {
   }
 }
 
-extension on String {
+extension JobTypeFromString on String {
   JobType toJobType() {
     switch (this) {
       case 'RELEASE':
@@ -3795,7 +3795,7 @@ enum Platform {
   web,
 }
 
-extension on Platform {
+extension PlatformValue on Platform {
   String toValue() {
     switch (this) {
       case Platform.web:
@@ -3804,7 +3804,7 @@ extension on Platform {
   }
 }
 
-extension on String {
+extension PlatformFromString on String {
   Platform toPlatform() {
     switch (this) {
       case 'WEB':
@@ -3852,7 +3852,7 @@ enum Stage {
   pullRequest,
 }
 
-extension on Stage {
+extension StageValue on Stage {
   String toValue() {
     switch (this) {
       case Stage.production:
@@ -3869,7 +3869,7 @@ extension on Stage {
   }
 }
 
-extension on String {
+extension StageFromString on String {
   Stage toStage() {
     switch (this) {
       case 'PRODUCTION':

--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -5379,7 +5379,7 @@ enum ApiKeySourceType {
   authorizer,
 }
 
-extension ApiKeySourceTypeValue on ApiKeySourceType {
+extension ApiKeySourceTypeValueExtension on ApiKeySourceType {
   String toValue() {
     switch (this) {
       case ApiKeySourceType.header:
@@ -5440,7 +5440,7 @@ enum ApiKeysFormat {
   csv,
 }
 
-extension ApiKeysFormatValue on ApiKeysFormat {
+extension ApiKeysFormatValueExtension on ApiKeysFormat {
   String toValue() {
     switch (this) {
       case ApiKeysFormat.csv:
@@ -5633,7 +5633,7 @@ enum AuthorizerType {
   cognitoUserPools,
 }
 
-extension AuthorizerTypeValue on AuthorizerType {
+extension AuthorizerTypeValueExtension on AuthorizerType {
   String toValue() {
     switch (this) {
       case AuthorizerType.token:
@@ -5755,7 +5755,7 @@ enum CacheClusterSize {
   $237,
 }
 
-extension CacheClusterSizeValue on CacheClusterSize {
+extension CacheClusterSizeValueExtension on CacheClusterSize {
   String toValue() {
     switch (this) {
       case CacheClusterSize.$0_5:
@@ -5811,7 +5811,7 @@ enum CacheClusterStatus {
   flushInProgress,
 }
 
-extension CacheClusterStatusValue on CacheClusterStatus {
+extension CacheClusterStatusValueExtension on CacheClusterStatus {
   String toValue() {
     switch (this) {
       case CacheClusterStatus.createInProgress:
@@ -5975,7 +5975,7 @@ enum ConnectionType {
   vpcLink,
 }
 
-extension ConnectionTypeValue on ConnectionType {
+extension ConnectionTypeValueExtension on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.internet:
@@ -6003,7 +6003,7 @@ enum ContentHandlingStrategy {
   convertToText,
 }
 
-extension ContentHandlingStrategyValue on ContentHandlingStrategy {
+extension ContentHandlingStrategyValueExtension on ContentHandlingStrategy {
   String toValue() {
     switch (this) {
       case ContentHandlingStrategy.convertToBinary:
@@ -6331,7 +6331,7 @@ enum DocumentationPartType {
   responseBody,
 }
 
-extension DocumentationPartTypeValue on DocumentationPartType {
+extension DocumentationPartTypeValueExtension on DocumentationPartType {
   String toValue() {
     switch (this) {
       case DocumentationPartType.api:
@@ -6636,7 +6636,7 @@ enum DomainNameStatus {
   pending,
 }
 
-extension DomainNameStatusValue on DomainNameStatus {
+extension DomainNameStatusValueExtension on DomainNameStatus {
   String toValue() {
     switch (this) {
       case DomainNameStatus.available:
@@ -6739,7 +6739,7 @@ enum EndpointType {
   private,
 }
 
-extension EndpointTypeValue on EndpointType {
+extension EndpointTypeValueExtension on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.regional:
@@ -6919,7 +6919,7 @@ enum GatewayResponseType {
   quotaExceeded,
 }
 
-extension GatewayResponseTypeValue on GatewayResponseType {
+extension GatewayResponseTypeValueExtension on GatewayResponseType {
   String toValue() {
     switch (this) {
       case GatewayResponseType.default_4xx:
@@ -7604,7 +7604,7 @@ enum IntegrationType {
   awsProxy,
 }
 
-extension IntegrationTypeValue on IntegrationType {
+extension IntegrationTypeValueExtension on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.http:
@@ -7644,7 +7644,7 @@ enum LocationStatusType {
   undocumented,
 }
 
-extension LocationStatusTypeValue on LocationStatusType {
+extension LocationStatusTypeValueExtension on LocationStatusType {
   String toValue() {
     switch (this) {
       case LocationStatusType.documented:
@@ -8292,7 +8292,7 @@ enum Op {
   test,
 }
 
-extension OpValue on Op {
+extension OpValueExtension on Op {
   String toValue() {
     switch (this) {
       case Op.add:
@@ -8399,7 +8399,7 @@ enum PutMode {
   overwrite,
 }
 
-extension PutModeValue on PutMode {
+extension PutModeValueExtension on PutMode {
   String toValue() {
     switch (this) {
       case PutMode.merge:
@@ -8428,7 +8428,7 @@ enum QuotaPeriodType {
   month,
 }
 
-extension QuotaPeriodTypeValue on QuotaPeriodType {
+extension QuotaPeriodTypeValueExtension on QuotaPeriodType {
   String toValue() {
     switch (this) {
       case QuotaPeriodType.day:
@@ -8954,7 +8954,7 @@ enum SecurityPolicy {
   tls_1_2,
 }
 
-extension SecurityPolicyValue on SecurityPolicy {
+extension SecurityPolicyValueExtension on SecurityPolicy {
   String toValue() {
     switch (this) {
       case SecurityPolicy.tls_1_0:
@@ -9348,7 +9348,7 @@ enum UnauthorizedCacheControlHeaderStrategy {
   succeedWithoutResponseHeader,
 }
 
-extension UnauthorizedCacheControlHeaderStrategyValue
+extension UnauthorizedCacheControlHeaderStrategyValueExtension
     on UnauthorizedCacheControlHeaderStrategy {
   String toValue() {
     switch (this) {
@@ -9658,7 +9658,7 @@ enum VpcLinkStatus {
   failed,
 }
 
-extension VpcLinkStatusValue on VpcLinkStatus {
+extension VpcLinkStatusValueExtension on VpcLinkStatus {
   String toValue() {
     switch (this) {
       case VpcLinkStatus.available:

--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -5379,7 +5379,7 @@ enum ApiKeySourceType {
   authorizer,
 }
 
-extension on ApiKeySourceType {
+extension ApiKeySourceTypeValue on ApiKeySourceType {
   String toValue() {
     switch (this) {
       case ApiKeySourceType.header:
@@ -5390,7 +5390,7 @@ extension on ApiKeySourceType {
   }
 }
 
-extension on String {
+extension ApiKeySourceTypeFromString on String {
   ApiKeySourceType toApiKeySourceType() {
     switch (this) {
       case 'HEADER':
@@ -5440,7 +5440,7 @@ enum ApiKeysFormat {
   csv,
 }
 
-extension on ApiKeysFormat {
+extension ApiKeysFormatValue on ApiKeysFormat {
   String toValue() {
     switch (this) {
       case ApiKeysFormat.csv:
@@ -5449,7 +5449,7 @@ extension on ApiKeysFormat {
   }
 }
 
-extension on String {
+extension ApiKeysFormatFromString on String {
   ApiKeysFormat toApiKeysFormat() {
     switch (this) {
       case 'csv':
@@ -5633,7 +5633,7 @@ enum AuthorizerType {
   cognitoUserPools,
 }
 
-extension on AuthorizerType {
+extension AuthorizerTypeValue on AuthorizerType {
   String toValue() {
     switch (this) {
       case AuthorizerType.token:
@@ -5646,7 +5646,7 @@ extension on AuthorizerType {
   }
 }
 
-extension on String {
+extension AuthorizerTypeFromString on String {
   AuthorizerType toAuthorizerType() {
     switch (this) {
       case 'TOKEN':
@@ -5755,7 +5755,7 @@ enum CacheClusterSize {
   $237,
 }
 
-extension on CacheClusterSize {
+extension CacheClusterSizeValue on CacheClusterSize {
   String toValue() {
     switch (this) {
       case CacheClusterSize.$0_5:
@@ -5778,7 +5778,7 @@ extension on CacheClusterSize {
   }
 }
 
-extension on String {
+extension CacheClusterSizeFromString on String {
   CacheClusterSize toCacheClusterSize() {
     switch (this) {
       case '0.5':
@@ -5811,7 +5811,7 @@ enum CacheClusterStatus {
   flushInProgress,
 }
 
-extension on CacheClusterStatus {
+extension CacheClusterStatusValue on CacheClusterStatus {
   String toValue() {
     switch (this) {
       case CacheClusterStatus.createInProgress:
@@ -5828,7 +5828,7 @@ extension on CacheClusterStatus {
   }
 }
 
-extension on String {
+extension CacheClusterStatusFromString on String {
   CacheClusterStatus toCacheClusterStatus() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -5975,7 +5975,7 @@ enum ConnectionType {
   vpcLink,
 }
 
-extension on ConnectionType {
+extension ConnectionTypeValue on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.internet:
@@ -5986,7 +5986,7 @@ extension on ConnectionType {
   }
 }
 
-extension on String {
+extension ConnectionTypeFromString on String {
   ConnectionType toConnectionType() {
     switch (this) {
       case 'INTERNET':
@@ -6003,7 +6003,7 @@ enum ContentHandlingStrategy {
   convertToText,
 }
 
-extension on ContentHandlingStrategy {
+extension ContentHandlingStrategyValue on ContentHandlingStrategy {
   String toValue() {
     switch (this) {
       case ContentHandlingStrategy.convertToBinary:
@@ -6014,7 +6014,7 @@ extension on ContentHandlingStrategy {
   }
 }
 
-extension on String {
+extension ContentHandlingStrategyFromString on String {
   ContentHandlingStrategy toContentHandlingStrategy() {
     switch (this) {
       case 'CONVERT_TO_BINARY':
@@ -6331,7 +6331,7 @@ enum DocumentationPartType {
   responseBody,
 }
 
-extension on DocumentationPartType {
+extension DocumentationPartTypeValue on DocumentationPartType {
   String toValue() {
     switch (this) {
       case DocumentationPartType.api:
@@ -6362,7 +6362,7 @@ extension on DocumentationPartType {
   }
 }
 
-extension on String {
+extension DocumentationPartTypeFromString on String {
   DocumentationPartType toDocumentationPartType() {
     switch (this) {
       case 'API':
@@ -6636,7 +6636,7 @@ enum DomainNameStatus {
   pending,
 }
 
-extension on DomainNameStatus {
+extension DomainNameStatusValue on DomainNameStatus {
   String toValue() {
     switch (this) {
       case DomainNameStatus.available:
@@ -6649,7 +6649,7 @@ extension on DomainNameStatus {
   }
 }
 
-extension on String {
+extension DomainNameStatusFromString on String {
   DomainNameStatus toDomainNameStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -6739,7 +6739,7 @@ enum EndpointType {
   private,
 }
 
-extension on EndpointType {
+extension EndpointTypeValue on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.regional:
@@ -6752,7 +6752,7 @@ extension on EndpointType {
   }
 }
 
-extension on String {
+extension EndpointTypeFromString on String {
   EndpointType toEndpointType() {
     switch (this) {
       case 'REGIONAL':
@@ -6919,7 +6919,7 @@ enum GatewayResponseType {
   quotaExceeded,
 }
 
-extension on GatewayResponseType {
+extension GatewayResponseTypeValue on GatewayResponseType {
   String toValue() {
     switch (this) {
       case GatewayResponseType.default_4xx:
@@ -6966,7 +6966,7 @@ extension on GatewayResponseType {
   }
 }
 
-extension on String {
+extension GatewayResponseTypeFromString on String {
   GatewayResponseType toGatewayResponseType() {
     switch (this) {
       case 'DEFAULT_4XX':
@@ -7604,7 +7604,7 @@ enum IntegrationType {
   awsProxy,
 }
 
-extension on IntegrationType {
+extension IntegrationTypeValue on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.http:
@@ -7621,7 +7621,7 @@ extension on IntegrationType {
   }
 }
 
-extension on String {
+extension IntegrationTypeFromString on String {
   IntegrationType toIntegrationType() {
     switch (this) {
       case 'HTTP':
@@ -7644,7 +7644,7 @@ enum LocationStatusType {
   undocumented,
 }
 
-extension on LocationStatusType {
+extension LocationStatusTypeValue on LocationStatusType {
   String toValue() {
     switch (this) {
       case LocationStatusType.documented:
@@ -7655,7 +7655,7 @@ extension on LocationStatusType {
   }
 }
 
-extension on String {
+extension LocationStatusTypeFromString on String {
   LocationStatusType toLocationStatusType() {
     switch (this) {
       case 'DOCUMENTED':
@@ -8292,7 +8292,7 @@ enum Op {
   test,
 }
 
-extension on Op {
+extension OpValue on Op {
   String toValue() {
     switch (this) {
       case Op.add:
@@ -8311,7 +8311,7 @@ extension on Op {
   }
 }
 
-extension on String {
+extension OpFromString on String {
   Op toOp() {
     switch (this) {
       case 'add':
@@ -8399,7 +8399,7 @@ enum PutMode {
   overwrite,
 }
 
-extension on PutMode {
+extension PutModeValue on PutMode {
   String toValue() {
     switch (this) {
       case PutMode.merge:
@@ -8410,7 +8410,7 @@ extension on PutMode {
   }
 }
 
-extension on String {
+extension PutModeFromString on String {
   PutMode toPutMode() {
     switch (this) {
       case 'merge':
@@ -8428,7 +8428,7 @@ enum QuotaPeriodType {
   month,
 }
 
-extension on QuotaPeriodType {
+extension QuotaPeriodTypeValue on QuotaPeriodType {
   String toValue() {
     switch (this) {
       case QuotaPeriodType.day:
@@ -8441,7 +8441,7 @@ extension on QuotaPeriodType {
   }
 }
 
-extension on String {
+extension QuotaPeriodTypeFromString on String {
   QuotaPeriodType toQuotaPeriodType() {
     switch (this) {
       case 'DAY':
@@ -8954,7 +8954,7 @@ enum SecurityPolicy {
   tls_1_2,
 }
 
-extension on SecurityPolicy {
+extension SecurityPolicyValue on SecurityPolicy {
   String toValue() {
     switch (this) {
       case SecurityPolicy.tls_1_0:
@@ -8965,7 +8965,7 @@ extension on SecurityPolicy {
   }
 }
 
-extension on String {
+extension SecurityPolicyFromString on String {
   SecurityPolicy toSecurityPolicy() {
     switch (this) {
       case 'TLS_1_0':
@@ -9348,7 +9348,8 @@ enum UnauthorizedCacheControlHeaderStrategy {
   succeedWithoutResponseHeader,
 }
 
-extension on UnauthorizedCacheControlHeaderStrategy {
+extension UnauthorizedCacheControlHeaderStrategyValue
+    on UnauthorizedCacheControlHeaderStrategy {
   String toValue() {
     switch (this) {
       case UnauthorizedCacheControlHeaderStrategy.failWith_403:
@@ -9361,7 +9362,7 @@ extension on UnauthorizedCacheControlHeaderStrategy {
   }
 }
 
-extension on String {
+extension UnauthorizedCacheControlHeaderStrategyFromString on String {
   UnauthorizedCacheControlHeaderStrategy
       toUnauthorizedCacheControlHeaderStrategy() {
     switch (this) {
@@ -9657,7 +9658,7 @@ enum VpcLinkStatus {
   failed,
 }
 
-extension on VpcLinkStatus {
+extension VpcLinkStatusValue on VpcLinkStatus {
   String toValue() {
     switch (this) {
       case VpcLinkStatus.available:
@@ -9672,7 +9673,7 @@ extension on VpcLinkStatus {
   }
 }
 
-extension on String {
+extension VpcLinkStatusFromString on String {
   VpcLinkStatus toVpcLinkStatus() {
     switch (this) {
       case 'AVAILABLE':

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -3686,7 +3686,7 @@ enum AuthorizationType {
   jwt,
 }
 
-extension AuthorizationTypeValue on AuthorizationType {
+extension AuthorizationTypeValueExtension on AuthorizationType {
   String toValue() {
     switch (this) {
       case AuthorizationType.none:
@@ -3850,7 +3850,7 @@ enum AuthorizerType {
   jwt,
 }
 
-extension AuthorizerTypeValue on AuthorizerType {
+extension AuthorizerTypeValueExtension on AuthorizerType {
   String toValue() {
     switch (this) {
       case AuthorizerType.request:
@@ -3879,7 +3879,7 @@ enum ConnectionType {
   vpcLink,
 }
 
-extension ConnectionTypeValue on ConnectionType {
+extension ConnectionTypeValueExtension on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.internet:
@@ -3909,7 +3909,7 @@ enum ContentHandlingStrategy {
   convertToText,
 }
 
-extension ContentHandlingStrategyValue on ContentHandlingStrategy {
+extension ContentHandlingStrategyValueExtension on ContentHandlingStrategy {
   String toValue() {
     switch (this) {
       case ContentHandlingStrategy.convertToBinary:
@@ -5063,7 +5063,7 @@ enum DeploymentStatus {
   deployed,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pending:
@@ -5234,7 +5234,7 @@ enum DomainNameStatus {
   updating,
 }
 
-extension DomainNameStatusValue on DomainNameStatus {
+extension DomainNameStatusValueExtension on DomainNameStatus {
   String toValue() {
     switch (this) {
       case DomainNameStatus.available:
@@ -5263,7 +5263,7 @@ enum EndpointType {
   edge,
 }
 
-extension EndpointTypeValue on EndpointType {
+extension EndpointTypeValueExtension on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.regional:
@@ -7038,7 +7038,7 @@ enum IntegrationType {
   awsProxy,
 }
 
-extension IntegrationTypeValue on IntegrationType {
+extension IntegrationTypeValueExtension on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.aws:
@@ -7119,7 +7119,7 @@ enum LoggingLevel {
   off,
 }
 
-extension LoggingLevelValue on LoggingLevel {
+extension LoggingLevelValueExtension on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -7282,7 +7282,7 @@ enum PassthroughBehavior {
   whenNoTemplates,
 }
 
-extension PassthroughBehaviorValue on PassthroughBehavior {
+extension PassthroughBehaviorValueExtension on PassthroughBehavior {
   String toValue() {
     switch (this) {
       case PassthroughBehavior.whenNoMatch:
@@ -7315,7 +7315,7 @@ enum ProtocolType {
   http,
 }
 
-extension ProtocolTypeValue on ProtocolType {
+extension ProtocolTypeValueExtension on ProtocolType {
   String toValue() {
     switch (this) {
       case ProtocolType.websocket:
@@ -7657,7 +7657,7 @@ enum SecurityPolicy {
   tls_1_2,
 }
 
-extension SecurityPolicyValue on SecurityPolicy {
+extension SecurityPolicyValueExtension on SecurityPolicy {
   String toValue() {
     switch (this) {
       case SecurityPolicy.tls_1_0:
@@ -8897,7 +8897,7 @@ enum VpcLinkStatus {
   inactive,
 }
 
-extension VpcLinkStatusValue on VpcLinkStatus {
+extension VpcLinkStatusValueExtension on VpcLinkStatus {
   String toValue() {
     switch (this) {
       case VpcLinkStatus.pending:
@@ -8937,7 +8937,7 @@ enum VpcLinkVersion {
   v2,
 }
 
-extension VpcLinkVersionValue on VpcLinkVersion {
+extension VpcLinkVersionValueExtension on VpcLinkVersion {
   String toValue() {
     switch (this) {
       case VpcLinkVersion.v2:

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -3686,7 +3686,7 @@ enum AuthorizationType {
   jwt,
 }
 
-extension on AuthorizationType {
+extension AuthorizationTypeValue on AuthorizationType {
   String toValue() {
     switch (this) {
       case AuthorizationType.none:
@@ -3701,7 +3701,7 @@ extension on AuthorizationType {
   }
 }
 
-extension on String {
+extension AuthorizationTypeFromString on String {
   AuthorizationType toAuthorizationType() {
     switch (this) {
       case 'NONE':
@@ -3850,7 +3850,7 @@ enum AuthorizerType {
   jwt,
 }
 
-extension on AuthorizerType {
+extension AuthorizerTypeValue on AuthorizerType {
   String toValue() {
     switch (this) {
       case AuthorizerType.request:
@@ -3861,7 +3861,7 @@ extension on AuthorizerType {
   }
 }
 
-extension on String {
+extension AuthorizerTypeFromString on String {
   AuthorizerType toAuthorizerType() {
     switch (this) {
       case 'REQUEST':
@@ -3879,7 +3879,7 @@ enum ConnectionType {
   vpcLink,
 }
 
-extension on ConnectionType {
+extension ConnectionTypeValue on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.internet:
@@ -3890,7 +3890,7 @@ extension on ConnectionType {
   }
 }
 
-extension on String {
+extension ConnectionTypeFromString on String {
   ConnectionType toConnectionType() {
     switch (this) {
       case 'INTERNET':
@@ -3909,7 +3909,7 @@ enum ContentHandlingStrategy {
   convertToText,
 }
 
-extension on ContentHandlingStrategy {
+extension ContentHandlingStrategyValue on ContentHandlingStrategy {
   String toValue() {
     switch (this) {
       case ContentHandlingStrategy.convertToBinary:
@@ -3920,7 +3920,7 @@ extension on ContentHandlingStrategy {
   }
 }
 
-extension on String {
+extension ContentHandlingStrategyFromString on String {
   ContentHandlingStrategy toContentHandlingStrategy() {
     switch (this) {
       case 'CONVERT_TO_BINARY':
@@ -5063,7 +5063,7 @@ enum DeploymentStatus {
   deployed,
 }
 
-extension on DeploymentStatus {
+extension DeploymentStatusValue on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pending:
@@ -5076,7 +5076,7 @@ extension on DeploymentStatus {
   }
 }
 
-extension on String {
+extension DeploymentStatusFromString on String {
   DeploymentStatus toDeploymentStatus() {
     switch (this) {
       case 'PENDING':
@@ -5234,7 +5234,7 @@ enum DomainNameStatus {
   updating,
 }
 
-extension on DomainNameStatus {
+extension DomainNameStatusValue on DomainNameStatus {
   String toValue() {
     switch (this) {
       case DomainNameStatus.available:
@@ -5245,7 +5245,7 @@ extension on DomainNameStatus {
   }
 }
 
-extension on String {
+extension DomainNameStatusFromString on String {
   DomainNameStatus toDomainNameStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -5263,7 +5263,7 @@ enum EndpointType {
   edge,
 }
 
-extension on EndpointType {
+extension EndpointTypeValue on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.regional:
@@ -5274,7 +5274,7 @@ extension on EndpointType {
   }
 }
 
-extension on String {
+extension EndpointTypeFromString on String {
   EndpointType toEndpointType() {
     switch (this) {
       case 'REGIONAL':
@@ -7038,7 +7038,7 @@ enum IntegrationType {
   awsProxy,
 }
 
-extension on IntegrationType {
+extension IntegrationTypeValue on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.aws:
@@ -7055,7 +7055,7 @@ extension on IntegrationType {
   }
 }
 
-extension on String {
+extension IntegrationTypeFromString on String {
   IntegrationType toIntegrationType() {
     switch (this) {
       case 'AWS':
@@ -7119,7 +7119,7 @@ enum LoggingLevel {
   off,
 }
 
-extension on LoggingLevel {
+extension LoggingLevelValue on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -7132,7 +7132,7 @@ extension on LoggingLevel {
   }
 }
 
-extension on String {
+extension LoggingLevelFromString on String {
   LoggingLevel toLoggingLevel() {
     switch (this) {
       case 'ERROR':
@@ -7282,7 +7282,7 @@ enum PassthroughBehavior {
   whenNoTemplates,
 }
 
-extension on PassthroughBehavior {
+extension PassthroughBehaviorValue on PassthroughBehavior {
   String toValue() {
     switch (this) {
       case PassthroughBehavior.whenNoMatch:
@@ -7295,7 +7295,7 @@ extension on PassthroughBehavior {
   }
 }
 
-extension on String {
+extension PassthroughBehaviorFromString on String {
   PassthroughBehavior toPassthroughBehavior() {
     switch (this) {
       case 'WHEN_NO_MATCH':
@@ -7315,7 +7315,7 @@ enum ProtocolType {
   http,
 }
 
-extension on ProtocolType {
+extension ProtocolTypeValue on ProtocolType {
   String toValue() {
     switch (this) {
       case ProtocolType.websocket:
@@ -7326,7 +7326,7 @@ extension on ProtocolType {
   }
 }
 
-extension on String {
+extension ProtocolTypeFromString on String {
   ProtocolType toProtocolType() {
     switch (this) {
       case 'WEBSOCKET':
@@ -7657,7 +7657,7 @@ enum SecurityPolicy {
   tls_1_2,
 }
 
-extension on SecurityPolicy {
+extension SecurityPolicyValue on SecurityPolicy {
   String toValue() {
     switch (this) {
       case SecurityPolicy.tls_1_0:
@@ -7668,7 +7668,7 @@ extension on SecurityPolicy {
   }
 }
 
-extension on String {
+extension SecurityPolicyFromString on String {
   SecurityPolicy toSecurityPolicy() {
     switch (this) {
       case 'TLS_1_0':
@@ -8897,7 +8897,7 @@ enum VpcLinkStatus {
   inactive,
 }
 
-extension on VpcLinkStatus {
+extension VpcLinkStatusValue on VpcLinkStatus {
   String toValue() {
     switch (this) {
       case VpcLinkStatus.pending:
@@ -8914,7 +8914,7 @@ extension on VpcLinkStatus {
   }
 }
 
-extension on String {
+extension VpcLinkStatusFromString on String {
   VpcLinkStatus toVpcLinkStatus() {
     switch (this) {
       case 'PENDING':
@@ -8937,7 +8937,7 @@ enum VpcLinkVersion {
   v2,
 }
 
-extension on VpcLinkVersion {
+extension VpcLinkVersionValue on VpcLinkVersion {
   String toValue() {
     switch (this) {
       case VpcLinkVersion.v2:
@@ -8946,7 +8946,7 @@ extension on VpcLinkVersion {
   }
 }
 
-extension on String {
+extension VpcLinkVersionFromString on String {
   VpcLinkVersion toVpcLinkVersion() {
     switch (this) {
       case 'V2':

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -2095,7 +2095,7 @@ enum DeploymentEventType {
   deploymentCompleted,
 }
 
-extension on DeploymentEventType {
+extension DeploymentEventTypeValue on DeploymentEventType {
   String toValue() {
     switch (this) {
       case DeploymentEventType.percentageUpdated:
@@ -2114,7 +2114,7 @@ extension on DeploymentEventType {
   }
 }
 
-extension on String {
+extension DeploymentEventTypeFromString on String {
   DeploymentEventType toDeploymentEventType() {
     switch (this) {
       case 'PERCENTAGE_UPDATED':
@@ -2143,7 +2143,7 @@ enum DeploymentState {
   rolledBack,
 }
 
-extension on DeploymentState {
+extension DeploymentStateValue on DeploymentState {
   String toValue() {
     switch (this) {
       case DeploymentState.baking:
@@ -2162,7 +2162,7 @@ extension on DeploymentState {
   }
 }
 
-extension on String {
+extension DeploymentStateFromString on String {
   DeploymentState toDeploymentState() {
     switch (this) {
       case 'BAKING':
@@ -2397,7 +2397,7 @@ enum EnvironmentState {
   rolledBack,
 }
 
-extension on EnvironmentState {
+extension EnvironmentStateValue on EnvironmentState {
   String toValue() {
     switch (this) {
       case EnvironmentState.readyForDeployment:
@@ -2412,7 +2412,7 @@ extension on EnvironmentState {
   }
 }
 
-extension on String {
+extension EnvironmentStateFromString on String {
   EnvironmentState toEnvironmentState() {
     switch (this) {
       case 'READY_FOR_DEPLOYMENT':
@@ -2456,7 +2456,7 @@ enum GrowthType {
   exponential,
 }
 
-extension on GrowthType {
+extension GrowthTypeValue on GrowthType {
   String toValue() {
     switch (this) {
       case GrowthType.linear:
@@ -2467,7 +2467,7 @@ extension on GrowthType {
   }
 }
 
-extension on String {
+extension GrowthTypeFromString on String {
   GrowthType toGrowthType() {
     switch (this) {
       case 'LINEAR':
@@ -2606,7 +2606,7 @@ enum ReplicateTo {
   ssmDocument,
 }
 
-extension on ReplicateTo {
+extension ReplicateToValue on ReplicateTo {
   String toValue() {
     switch (this) {
       case ReplicateTo.none:
@@ -2617,7 +2617,7 @@ extension on ReplicateTo {
   }
 }
 
-extension on String {
+extension ReplicateToFromString on String {
   ReplicateTo toReplicateTo() {
     switch (this) {
       case 'NONE':
@@ -2653,7 +2653,7 @@ enum TriggeredBy {
   internalError,
 }
 
-extension on TriggeredBy {
+extension TriggeredByValue on TriggeredBy {
   String toValue() {
     switch (this) {
       case TriggeredBy.user:
@@ -2668,7 +2668,7 @@ extension on TriggeredBy {
   }
 }
 
-extension on String {
+extension TriggeredByFromString on String {
   TriggeredBy toTriggeredBy() {
     switch (this) {
       case 'USER':
@@ -2724,7 +2724,7 @@ enum ValidatorType {
   lambda,
 }
 
-extension on ValidatorType {
+extension ValidatorTypeValue on ValidatorType {
   String toValue() {
     switch (this) {
       case ValidatorType.jsonSchema:
@@ -2735,7 +2735,7 @@ extension on ValidatorType {
   }
 }
 
-extension on String {
+extension ValidatorTypeFromString on String {
   ValidatorType toValidatorType() {
     switch (this) {
       case 'JSON_SCHEMA':

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -2095,7 +2095,7 @@ enum DeploymentEventType {
   deploymentCompleted,
 }
 
-extension DeploymentEventTypeValue on DeploymentEventType {
+extension DeploymentEventTypeValueExtension on DeploymentEventType {
   String toValue() {
     switch (this) {
       case DeploymentEventType.percentageUpdated:
@@ -2143,7 +2143,7 @@ enum DeploymentState {
   rolledBack,
 }
 
-extension DeploymentStateValue on DeploymentState {
+extension DeploymentStateValueExtension on DeploymentState {
   String toValue() {
     switch (this) {
       case DeploymentState.baking:
@@ -2397,7 +2397,7 @@ enum EnvironmentState {
   rolledBack,
 }
 
-extension EnvironmentStateValue on EnvironmentState {
+extension EnvironmentStateValueExtension on EnvironmentState {
   String toValue() {
     switch (this) {
       case EnvironmentState.readyForDeployment:
@@ -2456,7 +2456,7 @@ enum GrowthType {
   exponential,
 }
 
-extension GrowthTypeValue on GrowthType {
+extension GrowthTypeValueExtension on GrowthType {
   String toValue() {
     switch (this) {
       case GrowthType.linear:
@@ -2606,7 +2606,7 @@ enum ReplicateTo {
   ssmDocument,
 }
 
-extension ReplicateToValue on ReplicateTo {
+extension ReplicateToValueExtension on ReplicateTo {
   String toValue() {
     switch (this) {
       case ReplicateTo.none:
@@ -2653,7 +2653,7 @@ enum TriggeredBy {
   internalError,
 }
 
-extension TriggeredByValue on TriggeredBy {
+extension TriggeredByValueExtension on TriggeredBy {
   String toValue() {
     switch (this) {
       case TriggeredBy.user:
@@ -2724,7 +2724,7 @@ enum ValidatorType {
   lambda,
 }
 
-extension ValidatorTypeValue on ValidatorType {
+extension ValidatorTypeValueExtension on ValidatorType {
   String toValue() {
     switch (this) {
       case ValidatorType.jsonSchema:

--- a/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
+++ b/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
@@ -2624,7 +2624,7 @@ enum AdjustmentType {
   exactCapacity,
 }
 
-extension on AdjustmentType {
+extension AdjustmentTypeValue on AdjustmentType {
   String toValue() {
     switch (this) {
       case AdjustmentType.changeInCapacity:
@@ -2637,7 +2637,7 @@ extension on AdjustmentType {
   }
 }
 
-extension on String {
+extension AdjustmentTypeFromString on String {
   AdjustmentType toAdjustmentType() {
     switch (this) {
       case 'ChangeInCapacity':
@@ -2875,7 +2875,7 @@ enum MetricAggregationType {
   maximum,
 }
 
-extension on MetricAggregationType {
+extension MetricAggregationTypeValue on MetricAggregationType {
   String toValue() {
     switch (this) {
       case MetricAggregationType.average:
@@ -2888,7 +2888,7 @@ extension on MetricAggregationType {
   }
 }
 
-extension on String {
+extension MetricAggregationTypeFromString on String {
   MetricAggregationType toMetricAggregationType() {
     switch (this) {
       case 'Average':
@@ -2939,7 +2939,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension on MetricStatistic {
+extension MetricStatisticValue on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -2956,7 +2956,7 @@ extension on MetricStatistic {
   }
 }
 
-extension on String {
+extension MetricStatisticFromString on String {
   MetricStatistic toMetricStatistic() {
     switch (this) {
       case 'Average':
@@ -2994,7 +2994,7 @@ enum MetricType {
   kafkaBrokerStorageUtilization,
 }
 
-extension on MetricType {
+extension MetricTypeValue on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.dynamoDBReadCapacityUtilization:
@@ -3035,7 +3035,7 @@ extension on MetricType {
   }
 }
 
-extension on String {
+extension MetricTypeFromString on String {
   MetricType toMetricType() {
     switch (this) {
       case 'DynamoDBReadCapacityUtilization':
@@ -3082,7 +3082,7 @@ enum PolicyType {
   targetTrackingScaling,
 }
 
-extension on PolicyType {
+extension PolicyTypeValue on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.stepScaling:
@@ -3093,7 +3093,7 @@ extension on PolicyType {
   }
 }
 
-extension on String {
+extension PolicyTypeFromString on String {
   PolicyType toPolicyType() {
     switch (this) {
       case 'StepScaling':
@@ -3229,7 +3229,7 @@ enum ScalableDimension {
   kafkaBrokerStorageVolumeSize,
 }
 
-extension on ScalableDimension {
+extension ScalableDimensionValue on ScalableDimension {
   String toValue() {
     switch (this) {
       case ScalableDimension.ecsServiceDesiredCount:
@@ -3272,7 +3272,7 @@ extension on ScalableDimension {
   }
 }
 
-extension on String {
+extension ScalableDimensionFromString on String {
   ScalableDimension toScalableDimension() {
     switch (this) {
       case 'ecs:service:DesiredCount':
@@ -3796,7 +3796,7 @@ enum ScalingActivityStatusCode {
   failed,
 }
 
-extension on ScalingActivityStatusCode {
+extension ScalingActivityStatusCodeValue on ScalingActivityStatusCode {
   String toValue() {
     switch (this) {
       case ScalingActivityStatusCode.pending:
@@ -3815,7 +3815,7 @@ extension on ScalingActivityStatusCode {
   }
 }
 
-extension on String {
+extension ScalingActivityStatusCodeFromString on String {
   ScalingActivityStatusCode toScalingActivityStatusCode() {
     switch (this) {
       case 'Pending':
@@ -4332,7 +4332,7 @@ enum ServiceNamespace {
   kafka,
 }
 
-extension on ServiceNamespace {
+extension ServiceNamespaceValue on ServiceNamespace {
   String toValue() {
     switch (this) {
       case ServiceNamespace.ecs:
@@ -4363,7 +4363,7 @@ extension on ServiceNamespace {
   }
 }
 
-extension on String {
+extension ServiceNamespaceFromString on String {
   ServiceNamespace toServiceNamespace() {
     switch (this) {
       case 'ecs':

--- a/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
+++ b/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
@@ -2624,7 +2624,7 @@ enum AdjustmentType {
   exactCapacity,
 }
 
-extension AdjustmentTypeValue on AdjustmentType {
+extension AdjustmentTypeValueExtension on AdjustmentType {
   String toValue() {
     switch (this) {
       case AdjustmentType.changeInCapacity:
@@ -2875,7 +2875,7 @@ enum MetricAggregationType {
   maximum,
 }
 
-extension MetricAggregationTypeValue on MetricAggregationType {
+extension MetricAggregationTypeValueExtension on MetricAggregationType {
   String toValue() {
     switch (this) {
       case MetricAggregationType.average:
@@ -2939,7 +2939,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension MetricStatisticValue on MetricStatistic {
+extension MetricStatisticValueExtension on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -2994,7 +2994,7 @@ enum MetricType {
   kafkaBrokerStorageUtilization,
 }
 
-extension MetricTypeValue on MetricType {
+extension MetricTypeValueExtension on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.dynamoDBReadCapacityUtilization:
@@ -3082,7 +3082,7 @@ enum PolicyType {
   targetTrackingScaling,
 }
 
-extension PolicyTypeValue on PolicyType {
+extension PolicyTypeValueExtension on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.stepScaling:
@@ -3229,7 +3229,7 @@ enum ScalableDimension {
   kafkaBrokerStorageVolumeSize,
 }
 
-extension ScalableDimensionValue on ScalableDimension {
+extension ScalableDimensionValueExtension on ScalableDimension {
   String toValue() {
     switch (this) {
       case ScalableDimension.ecsServiceDesiredCount:
@@ -3796,7 +3796,7 @@ enum ScalingActivityStatusCode {
   failed,
 }
 
-extension ScalingActivityStatusCodeValue on ScalingActivityStatusCode {
+extension ScalingActivityStatusCodeValueExtension on ScalingActivityStatusCode {
   String toValue() {
     switch (this) {
       case ScalingActivityStatusCode.pending:
@@ -4332,7 +4332,7 @@ enum ServiceNamespace {
   kafka,
 }
 
-extension ServiceNamespaceValue on ServiceNamespace {
+extension ServiceNamespaceValueExtension on ServiceNamespace {
   String toValue() {
     switch (this) {
       case ServiceNamespace.ecs:

--- a/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
+++ b/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
@@ -1783,7 +1783,7 @@ enum CloudWatchEventSource {
   rds,
 }
 
-extension on CloudWatchEventSource {
+extension CloudWatchEventSourceValue on CloudWatchEventSource {
   String toValue() {
     switch (this) {
       case CloudWatchEventSource.ec2:
@@ -1798,7 +1798,7 @@ extension on CloudWatchEventSource {
   }
 }
 
-extension on String {
+extension CloudWatchEventSourceFromString on String {
   CloudWatchEventSource toCloudWatchEventSource() {
     switch (this) {
       case 'EC2':
@@ -1865,7 +1865,8 @@ enum ConfigurationEventResourceType {
   ssmAssociation,
 }
 
-extension on ConfigurationEventResourceType {
+extension ConfigurationEventResourceTypeValue
+    on ConfigurationEventResourceType {
   String toValue() {
     switch (this) {
       case ConfigurationEventResourceType.cloudwatchAlarm:
@@ -1880,7 +1881,7 @@ extension on ConfigurationEventResourceType {
   }
 }
 
-extension on String {
+extension ConfigurationEventResourceTypeFromString on String {
   ConfigurationEventResourceType toConfigurationEventResourceType() {
     switch (this) {
       case 'CLOUDWATCH_ALARM':
@@ -1903,7 +1904,7 @@ enum ConfigurationEventStatus {
   error,
 }
 
-extension on ConfigurationEventStatus {
+extension ConfigurationEventStatusValue on ConfigurationEventStatus {
   String toValue() {
     switch (this) {
       case ConfigurationEventStatus.info:
@@ -1916,7 +1917,7 @@ extension on ConfigurationEventStatus {
   }
 }
 
-extension on String {
+extension ConfigurationEventStatusFromString on String {
   ConfigurationEventStatus toConfigurationEventStatus() {
     switch (this) {
       case 'INFO':
@@ -2156,7 +2157,7 @@ enum FeedbackKey {
   insightsFeedback,
 }
 
-extension on FeedbackKey {
+extension FeedbackKeyValue on FeedbackKey {
   String toValue() {
     switch (this) {
       case FeedbackKey.insightsFeedback:
@@ -2165,7 +2166,7 @@ extension on FeedbackKey {
   }
 }
 
-extension on String {
+extension FeedbackKeyFromString on String {
   FeedbackKey toFeedbackKey() {
     switch (this) {
       case 'INSIGHTS_FEEDBACK':
@@ -2181,7 +2182,7 @@ enum FeedbackValue {
   notUseful,
 }
 
-extension on FeedbackValue {
+extension FeedbackValueValue on FeedbackValue {
   String toValue() {
     switch (this) {
       case FeedbackValue.notSpecified:
@@ -2194,7 +2195,7 @@ extension on FeedbackValue {
   }
 }
 
-extension on String {
+extension FeedbackValueFromString on String {
   FeedbackValue toFeedbackValue() {
     switch (this) {
       case 'NOT_SPECIFIED':
@@ -2384,7 +2385,7 @@ enum LogFilter {
   info,
 }
 
-extension on LogFilter {
+extension LogFilterValue on LogFilter {
   String toValue() {
     switch (this) {
       case LogFilter.error:
@@ -2397,7 +2398,7 @@ extension on LogFilter {
   }
 }
 
-extension on String {
+extension LogFilterFromString on String {
   LogFilter toLogFilter() {
     switch (this) {
       case 'ERROR':
@@ -2711,7 +2712,7 @@ enum OsType {
   linux,
 }
 
-extension on OsType {
+extension OsTypeValue on OsType {
   String toValue() {
     switch (this) {
       case OsType.windows:
@@ -2722,7 +2723,7 @@ extension on OsType {
   }
 }
 
-extension on String {
+extension OsTypeFromString on String {
   OsType toOsType() {
     switch (this) {
       case 'WINDOWS':
@@ -2819,7 +2820,7 @@ enum SeverityLevel {
   high,
 }
 
-extension on SeverityLevel {
+extension SeverityLevelValue on SeverityLevel {
   String toValue() {
     switch (this) {
       case SeverityLevel.low:
@@ -2832,7 +2833,7 @@ extension on SeverityLevel {
   }
 }
 
-extension on String {
+extension SeverityLevelFromString on String {
   SeverityLevel toSeverityLevel() {
     switch (this) {
       case 'Low':
@@ -2852,7 +2853,7 @@ enum Status {
   pending,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.ignore:
@@ -2865,7 +2866,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'IGNORE':
@@ -2961,7 +2962,7 @@ enum Tier {
   oracle,
 }
 
-extension on Tier {
+extension TierValue on Tier {
   String toValue() {
     switch (this) {
       case Tier.custom:
@@ -2992,7 +2993,7 @@ extension on Tier {
   }
 }
 
-extension on String {
+extension TierFromString on String {
   Tier toTier() {
     switch (this) {
       case 'CUSTOM':

--- a/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
+++ b/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
@@ -1783,7 +1783,7 @@ enum CloudWatchEventSource {
   rds,
 }
 
-extension CloudWatchEventSourceValue on CloudWatchEventSource {
+extension CloudWatchEventSourceValueExtension on CloudWatchEventSource {
   String toValue() {
     switch (this) {
       case CloudWatchEventSource.ec2:
@@ -1865,7 +1865,7 @@ enum ConfigurationEventResourceType {
   ssmAssociation,
 }
 
-extension ConfigurationEventResourceTypeValue
+extension ConfigurationEventResourceTypeValueExtension
     on ConfigurationEventResourceType {
   String toValue() {
     switch (this) {
@@ -1904,7 +1904,7 @@ enum ConfigurationEventStatus {
   error,
 }
 
-extension ConfigurationEventStatusValue on ConfigurationEventStatus {
+extension ConfigurationEventStatusValueExtension on ConfigurationEventStatus {
   String toValue() {
     switch (this) {
       case ConfigurationEventStatus.info:
@@ -2157,7 +2157,7 @@ enum FeedbackKey {
   insightsFeedback,
 }
 
-extension FeedbackKeyValue on FeedbackKey {
+extension FeedbackKeyValueExtension on FeedbackKey {
   String toValue() {
     switch (this) {
       case FeedbackKey.insightsFeedback:
@@ -2182,7 +2182,7 @@ enum FeedbackValue {
   notUseful,
 }
 
-extension FeedbackValueValue on FeedbackValue {
+extension FeedbackValueValueExtension on FeedbackValue {
   String toValue() {
     switch (this) {
       case FeedbackValue.notSpecified:
@@ -2385,7 +2385,7 @@ enum LogFilter {
   info,
 }
 
-extension LogFilterValue on LogFilter {
+extension LogFilterValueExtension on LogFilter {
   String toValue() {
     switch (this) {
       case LogFilter.error:
@@ -2712,7 +2712,7 @@ enum OsType {
   linux,
 }
 
-extension OsTypeValue on OsType {
+extension OsTypeValueExtension on OsType {
   String toValue() {
     switch (this) {
       case OsType.windows:
@@ -2820,7 +2820,7 @@ enum SeverityLevel {
   high,
 }
 
-extension SeverityLevelValue on SeverityLevel {
+extension SeverityLevelValueExtension on SeverityLevel {
   String toValue() {
     switch (this) {
       case SeverityLevel.low:
@@ -2853,7 +2853,7 @@ enum Status {
   pending,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.ignore:
@@ -2962,7 +2962,7 @@ enum Tier {
   oracle,
 }
 
-extension TierValue on Tier {
+extension TierValueExtension on Tier {
   String toValue() {
     switch (this) {
       case Tier.custom:

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -1285,7 +1285,7 @@ enum MeshStatusCode {
   inactive,
 }
 
-extension MeshStatusCodeValue on MeshStatusCode {
+extension MeshStatusCodeValueExtension on MeshStatusCode {
   String toValue() {
     switch (this) {
       case MeshStatusCode.active:
@@ -1852,7 +1852,7 @@ enum VirtualRouterStatusCode {
   inactive,
 }
 
-extension VirtualRouterStatusCodeValue on VirtualRouterStatusCode {
+extension VirtualRouterStatusCodeValueExtension on VirtualRouterStatusCode {
   String toValue() {
     switch (this) {
       case VirtualRouterStatusCode.active:
@@ -1966,7 +1966,7 @@ enum PortProtocol {
   tcp,
 }
 
-extension PortProtocolValue on PortProtocol {
+extension PortProtocolValueExtension on PortProtocol {
   String toValue() {
     switch (this) {
       case PortProtocol.http:
@@ -2081,7 +2081,7 @@ enum VirtualNodeStatusCode {
   inactive,
 }
 
-extension VirtualNodeStatusCodeValue on VirtualNodeStatusCode {
+extension VirtualNodeStatusCodeValueExtension on VirtualNodeStatusCode {
   String toValue() {
     switch (this) {
       case VirtualNodeStatusCode.active:
@@ -2414,7 +2414,7 @@ enum RouteStatusCode {
   inactive,
 }
 
-extension RouteStatusCodeValue on RouteStatusCode {
+extension RouteStatusCodeValueExtension on RouteStatusCode {
   String toValue() {
     switch (this) {
       case RouteStatusCode.active:

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -1285,7 +1285,7 @@ enum MeshStatusCode {
   inactive,
 }
 
-extension on MeshStatusCode {
+extension MeshStatusCodeValue on MeshStatusCode {
   String toValue() {
     switch (this) {
       case MeshStatusCode.active:
@@ -1298,7 +1298,7 @@ extension on MeshStatusCode {
   }
 }
 
-extension on String {
+extension MeshStatusCodeFromString on String {
   MeshStatusCode toMeshStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -1852,7 +1852,7 @@ enum VirtualRouterStatusCode {
   inactive,
 }
 
-extension on VirtualRouterStatusCode {
+extension VirtualRouterStatusCodeValue on VirtualRouterStatusCode {
   String toValue() {
     switch (this) {
       case VirtualRouterStatusCode.active:
@@ -1865,7 +1865,7 @@ extension on VirtualRouterStatusCode {
   }
 }
 
-extension on String {
+extension VirtualRouterStatusCodeFromString on String {
   VirtualRouterStatusCode toVirtualRouterStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -1966,7 +1966,7 @@ enum PortProtocol {
   tcp,
 }
 
-extension on PortProtocol {
+extension PortProtocolValue on PortProtocol {
   String toValue() {
     switch (this) {
       case PortProtocol.http:
@@ -1977,7 +1977,7 @@ extension on PortProtocol {
   }
 }
 
-extension on String {
+extension PortProtocolFromString on String {
   PortProtocol toPortProtocol() {
     switch (this) {
       case 'http':
@@ -2081,7 +2081,7 @@ enum VirtualNodeStatusCode {
   inactive,
 }
 
-extension on VirtualNodeStatusCode {
+extension VirtualNodeStatusCodeValue on VirtualNodeStatusCode {
   String toValue() {
     switch (this) {
       case VirtualNodeStatusCode.active:
@@ -2094,7 +2094,7 @@ extension on VirtualNodeStatusCode {
   }
 }
 
-extension on String {
+extension VirtualNodeStatusCodeFromString on String {
   VirtualNodeStatusCode toVirtualNodeStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -2414,7 +2414,7 @@ enum RouteStatusCode {
   inactive,
 }
 
-extension on RouteStatusCode {
+extension RouteStatusCodeValue on RouteStatusCode {
   String toValue() {
     switch (this) {
       case RouteStatusCode.active:
@@ -2427,7 +2427,7 @@ extension on RouteStatusCode {
   }
 }
 
-extension on String {
+extension RouteStatusCodeFromString on String {
   RouteStatusCode toRouteStatusCode() {
     switch (this) {
       case 'ACTIVE':

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -3444,7 +3444,7 @@ enum DurationUnit {
   ms,
 }
 
-extension on DurationUnit {
+extension DurationUnitValue on DurationUnit {
   String toValue() {
     switch (this) {
       case DurationUnit.s:
@@ -3455,7 +3455,7 @@ extension on DurationUnit {
   }
 }
 
-extension on String {
+extension DurationUnitFromString on String {
   DurationUnit toDurationUnit() {
     switch (this) {
       case 's':
@@ -3498,7 +3498,7 @@ enum EgressFilterType {
   dropAll,
 }
 
-extension on EgressFilterType {
+extension EgressFilterTypeValue on EgressFilterType {
   String toValue() {
     switch (this) {
       case EgressFilterType.allowAll:
@@ -3509,7 +3509,7 @@ extension on EgressFilterType {
   }
 }
 
-extension on String {
+extension EgressFilterTypeFromString on String {
   EgressFilterType toEgressFilterType() {
     switch (this) {
       case 'ALLOW_ALL':
@@ -3721,7 +3721,7 @@ enum GatewayRouteStatusCode {
   deleted,
 }
 
-extension on GatewayRouteStatusCode {
+extension GatewayRouteStatusCodeValue on GatewayRouteStatusCode {
   String toValue() {
     switch (this) {
       case GatewayRouteStatusCode.active:
@@ -3734,7 +3734,7 @@ extension on GatewayRouteStatusCode {
   }
 }
 
-extension on String {
+extension GatewayRouteStatusCodeFromString on String {
   GatewayRouteStatusCode toGatewayRouteStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -3960,7 +3960,7 @@ enum GrpcRetryPolicyEvent {
   unavailable,
 }
 
-extension on GrpcRetryPolicyEvent {
+extension GrpcRetryPolicyEventValue on GrpcRetryPolicyEvent {
   String toValue() {
     switch (this) {
       case GrpcRetryPolicyEvent.cancelled:
@@ -3977,7 +3977,7 @@ extension on GrpcRetryPolicyEvent {
   }
 }
 
-extension on String {
+extension GrpcRetryPolicyEventFromString on String {
   GrpcRetryPolicyEvent toGrpcRetryPolicyEvent() {
     switch (this) {
       case 'cancelled':
@@ -4462,7 +4462,7 @@ enum HttpMethod {
   patch,
 }
 
-extension on HttpMethod {
+extension HttpMethodValue on HttpMethod {
   String toValue() {
     switch (this) {
       case HttpMethod.get:
@@ -4487,7 +4487,7 @@ extension on HttpMethod {
   }
 }
 
-extension on String {
+extension HttpMethodFromString on String {
   HttpMethod toHttpMethod() {
     switch (this) {
       case 'GET':
@@ -4755,7 +4755,7 @@ enum HttpScheme {
   https,
 }
 
-extension on HttpScheme {
+extension HttpSchemeValue on HttpScheme {
   String toValue() {
     switch (this) {
       case HttpScheme.http:
@@ -4766,7 +4766,7 @@ extension on HttpScheme {
   }
 }
 
-extension on String {
+extension HttpSchemeFromString on String {
   HttpScheme toHttpScheme() {
     switch (this) {
       case 'http':
@@ -5301,7 +5301,7 @@ enum ListenerTlsMode {
   disabled,
 }
 
-extension on ListenerTlsMode {
+extension ListenerTlsModeValue on ListenerTlsMode {
   String toValue() {
     switch (this) {
       case ListenerTlsMode.strict:
@@ -5314,7 +5314,7 @@ extension on ListenerTlsMode {
   }
 }
 
-extension on String {
+extension ListenerTlsModeFromString on String {
   ListenerTlsMode toListenerTlsMode() {
     switch (this) {
       case 'STRICT':
@@ -5515,7 +5515,7 @@ enum MeshStatusCode {
   deleted,
 }
 
-extension on MeshStatusCode {
+extension MeshStatusCodeValue on MeshStatusCode {
   String toValue() {
     switch (this) {
       case MeshStatusCode.active:
@@ -5528,7 +5528,7 @@ extension on MeshStatusCode {
   }
 }
 
-extension on String {
+extension MeshStatusCodeFromString on String {
   MeshStatusCode toMeshStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -5624,7 +5624,7 @@ enum PortProtocol {
   grpc,
 }
 
-extension on PortProtocol {
+extension PortProtocolValue on PortProtocol {
   String toValue() {
     switch (this) {
       case PortProtocol.http:
@@ -5639,7 +5639,7 @@ extension on PortProtocol {
   }
 }
 
-extension on String {
+extension PortProtocolFromString on String {
   PortProtocol toPortProtocol() {
     switch (this) {
       case 'http':
@@ -5896,7 +5896,7 @@ enum RouteStatusCode {
   deleted,
 }
 
-extension on RouteStatusCode {
+extension RouteStatusCodeValue on RouteStatusCode {
   String toValue() {
     switch (this) {
       case RouteStatusCode.active:
@@ -5909,7 +5909,7 @@ extension on RouteStatusCode {
   }
 }
 
-extension on String {
+extension RouteStatusCodeFromString on String {
   RouteStatusCode toRouteStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -6004,7 +6004,7 @@ enum TcpRetryPolicyEvent {
   connectionError,
 }
 
-extension on TcpRetryPolicyEvent {
+extension TcpRetryPolicyEventValue on TcpRetryPolicyEvent {
   String toValue() {
     switch (this) {
       case TcpRetryPolicyEvent.connectionError:
@@ -6013,7 +6013,7 @@ extension on TcpRetryPolicyEvent {
   }
 }
 
-extension on String {
+extension TcpRetryPolicyEventFromString on String {
   TcpRetryPolicyEvent toTcpRetryPolicyEvent() {
     switch (this) {
       case 'connection-error':
@@ -6876,7 +6876,7 @@ enum VirtualGatewayListenerTlsMode {
   disabled,
 }
 
-extension on VirtualGatewayListenerTlsMode {
+extension VirtualGatewayListenerTlsModeValue on VirtualGatewayListenerTlsMode {
   String toValue() {
     switch (this) {
       case VirtualGatewayListenerTlsMode.strict:
@@ -6889,7 +6889,7 @@ extension on VirtualGatewayListenerTlsMode {
   }
 }
 
-extension on String {
+extension VirtualGatewayListenerTlsModeFromString on String {
   VirtualGatewayListenerTlsMode toVirtualGatewayListenerTlsMode() {
     switch (this) {
       case 'STRICT':
@@ -6963,7 +6963,7 @@ enum VirtualGatewayPortProtocol {
   grpc,
 }
 
-extension on VirtualGatewayPortProtocol {
+extension VirtualGatewayPortProtocolValue on VirtualGatewayPortProtocol {
   String toValue() {
     switch (this) {
       case VirtualGatewayPortProtocol.http:
@@ -6976,7 +6976,7 @@ extension on VirtualGatewayPortProtocol {
   }
 }
 
-extension on String {
+extension VirtualGatewayPortProtocolFromString on String {
   VirtualGatewayPortProtocol toVirtualGatewayPortProtocol() {
     switch (this) {
       case 'http':
@@ -7116,7 +7116,7 @@ enum VirtualGatewayStatusCode {
   deleted,
 }
 
-extension on VirtualGatewayStatusCode {
+extension VirtualGatewayStatusCodeValue on VirtualGatewayStatusCode {
   String toValue() {
     switch (this) {
       case VirtualGatewayStatusCode.active:
@@ -7129,7 +7129,7 @@ extension on VirtualGatewayStatusCode {
   }
 }
 
-extension on String {
+extension VirtualGatewayStatusCodeFromString on String {
   VirtualGatewayStatusCode toVirtualGatewayStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -7605,7 +7605,7 @@ enum VirtualNodeStatusCode {
   deleted,
 }
 
-extension on VirtualNodeStatusCode {
+extension VirtualNodeStatusCodeValue on VirtualNodeStatusCode {
   String toValue() {
     switch (this) {
       case VirtualNodeStatusCode.active:
@@ -7618,7 +7618,7 @@ extension on VirtualNodeStatusCode {
   }
 }
 
-extension on String {
+extension VirtualNodeStatusCodeFromString on String {
   VirtualNodeStatusCode toVirtualNodeStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -7843,7 +7843,7 @@ enum VirtualRouterStatusCode {
   deleted,
 }
 
-extension on VirtualRouterStatusCode {
+extension VirtualRouterStatusCodeValue on VirtualRouterStatusCode {
   String toValue() {
     switch (this) {
       case VirtualRouterStatusCode.active:
@@ -7856,7 +7856,7 @@ extension on VirtualRouterStatusCode {
   }
 }
 
-extension on String {
+extension VirtualRouterStatusCodeFromString on String {
   VirtualRouterStatusCode toVirtualRouterStatusCode() {
     switch (this) {
       case 'ACTIVE':
@@ -8079,7 +8079,7 @@ enum VirtualServiceStatusCode {
   deleted,
 }
 
-extension on VirtualServiceStatusCode {
+extension VirtualServiceStatusCodeValue on VirtualServiceStatusCode {
   String toValue() {
     switch (this) {
       case VirtualServiceStatusCode.active:
@@ -8092,7 +8092,7 @@ extension on VirtualServiceStatusCode {
   }
 }
 
-extension on String {
+extension VirtualServiceStatusCodeFromString on String {
   VirtualServiceStatusCode toVirtualServiceStatusCode() {
     switch (this) {
       case 'ACTIVE':

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -3444,7 +3444,7 @@ enum DurationUnit {
   ms,
 }
 
-extension DurationUnitValue on DurationUnit {
+extension DurationUnitValueExtension on DurationUnit {
   String toValue() {
     switch (this) {
       case DurationUnit.s:
@@ -3498,7 +3498,7 @@ enum EgressFilterType {
   dropAll,
 }
 
-extension EgressFilterTypeValue on EgressFilterType {
+extension EgressFilterTypeValueExtension on EgressFilterType {
   String toValue() {
     switch (this) {
       case EgressFilterType.allowAll:
@@ -3721,7 +3721,7 @@ enum GatewayRouteStatusCode {
   deleted,
 }
 
-extension GatewayRouteStatusCodeValue on GatewayRouteStatusCode {
+extension GatewayRouteStatusCodeValueExtension on GatewayRouteStatusCode {
   String toValue() {
     switch (this) {
       case GatewayRouteStatusCode.active:
@@ -3960,7 +3960,7 @@ enum GrpcRetryPolicyEvent {
   unavailable,
 }
 
-extension GrpcRetryPolicyEventValue on GrpcRetryPolicyEvent {
+extension GrpcRetryPolicyEventValueExtension on GrpcRetryPolicyEvent {
   String toValue() {
     switch (this) {
       case GrpcRetryPolicyEvent.cancelled:
@@ -4462,7 +4462,7 @@ enum HttpMethod {
   patch,
 }
 
-extension HttpMethodValue on HttpMethod {
+extension HttpMethodValueExtension on HttpMethod {
   String toValue() {
     switch (this) {
       case HttpMethod.get:
@@ -4755,7 +4755,7 @@ enum HttpScheme {
   https,
 }
 
-extension HttpSchemeValue on HttpScheme {
+extension HttpSchemeValueExtension on HttpScheme {
   String toValue() {
     switch (this) {
       case HttpScheme.http:
@@ -5301,7 +5301,7 @@ enum ListenerTlsMode {
   disabled,
 }
 
-extension ListenerTlsModeValue on ListenerTlsMode {
+extension ListenerTlsModeValueExtension on ListenerTlsMode {
   String toValue() {
     switch (this) {
       case ListenerTlsMode.strict:
@@ -5515,7 +5515,7 @@ enum MeshStatusCode {
   deleted,
 }
 
-extension MeshStatusCodeValue on MeshStatusCode {
+extension MeshStatusCodeValueExtension on MeshStatusCode {
   String toValue() {
     switch (this) {
       case MeshStatusCode.active:
@@ -5624,7 +5624,7 @@ enum PortProtocol {
   grpc,
 }
 
-extension PortProtocolValue on PortProtocol {
+extension PortProtocolValueExtension on PortProtocol {
   String toValue() {
     switch (this) {
       case PortProtocol.http:
@@ -5896,7 +5896,7 @@ enum RouteStatusCode {
   deleted,
 }
 
-extension RouteStatusCodeValue on RouteStatusCode {
+extension RouteStatusCodeValueExtension on RouteStatusCode {
   String toValue() {
     switch (this) {
       case RouteStatusCode.active:
@@ -6004,7 +6004,7 @@ enum TcpRetryPolicyEvent {
   connectionError,
 }
 
-extension TcpRetryPolicyEventValue on TcpRetryPolicyEvent {
+extension TcpRetryPolicyEventValueExtension on TcpRetryPolicyEvent {
   String toValue() {
     switch (this) {
       case TcpRetryPolicyEvent.connectionError:
@@ -6876,7 +6876,8 @@ enum VirtualGatewayListenerTlsMode {
   disabled,
 }
 
-extension VirtualGatewayListenerTlsModeValue on VirtualGatewayListenerTlsMode {
+extension VirtualGatewayListenerTlsModeValueExtension
+    on VirtualGatewayListenerTlsMode {
   String toValue() {
     switch (this) {
       case VirtualGatewayListenerTlsMode.strict:
@@ -6963,7 +6964,8 @@ enum VirtualGatewayPortProtocol {
   grpc,
 }
 
-extension VirtualGatewayPortProtocolValue on VirtualGatewayPortProtocol {
+extension VirtualGatewayPortProtocolValueExtension
+    on VirtualGatewayPortProtocol {
   String toValue() {
     switch (this) {
       case VirtualGatewayPortProtocol.http:
@@ -7116,7 +7118,7 @@ enum VirtualGatewayStatusCode {
   deleted,
 }
 
-extension VirtualGatewayStatusCodeValue on VirtualGatewayStatusCode {
+extension VirtualGatewayStatusCodeValueExtension on VirtualGatewayStatusCode {
   String toValue() {
     switch (this) {
       case VirtualGatewayStatusCode.active:
@@ -7605,7 +7607,7 @@ enum VirtualNodeStatusCode {
   deleted,
 }
 
-extension VirtualNodeStatusCodeValue on VirtualNodeStatusCode {
+extension VirtualNodeStatusCodeValueExtension on VirtualNodeStatusCode {
   String toValue() {
     switch (this) {
       case VirtualNodeStatusCode.active:
@@ -7843,7 +7845,7 @@ enum VirtualRouterStatusCode {
   deleted,
 }
 
-extension VirtualRouterStatusCodeValue on VirtualRouterStatusCode {
+extension VirtualRouterStatusCodeValueExtension on VirtualRouterStatusCode {
   String toValue() {
     switch (this) {
       case VirtualRouterStatusCode.active:
@@ -8079,7 +8081,7 @@ enum VirtualServiceStatusCode {
   deleted,
 }
 
-extension VirtualServiceStatusCodeValue on VirtualServiceStatusCode {
+extension VirtualServiceStatusCodeValueExtension on VirtualServiceStatusCode {
   String toValue() {
     switch (this) {
       case VirtualServiceStatusCode.active:

--- a/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
+++ b/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
@@ -3230,7 +3230,7 @@ enum AccessEndpointType {
   streaming,
 }
 
-extension on AccessEndpointType {
+extension AccessEndpointTypeValue on AccessEndpointType {
   String toValue() {
     switch (this) {
       case AccessEndpointType.streaming:
@@ -3239,7 +3239,7 @@ extension on AccessEndpointType {
   }
 }
 
-extension on String {
+extension AccessEndpointTypeFromString on String {
   AccessEndpointType toAccessEndpointType() {
     switch (this) {
       case 'STREAMING':
@@ -3257,7 +3257,7 @@ enum Action {
   printingToLocalDevice,
 }
 
-extension on Action {
+extension ActionValue on Action {
   String toValue() {
     switch (this) {
       case Action.clipboardCopyFromLocalDevice:
@@ -3274,7 +3274,7 @@ extension on Action {
   }
 }
 
-extension on String {
+extension ActionFromString on String {
   Action toAction() {
     switch (this) {
       case 'CLIPBOARD_COPY_FROM_LOCAL_DEVICE':
@@ -3407,7 +3407,7 @@ enum AuthenticationType {
   userpool,
 }
 
-extension on AuthenticationType {
+extension AuthenticationTypeValue on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.api:
@@ -3420,7 +3420,7 @@ extension on AuthenticationType {
   }
 }
 
-extension on String {
+extension AuthenticationTypeFromString on String {
   AuthenticationType toAuthenticationType() {
     switch (this) {
       case 'API':
@@ -4375,7 +4375,7 @@ enum FleetAttribute {
   iamRoleArn,
 }
 
-extension on FleetAttribute {
+extension FleetAttributeValue on FleetAttribute {
   String toValue() {
     switch (this) {
       case FleetAttribute.vpcConfiguration:
@@ -4390,7 +4390,7 @@ extension on FleetAttribute {
   }
 }
 
-extension on String {
+extension FleetAttributeFromString on String {
   FleetAttribute toFleetAttribute() {
     switch (this) {
       case 'VPC_CONFIGURATION':
@@ -4457,7 +4457,7 @@ enum FleetErrorCode {
   domainJoinInternalServiceError,
 }
 
-extension on FleetErrorCode {
+extension FleetErrorCodeValue on FleetErrorCode {
   String toValue() {
     switch (this) {
       case FleetErrorCode.iamServiceRoleMissingEniDescribeAction:
@@ -4520,7 +4520,7 @@ extension on FleetErrorCode {
   }
 }
 
-extension on String {
+extension FleetErrorCodeFromString on String {
   FleetErrorCode toFleetErrorCode() {
     switch (this) {
       case 'IAM_SERVICE_ROLE_MISSING_ENI_DESCRIBE_ACTION':
@@ -4591,7 +4591,7 @@ enum FleetState {
   stopped,
 }
 
-extension on FleetState {
+extension FleetStateValue on FleetState {
   String toValue() {
     switch (this) {
       case FleetState.starting:
@@ -4606,7 +4606,7 @@ extension on FleetState {
   }
 }
 
-extension on String {
+extension FleetStateFromString on String {
   FleetState toFleetState() {
     switch (this) {
       case 'STARTING':
@@ -4627,7 +4627,7 @@ enum FleetType {
   onDemand,
 }
 
-extension on FleetType {
+extension FleetTypeValue on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.alwaysOn:
@@ -4638,7 +4638,7 @@ extension on FleetType {
   }
 }
 
-extension on String {
+extension FleetTypeFromString on String {
   FleetType toFleetType() {
     switch (this) {
       case 'ALWAYS_ON':
@@ -4998,7 +4998,7 @@ enum ImageBuilderState {
   failed,
 }
 
-extension on ImageBuilderState {
+extension ImageBuilderStateValue on ImageBuilderState {
   String toValue() {
     switch (this) {
       case ImageBuilderState.pending:
@@ -5023,7 +5023,7 @@ extension on ImageBuilderState {
   }
 }
 
-extension on String {
+extension ImageBuilderStateFromString on String {
   ImageBuilderState toImageBuilderState() {
     switch (this) {
       case 'PENDING':
@@ -5074,7 +5074,8 @@ enum ImageBuilderStateChangeReasonCode {
   imageUnavailable,
 }
 
-extension on ImageBuilderStateChangeReasonCode {
+extension ImageBuilderStateChangeReasonCodeValue
+    on ImageBuilderStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case ImageBuilderStateChangeReasonCode.internalError:
@@ -5085,7 +5086,7 @@ extension on ImageBuilderStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension ImageBuilderStateChangeReasonCodeFromString on String {
   ImageBuilderStateChangeReasonCode toImageBuilderStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -5135,7 +5136,7 @@ enum ImageState {
   deleting,
 }
 
-extension on ImageState {
+extension ImageStateValue on ImageState {
   String toValue() {
     switch (this) {
       case ImageState.pending:
@@ -5152,7 +5153,7 @@ extension on ImageState {
   }
 }
 
-extension on String {
+extension ImageStateFromString on String {
   ImageState toImageState() {
     switch (this) {
       case 'PENDING':
@@ -5196,7 +5197,7 @@ enum ImageStateChangeReasonCode {
   imageCopyFailure,
 }
 
-extension on ImageStateChangeReasonCode {
+extension ImageStateChangeReasonCodeValue on ImageStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case ImageStateChangeReasonCode.internalError:
@@ -5209,7 +5210,7 @@ extension on ImageStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension ImageStateChangeReasonCodeFromString on String {
   ImageStateChangeReasonCode toImageStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -5313,7 +5314,7 @@ enum MessageAction {
   resend,
 }
 
-extension on MessageAction {
+extension MessageActionValue on MessageAction {
   String toValue() {
     switch (this) {
       case MessageAction.suppress:
@@ -5324,7 +5325,7 @@ extension on MessageAction {
   }
 }
 
-extension on String {
+extension MessageActionFromString on String {
   MessageAction toMessageAction() {
     switch (this) {
       case 'SUPPRESS':
@@ -5364,7 +5365,7 @@ enum Permission {
   disabled,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.enabled:
@@ -5375,7 +5376,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'ENABLED':
@@ -5393,7 +5394,7 @@ enum PlatformType {
   windowsServer_2019,
 }
 
-extension on PlatformType {
+extension PlatformTypeValue on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.windows:
@@ -5406,7 +5407,7 @@ extension on PlatformType {
   }
 }
 
-extension on String {
+extension PlatformTypeFromString on String {
   PlatformType toPlatformType() {
     switch (this) {
       case 'WINDOWS':
@@ -5557,7 +5558,7 @@ enum SessionConnectionState {
   notConnected,
 }
 
-extension on SessionConnectionState {
+extension SessionConnectionStateValue on SessionConnectionState {
   String toValue() {
     switch (this) {
       case SessionConnectionState.connected:
@@ -5568,7 +5569,7 @@ extension on SessionConnectionState {
   }
 }
 
-extension on String {
+extension SessionConnectionStateFromString on String {
   SessionConnectionState toSessionConnectionState() {
     switch (this) {
       case 'CONNECTED':
@@ -5587,7 +5588,7 @@ enum SessionState {
   expired,
 }
 
-extension on SessionState {
+extension SessionStateValue on SessionState {
   String toValue() {
     switch (this) {
       case SessionState.active:
@@ -5600,7 +5601,7 @@ extension on SessionState {
   }
 }
 
-extension on String {
+extension SessionStateFromString on String {
   SessionState toSessionState() {
     switch (this) {
       case 'ACTIVE':
@@ -5748,7 +5749,7 @@ enum StackAttribute {
   accessEndpoints,
 }
 
-extension on StackAttribute {
+extension StackAttributeValue on StackAttribute {
   String toValue() {
     switch (this) {
       case StackAttribute.storageConnectors:
@@ -5777,7 +5778,7 @@ extension on StackAttribute {
   }
 }
 
-extension on String {
+extension StackAttributeFromString on String {
   StackAttribute toStackAttribute() {
     switch (this) {
       case 'STORAGE_CONNECTORS':
@@ -5832,7 +5833,7 @@ enum StackErrorCode {
   internalServiceError,
 }
 
-extension on StackErrorCode {
+extension StackErrorCodeValue on StackErrorCode {
   String toValue() {
     switch (this) {
       case StackErrorCode.storageConnectorError:
@@ -5843,7 +5844,7 @@ extension on StackErrorCode {
   }
 }
 
-extension on String {
+extension StackErrorCodeFromString on String {
   StackErrorCode toStackErrorCode() {
     switch (this) {
       case 'STORAGE_CONNECTOR_ERROR':
@@ -5947,7 +5948,7 @@ enum StorageConnectorType {
   oneDrive,
 }
 
-extension on StorageConnectorType {
+extension StorageConnectorTypeValue on StorageConnectorType {
   String toValue() {
     switch (this) {
       case StorageConnectorType.homefolders:
@@ -5960,7 +5961,7 @@ extension on StorageConnectorType {
   }
 }
 
-extension on String {
+extension StorageConnectorTypeFromString on String {
   StorageConnectorType toStorageConnectorType() {
     switch (this) {
       case 'HOMEFOLDERS':
@@ -5979,7 +5980,7 @@ enum StreamView {
   desktop,
 }
 
-extension on StreamView {
+extension StreamViewValue on StreamView {
   String toValue() {
     switch (this) {
       case StreamView.app:
@@ -5990,7 +5991,7 @@ extension on StreamView {
   }
 }
 
-extension on String {
+extension StreamViewFromString on String {
   StreamView toStreamView() {
     switch (this) {
       case 'APP':
@@ -6078,7 +6079,7 @@ enum UsageReportExecutionErrorCode {
   internalServiceError,
 }
 
-extension on UsageReportExecutionErrorCode {
+extension UsageReportExecutionErrorCodeValue on UsageReportExecutionErrorCode {
   String toValue() {
     switch (this) {
       case UsageReportExecutionErrorCode.resourceNotFound:
@@ -6091,7 +6092,7 @@ extension on UsageReportExecutionErrorCode {
   }
 }
 
-extension on String {
+extension UsageReportExecutionErrorCodeFromString on String {
   UsageReportExecutionErrorCode toUsageReportExecutionErrorCode() {
     switch (this) {
       case 'RESOURCE_NOT_FOUND':
@@ -6109,7 +6110,7 @@ enum UsageReportSchedule {
   daily,
 }
 
-extension on UsageReportSchedule {
+extension UsageReportScheduleValue on UsageReportSchedule {
   String toValue() {
     switch (this) {
       case UsageReportSchedule.daily:
@@ -6118,7 +6119,7 @@ extension on UsageReportSchedule {
   }
 }
 
-extension on String {
+extension UsageReportScheduleFromString on String {
   UsageReportSchedule toUsageReportSchedule() {
     switch (this) {
       case 'DAILY':
@@ -6362,7 +6363,7 @@ enum UserStackAssociationErrorCode {
   internalError,
 }
 
-extension on UserStackAssociationErrorCode {
+extension UserStackAssociationErrorCodeValue on UserStackAssociationErrorCode {
   String toValue() {
     switch (this) {
       case UserStackAssociationErrorCode.stackNotFound:
@@ -6377,7 +6378,7 @@ extension on UserStackAssociationErrorCode {
   }
 }
 
-extension on String {
+extension UserStackAssociationErrorCodeFromString on String {
   UserStackAssociationErrorCode toUserStackAssociationErrorCode() {
     switch (this) {
       case 'STACK_NOT_FOUND':
@@ -6399,7 +6400,7 @@ enum VisibilityType {
   shared,
 }
 
-extension on VisibilityType {
+extension VisibilityTypeValue on VisibilityType {
   String toValue() {
     switch (this) {
       case VisibilityType.public:
@@ -6412,7 +6413,7 @@ extension on VisibilityType {
   }
 }
 
-extension on String {
+extension VisibilityTypeFromString on String {
   VisibilityType toVisibilityType() {
     switch (this) {
       case 'PUBLIC':

--- a/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
+++ b/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
@@ -3230,7 +3230,7 @@ enum AccessEndpointType {
   streaming,
 }
 
-extension AccessEndpointTypeValue on AccessEndpointType {
+extension AccessEndpointTypeValueExtension on AccessEndpointType {
   String toValue() {
     switch (this) {
       case AccessEndpointType.streaming:
@@ -3257,7 +3257,7 @@ enum Action {
   printingToLocalDevice,
 }
 
-extension ActionValue on Action {
+extension ActionValueExtension on Action {
   String toValue() {
     switch (this) {
       case Action.clipboardCopyFromLocalDevice:
@@ -3407,7 +3407,7 @@ enum AuthenticationType {
   userpool,
 }
 
-extension AuthenticationTypeValue on AuthenticationType {
+extension AuthenticationTypeValueExtension on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.api:
@@ -4375,7 +4375,7 @@ enum FleetAttribute {
   iamRoleArn,
 }
 
-extension FleetAttributeValue on FleetAttribute {
+extension FleetAttributeValueExtension on FleetAttribute {
   String toValue() {
     switch (this) {
       case FleetAttribute.vpcConfiguration:
@@ -4457,7 +4457,7 @@ enum FleetErrorCode {
   domainJoinInternalServiceError,
 }
 
-extension FleetErrorCodeValue on FleetErrorCode {
+extension FleetErrorCodeValueExtension on FleetErrorCode {
   String toValue() {
     switch (this) {
       case FleetErrorCode.iamServiceRoleMissingEniDescribeAction:
@@ -4591,7 +4591,7 @@ enum FleetState {
   stopped,
 }
 
-extension FleetStateValue on FleetState {
+extension FleetStateValueExtension on FleetState {
   String toValue() {
     switch (this) {
       case FleetState.starting:
@@ -4627,7 +4627,7 @@ enum FleetType {
   onDemand,
 }
 
-extension FleetTypeValue on FleetType {
+extension FleetTypeValueExtension on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.alwaysOn:
@@ -4998,7 +4998,7 @@ enum ImageBuilderState {
   failed,
 }
 
-extension ImageBuilderStateValue on ImageBuilderState {
+extension ImageBuilderStateValueExtension on ImageBuilderState {
   String toValue() {
     switch (this) {
       case ImageBuilderState.pending:
@@ -5074,7 +5074,7 @@ enum ImageBuilderStateChangeReasonCode {
   imageUnavailable,
 }
 
-extension ImageBuilderStateChangeReasonCodeValue
+extension ImageBuilderStateChangeReasonCodeValueExtension
     on ImageBuilderStateChangeReasonCode {
   String toValue() {
     switch (this) {
@@ -5136,7 +5136,7 @@ enum ImageState {
   deleting,
 }
 
-extension ImageStateValue on ImageState {
+extension ImageStateValueExtension on ImageState {
   String toValue() {
     switch (this) {
       case ImageState.pending:
@@ -5197,7 +5197,8 @@ enum ImageStateChangeReasonCode {
   imageCopyFailure,
 }
 
-extension ImageStateChangeReasonCodeValue on ImageStateChangeReasonCode {
+extension ImageStateChangeReasonCodeValueExtension
+    on ImageStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case ImageStateChangeReasonCode.internalError:
@@ -5314,7 +5315,7 @@ enum MessageAction {
   resend,
 }
 
-extension MessageActionValue on MessageAction {
+extension MessageActionValueExtension on MessageAction {
   String toValue() {
     switch (this) {
       case MessageAction.suppress:
@@ -5365,7 +5366,7 @@ enum Permission {
   disabled,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.enabled:
@@ -5394,7 +5395,7 @@ enum PlatformType {
   windowsServer_2019,
 }
 
-extension PlatformTypeValue on PlatformType {
+extension PlatformTypeValueExtension on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.windows:
@@ -5558,7 +5559,7 @@ enum SessionConnectionState {
   notConnected,
 }
 
-extension SessionConnectionStateValue on SessionConnectionState {
+extension SessionConnectionStateValueExtension on SessionConnectionState {
   String toValue() {
     switch (this) {
       case SessionConnectionState.connected:
@@ -5588,7 +5589,7 @@ enum SessionState {
   expired,
 }
 
-extension SessionStateValue on SessionState {
+extension SessionStateValueExtension on SessionState {
   String toValue() {
     switch (this) {
       case SessionState.active:
@@ -5749,7 +5750,7 @@ enum StackAttribute {
   accessEndpoints,
 }
 
-extension StackAttributeValue on StackAttribute {
+extension StackAttributeValueExtension on StackAttribute {
   String toValue() {
     switch (this) {
       case StackAttribute.storageConnectors:
@@ -5833,7 +5834,7 @@ enum StackErrorCode {
   internalServiceError,
 }
 
-extension StackErrorCodeValue on StackErrorCode {
+extension StackErrorCodeValueExtension on StackErrorCode {
   String toValue() {
     switch (this) {
       case StackErrorCode.storageConnectorError:
@@ -5948,7 +5949,7 @@ enum StorageConnectorType {
   oneDrive,
 }
 
-extension StorageConnectorTypeValue on StorageConnectorType {
+extension StorageConnectorTypeValueExtension on StorageConnectorType {
   String toValue() {
     switch (this) {
       case StorageConnectorType.homefolders:
@@ -5980,7 +5981,7 @@ enum StreamView {
   desktop,
 }
 
-extension StreamViewValue on StreamView {
+extension StreamViewValueExtension on StreamView {
   String toValue() {
     switch (this) {
       case StreamView.app:
@@ -6079,7 +6080,8 @@ enum UsageReportExecutionErrorCode {
   internalServiceError,
 }
 
-extension UsageReportExecutionErrorCodeValue on UsageReportExecutionErrorCode {
+extension UsageReportExecutionErrorCodeValueExtension
+    on UsageReportExecutionErrorCode {
   String toValue() {
     switch (this) {
       case UsageReportExecutionErrorCode.resourceNotFound:
@@ -6110,7 +6112,7 @@ enum UsageReportSchedule {
   daily,
 }
 
-extension UsageReportScheduleValue on UsageReportSchedule {
+extension UsageReportScheduleValueExtension on UsageReportSchedule {
   String toValue() {
     switch (this) {
       case UsageReportSchedule.daily:
@@ -6363,7 +6365,8 @@ enum UserStackAssociationErrorCode {
   internalError,
 }
 
-extension UserStackAssociationErrorCodeValue on UserStackAssociationErrorCode {
+extension UserStackAssociationErrorCodeValueExtension
+    on UserStackAssociationErrorCode {
   String toValue() {
     switch (this) {
       case UserStackAssociationErrorCode.stackNotFound:
@@ -6400,7 +6403,7 @@ enum VisibilityType {
   shared,
 }
 
-extension VisibilityTypeValue on VisibilityType {
+extension VisibilityTypeValueExtension on VisibilityType {
   String toValue() {
     switch (this) {
       case VisibilityType.public:

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -2404,7 +2404,7 @@ enum ApiCacheStatus {
   failed,
 }
 
-extension ApiCacheStatusValue on ApiCacheStatus {
+extension ApiCacheStatusValueExtension on ApiCacheStatus {
   String toValue() {
     switch (this) {
       case ApiCacheStatus.available:
@@ -2457,7 +2457,7 @@ enum ApiCacheType {
   large_12x,
 }
 
-extension ApiCacheTypeValue on ApiCacheType {
+extension ApiCacheTypeValueExtension on ApiCacheType {
   String toValue() {
     switch (this) {
       case ApiCacheType.t2Small:
@@ -2537,7 +2537,7 @@ enum ApiCachingBehavior {
   perResolverCaching,
 }
 
-extension ApiCachingBehaviorValue on ApiCachingBehavior {
+extension ApiCachingBehaviorValueExtension on ApiCachingBehavior {
   String toValue() {
     switch (this) {
       case ApiCachingBehavior.fullRequestCaching:
@@ -2659,7 +2659,7 @@ enum AuthenticationType {
   openidConnect,
 }
 
-extension AuthenticationTypeValue on AuthenticationType {
+extension AuthenticationTypeValueExtension on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.apiKey:
@@ -2732,7 +2732,7 @@ enum AuthorizationType {
   awsIam,
 }
 
-extension AuthorizationTypeValue on AuthorizationType {
+extension AuthorizationTypeValueExtension on AuthorizationType {
   String toValue() {
     switch (this) {
       case AuthorizationType.awsIam:
@@ -2859,7 +2859,7 @@ enum ConflictDetectionType {
   none,
 }
 
-extension ConflictDetectionTypeValue on ConflictDetectionType {
+extension ConflictDetectionTypeValueExtension on ConflictDetectionType {
   String toValue() {
     switch (this) {
       case ConflictDetectionType.version:
@@ -2889,7 +2889,7 @@ enum ConflictHandlerType {
   none,
 }
 
-extension ConflictHandlerTypeValue on ConflictHandlerType {
+extension ConflictHandlerTypeValueExtension on ConflictHandlerType {
   String toValue() {
     switch (this) {
       case ConflictHandlerType.optimisticConcurrency:
@@ -3144,7 +3144,7 @@ enum DataSourceType {
   relationalDatabase,
 }
 
-extension DataSourceTypeValue on DataSourceType {
+extension DataSourceTypeValueExtension on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.awsLambda:
@@ -3188,7 +3188,7 @@ enum DefaultAction {
   deny,
 }
 
-extension DefaultActionValue on DefaultAction {
+extension DefaultActionValueExtension on DefaultAction {
   String toValue() {
     switch (this) {
       case DefaultAction.allow:
@@ -3387,7 +3387,7 @@ enum FieldLogLevel {
   all,
 }
 
-extension FieldLogLevelValue on FieldLogLevel {
+extension FieldLogLevelValueExtension on FieldLogLevel {
   String toValue() {
     switch (this) {
       case FieldLogLevel.none:
@@ -4075,7 +4075,7 @@ enum OutputType {
   json,
 }
 
-extension OutputTypeValue on OutputType {
+extension OutputTypeValueExtension on OutputType {
   String toValue() {
     switch (this) {
       case OutputType.sdl:
@@ -4222,7 +4222,8 @@ enum RelationalDatabaseSourceType {
   rdsHttpEndpoint,
 }
 
-extension RelationalDatabaseSourceTypeValue on RelationalDatabaseSourceType {
+extension RelationalDatabaseSourceTypeValueExtension
+    on RelationalDatabaseSourceType {
   String toValue() {
     switch (this) {
       case RelationalDatabaseSourceType.rdsHttpEndpoint:
@@ -4329,7 +4330,7 @@ enum ResolverKind {
   pipeline,
 }
 
-extension ResolverKindValue on ResolverKind {
+extension ResolverKindValueExtension on ResolverKind {
   String toValue() {
     switch (this) {
       case ResolverKind.unit:
@@ -4361,7 +4362,7 @@ enum SchemaStatus {
   notApplicable,
 }
 
-extension SchemaStatusValue on SchemaStatus {
+extension SchemaStatusValueExtension on SchemaStatus {
   String toValue() {
     switch (this) {
       case SchemaStatus.processing:
@@ -4533,7 +4534,7 @@ enum TypeDefinitionFormat {
   json,
 }
 
-extension TypeDefinitionFormatValue on TypeDefinitionFormat {
+extension TypeDefinitionFormatValueExtension on TypeDefinitionFormat {
   String toValue() {
     switch (this) {
       case TypeDefinitionFormat.sdl:

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -2404,7 +2404,7 @@ enum ApiCacheStatus {
   failed,
 }
 
-extension on ApiCacheStatus {
+extension ApiCacheStatusValue on ApiCacheStatus {
   String toValue() {
     switch (this) {
       case ApiCacheStatus.available:
@@ -2421,7 +2421,7 @@ extension on ApiCacheStatus {
   }
 }
 
-extension on String {
+extension ApiCacheStatusFromString on String {
   ApiCacheStatus toApiCacheStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -2457,7 +2457,7 @@ enum ApiCacheType {
   large_12x,
 }
 
-extension on ApiCacheType {
+extension ApiCacheTypeValue on ApiCacheType {
   String toValue() {
     switch (this) {
       case ApiCacheType.t2Small:
@@ -2494,7 +2494,7 @@ extension on ApiCacheType {
   }
 }
 
-extension on String {
+extension ApiCacheTypeFromString on String {
   ApiCacheType toApiCacheType() {
     switch (this) {
       case 'T2_SMALL':
@@ -2537,7 +2537,7 @@ enum ApiCachingBehavior {
   perResolverCaching,
 }
 
-extension on ApiCachingBehavior {
+extension ApiCachingBehaviorValue on ApiCachingBehavior {
   String toValue() {
     switch (this) {
       case ApiCachingBehavior.fullRequestCaching:
@@ -2548,7 +2548,7 @@ extension on ApiCachingBehavior {
   }
 }
 
-extension on String {
+extension ApiCachingBehaviorFromString on String {
   ApiCachingBehavior toApiCachingBehavior() {
     switch (this) {
       case 'FULL_REQUEST_CACHING':
@@ -2659,7 +2659,7 @@ enum AuthenticationType {
   openidConnect,
 }
 
-extension on AuthenticationType {
+extension AuthenticationTypeValue on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.apiKey:
@@ -2674,7 +2674,7 @@ extension on AuthenticationType {
   }
 }
 
-extension on String {
+extension AuthenticationTypeFromString on String {
   AuthenticationType toAuthenticationType() {
     switch (this) {
       case 'API_KEY':
@@ -2732,7 +2732,7 @@ enum AuthorizationType {
   awsIam,
 }
 
-extension on AuthorizationType {
+extension AuthorizationTypeValue on AuthorizationType {
   String toValue() {
     switch (this) {
       case AuthorizationType.awsIam:
@@ -2741,7 +2741,7 @@ extension on AuthorizationType {
   }
 }
 
-extension on String {
+extension AuthorizationTypeFromString on String {
   AuthorizationType toAuthorizationType() {
     switch (this) {
       case 'AWS_IAM':
@@ -2859,7 +2859,7 @@ enum ConflictDetectionType {
   none,
 }
 
-extension on ConflictDetectionType {
+extension ConflictDetectionTypeValue on ConflictDetectionType {
   String toValue() {
     switch (this) {
       case ConflictDetectionType.version:
@@ -2870,7 +2870,7 @@ extension on ConflictDetectionType {
   }
 }
 
-extension on String {
+extension ConflictDetectionTypeFromString on String {
   ConflictDetectionType toConflictDetectionType() {
     switch (this) {
       case 'VERSION':
@@ -2889,7 +2889,7 @@ enum ConflictHandlerType {
   none,
 }
 
-extension on ConflictHandlerType {
+extension ConflictHandlerTypeValue on ConflictHandlerType {
   String toValue() {
     switch (this) {
       case ConflictHandlerType.optimisticConcurrency:
@@ -2904,7 +2904,7 @@ extension on ConflictHandlerType {
   }
 }
 
-extension on String {
+extension ConflictHandlerTypeFromString on String {
   ConflictHandlerType toConflictHandlerType() {
     switch (this) {
       case 'OPTIMISTIC_CONCURRENCY':
@@ -3144,7 +3144,7 @@ enum DataSourceType {
   relationalDatabase,
 }
 
-extension on DataSourceType {
+extension DataSourceTypeValue on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.awsLambda:
@@ -3163,7 +3163,7 @@ extension on DataSourceType {
   }
 }
 
-extension on String {
+extension DataSourceTypeFromString on String {
   DataSourceType toDataSourceType() {
     switch (this) {
       case 'AWS_LAMBDA':
@@ -3188,7 +3188,7 @@ enum DefaultAction {
   deny,
 }
 
-extension on DefaultAction {
+extension DefaultActionValue on DefaultAction {
   String toValue() {
     switch (this) {
       case DefaultAction.allow:
@@ -3199,7 +3199,7 @@ extension on DefaultAction {
   }
 }
 
-extension on String {
+extension DefaultActionFromString on String {
   DefaultAction toDefaultAction() {
     switch (this) {
       case 'ALLOW':
@@ -3387,7 +3387,7 @@ enum FieldLogLevel {
   all,
 }
 
-extension on FieldLogLevel {
+extension FieldLogLevelValue on FieldLogLevel {
   String toValue() {
     switch (this) {
       case FieldLogLevel.none:
@@ -3400,7 +3400,7 @@ extension on FieldLogLevel {
   }
 }
 
-extension on String {
+extension FieldLogLevelFromString on String {
   FieldLogLevel toFieldLogLevel() {
     switch (this) {
       case 'NONE':
@@ -4075,7 +4075,7 @@ enum OutputType {
   json,
 }
 
-extension on OutputType {
+extension OutputTypeValue on OutputType {
   String toValue() {
     switch (this) {
       case OutputType.sdl:
@@ -4086,7 +4086,7 @@ extension on OutputType {
   }
 }
 
-extension on String {
+extension OutputTypeFromString on String {
   OutputType toOutputType() {
     switch (this) {
       case 'SDL':
@@ -4222,7 +4222,7 @@ enum RelationalDatabaseSourceType {
   rdsHttpEndpoint,
 }
 
-extension on RelationalDatabaseSourceType {
+extension RelationalDatabaseSourceTypeValue on RelationalDatabaseSourceType {
   String toValue() {
     switch (this) {
       case RelationalDatabaseSourceType.rdsHttpEndpoint:
@@ -4231,7 +4231,7 @@ extension on RelationalDatabaseSourceType {
   }
 }
 
-extension on String {
+extension RelationalDatabaseSourceTypeFromString on String {
   RelationalDatabaseSourceType toRelationalDatabaseSourceType() {
     switch (this) {
       case 'RDS_HTTP_ENDPOINT':
@@ -4329,7 +4329,7 @@ enum ResolverKind {
   pipeline,
 }
 
-extension on ResolverKind {
+extension ResolverKindValue on ResolverKind {
   String toValue() {
     switch (this) {
       case ResolverKind.unit:
@@ -4340,7 +4340,7 @@ extension on ResolverKind {
   }
 }
 
-extension on String {
+extension ResolverKindFromString on String {
   ResolverKind toResolverKind() {
     switch (this) {
       case 'UNIT':
@@ -4361,7 +4361,7 @@ enum SchemaStatus {
   notApplicable,
 }
 
-extension on SchemaStatus {
+extension SchemaStatusValue on SchemaStatus {
   String toValue() {
     switch (this) {
       case SchemaStatus.processing:
@@ -4380,7 +4380,7 @@ extension on SchemaStatus {
   }
 }
 
-extension on String {
+extension SchemaStatusFromString on String {
   SchemaStatus toSchemaStatus() {
     switch (this) {
       case 'PROCESSING':
@@ -4533,7 +4533,7 @@ enum TypeDefinitionFormat {
   json,
 }
 
-extension on TypeDefinitionFormat {
+extension TypeDefinitionFormatValue on TypeDefinitionFormat {
   String toValue() {
     switch (this) {
       case TypeDefinitionFormat.sdl:
@@ -4544,7 +4544,7 @@ extension on TypeDefinitionFormat {
   }
 }
 
-extension on String {
+extension TypeDefinitionFormatFromString on String {
   TypeDefinitionFormat toTypeDefinitionFormat() {
     switch (this) {
       case 'SDL':

--- a/generated/aws_athena_api/lib/athena-2017-05-18.dart
+++ b/generated/aws_athena_api/lib/athena-2017-05-18.dart
@@ -1752,7 +1752,7 @@ enum ColumnNullable {
   unknown,
 }
 
-extension on ColumnNullable {
+extension ColumnNullableValue on ColumnNullable {
   String toValue() {
     switch (this) {
       case ColumnNullable.notNull:
@@ -1765,7 +1765,7 @@ extension on ColumnNullable {
   }
 }
 
-extension on String {
+extension ColumnNullableFromString on String {
   ColumnNullable toColumnNullable() {
     switch (this) {
       case 'NOT_NULL':
@@ -1905,7 +1905,7 @@ enum DataCatalogType {
   hive,
 }
 
-extension on DataCatalogType {
+extension DataCatalogTypeValue on DataCatalogType {
   String toValue() {
     switch (this) {
       case DataCatalogType.lambda:
@@ -1918,7 +1918,7 @@ extension on DataCatalogType {
   }
 }
 
-extension on String {
+extension DataCatalogTypeFromString on String {
   DataCatalogType toDataCatalogType() {
     switch (this) {
       case 'LAMBDA':
@@ -2041,7 +2041,7 @@ enum EncryptionOption {
   cseKms,
 }
 
-extension on EncryptionOption {
+extension EncryptionOptionValue on EncryptionOption {
   String toValue() {
     switch (this) {
       case EncryptionOption.sseS3:
@@ -2054,7 +2054,7 @@ extension on EncryptionOption {
   }
 }
 
-extension on String {
+extension EncryptionOptionFromString on String {
   EncryptionOption toEncryptionOption() {
     switch (this) {
       case 'SSE_S3':
@@ -2516,7 +2516,7 @@ enum QueryExecutionState {
   cancelled,
 }
 
-extension on QueryExecutionState {
+extension QueryExecutionStateValue on QueryExecutionState {
   String toValue() {
     switch (this) {
       case QueryExecutionState.queued:
@@ -2533,7 +2533,7 @@ extension on QueryExecutionState {
   }
 }
 
-extension on String {
+extension QueryExecutionStateFromString on String {
   QueryExecutionState toQueryExecutionState() {
     switch (this) {
       case 'QUEUED':
@@ -2856,7 +2856,7 @@ enum StatementType {
   utility,
 }
 
-extension on StatementType {
+extension StatementTypeValue on StatementType {
   String toValue() {
     switch (this) {
       case StatementType.ddl:
@@ -2869,7 +2869,7 @@ extension on StatementType {
   }
 }
 
-extension on String {
+extension StatementTypeFromString on String {
   StatementType toStatementType() {
     switch (this) {
       case 'DDL':
@@ -3295,7 +3295,7 @@ enum WorkGroupState {
   disabled,
 }
 
-extension on WorkGroupState {
+extension WorkGroupStateValue on WorkGroupState {
   String toValue() {
     switch (this) {
       case WorkGroupState.enabled:
@@ -3306,7 +3306,7 @@ extension on WorkGroupState {
   }
 }
 
-extension on String {
+extension WorkGroupStateFromString on String {
   WorkGroupState toWorkGroupState() {
     switch (this) {
       case 'ENABLED':

--- a/generated/aws_athena_api/lib/athena-2017-05-18.dart
+++ b/generated/aws_athena_api/lib/athena-2017-05-18.dart
@@ -1752,7 +1752,7 @@ enum ColumnNullable {
   unknown,
 }
 
-extension ColumnNullableValue on ColumnNullable {
+extension ColumnNullableValueExtension on ColumnNullable {
   String toValue() {
     switch (this) {
       case ColumnNullable.notNull:
@@ -1905,7 +1905,7 @@ enum DataCatalogType {
   hive,
 }
 
-extension DataCatalogTypeValue on DataCatalogType {
+extension DataCatalogTypeValueExtension on DataCatalogType {
   String toValue() {
     switch (this) {
       case DataCatalogType.lambda:
@@ -2041,7 +2041,7 @@ enum EncryptionOption {
   cseKms,
 }
 
-extension EncryptionOptionValue on EncryptionOption {
+extension EncryptionOptionValueExtension on EncryptionOption {
   String toValue() {
     switch (this) {
       case EncryptionOption.sseS3:
@@ -2516,7 +2516,7 @@ enum QueryExecutionState {
   cancelled,
 }
 
-extension QueryExecutionStateValue on QueryExecutionState {
+extension QueryExecutionStateValueExtension on QueryExecutionState {
   String toValue() {
     switch (this) {
       case QueryExecutionState.queued:
@@ -2856,7 +2856,7 @@ enum StatementType {
   utility,
 }
 
-extension StatementTypeValue on StatementType {
+extension StatementTypeValueExtension on StatementType {
   String toValue() {
     switch (this) {
       case StatementType.ddl:
@@ -3295,7 +3295,7 @@ enum WorkGroupState {
   disabled,
 }
 
-extension WorkGroupStateValue on WorkGroupState {
+extension WorkGroupStateValueExtension on WorkGroupState {
   String toValue() {
     switch (this) {
       case WorkGroupState.enabled:

--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -5540,7 +5540,8 @@ enum InstanceMetadataEndpointState {
   enabled,
 }
 
-extension InstanceMetadataEndpointStateValue on InstanceMetadataEndpointState {
+extension InstanceMetadataEndpointStateValueExtension
+    on InstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
       case InstanceMetadataEndpointState.disabled:
@@ -5568,7 +5569,7 @@ enum InstanceMetadataHttpTokensState {
   required,
 }
 
-extension InstanceMetadataHttpTokensStateValue
+extension InstanceMetadataHttpTokensStateValueExtension
     on InstanceMetadataHttpTokensState {
   String toValue() {
     switch (this) {
@@ -5777,7 +5778,7 @@ enum InstanceRefreshStatus {
   cancelled,
 }
 
-extension InstanceRefreshStatusValue on InstanceRefreshStatus {
+extension InstanceRefreshStatusValueExtension on InstanceRefreshStatus {
   String toValue() {
     switch (this) {
       case InstanceRefreshStatus.pending:
@@ -6539,7 +6540,7 @@ enum LifecycleState {
   standby,
 }
 
-extension LifecycleStateValue on LifecycleState {
+extension LifecycleStateValueExtension on LifecycleState {
   String toValue() {
     switch (this) {
       case LifecycleState.pending:
@@ -6825,7 +6826,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension MetricStatisticValue on MetricStatistic {
+extension MetricStatisticValueExtension on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -6867,7 +6868,7 @@ enum MetricType {
   aLBRequestCountPerTarget,
 }
 
-extension MetricTypeValue on MetricType {
+extension MetricTypeValueExtension on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.aSGAverageCPUUtilization:
@@ -7234,7 +7235,7 @@ enum RefreshStrategy {
   rolling,
 }
 
-extension RefreshStrategyValue on RefreshStrategy {
+extension RefreshStrategyValueExtension on RefreshStrategy {
   String toValue() {
     switch (this) {
       case RefreshStrategy.rolling:
@@ -7268,7 +7269,7 @@ enum ScalingActivityStatusCode {
   cancelled,
 }
 
-extension ScalingActivityStatusCodeValue on ScalingActivityStatusCode {
+extension ScalingActivityStatusCodeValueExtension on ScalingActivityStatusCode {
   String toValue() {
     switch (this) {
       case ScalingActivityStatusCode.pendingSpotBidPlacement:

--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -5540,7 +5540,7 @@ enum InstanceMetadataEndpointState {
   enabled,
 }
 
-extension on InstanceMetadataEndpointState {
+extension InstanceMetadataEndpointStateValue on InstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
       case InstanceMetadataEndpointState.disabled:
@@ -5551,7 +5551,7 @@ extension on InstanceMetadataEndpointState {
   }
 }
 
-extension on String {
+extension InstanceMetadataEndpointStateFromString on String {
   InstanceMetadataEndpointState toInstanceMetadataEndpointState() {
     switch (this) {
       case 'disabled':
@@ -5568,7 +5568,8 @@ enum InstanceMetadataHttpTokensState {
   required,
 }
 
-extension on InstanceMetadataHttpTokensState {
+extension InstanceMetadataHttpTokensStateValue
+    on InstanceMetadataHttpTokensState {
   String toValue() {
     switch (this) {
       case InstanceMetadataHttpTokensState.optional:
@@ -5579,7 +5580,7 @@ extension on InstanceMetadataHttpTokensState {
   }
 }
 
-extension on String {
+extension InstanceMetadataHttpTokensStateFromString on String {
   InstanceMetadataHttpTokensState toInstanceMetadataHttpTokensState() {
     switch (this) {
       case 'optional':
@@ -5776,7 +5777,7 @@ enum InstanceRefreshStatus {
   cancelled,
 }
 
-extension on InstanceRefreshStatus {
+extension InstanceRefreshStatusValue on InstanceRefreshStatus {
   String toValue() {
     switch (this) {
       case InstanceRefreshStatus.pending:
@@ -5795,7 +5796,7 @@ extension on InstanceRefreshStatus {
   }
 }
 
-extension on String {
+extension InstanceRefreshStatusFromString on String {
   InstanceRefreshStatus toInstanceRefreshStatus() {
     switch (this) {
       case 'Pending':
@@ -6538,7 +6539,7 @@ enum LifecycleState {
   standby,
 }
 
-extension on LifecycleState {
+extension LifecycleStateValue on LifecycleState {
   String toValue() {
     switch (this) {
       case LifecycleState.pending:
@@ -6571,7 +6572,7 @@ extension on LifecycleState {
   }
 }
 
-extension on String {
+extension LifecycleStateFromString on String {
   LifecycleState toLifecycleState() {
     switch (this) {
       case 'Pending':
@@ -6824,7 +6825,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension on MetricStatistic {
+extension MetricStatisticValue on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -6841,7 +6842,7 @@ extension on MetricStatistic {
   }
 }
 
-extension on String {
+extension MetricStatisticFromString on String {
   MetricStatistic toMetricStatistic() {
     switch (this) {
       case 'Average':
@@ -6866,7 +6867,7 @@ enum MetricType {
   aLBRequestCountPerTarget,
 }
 
-extension on MetricType {
+extension MetricTypeValue on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.aSGAverageCPUUtilization:
@@ -6881,7 +6882,7 @@ extension on MetricType {
   }
 }
 
-extension on String {
+extension MetricTypeFromString on String {
   MetricType toMetricType() {
     switch (this) {
       case 'ASGAverageCPUUtilization':
@@ -7233,7 +7234,7 @@ enum RefreshStrategy {
   rolling,
 }
 
-extension on RefreshStrategy {
+extension RefreshStrategyValue on RefreshStrategy {
   String toValue() {
     switch (this) {
       case RefreshStrategy.rolling:
@@ -7242,7 +7243,7 @@ extension on RefreshStrategy {
   }
 }
 
-extension on String {
+extension RefreshStrategyFromString on String {
   RefreshStrategy toRefreshStrategy() {
     switch (this) {
       case 'Rolling':
@@ -7267,7 +7268,7 @@ enum ScalingActivityStatusCode {
   cancelled,
 }
 
-extension on ScalingActivityStatusCode {
+extension ScalingActivityStatusCodeValue on ScalingActivityStatusCode {
   String toValue() {
     switch (this) {
       case ScalingActivityStatusCode.pendingSpotBidPlacement:
@@ -7298,7 +7299,7 @@ extension on ScalingActivityStatusCode {
   }
 }
 
-extension on String {
+extension ScalingActivityStatusCodeFromString on String {
   ScalingActivityStatusCode toScalingActivityStatusCode() {
     switch (this) {
       case 'PendingSpotBidPlacement':

--- a/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
+++ b/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
@@ -759,7 +759,7 @@ enum ForecastDataType {
   scheduledActionMaxCapacity,
 }
 
-extension ForecastDataTypeValue on ForecastDataType {
+extension ForecastDataTypeValueExtension on ForecastDataType {
   String toValue() {
     switch (this) {
       case ForecastDataType.capacityForecast:
@@ -815,7 +815,7 @@ enum LoadMetricType {
   aLBTargetGroupRequestCount,
 }
 
-extension LoadMetricTypeValue on LoadMetricType {
+extension LoadMetricTypeValueExtension on LoadMetricType {
   String toValue() {
     switch (this) {
       case LoadMetricType.aSGTotalCPUUtilization:
@@ -883,7 +883,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension MetricStatisticValue on MetricStatistic {
+extension MetricStatisticValueExtension on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -922,7 +922,7 @@ enum PolicyType {
   targetTrackingScaling,
 }
 
-extension PolicyTypeValue on PolicyType {
+extension PolicyTypeValueExtension on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.targetTrackingScaling:
@@ -1048,7 +1048,7 @@ enum PredictiveScalingMaxCapacityBehavior {
   setMaxCapacityAboveForecastCapacity,
 }
 
-extension PredictiveScalingMaxCapacityBehaviorValue
+extension PredictiveScalingMaxCapacityBehaviorValueExtension
     on PredictiveScalingMaxCapacityBehavior {
   String toValue() {
     switch (this) {
@@ -1089,7 +1089,7 @@ enum PredictiveScalingMode {
   forecastOnly,
 }
 
-extension PredictiveScalingModeValue on PredictiveScalingMode {
+extension PredictiveScalingModeValueExtension on PredictiveScalingMode {
   String toValue() {
     switch (this) {
       case PredictiveScalingMode.forecastAndScale:
@@ -1123,7 +1123,7 @@ enum ScalableDimension {
   dynamodbIndexWriteCapacityUnits,
 }
 
-extension ScalableDimensionValue on ScalableDimension {
+extension ScalableDimensionValueExtension on ScalableDimension {
   String toValue() {
     switch (this) {
       case ScalableDimension.autoscalingAutoScalingGroupDesiredCapacity:
@@ -1514,7 +1514,7 @@ enum ScalingMetricType {
   eC2SpotFleetRequestAverageNetworkOut,
 }
 
-extension ScalingMetricTypeValue on ScalingMetricType {
+extension ScalingMetricTypeValueExtension on ScalingMetricType {
   String toValue() {
     switch (this) {
       case ScalingMetricType.aSGAverageCPUUtilization:
@@ -1815,7 +1815,7 @@ enum ScalingPlanStatusCode {
   updateFailed,
 }
 
-extension ScalingPlanStatusCodeValue on ScalingPlanStatusCode {
+extension ScalingPlanStatusCodeValueExtension on ScalingPlanStatusCode {
   String toValue() {
     switch (this) {
       case ScalingPlanStatusCode.active:
@@ -1896,7 +1896,8 @@ enum ScalingPolicyUpdateBehavior {
   replaceExternalPolicies,
 }
 
-extension ScalingPolicyUpdateBehaviorValue on ScalingPolicyUpdateBehavior {
+extension ScalingPolicyUpdateBehaviorValueExtension
+    on ScalingPolicyUpdateBehavior {
   String toValue() {
     switch (this) {
       case ScalingPolicyUpdateBehavior.keepExternalPolicies:
@@ -1925,7 +1926,7 @@ enum ScalingStatusCode {
   active,
 }
 
-extension ScalingStatusCodeValue on ScalingStatusCode {
+extension ScalingStatusCodeValueExtension on ScalingStatusCode {
   String toValue() {
     switch (this) {
       case ScalingStatusCode.inactive:
@@ -1960,7 +1961,7 @@ enum ServiceNamespace {
   dynamodb,
 }
 
-extension ServiceNamespaceValue on ServiceNamespace {
+extension ServiceNamespaceValueExtension on ServiceNamespace {
   String toValue() {
     switch (this) {
       case ServiceNamespace.autoscaling:

--- a/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
+++ b/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
@@ -759,7 +759,7 @@ enum ForecastDataType {
   scheduledActionMaxCapacity,
 }
 
-extension on ForecastDataType {
+extension ForecastDataTypeValue on ForecastDataType {
   String toValue() {
     switch (this) {
       case ForecastDataType.capacityForecast:
@@ -774,7 +774,7 @@ extension on ForecastDataType {
   }
 }
 
-extension on String {
+extension ForecastDataTypeFromString on String {
   ForecastDataType toForecastDataType() {
     switch (this) {
       case 'CapacityForecast':
@@ -815,7 +815,7 @@ enum LoadMetricType {
   aLBTargetGroupRequestCount,
 }
 
-extension on LoadMetricType {
+extension LoadMetricTypeValue on LoadMetricType {
   String toValue() {
     switch (this) {
       case LoadMetricType.aSGTotalCPUUtilization:
@@ -830,7 +830,7 @@ extension on LoadMetricType {
   }
 }
 
-extension on String {
+extension LoadMetricTypeFromString on String {
   LoadMetricType toLoadMetricType() {
     switch (this) {
       case 'ASGTotalCPUUtilization':
@@ -883,7 +883,7 @@ enum MetricStatistic {
   sum,
 }
 
-extension on MetricStatistic {
+extension MetricStatisticValue on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.average:
@@ -900,7 +900,7 @@ extension on MetricStatistic {
   }
 }
 
-extension on String {
+extension MetricStatisticFromString on String {
   MetricStatistic toMetricStatistic() {
     switch (this) {
       case 'Average':
@@ -922,7 +922,7 @@ enum PolicyType {
   targetTrackingScaling,
 }
 
-extension on PolicyType {
+extension PolicyTypeValue on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.targetTrackingScaling:
@@ -931,7 +931,7 @@ extension on PolicyType {
   }
 }
 
-extension on String {
+extension PolicyTypeFromString on String {
   PolicyType toPolicyType() {
     switch (this) {
       case 'TargetTrackingScaling':
@@ -1048,7 +1048,8 @@ enum PredictiveScalingMaxCapacityBehavior {
   setMaxCapacityAboveForecastCapacity,
 }
 
-extension on PredictiveScalingMaxCapacityBehavior {
+extension PredictiveScalingMaxCapacityBehaviorValue
+    on PredictiveScalingMaxCapacityBehavior {
   String toValue() {
     switch (this) {
       case PredictiveScalingMaxCapacityBehavior
@@ -1064,7 +1065,7 @@ extension on PredictiveScalingMaxCapacityBehavior {
   }
 }
 
-extension on String {
+extension PredictiveScalingMaxCapacityBehaviorFromString on String {
   PredictiveScalingMaxCapacityBehavior
       toPredictiveScalingMaxCapacityBehavior() {
     switch (this) {
@@ -1088,7 +1089,7 @@ enum PredictiveScalingMode {
   forecastOnly,
 }
 
-extension on PredictiveScalingMode {
+extension PredictiveScalingModeValue on PredictiveScalingMode {
   String toValue() {
     switch (this) {
       case PredictiveScalingMode.forecastAndScale:
@@ -1099,7 +1100,7 @@ extension on PredictiveScalingMode {
   }
 }
 
-extension on String {
+extension PredictiveScalingModeFromString on String {
   PredictiveScalingMode toPredictiveScalingMode() {
     switch (this) {
       case 'ForecastAndScale':
@@ -1122,7 +1123,7 @@ enum ScalableDimension {
   dynamodbIndexWriteCapacityUnits,
 }
 
-extension on ScalableDimension {
+extension ScalableDimensionValue on ScalableDimension {
   String toValue() {
     switch (this) {
       case ScalableDimension.autoscalingAutoScalingGroupDesiredCapacity:
@@ -1145,7 +1146,7 @@ extension on ScalableDimension {
   }
 }
 
-extension on String {
+extension ScalableDimensionFromString on String {
   ScalableDimension toScalableDimension() {
     switch (this) {
       case 'autoscaling:autoScalingGroup:DesiredCapacity':
@@ -1513,7 +1514,7 @@ enum ScalingMetricType {
   eC2SpotFleetRequestAverageNetworkOut,
 }
 
-extension on ScalingMetricType {
+extension ScalingMetricTypeValue on ScalingMetricType {
   String toValue() {
     switch (this) {
       case ScalingMetricType.aSGAverageCPUUtilization:
@@ -1546,7 +1547,7 @@ extension on ScalingMetricType {
   }
 }
 
-extension on String {
+extension ScalingMetricTypeFromString on String {
   ScalingMetricType toScalingMetricType() {
     switch (this) {
       case 'ASGAverageCPUUtilization':
@@ -1814,7 +1815,7 @@ enum ScalingPlanStatusCode {
   updateFailed,
 }
 
-extension on ScalingPlanStatusCode {
+extension ScalingPlanStatusCodeValue on ScalingPlanStatusCode {
   String toValue() {
     switch (this) {
       case ScalingPlanStatusCode.active:
@@ -1837,7 +1838,7 @@ extension on ScalingPlanStatusCode {
   }
 }
 
-extension on String {
+extension ScalingPlanStatusCodeFromString on String {
   ScalingPlanStatusCode toScalingPlanStatusCode() {
     switch (this) {
       case 'Active':
@@ -1895,7 +1896,7 @@ enum ScalingPolicyUpdateBehavior {
   replaceExternalPolicies,
 }
 
-extension on ScalingPolicyUpdateBehavior {
+extension ScalingPolicyUpdateBehaviorValue on ScalingPolicyUpdateBehavior {
   String toValue() {
     switch (this) {
       case ScalingPolicyUpdateBehavior.keepExternalPolicies:
@@ -1906,7 +1907,7 @@ extension on ScalingPolicyUpdateBehavior {
   }
 }
 
-extension on String {
+extension ScalingPolicyUpdateBehaviorFromString on String {
   ScalingPolicyUpdateBehavior toScalingPolicyUpdateBehavior() {
     switch (this) {
       case 'KeepExternalPolicies':
@@ -1924,7 +1925,7 @@ enum ScalingStatusCode {
   active,
 }
 
-extension on ScalingStatusCode {
+extension ScalingStatusCodeValue on ScalingStatusCode {
   String toValue() {
     switch (this) {
       case ScalingStatusCode.inactive:
@@ -1937,7 +1938,7 @@ extension on ScalingStatusCode {
   }
 }
 
-extension on String {
+extension ScalingStatusCodeFromString on String {
   ScalingStatusCode toScalingStatusCode() {
     switch (this) {
       case 'Inactive':
@@ -1959,7 +1960,7 @@ enum ServiceNamespace {
   dynamodb,
 }
 
-extension on ServiceNamespace {
+extension ServiceNamespaceValue on ServiceNamespace {
   String toValue() {
     switch (this) {
       case ServiceNamespace.autoscaling:
@@ -1976,7 +1977,7 @@ extension on ServiceNamespace {
   }
 }
 
-extension on String {
+extension ServiceNamespaceFromString on String {
   ServiceNamespace toServiceNamespace() {
     switch (this) {
       case 'autoscaling':

--- a/generated/aws_backup_api/lib/backup-2018-11-15.dart
+++ b/generated/aws_backup_api/lib/backup-2018-11-15.dart
@@ -2311,7 +2311,7 @@ enum BackupJobState {
   expired,
 }
 
-extension BackupJobStateValue on BackupJobState {
+extension BackupJobStateValueExtension on BackupJobState {
   String toValue() {
     switch (this) {
       case BackupJobState.created:
@@ -2793,7 +2793,7 @@ enum BackupVaultEvent {
   backupPlanModified,
 }
 
-extension BackupVaultEventValue on BackupVaultEvent {
+extension BackupVaultEventValueExtension on BackupVaultEvent {
   String toValue() {
     switch (this) {
       case BackupVaultEvent.backupJobStarted:
@@ -2998,7 +2998,7 @@ enum ConditionType {
   stringequals,
 }
 
-extension ConditionTypeValue on ConditionType {
+extension ConditionTypeValueExtension on ConditionType {
   String toValue() {
     switch (this) {
       case ConditionType.stringequals:
@@ -3159,7 +3159,7 @@ enum CopyJobState {
   failed,
 }
 
-extension CopyJobStateValue on CopyJobState {
+extension CopyJobStateValueExtension on CopyJobState {
   String toValue() {
     switch (this) {
       case CopyJobState.created:
@@ -4781,7 +4781,7 @@ enum RecoveryPointStatus {
   expired,
 }
 
-extension RecoveryPointStatusValue on RecoveryPointStatus {
+extension RecoveryPointStatusValueExtension on RecoveryPointStatus {
   String toValue() {
     switch (this) {
       case RecoveryPointStatus.completed:
@@ -4820,7 +4820,7 @@ enum RestoreJobStatus {
   failed,
 }
 
-extension RestoreJobStatusValue on RestoreJobStatus {
+extension RestoreJobStatusValueExtension on RestoreJobStatus {
   String toValue() {
     switch (this) {
       case RestoreJobStatus.pending:
@@ -5017,7 +5017,7 @@ enum StorageClass {
   deleted,
 }
 
-extension StorageClassValue on StorageClass {
+extension StorageClassValueExtension on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.warm:

--- a/generated/aws_backup_api/lib/backup-2018-11-15.dart
+++ b/generated/aws_backup_api/lib/backup-2018-11-15.dart
@@ -2311,7 +2311,7 @@ enum BackupJobState {
   expired,
 }
 
-extension on BackupJobState {
+extension BackupJobStateValue on BackupJobState {
   String toValue() {
     switch (this) {
       case BackupJobState.created:
@@ -2334,7 +2334,7 @@ extension on BackupJobState {
   }
 }
 
-extension on String {
+extension BackupJobStateFromString on String {
   BackupJobState toBackupJobState() {
     switch (this) {
       case 'CREATED':
@@ -2793,7 +2793,7 @@ enum BackupVaultEvent {
   backupPlanModified,
 }
 
-extension on BackupVaultEvent {
+extension BackupVaultEventValue on BackupVaultEvent {
   String toValue() {
     switch (this) {
       case BackupVaultEvent.backupJobStarted:
@@ -2830,7 +2830,7 @@ extension on BackupVaultEvent {
   }
 }
 
-extension on String {
+extension BackupVaultEventFromString on String {
   BackupVaultEvent toBackupVaultEvent() {
     switch (this) {
       case 'BACKUP_JOB_STARTED':
@@ -2998,7 +2998,7 @@ enum ConditionType {
   stringequals,
 }
 
-extension on ConditionType {
+extension ConditionTypeValue on ConditionType {
   String toValue() {
     switch (this) {
       case ConditionType.stringequals:
@@ -3007,7 +3007,7 @@ extension on ConditionType {
   }
 }
 
-extension on String {
+extension ConditionTypeFromString on String {
   ConditionType toConditionType() {
     switch (this) {
       case 'STRINGEQUALS':
@@ -3159,7 +3159,7 @@ enum CopyJobState {
   failed,
 }
 
-extension on CopyJobState {
+extension CopyJobStateValue on CopyJobState {
   String toValue() {
     switch (this) {
       case CopyJobState.created:
@@ -3174,7 +3174,7 @@ extension on CopyJobState {
   }
 }
 
-extension on String {
+extension CopyJobStateFromString on String {
   CopyJobState toCopyJobState() {
     switch (this) {
       case 'CREATED':
@@ -4781,7 +4781,7 @@ enum RecoveryPointStatus {
   expired,
 }
 
-extension on RecoveryPointStatus {
+extension RecoveryPointStatusValue on RecoveryPointStatus {
   String toValue() {
     switch (this) {
       case RecoveryPointStatus.completed:
@@ -4796,7 +4796,7 @@ extension on RecoveryPointStatus {
   }
 }
 
-extension on String {
+extension RecoveryPointStatusFromString on String {
   RecoveryPointStatus toRecoveryPointStatus() {
     switch (this) {
       case 'COMPLETED':
@@ -4820,7 +4820,7 @@ enum RestoreJobStatus {
   failed,
 }
 
-extension on RestoreJobStatus {
+extension RestoreJobStatusValue on RestoreJobStatus {
   String toValue() {
     switch (this) {
       case RestoreJobStatus.pending:
@@ -4837,7 +4837,7 @@ extension on RestoreJobStatus {
   }
 }
 
-extension on String {
+extension RestoreJobStatusFromString on String {
   RestoreJobStatus toRestoreJobStatus() {
     switch (this) {
       case 'PENDING':
@@ -5017,7 +5017,7 @@ enum StorageClass {
   deleted,
 }
 
-extension on StorageClass {
+extension StorageClassValue on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.warm:
@@ -5030,7 +5030,7 @@ extension on StorageClass {
   }
 }
 
-extension on String {
+extension StorageClassFromString on String {
   StorageClass toStorageClass() {
     switch (this) {
       case 'WARM':

--- a/generated/aws_batch_api/lib/batch-2016-08-10.dart
+++ b/generated/aws_batch_api/lib/batch-2016-08-10.dart
@@ -1234,7 +1234,7 @@ enum ArrayJobDependency {
   sequential,
 }
 
-extension on ArrayJobDependency {
+extension ArrayJobDependencyValue on ArrayJobDependency {
   String toValue() {
     switch (this) {
       case ArrayJobDependency.nToN:
@@ -1245,7 +1245,7 @@ extension on ArrayJobDependency {
   }
 }
 
-extension on String {
+extension ArrayJobDependencyFromString on String {
   ArrayJobDependency toArrayJobDependency() {
     switch (this) {
       case 'N_TO_N':
@@ -1327,7 +1327,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension on AssignPublicIp {
+extension AssignPublicIpValue on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -1338,7 +1338,7 @@ extension on AssignPublicIp {
   }
 }
 
-extension on String {
+extension AssignPublicIpFromString on String {
   AssignPublicIp toAssignPublicIp() {
     switch (this) {
       case 'ENABLED':
@@ -1445,7 +1445,7 @@ enum CEState {
   disabled,
 }
 
-extension on CEState {
+extension CEStateValue on CEState {
   String toValue() {
     switch (this) {
       case CEState.enabled:
@@ -1456,7 +1456,7 @@ extension on CEState {
   }
 }
 
-extension on String {
+extension CEStateFromString on String {
   CEState toCEState() {
     switch (this) {
       case 'ENABLED':
@@ -1477,7 +1477,7 @@ enum CEStatus {
   invalid,
 }
 
-extension on CEStatus {
+extension CEStatusValue on CEStatus {
   String toValue() {
     switch (this) {
       case CEStatus.creating:
@@ -1496,7 +1496,7 @@ extension on CEStatus {
   }
 }
 
-extension on String {
+extension CEStatusFromString on String {
   CEStatus toCEStatus() {
     switch (this) {
       case 'CREATING':
@@ -1521,7 +1521,7 @@ enum CEType {
   unmanaged,
 }
 
-extension on CEType {
+extension CETypeValue on CEType {
   String toValue() {
     switch (this) {
       case CEType.managed:
@@ -1532,7 +1532,7 @@ extension on CEType {
   }
 }
 
-extension on String {
+extension CETypeFromString on String {
   CEType toCEType() {
     switch (this) {
       case 'MANAGED':
@@ -1550,7 +1550,7 @@ enum CRAllocationStrategy {
   spotCapacityOptimized,
 }
 
-extension on CRAllocationStrategy {
+extension CRAllocationStrategyValue on CRAllocationStrategy {
   String toValue() {
     switch (this) {
       case CRAllocationStrategy.bestFit:
@@ -1563,7 +1563,7 @@ extension on CRAllocationStrategy {
   }
 }
 
-extension on String {
+extension CRAllocationStrategyFromString on String {
   CRAllocationStrategy toCRAllocationStrategy() {
     switch (this) {
       case 'BEST_FIT':
@@ -1584,7 +1584,7 @@ enum CRType {
   fargateSpot,
 }
 
-extension on CRType {
+extension CRTypeValue on CRType {
   String toValue() {
     switch (this) {
       case CRType.ec2:
@@ -1599,7 +1599,7 @@ extension on CRType {
   }
 }
 
-extension on String {
+extension CRTypeFromString on String {
   CRType toCRType() {
     switch (this) {
       case 'EC2':
@@ -3162,7 +3162,7 @@ enum DeviceCgroupPermission {
   mknod,
 }
 
-extension on DeviceCgroupPermission {
+extension DeviceCgroupPermissionValue on DeviceCgroupPermission {
   String toValue() {
     switch (this) {
       case DeviceCgroupPermission.read:
@@ -3175,7 +3175,7 @@ extension on DeviceCgroupPermission {
   }
 }
 
-extension on String {
+extension DeviceCgroupPermissionFromString on String {
   DeviceCgroupPermission toDeviceCgroupPermission() {
     switch (this) {
       case 'READ':
@@ -3376,7 +3376,7 @@ enum JQState {
   disabled,
 }
 
-extension on JQState {
+extension JQStateValue on JQState {
   String toValue() {
     switch (this) {
       case JQState.enabled:
@@ -3387,7 +3387,7 @@ extension on JQState {
   }
 }
 
-extension on String {
+extension JQStateFromString on String {
   JQState toJQState() {
     switch (this) {
       case 'ENABLED':
@@ -3408,7 +3408,7 @@ enum JQStatus {
   invalid,
 }
 
-extension on JQStatus {
+extension JQStatusValue on JQStatus {
   String toValue() {
     switch (this) {
       case JQStatus.creating:
@@ -3427,7 +3427,7 @@ extension on JQStatus {
   }
 }
 
-extension on String {
+extension JQStatusFromString on String {
   JQStatus toJQStatus() {
     switch (this) {
       case 'CREATING':
@@ -3567,7 +3567,7 @@ enum JobDefinitionType {
   multinode,
 }
 
-extension on JobDefinitionType {
+extension JobDefinitionTypeValue on JobDefinitionType {
   String toValue() {
     switch (this) {
       case JobDefinitionType.container:
@@ -3578,7 +3578,7 @@ extension on JobDefinitionType {
   }
 }
 
-extension on String {
+extension JobDefinitionTypeFromString on String {
   JobDefinitionType toJobDefinitionType() {
     switch (this) {
       case 'container':
@@ -3878,7 +3878,7 @@ enum JobStatus {
   failed,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -3899,7 +3899,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -4424,7 +4424,7 @@ enum LogDriver {
   splunk,
 }
 
-extension on LogDriver {
+extension LogDriverValue on LogDriver {
   String toValue() {
     switch (this) {
       case LogDriver.jsonFile:
@@ -4445,7 +4445,7 @@ extension on LogDriver {
   }
 }
 
-extension on String {
+extension LogDriverFromString on String {
   LogDriver toLogDriver() {
     switch (this) {
       case 'json-file':
@@ -4776,7 +4776,7 @@ enum PlatformCapability {
   fargate,
 }
 
-extension on PlatformCapability {
+extension PlatformCapabilityValue on PlatformCapability {
   String toValue() {
     switch (this) {
       case PlatformCapability.ec2:
@@ -4787,7 +4787,7 @@ extension on PlatformCapability {
   }
 }
 
-extension on String {
+extension PlatformCapabilityFromString on String {
   PlatformCapability toPlatformCapability() {
     switch (this) {
       case 'EC2':
@@ -4947,7 +4947,7 @@ enum ResourceType {
   memory,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.gpu:
@@ -4960,7 +4960,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'GPU':
@@ -4979,7 +4979,7 @@ enum RetryAction {
   exit,
 }
 
-extension on RetryAction {
+extension RetryActionValue on RetryAction {
   String toValue() {
     switch (this) {
       case RetryAction.retry:
@@ -4990,7 +4990,7 @@ extension on RetryAction {
   }
 }
 
-extension on String {
+extension RetryActionFromString on String {
   RetryAction toRetryAction() {
     switch (this) {
       case 'RETRY':

--- a/generated/aws_batch_api/lib/batch-2016-08-10.dart
+++ b/generated/aws_batch_api/lib/batch-2016-08-10.dart
@@ -1234,7 +1234,7 @@ enum ArrayJobDependency {
   sequential,
 }
 
-extension ArrayJobDependencyValue on ArrayJobDependency {
+extension ArrayJobDependencyValueExtension on ArrayJobDependency {
   String toValue() {
     switch (this) {
       case ArrayJobDependency.nToN:
@@ -1327,7 +1327,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension AssignPublicIpValue on AssignPublicIp {
+extension AssignPublicIpValueExtension on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -1445,7 +1445,7 @@ enum CEState {
   disabled,
 }
 
-extension CEStateValue on CEState {
+extension CEStateValueExtension on CEState {
   String toValue() {
     switch (this) {
       case CEState.enabled:
@@ -1477,7 +1477,7 @@ enum CEStatus {
   invalid,
 }
 
-extension CEStatusValue on CEStatus {
+extension CEStatusValueExtension on CEStatus {
   String toValue() {
     switch (this) {
       case CEStatus.creating:
@@ -1521,7 +1521,7 @@ enum CEType {
   unmanaged,
 }
 
-extension CETypeValue on CEType {
+extension CETypeValueExtension on CEType {
   String toValue() {
     switch (this) {
       case CEType.managed:
@@ -1550,7 +1550,7 @@ enum CRAllocationStrategy {
   spotCapacityOptimized,
 }
 
-extension CRAllocationStrategyValue on CRAllocationStrategy {
+extension CRAllocationStrategyValueExtension on CRAllocationStrategy {
   String toValue() {
     switch (this) {
       case CRAllocationStrategy.bestFit:
@@ -1584,7 +1584,7 @@ enum CRType {
   fargateSpot,
 }
 
-extension CRTypeValue on CRType {
+extension CRTypeValueExtension on CRType {
   String toValue() {
     switch (this) {
       case CRType.ec2:
@@ -3162,7 +3162,7 @@ enum DeviceCgroupPermission {
   mknod,
 }
 
-extension DeviceCgroupPermissionValue on DeviceCgroupPermission {
+extension DeviceCgroupPermissionValueExtension on DeviceCgroupPermission {
   String toValue() {
     switch (this) {
       case DeviceCgroupPermission.read:
@@ -3376,7 +3376,7 @@ enum JQState {
   disabled,
 }
 
-extension JQStateValue on JQState {
+extension JQStateValueExtension on JQState {
   String toValue() {
     switch (this) {
       case JQState.enabled:
@@ -3408,7 +3408,7 @@ enum JQStatus {
   invalid,
 }
 
-extension JQStatusValue on JQStatus {
+extension JQStatusValueExtension on JQStatus {
   String toValue() {
     switch (this) {
       case JQStatus.creating:
@@ -3567,7 +3567,7 @@ enum JobDefinitionType {
   multinode,
 }
 
-extension JobDefinitionTypeValue on JobDefinitionType {
+extension JobDefinitionTypeValueExtension on JobDefinitionType {
   String toValue() {
     switch (this) {
       case JobDefinitionType.container:
@@ -3878,7 +3878,7 @@ enum JobStatus {
   failed,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -4424,7 +4424,7 @@ enum LogDriver {
   splunk,
 }
 
-extension LogDriverValue on LogDriver {
+extension LogDriverValueExtension on LogDriver {
   String toValue() {
     switch (this) {
       case LogDriver.jsonFile:
@@ -4776,7 +4776,7 @@ enum PlatformCapability {
   fargate,
 }
 
-extension PlatformCapabilityValue on PlatformCapability {
+extension PlatformCapabilityValueExtension on PlatformCapability {
   String toValue() {
     switch (this) {
       case PlatformCapability.ec2:
@@ -4947,7 +4947,7 @@ enum ResourceType {
   memory,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.gpu:
@@ -4979,7 +4979,7 @@ enum RetryAction {
   exit,
 }
 
-extension RetryActionValue on RetryAction {
+extension RetryActionValueExtension on RetryAction {
   String toValue() {
     switch (this) {
       case RetryAction.retry:

--- a/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
+++ b/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
@@ -1701,7 +1701,7 @@ enum ActionStatus {
   resetFailure,
 }
 
-extension ActionStatusValue on ActionStatus {
+extension ActionStatusValueExtension on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.standby:
@@ -1761,7 +1761,7 @@ enum ActionSubType {
   stopRdsInstances,
 }
 
-extension ActionSubTypeValue on ActionSubType {
+extension ActionSubTypeValueExtension on ActionSubType {
   String toValue() {
     switch (this) {
       case ActionSubType.stopEc2Instances:
@@ -1817,7 +1817,7 @@ enum ActionType {
   runSsmDocuments,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.applyIamPolicy:
@@ -1849,7 +1849,7 @@ enum ApprovalModel {
   manual,
 }
 
-extension ApprovalModelValue on ApprovalModel {
+extension ApprovalModelValueExtension on ApprovalModel {
   String toValue() {
     switch (this) {
       case ApprovalModel.automatic:
@@ -2129,7 +2129,7 @@ enum BudgetType {
   savingsPlansCoverage,
 }
 
-extension BudgetTypeValue on BudgetType {
+extension BudgetTypeValueExtension on BudgetType {
   String toValue() {
     switch (this) {
       case BudgetType.usage:
@@ -2251,7 +2251,7 @@ enum ComparisonOperator {
   equalTo,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThan:
@@ -2747,7 +2747,7 @@ enum EventType {
   executeAction,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.system:
@@ -2815,7 +2815,7 @@ enum ExecutionType {
   resetBudgetAction,
 }
 
-extension ExecutionTypeValue on ExecutionType {
+extension ExecutionTypeValueExtension on ExecutionType {
   String toValue() {
     switch (this) {
       case ExecutionType.approveBudgetAction:
@@ -2993,7 +2993,7 @@ enum NotificationState {
   alarm,
 }
 
-extension NotificationStateValue on NotificationState {
+extension NotificationStateValueExtension on NotificationState {
   String toValue() {
     switch (this) {
       case NotificationState.ok:
@@ -3022,7 +3022,7 @@ enum NotificationType {
   forecasted,
 }
 
-extension NotificationTypeValue on NotificationType {
+extension NotificationTypeValueExtension on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.actual:
@@ -3234,7 +3234,7 @@ enum SubscriptionType {
   email,
 }
 
-extension SubscriptionTypeValue on SubscriptionType {
+extension SubscriptionTypeValueExtension on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.sns:
@@ -3263,7 +3263,7 @@ enum ThresholdType {
   absoluteValue,
 }
 
-extension ThresholdTypeValue on ThresholdType {
+extension ThresholdTypeValueExtension on ThresholdType {
   String toValue() {
     switch (this) {
       case ThresholdType.percentage:
@@ -3340,7 +3340,7 @@ enum TimeUnit {
   annually,
 }
 
-extension TimeUnitValue on TimeUnit {
+extension TimeUnitValueExtension on TimeUnit {
   String toValue() {
     switch (this) {
       case TimeUnit.daily:

--- a/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
+++ b/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
@@ -1701,7 +1701,7 @@ enum ActionStatus {
   resetFailure,
 }
 
-extension on ActionStatus {
+extension ActionStatusValue on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.standby:
@@ -1728,7 +1728,7 @@ extension on ActionStatus {
   }
 }
 
-extension on String {
+extension ActionStatusFromString on String {
   ActionStatus toActionStatus() {
     switch (this) {
       case 'STANDBY':
@@ -1761,7 +1761,7 @@ enum ActionSubType {
   stopRdsInstances,
 }
 
-extension on ActionSubType {
+extension ActionSubTypeValue on ActionSubType {
   String toValue() {
     switch (this) {
       case ActionSubType.stopEc2Instances:
@@ -1772,7 +1772,7 @@ extension on ActionSubType {
   }
 }
 
-extension on String {
+extension ActionSubTypeFromString on String {
   ActionSubType toActionSubType() {
     switch (this) {
       case 'STOP_EC2_INSTANCES':
@@ -1817,7 +1817,7 @@ enum ActionType {
   runSsmDocuments,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.applyIamPolicy:
@@ -1830,7 +1830,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'APPLY_IAM_POLICY':
@@ -1849,7 +1849,7 @@ enum ApprovalModel {
   manual,
 }
 
-extension on ApprovalModel {
+extension ApprovalModelValue on ApprovalModel {
   String toValue() {
     switch (this) {
       case ApprovalModel.automatic:
@@ -1860,7 +1860,7 @@ extension on ApprovalModel {
   }
 }
 
-extension on String {
+extension ApprovalModelFromString on String {
   ApprovalModel toApprovalModel() {
     switch (this) {
       case 'AUTOMATIC':
@@ -2129,7 +2129,7 @@ enum BudgetType {
   savingsPlansCoverage,
 }
 
-extension on BudgetType {
+extension BudgetTypeValue on BudgetType {
   String toValue() {
     switch (this) {
       case BudgetType.usage:
@@ -2148,7 +2148,7 @@ extension on BudgetType {
   }
 }
 
-extension on String {
+extension BudgetTypeFromString on String {
   BudgetType toBudgetType() {
     switch (this) {
       case 'USAGE':
@@ -2251,7 +2251,7 @@ enum ComparisonOperator {
   equalTo,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThan:
@@ -2264,7 +2264,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'GREATER_THAN':
@@ -2747,7 +2747,7 @@ enum EventType {
   executeAction,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.system:
@@ -2764,7 +2764,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'SYSTEM':
@@ -2815,7 +2815,7 @@ enum ExecutionType {
   resetBudgetAction,
 }
 
-extension on ExecutionType {
+extension ExecutionTypeValue on ExecutionType {
   String toValue() {
     switch (this) {
       case ExecutionType.approveBudgetAction:
@@ -2830,7 +2830,7 @@ extension on ExecutionType {
   }
 }
 
-extension on String {
+extension ExecutionTypeFromString on String {
   ExecutionType toExecutionType() {
     switch (this) {
       case 'APPROVE_BUDGET_ACTION':
@@ -2993,7 +2993,7 @@ enum NotificationState {
   alarm,
 }
 
-extension on NotificationState {
+extension NotificationStateValue on NotificationState {
   String toValue() {
     switch (this) {
       case NotificationState.ok:
@@ -3004,7 +3004,7 @@ extension on NotificationState {
   }
 }
 
-extension on String {
+extension NotificationStateFromString on String {
   NotificationState toNotificationState() {
     switch (this) {
       case 'OK':
@@ -3022,7 +3022,7 @@ enum NotificationType {
   forecasted,
 }
 
-extension on NotificationType {
+extension NotificationTypeValue on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.actual:
@@ -3033,7 +3033,7 @@ extension on NotificationType {
   }
 }
 
-extension on String {
+extension NotificationTypeFromString on String {
   NotificationType toNotificationType() {
     switch (this) {
       case 'ACTUAL':
@@ -3234,7 +3234,7 @@ enum SubscriptionType {
   email,
 }
 
-extension on SubscriptionType {
+extension SubscriptionTypeValue on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.sns:
@@ -3245,7 +3245,7 @@ extension on SubscriptionType {
   }
 }
 
-extension on String {
+extension SubscriptionTypeFromString on String {
   SubscriptionType toSubscriptionType() {
     switch (this) {
       case 'SNS':
@@ -3263,7 +3263,7 @@ enum ThresholdType {
   absoluteValue,
 }
 
-extension on ThresholdType {
+extension ThresholdTypeValue on ThresholdType {
   String toValue() {
     switch (this) {
       case ThresholdType.percentage:
@@ -3274,7 +3274,7 @@ extension on ThresholdType {
   }
 }
 
-extension on String {
+extension ThresholdTypeFromString on String {
   ThresholdType toThresholdType() {
     switch (this) {
       case 'PERCENTAGE':
@@ -3340,7 +3340,7 @@ enum TimeUnit {
   annually,
 }
 
-extension on TimeUnit {
+extension TimeUnitValue on TimeUnit {
   String toValue() {
     switch (this) {
       case TimeUnit.daily:
@@ -3355,7 +3355,7 @@ extension on TimeUnit {
   }
 }
 
-extension on String {
+extension TimeUnitFromString on String {
   TimeUnit toTimeUnit() {
     switch (this) {
       case 'DAILY':

--- a/generated/aws_ce_api/lib/ce-2017-10-25.dart
+++ b/generated/aws_ce_api/lib/ce-2017-10-25.dart
@@ -2468,7 +2468,7 @@ enum AccountScope {
   linked,
 }
 
-extension AccountScopeValue on AccountScope {
+extension AccountScopeValueExtension on AccountScope {
   String toValue() {
     switch (this) {
       case AccountScope.payer:
@@ -2581,7 +2581,7 @@ enum AnomalyFeedbackType {
   plannedActivity,
 }
 
-extension AnomalyFeedbackTypeValue on AnomalyFeedbackType {
+extension AnomalyFeedbackTypeValueExtension on AnomalyFeedbackType {
   String toValue() {
     switch (this) {
       case AnomalyFeedbackType.yes:
@@ -2793,7 +2793,8 @@ enum AnomalySubscriptionFrequency {
   weekly,
 }
 
-extension AnomalySubscriptionFrequencyValue on AnomalySubscriptionFrequency {
+extension AnomalySubscriptionFrequencyValueExtension
+    on AnomalySubscriptionFrequency {
   String toValue() {
     switch (this) {
       case AnomalySubscriptionFrequency.daily:
@@ -2826,7 +2827,7 @@ enum Context {
   savingsPlans,
 }
 
-extension ContextValue on Context {
+extension ContextValueExtension on Context {
   String toValue() {
     switch (this) {
       case Context.costAndUsage:
@@ -3031,7 +3032,7 @@ enum CostCategoryRuleVersion {
   costCategoryExpressionV1,
 }
 
-extension CostCategoryRuleVersionValue on CostCategoryRuleVersion {
+extension CostCategoryRuleVersionValueExtension on CostCategoryRuleVersion {
   String toValue() {
     switch (this) {
       case CostCategoryRuleVersion.costCategoryExpressionV1:
@@ -3055,7 +3056,7 @@ enum CostCategoryStatus {
   applied,
 }
 
-extension CostCategoryStatusValue on CostCategoryStatus {
+extension CostCategoryStatusValueExtension on CostCategoryStatus {
   String toValue() {
     switch (this) {
       case CostCategoryStatus.processing:
@@ -3082,7 +3083,8 @@ enum CostCategoryStatusComponent {
   costExplorer,
 }
 
-extension CostCategoryStatusComponentValue on CostCategoryStatusComponent {
+extension CostCategoryStatusComponentValueExtension
+    on CostCategoryStatusComponent {
   String toValue() {
     switch (this) {
       case CostCategoryStatusComponent.costExplorer:
@@ -3550,7 +3552,7 @@ enum Dimension {
   paymentOption,
 }
 
-extension DimensionValue on Dimension {
+extension DimensionValueExtension on Dimension {
   String toValue() {
     switch (this) {
       case Dimension.az:
@@ -4861,7 +4863,7 @@ enum Granularity {
   hourly,
 }
 
-extension GranularityValue on Granularity {
+extension GranularityValueExtension on Granularity {
   String toValue() {
     switch (this) {
       case Granularity.daily:
@@ -4948,7 +4950,7 @@ enum GroupDefinitionType {
   costCategory,
 }
 
-extension GroupDefinitionTypeValue on GroupDefinitionType {
+extension GroupDefinitionTypeValueExtension on GroupDefinitionType {
   String toValue() {
     switch (this) {
       case GroupDefinitionType.dimension:
@@ -5077,7 +5079,7 @@ enum LookbackPeriodInDays {
   sixtyDays,
 }
 
-extension LookbackPeriodInDaysValue on LookbackPeriodInDays {
+extension LookbackPeriodInDaysValueExtension on LookbackPeriodInDays {
   String toValue() {
     switch (this) {
       case LookbackPeriodInDays.sevenDays:
@@ -5113,7 +5115,7 @@ enum MatchOption {
   caseInsensitive,
 }
 
-extension MatchOptionValue on MatchOption {
+extension MatchOptionValueExtension on MatchOption {
   String toValue() {
     switch (this) {
       case MatchOption.equals:
@@ -5162,7 +5164,7 @@ enum Metric {
   normalizedUsageAmount,
 }
 
-extension MetricValue on Metric {
+extension MetricValueExtension on Metric {
   String toValue() {
     switch (this) {
       case Metric.blendedCost:
@@ -5247,7 +5249,7 @@ enum MonitorDimension {
   service,
 }
 
-extension MonitorDimensionValue on MonitorDimension {
+extension MonitorDimensionValueExtension on MonitorDimension {
   String toValue() {
     switch (this) {
       case MonitorDimension.service:
@@ -5271,7 +5273,7 @@ enum MonitorType {
   custom,
 }
 
-extension MonitorTypeValue on MonitorType {
+extension MonitorTypeValueExtension on MonitorType {
   String toValue() {
     switch (this) {
       case MonitorType.dimensional:
@@ -5303,7 +5305,7 @@ enum NumericOperator {
   between,
 }
 
-extension NumericOperatorValue on NumericOperator {
+extension NumericOperatorValueExtension on NumericOperator {
   String toValue() {
     switch (this) {
       case NumericOperator.equal:
@@ -5347,7 +5349,7 @@ enum OfferingClass {
   convertible,
 }
 
-extension OfferingClassValue on OfferingClass {
+extension OfferingClassValueExtension on OfferingClass {
   String toValue() {
     switch (this) {
       case OfferingClass.standard:
@@ -5379,7 +5381,7 @@ enum PaymentOption {
   heavyUtilization,
 }
 
-extension PaymentOptionValue on PaymentOption {
+extension PaymentOptionValueExtension on PaymentOption {
   String toValue() {
     switch (this) {
       case PaymentOption.noUpfront:
@@ -5494,7 +5496,7 @@ enum RecommendationTarget {
   crossInstanceFamily,
 }
 
-extension RecommendationTargetValue on RecommendationTarget {
+extension RecommendationTargetValueExtension on RecommendationTarget {
   String toValue() {
     switch (this) {
       case RecommendationTarget.sameInstanceFamily:
@@ -6181,7 +6183,7 @@ enum RightsizingType {
   modify,
 }
 
-extension RightsizingTypeValue on RightsizingType {
+extension RightsizingTypeValueExtension on RightsizingType {
   String toValue() {
     switch (this) {
       case RightsizingType.terminate:
@@ -6901,7 +6903,7 @@ enum SubscriberStatus {
   declined,
 }
 
-extension SubscriberStatusValue on SubscriberStatus {
+extension SubscriberStatusValueExtension on SubscriberStatus {
   String toValue() {
     switch (this) {
       case SubscriberStatus.confirmed:
@@ -6929,7 +6931,7 @@ enum SubscriberType {
   sns,
 }
 
-extension SubscriberTypeValue on SubscriberType {
+extension SubscriberTypeValueExtension on SubscriberType {
   String toValue() {
     switch (this) {
       case SubscriberType.email:
@@ -6957,7 +6959,7 @@ enum SupportedSavingsPlansType {
   ec2InstanceSp,
 }
 
-extension SupportedSavingsPlansTypeValue on SupportedSavingsPlansType {
+extension SupportedSavingsPlansTypeValueExtension on SupportedSavingsPlansType {
   String toValue() {
     switch (this) {
       case SupportedSavingsPlansType.computeSp:
@@ -7077,7 +7079,7 @@ enum TermInYears {
   threeYears,
 }
 
-extension TermInYearsValue on TermInYears {
+extension TermInYearsValueExtension on TermInYears {
   String toValue() {
     switch (this) {
       case TermInYears.oneYear:

--- a/generated/aws_ce_api/lib/ce-2017-10-25.dart
+++ b/generated/aws_ce_api/lib/ce-2017-10-25.dart
@@ -2468,7 +2468,7 @@ enum AccountScope {
   linked,
 }
 
-extension on AccountScope {
+extension AccountScopeValue on AccountScope {
   String toValue() {
     switch (this) {
       case AccountScope.payer:
@@ -2479,7 +2479,7 @@ extension on AccountScope {
   }
 }
 
-extension on String {
+extension AccountScopeFromString on String {
   AccountScope toAccountScope() {
     switch (this) {
       case 'PAYER':
@@ -2581,7 +2581,7 @@ enum AnomalyFeedbackType {
   plannedActivity,
 }
 
-extension on AnomalyFeedbackType {
+extension AnomalyFeedbackTypeValue on AnomalyFeedbackType {
   String toValue() {
     switch (this) {
       case AnomalyFeedbackType.yes:
@@ -2594,7 +2594,7 @@ extension on AnomalyFeedbackType {
   }
 }
 
-extension on String {
+extension AnomalyFeedbackTypeFromString on String {
   AnomalyFeedbackType toAnomalyFeedbackType() {
     switch (this) {
       case 'YES':
@@ -2793,7 +2793,7 @@ enum AnomalySubscriptionFrequency {
   weekly,
 }
 
-extension on AnomalySubscriptionFrequency {
+extension AnomalySubscriptionFrequencyValue on AnomalySubscriptionFrequency {
   String toValue() {
     switch (this) {
       case AnomalySubscriptionFrequency.daily:
@@ -2806,7 +2806,7 @@ extension on AnomalySubscriptionFrequency {
   }
 }
 
-extension on String {
+extension AnomalySubscriptionFrequencyFromString on String {
   AnomalySubscriptionFrequency toAnomalySubscriptionFrequency() {
     switch (this) {
       case 'DAILY':
@@ -2826,7 +2826,7 @@ enum Context {
   savingsPlans,
 }
 
-extension on Context {
+extension ContextValue on Context {
   String toValue() {
     switch (this) {
       case Context.costAndUsage:
@@ -2839,7 +2839,7 @@ extension on Context {
   }
 }
 
-extension on String {
+extension ContextFromString on String {
   Context toContext() {
     switch (this) {
       case 'COST_AND_USAGE':
@@ -3031,7 +3031,7 @@ enum CostCategoryRuleVersion {
   costCategoryExpressionV1,
 }
 
-extension on CostCategoryRuleVersion {
+extension CostCategoryRuleVersionValue on CostCategoryRuleVersion {
   String toValue() {
     switch (this) {
       case CostCategoryRuleVersion.costCategoryExpressionV1:
@@ -3040,7 +3040,7 @@ extension on CostCategoryRuleVersion {
   }
 }
 
-extension on String {
+extension CostCategoryRuleVersionFromString on String {
   CostCategoryRuleVersion toCostCategoryRuleVersion() {
     switch (this) {
       case 'CostCategoryExpression.v1':
@@ -3055,7 +3055,7 @@ enum CostCategoryStatus {
   applied,
 }
 
-extension on CostCategoryStatus {
+extension CostCategoryStatusValue on CostCategoryStatus {
   String toValue() {
     switch (this) {
       case CostCategoryStatus.processing:
@@ -3066,7 +3066,7 @@ extension on CostCategoryStatus {
   }
 }
 
-extension on String {
+extension CostCategoryStatusFromString on String {
   CostCategoryStatus toCostCategoryStatus() {
     switch (this) {
       case 'PROCESSING':
@@ -3082,7 +3082,7 @@ enum CostCategoryStatusComponent {
   costExplorer,
 }
 
-extension on CostCategoryStatusComponent {
+extension CostCategoryStatusComponentValue on CostCategoryStatusComponent {
   String toValue() {
     switch (this) {
       case CostCategoryStatusComponent.costExplorer:
@@ -3091,7 +3091,7 @@ extension on CostCategoryStatusComponent {
   }
 }
 
-extension on String {
+extension CostCategoryStatusComponentFromString on String {
   CostCategoryStatusComponent toCostCategoryStatusComponent() {
     switch (this) {
       case 'COST_EXPLORER':
@@ -3550,7 +3550,7 @@ enum Dimension {
   paymentOption,
 }
 
-extension on Dimension {
+extension DimensionValue on Dimension {
   String toValue() {
     switch (this) {
       case Dimension.az:
@@ -3615,7 +3615,7 @@ extension on Dimension {
   }
 }
 
-extension on String {
+extension DimensionFromString on String {
   Dimension toDimension() {
     switch (this) {
       case 'AZ':
@@ -4861,7 +4861,7 @@ enum Granularity {
   hourly,
 }
 
-extension on Granularity {
+extension GranularityValue on Granularity {
   String toValue() {
     switch (this) {
       case Granularity.daily:
@@ -4874,7 +4874,7 @@ extension on Granularity {
   }
 }
 
-extension on String {
+extension GranularityFromString on String {
   Granularity toGranularity() {
     switch (this) {
       case 'DAILY':
@@ -4948,7 +4948,7 @@ enum GroupDefinitionType {
   costCategory,
 }
 
-extension on GroupDefinitionType {
+extension GroupDefinitionTypeValue on GroupDefinitionType {
   String toValue() {
     switch (this) {
       case GroupDefinitionType.dimension:
@@ -4961,7 +4961,7 @@ extension on GroupDefinitionType {
   }
 }
 
-extension on String {
+extension GroupDefinitionTypeFromString on String {
   GroupDefinitionType toGroupDefinitionType() {
     switch (this) {
       case 'DIMENSION':
@@ -5077,7 +5077,7 @@ enum LookbackPeriodInDays {
   sixtyDays,
 }
 
-extension on LookbackPeriodInDays {
+extension LookbackPeriodInDaysValue on LookbackPeriodInDays {
   String toValue() {
     switch (this) {
       case LookbackPeriodInDays.sevenDays:
@@ -5090,7 +5090,7 @@ extension on LookbackPeriodInDays {
   }
 }
 
-extension on String {
+extension LookbackPeriodInDaysFromString on String {
   LookbackPeriodInDays toLookbackPeriodInDays() {
     switch (this) {
       case 'SEVEN_DAYS':
@@ -5113,7 +5113,7 @@ enum MatchOption {
   caseInsensitive,
 }
 
-extension on MatchOption {
+extension MatchOptionValue on MatchOption {
   String toValue() {
     switch (this) {
       case MatchOption.equals:
@@ -5132,7 +5132,7 @@ extension on MatchOption {
   }
 }
 
-extension on String {
+extension MatchOptionFromString on String {
   MatchOption toMatchOption() {
     switch (this) {
       case 'EQUALS':
@@ -5162,7 +5162,7 @@ enum Metric {
   normalizedUsageAmount,
 }
 
-extension on Metric {
+extension MetricValue on Metric {
   String toValue() {
     switch (this) {
       case Metric.blendedCost:
@@ -5183,7 +5183,7 @@ extension on Metric {
   }
 }
 
-extension on String {
+extension MetricFromString on String {
   Metric toMetric() {
     switch (this) {
       case 'BLENDED_COST':
@@ -5247,7 +5247,7 @@ enum MonitorDimension {
   service,
 }
 
-extension on MonitorDimension {
+extension MonitorDimensionValue on MonitorDimension {
   String toValue() {
     switch (this) {
       case MonitorDimension.service:
@@ -5256,7 +5256,7 @@ extension on MonitorDimension {
   }
 }
 
-extension on String {
+extension MonitorDimensionFromString on String {
   MonitorDimension toMonitorDimension() {
     switch (this) {
       case 'SERVICE':
@@ -5271,7 +5271,7 @@ enum MonitorType {
   custom,
 }
 
-extension on MonitorType {
+extension MonitorTypeValue on MonitorType {
   String toValue() {
     switch (this) {
       case MonitorType.dimensional:
@@ -5282,7 +5282,7 @@ extension on MonitorType {
   }
 }
 
-extension on String {
+extension MonitorTypeFromString on String {
   MonitorType toMonitorType() {
     switch (this) {
       case 'DIMENSIONAL':
@@ -5303,7 +5303,7 @@ enum NumericOperator {
   between,
 }
 
-extension on NumericOperator {
+extension NumericOperatorValue on NumericOperator {
   String toValue() {
     switch (this) {
       case NumericOperator.equal:
@@ -5322,7 +5322,7 @@ extension on NumericOperator {
   }
 }
 
-extension on String {
+extension NumericOperatorFromString on String {
   NumericOperator toNumericOperator() {
     switch (this) {
       case 'EQUAL':
@@ -5347,7 +5347,7 @@ enum OfferingClass {
   convertible,
 }
 
-extension on OfferingClass {
+extension OfferingClassValue on OfferingClass {
   String toValue() {
     switch (this) {
       case OfferingClass.standard:
@@ -5358,7 +5358,7 @@ extension on OfferingClass {
   }
 }
 
-extension on String {
+extension OfferingClassFromString on String {
   OfferingClass toOfferingClass() {
     switch (this) {
       case 'STANDARD':
@@ -5379,7 +5379,7 @@ enum PaymentOption {
   heavyUtilization,
 }
 
-extension on PaymentOption {
+extension PaymentOptionValue on PaymentOption {
   String toValue() {
     switch (this) {
       case PaymentOption.noUpfront:
@@ -5398,7 +5398,7 @@ extension on PaymentOption {
   }
 }
 
-extension on String {
+extension PaymentOptionFromString on String {
   PaymentOption toPaymentOption() {
     switch (this) {
       case 'NO_UPFRONT':
@@ -5494,7 +5494,7 @@ enum RecommendationTarget {
   crossInstanceFamily,
 }
 
-extension on RecommendationTarget {
+extension RecommendationTargetValue on RecommendationTarget {
   String toValue() {
     switch (this) {
       case RecommendationTarget.sameInstanceFamily:
@@ -5505,7 +5505,7 @@ extension on RecommendationTarget {
   }
 }
 
-extension on String {
+extension RecommendationTargetFromString on String {
   RecommendationTarget toRecommendationTarget() {
     switch (this) {
       case 'SAME_INSTANCE_FAMILY':
@@ -6181,7 +6181,7 @@ enum RightsizingType {
   modify,
 }
 
-extension on RightsizingType {
+extension RightsizingTypeValue on RightsizingType {
   String toValue() {
     switch (this) {
       case RightsizingType.terminate:
@@ -6192,7 +6192,7 @@ extension on RightsizingType {
   }
 }
 
-extension on String {
+extension RightsizingTypeFromString on String {
   RightsizingType toRightsizingType() {
     switch (this) {
       case 'TERMINATE':
@@ -6901,7 +6901,7 @@ enum SubscriberStatus {
   declined,
 }
 
-extension on SubscriberStatus {
+extension SubscriberStatusValue on SubscriberStatus {
   String toValue() {
     switch (this) {
       case SubscriberStatus.confirmed:
@@ -6912,7 +6912,7 @@ extension on SubscriberStatus {
   }
 }
 
-extension on String {
+extension SubscriberStatusFromString on String {
   SubscriberStatus toSubscriberStatus() {
     switch (this) {
       case 'CONFIRMED':
@@ -6929,7 +6929,7 @@ enum SubscriberType {
   sns,
 }
 
-extension on SubscriberType {
+extension SubscriberTypeValue on SubscriberType {
   String toValue() {
     switch (this) {
       case SubscriberType.email:
@@ -6940,7 +6940,7 @@ extension on SubscriberType {
   }
 }
 
-extension on String {
+extension SubscriberTypeFromString on String {
   SubscriberType toSubscriberType() {
     switch (this) {
       case 'EMAIL':
@@ -6957,7 +6957,7 @@ enum SupportedSavingsPlansType {
   ec2InstanceSp,
 }
 
-extension on SupportedSavingsPlansType {
+extension SupportedSavingsPlansTypeValue on SupportedSavingsPlansType {
   String toValue() {
     switch (this) {
       case SupportedSavingsPlansType.computeSp:
@@ -6968,7 +6968,7 @@ extension on SupportedSavingsPlansType {
   }
 }
 
-extension on String {
+extension SupportedSavingsPlansTypeFromString on String {
   SupportedSavingsPlansType toSupportedSavingsPlansType() {
     switch (this) {
       case 'COMPUTE_SP':
@@ -7077,7 +7077,7 @@ enum TermInYears {
   threeYears,
 }
 
-extension on TermInYears {
+extension TermInYearsValue on TermInYears {
   String toValue() {
     switch (this) {
       case TermInYears.oneYear:
@@ -7088,7 +7088,7 @@ extension on TermInYears {
   }
 }
 
-extension on String {
+extension TermInYearsFromString on String {
   TermInYears toTermInYears() {
     switch (this) {
       case 'ONE_YEAR':

--- a/generated/aws_chime_api/lib/chime-2018-05-01.dart
+++ b/generated/aws_chime_api/lib/chime-2018-05-01.dart
@@ -7927,7 +7927,7 @@ enum AccountType {
   enterpriseOIDC,
 }
 
-extension on AccountType {
+extension AccountTypeValue on AccountType {
   String toValue() {
     switch (this) {
       case AccountType.team:
@@ -7942,7 +7942,7 @@ extension on AccountType {
   }
 }
 
-extension on String {
+extension AccountTypeFromString on String {
   AccountType toAccountType() {
     switch (this) {
       case 'Team':
@@ -8075,7 +8075,7 @@ enum AppInstanceDataType {
   channelMessage,
 }
 
-extension on AppInstanceDataType {
+extension AppInstanceDataTypeValue on AppInstanceDataType {
   String toValue() {
     switch (this) {
       case AppInstanceDataType.channel:
@@ -8086,7 +8086,7 @@ extension on AppInstanceDataType {
   }
 }
 
-extension on String {
+extension AppInstanceDataTypeFromString on String {
   AppInstanceDataType toAppInstanceDataType() {
     switch (this) {
       case 'Channel':
@@ -8554,7 +8554,7 @@ enum BotType {
   chatBot,
 }
 
-extension on BotType {
+extension BotTypeValue on BotType {
   String toValue() {
     switch (this) {
       case BotType.chatBot:
@@ -8563,7 +8563,7 @@ extension on BotType {
   }
 }
 
-extension on String {
+extension BotTypeFromString on String {
   BotType toBotType() {
     switch (this) {
       case 'ChatBot':
@@ -8604,7 +8604,7 @@ enum CallingNameStatus {
   updateFailed,
 }
 
-extension on CallingNameStatus {
+extension CallingNameStatusValue on CallingNameStatus {
   String toValue() {
     switch (this) {
       case CallingNameStatus.unassigned:
@@ -8619,7 +8619,7 @@ extension on CallingNameStatus {
   }
 }
 
-extension on String {
+extension CallingNameStatusFromString on String {
   CallingNameStatus toCallingNameStatus() {
     switch (this) {
       case 'Unassigned':
@@ -8640,7 +8640,7 @@ enum Capability {
   sms,
 }
 
-extension on Capability {
+extension CapabilityValue on Capability {
   String toValue() {
     switch (this) {
       case Capability.voice:
@@ -8651,7 +8651,7 @@ extension on Capability {
   }
 }
 
-extension on String {
+extension CapabilityFromString on String {
   Capability toCapability() {
     switch (this) {
       case 'Voice':
@@ -8865,7 +8865,7 @@ enum ChannelMembershipType {
   hidden,
 }
 
-extension on ChannelMembershipType {
+extension ChannelMembershipTypeValue on ChannelMembershipType {
   String toValue() {
     switch (this) {
       case ChannelMembershipType.$default:
@@ -8876,7 +8876,7 @@ extension on ChannelMembershipType {
   }
 }
 
-extension on String {
+extension ChannelMembershipTypeFromString on String {
   ChannelMembershipType toChannelMembershipType() {
     switch (this) {
       case 'DEFAULT':
@@ -8960,7 +8960,7 @@ enum ChannelMessagePersistenceType {
   nonPersistent,
 }
 
-extension on ChannelMessagePersistenceType {
+extension ChannelMessagePersistenceTypeValue on ChannelMessagePersistenceType {
   String toValue() {
     switch (this) {
       case ChannelMessagePersistenceType.persistent:
@@ -8971,7 +8971,7 @@ extension on ChannelMessagePersistenceType {
   }
 }
 
-extension on String {
+extension ChannelMessagePersistenceTypeFromString on String {
   ChannelMessagePersistenceType toChannelMessagePersistenceType() {
     switch (this) {
       case 'PERSISTENT':
@@ -9041,7 +9041,7 @@ enum ChannelMessageType {
   control,
 }
 
-extension on ChannelMessageType {
+extension ChannelMessageTypeValue on ChannelMessageType {
   String toValue() {
     switch (this) {
       case ChannelMessageType.standard:
@@ -9052,7 +9052,7 @@ extension on ChannelMessageType {
   }
 }
 
-extension on String {
+extension ChannelMessageTypeFromString on String {
   ChannelMessageType toChannelMessageType() {
     switch (this) {
       case 'STANDARD':
@@ -9069,7 +9069,7 @@ enum ChannelMode {
   restricted,
 }
 
-extension on ChannelMode {
+extension ChannelModeValue on ChannelMode {
   String toValue() {
     switch (this) {
       case ChannelMode.unrestricted:
@@ -9080,7 +9080,7 @@ extension on ChannelMode {
   }
 }
 
-extension on String {
+extension ChannelModeFromString on String {
   ChannelMode toChannelMode() {
     switch (this) {
       case 'UNRESTRICTED':
@@ -9166,7 +9166,7 @@ enum ChannelPrivacy {
   private,
 }
 
-extension on ChannelPrivacy {
+extension ChannelPrivacyValue on ChannelPrivacy {
   String toValue() {
     switch (this) {
       case ChannelPrivacy.public:
@@ -9177,7 +9177,7 @@ extension on ChannelPrivacy {
   }
 }
 
-extension on String {
+extension ChannelPrivacyFromString on String {
   ChannelPrivacy toChannelPrivacy() {
     switch (this) {
       case 'PUBLIC':
@@ -10030,7 +10030,7 @@ enum EmailStatus {
   failed,
 }
 
-extension on EmailStatus {
+extension EmailStatusValue on EmailStatus {
   String toValue() {
     switch (this) {
       case EmailStatus.notSent:
@@ -10043,7 +10043,7 @@ extension on EmailStatus {
   }
 }
 
-extension on String {
+extension EmailStatusFromString on String {
   EmailStatus toEmailStatus() {
     switch (this) {
       case 'NotSent':
@@ -10103,7 +10103,7 @@ enum ErrorCode {
   phoneNumberAssociationsExist,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.badRequest:
@@ -10140,7 +10140,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'BadRequest':
@@ -10210,7 +10210,7 @@ enum GeoMatchLevel {
   areaCode,
 }
 
-extension on GeoMatchLevel {
+extension GeoMatchLevelValue on GeoMatchLevel {
   String toValue() {
     switch (this) {
       case GeoMatchLevel.country:
@@ -10221,7 +10221,7 @@ extension on GeoMatchLevel {
   }
 }
 
-extension on String {
+extension GeoMatchLevelFromString on String {
   GeoMatchLevel toGeoMatchLevel() {
     switch (this) {
       case 'Country':
@@ -10874,7 +10874,7 @@ enum InviteStatus {
   failed,
 }
 
-extension on InviteStatus {
+extension InviteStatusValue on InviteStatus {
   String toValue() {
     switch (this) {
       case InviteStatus.pending:
@@ -10887,7 +10887,7 @@ extension on InviteStatus {
   }
 }
 
-extension on String {
+extension InviteStatusFromString on String {
   InviteStatus toInviteStatus() {
     switch (this) {
       case 'Pending':
@@ -10925,7 +10925,7 @@ enum License {
   proTrial,
 }
 
-extension on License {
+extension LicenseValue on License {
   String toValue() {
     switch (this) {
       case License.basic:
@@ -10940,7 +10940,7 @@ extension on License {
   }
 }
 
-extension on String {
+extension LicenseFromString on String {
   License toLicense() {
     switch (this) {
       case 'Basic':
@@ -11811,7 +11811,7 @@ enum MemberType {
   webhook,
 }
 
-extension on MemberType {
+extension MemberTypeValue on MemberType {
   String toValue() {
     switch (this) {
       case MemberType.user:
@@ -11824,7 +11824,7 @@ extension on MemberType {
   }
 }
 
-extension on String {
+extension MemberTypeFromString on String {
   MemberType toMemberType() {
     switch (this) {
       case 'User':
@@ -11881,7 +11881,7 @@ enum NotificationTarget {
   sqs,
 }
 
-extension on NotificationTarget {
+extension NotificationTargetValue on NotificationTarget {
   String toValue() {
     switch (this) {
       case NotificationTarget.eventBridge:
@@ -11894,7 +11894,7 @@ extension on NotificationTarget {
   }
 }
 
-extension on String {
+extension NotificationTargetFromString on String {
   NotificationTarget toNotificationTarget() {
     switch (this) {
       case 'EventBridge':
@@ -11913,7 +11913,7 @@ enum NumberSelectionBehavior {
   avoidSticky,
 }
 
-extension on NumberSelectionBehavior {
+extension NumberSelectionBehaviorValue on NumberSelectionBehavior {
   String toValue() {
     switch (this) {
       case NumberSelectionBehavior.preferSticky:
@@ -11924,7 +11924,7 @@ extension on NumberSelectionBehavior {
   }
 }
 
-extension on String {
+extension NumberSelectionBehaviorFromString on String {
   NumberSelectionBehavior toNumberSelectionBehavior() {
     switch (this) {
       case 'PreferSticky':
@@ -11962,7 +11962,7 @@ enum OrderedPhoneNumberStatus {
   failed,
 }
 
-extension on OrderedPhoneNumberStatus {
+extension OrderedPhoneNumberStatusValue on OrderedPhoneNumberStatus {
   String toValue() {
     switch (this) {
       case OrderedPhoneNumberStatus.processing:
@@ -11975,7 +11975,7 @@ extension on OrderedPhoneNumberStatus {
   }
 }
 
-extension on String {
+extension OrderedPhoneNumberStatusFromString on String {
   OrderedPhoneNumberStatus toOrderedPhoneNumberStatus() {
     switch (this) {
       case 'Processing':
@@ -12084,7 +12084,7 @@ enum OriginationRouteProtocol {
   udp,
 }
 
-extension on OriginationRouteProtocol {
+extension OriginationRouteProtocolValue on OriginationRouteProtocol {
   String toValue() {
     switch (this) {
       case OriginationRouteProtocol.tcp:
@@ -12095,7 +12095,7 @@ extension on OriginationRouteProtocol {
   }
 }
 
-extension on String {
+extension OriginationRouteProtocolFromString on String {
   OriginationRouteProtocol toOriginationRouteProtocol() {
     switch (this) {
       case 'TCP':
@@ -12243,7 +12243,7 @@ enum PhoneNumberAssociationName {
   sipRuleId,
 }
 
-extension on PhoneNumberAssociationName {
+extension PhoneNumberAssociationNameValue on PhoneNumberAssociationName {
   String toValue() {
     switch (this) {
       case PhoneNumberAssociationName.accountId:
@@ -12260,7 +12260,7 @@ extension on PhoneNumberAssociationName {
   }
 }
 
-extension on String {
+extension PhoneNumberAssociationNameFromString on String {
   PhoneNumberAssociationName toPhoneNumberAssociationName() {
     switch (this) {
       case 'AccountId':
@@ -12397,7 +12397,7 @@ enum PhoneNumberOrderStatus {
   partial,
 }
 
-extension on PhoneNumberOrderStatus {
+extension PhoneNumberOrderStatusValue on PhoneNumberOrderStatus {
   String toValue() {
     switch (this) {
       case PhoneNumberOrderStatus.processing:
@@ -12412,7 +12412,7 @@ extension on PhoneNumberOrderStatus {
   }
 }
 
-extension on String {
+extension PhoneNumberOrderStatusFromString on String {
   PhoneNumberOrderStatus toPhoneNumberOrderStatus() {
     switch (this) {
       case 'Processing':
@@ -12433,7 +12433,7 @@ enum PhoneNumberProductType {
   voiceConnector,
 }
 
-extension on PhoneNumberProductType {
+extension PhoneNumberProductTypeValue on PhoneNumberProductType {
   String toValue() {
     switch (this) {
       case PhoneNumberProductType.businessCalling:
@@ -12444,7 +12444,7 @@ extension on PhoneNumberProductType {
   }
 }
 
-extension on String {
+extension PhoneNumberProductTypeFromString on String {
   PhoneNumberProductType toPhoneNumberProductType() {
     switch (this) {
       case 'BusinessCalling':
@@ -12467,7 +12467,7 @@ enum PhoneNumberStatus {
   deleteFailed,
 }
 
-extension on PhoneNumberStatus {
+extension PhoneNumberStatusValue on PhoneNumberStatus {
   String toValue() {
     switch (this) {
       case PhoneNumberStatus.acquireInProgress:
@@ -12490,7 +12490,7 @@ extension on PhoneNumberStatus {
   }
 }
 
-extension on String {
+extension PhoneNumberStatusFromString on String {
   PhoneNumberStatus toPhoneNumberStatus() {
     switch (this) {
       case 'AcquireInProgress':
@@ -12519,7 +12519,7 @@ enum PhoneNumberType {
   tollFree,
 }
 
-extension on PhoneNumberType {
+extension PhoneNumberTypeValue on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.local:
@@ -12530,7 +12530,7 @@ extension on PhoneNumberType {
   }
 }
 
-extension on String {
+extension PhoneNumberTypeFromString on String {
   PhoneNumberType toPhoneNumberType() {
     switch (this) {
       case 'Local':
@@ -12669,7 +12669,7 @@ enum ProxySessionStatus {
   closed,
 }
 
-extension on ProxySessionStatus {
+extension ProxySessionStatusValue on ProxySessionStatus {
   String toValue() {
     switch (this) {
       case ProxySessionStatus.open:
@@ -12682,7 +12682,7 @@ extension on ProxySessionStatus {
   }
 }
 
-extension on String {
+extension ProxySessionStatusFromString on String {
   ProxySessionStatus toProxySessionStatus() {
     switch (this) {
       case 'Open':
@@ -12961,7 +12961,7 @@ enum RegistrationStatus {
   suspended,
 }
 
-extension on RegistrationStatus {
+extension RegistrationStatusValue on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.unregistered:
@@ -12974,7 +12974,7 @@ extension on RegistrationStatus {
   }
 }
 
-extension on String {
+extension RegistrationStatusFromString on String {
   RegistrationStatus toRegistrationStatus() {
     switch (this) {
       case 'Unregistered':
@@ -13140,7 +13140,7 @@ enum RoomMembershipRole {
   member,
 }
 
-extension on RoomMembershipRole {
+extension RoomMembershipRoleValue on RoomMembershipRole {
   String toValue() {
     switch (this) {
       case RoomMembershipRole.administrator:
@@ -13151,7 +13151,7 @@ extension on RoomMembershipRole {
   }
 }
 
-extension on String {
+extension RoomMembershipRoleFromString on String {
   RoomMembershipRole toRoomMembershipRole() {
     switch (this) {
       case 'Administrator':
@@ -13464,7 +13464,7 @@ enum SipRuleTriggerType {
   requestUriHostname,
 }
 
-extension on SipRuleTriggerType {
+extension SipRuleTriggerTypeValue on SipRuleTriggerType {
   String toValue() {
     switch (this) {
       case SipRuleTriggerType.toPhoneNumber:
@@ -13475,7 +13475,7 @@ extension on SipRuleTriggerType {
   }
 }
 
-extension on String {
+extension SipRuleTriggerTypeFromString on String {
   SipRuleTriggerType toSipRuleTriggerType() {
     switch (this) {
       case 'ToPhoneNumber':
@@ -13492,7 +13492,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -13503,7 +13503,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -14195,7 +14195,7 @@ enum UserType {
   sharedDevice,
 }
 
-extension on UserType {
+extension UserTypeValue on UserType {
   String toValue() {
     switch (this) {
       case UserType.privateUser:
@@ -14206,7 +14206,7 @@ extension on UserType {
   }
 }
 
-extension on String {
+extension UserTypeFromString on String {
   UserType toUserType() {
     switch (this) {
       case 'PrivateUser':
@@ -14271,7 +14271,7 @@ enum VoiceConnectorAwsRegion {
   usWest_2,
 }
 
-extension on VoiceConnectorAwsRegion {
+extension VoiceConnectorAwsRegionValue on VoiceConnectorAwsRegion {
   String toValue() {
     switch (this) {
       case VoiceConnectorAwsRegion.usEast_1:
@@ -14282,7 +14282,7 @@ extension on VoiceConnectorAwsRegion {
   }
 }
 
-extension on String {
+extension VoiceConnectorAwsRegionFromString on String {
   VoiceConnectorAwsRegion toVoiceConnectorAwsRegion() {
     switch (this) {
       case 'us-east-1':

--- a/generated/aws_chime_api/lib/chime-2018-05-01.dart
+++ b/generated/aws_chime_api/lib/chime-2018-05-01.dart
@@ -7927,7 +7927,7 @@ enum AccountType {
   enterpriseOIDC,
 }
 
-extension AccountTypeValue on AccountType {
+extension AccountTypeValueExtension on AccountType {
   String toValue() {
     switch (this) {
       case AccountType.team:
@@ -8075,7 +8075,7 @@ enum AppInstanceDataType {
   channelMessage,
 }
 
-extension AppInstanceDataTypeValue on AppInstanceDataType {
+extension AppInstanceDataTypeValueExtension on AppInstanceDataType {
   String toValue() {
     switch (this) {
       case AppInstanceDataType.channel:
@@ -8554,7 +8554,7 @@ enum BotType {
   chatBot,
 }
 
-extension BotTypeValue on BotType {
+extension BotTypeValueExtension on BotType {
   String toValue() {
     switch (this) {
       case BotType.chatBot:
@@ -8604,7 +8604,7 @@ enum CallingNameStatus {
   updateFailed,
 }
 
-extension CallingNameStatusValue on CallingNameStatus {
+extension CallingNameStatusValueExtension on CallingNameStatus {
   String toValue() {
     switch (this) {
       case CallingNameStatus.unassigned:
@@ -8640,7 +8640,7 @@ enum Capability {
   sms,
 }
 
-extension CapabilityValue on Capability {
+extension CapabilityValueExtension on Capability {
   String toValue() {
     switch (this) {
       case Capability.voice:
@@ -8865,7 +8865,7 @@ enum ChannelMembershipType {
   hidden,
 }
 
-extension ChannelMembershipTypeValue on ChannelMembershipType {
+extension ChannelMembershipTypeValueExtension on ChannelMembershipType {
   String toValue() {
     switch (this) {
       case ChannelMembershipType.$default:
@@ -8960,7 +8960,8 @@ enum ChannelMessagePersistenceType {
   nonPersistent,
 }
 
-extension ChannelMessagePersistenceTypeValue on ChannelMessagePersistenceType {
+extension ChannelMessagePersistenceTypeValueExtension
+    on ChannelMessagePersistenceType {
   String toValue() {
     switch (this) {
       case ChannelMessagePersistenceType.persistent:
@@ -9041,7 +9042,7 @@ enum ChannelMessageType {
   control,
 }
 
-extension ChannelMessageTypeValue on ChannelMessageType {
+extension ChannelMessageTypeValueExtension on ChannelMessageType {
   String toValue() {
     switch (this) {
       case ChannelMessageType.standard:
@@ -9069,7 +9070,7 @@ enum ChannelMode {
   restricted,
 }
 
-extension ChannelModeValue on ChannelMode {
+extension ChannelModeValueExtension on ChannelMode {
   String toValue() {
     switch (this) {
       case ChannelMode.unrestricted:
@@ -9166,7 +9167,7 @@ enum ChannelPrivacy {
   private,
 }
 
-extension ChannelPrivacyValue on ChannelPrivacy {
+extension ChannelPrivacyValueExtension on ChannelPrivacy {
   String toValue() {
     switch (this) {
       case ChannelPrivacy.public:
@@ -10030,7 +10031,7 @@ enum EmailStatus {
   failed,
 }
 
-extension EmailStatusValue on EmailStatus {
+extension EmailStatusValueExtension on EmailStatus {
   String toValue() {
     switch (this) {
       case EmailStatus.notSent:
@@ -10103,7 +10104,7 @@ enum ErrorCode {
   phoneNumberAssociationsExist,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.badRequest:
@@ -10210,7 +10211,7 @@ enum GeoMatchLevel {
   areaCode,
 }
 
-extension GeoMatchLevelValue on GeoMatchLevel {
+extension GeoMatchLevelValueExtension on GeoMatchLevel {
   String toValue() {
     switch (this) {
       case GeoMatchLevel.country:
@@ -10874,7 +10875,7 @@ enum InviteStatus {
   failed,
 }
 
-extension InviteStatusValue on InviteStatus {
+extension InviteStatusValueExtension on InviteStatus {
   String toValue() {
     switch (this) {
       case InviteStatus.pending:
@@ -10925,7 +10926,7 @@ enum License {
   proTrial,
 }
 
-extension LicenseValue on License {
+extension LicenseValueExtension on License {
   String toValue() {
     switch (this) {
       case License.basic:
@@ -11811,7 +11812,7 @@ enum MemberType {
   webhook,
 }
 
-extension MemberTypeValue on MemberType {
+extension MemberTypeValueExtension on MemberType {
   String toValue() {
     switch (this) {
       case MemberType.user:
@@ -11881,7 +11882,7 @@ enum NotificationTarget {
   sqs,
 }
 
-extension NotificationTargetValue on NotificationTarget {
+extension NotificationTargetValueExtension on NotificationTarget {
   String toValue() {
     switch (this) {
       case NotificationTarget.eventBridge:
@@ -11913,7 +11914,7 @@ enum NumberSelectionBehavior {
   avoidSticky,
 }
 
-extension NumberSelectionBehaviorValue on NumberSelectionBehavior {
+extension NumberSelectionBehaviorValueExtension on NumberSelectionBehavior {
   String toValue() {
     switch (this) {
       case NumberSelectionBehavior.preferSticky:
@@ -11962,7 +11963,7 @@ enum OrderedPhoneNumberStatus {
   failed,
 }
 
-extension OrderedPhoneNumberStatusValue on OrderedPhoneNumberStatus {
+extension OrderedPhoneNumberStatusValueExtension on OrderedPhoneNumberStatus {
   String toValue() {
     switch (this) {
       case OrderedPhoneNumberStatus.processing:
@@ -12084,7 +12085,7 @@ enum OriginationRouteProtocol {
   udp,
 }
 
-extension OriginationRouteProtocolValue on OriginationRouteProtocol {
+extension OriginationRouteProtocolValueExtension on OriginationRouteProtocol {
   String toValue() {
     switch (this) {
       case OriginationRouteProtocol.tcp:
@@ -12243,7 +12244,8 @@ enum PhoneNumberAssociationName {
   sipRuleId,
 }
 
-extension PhoneNumberAssociationNameValue on PhoneNumberAssociationName {
+extension PhoneNumberAssociationNameValueExtension
+    on PhoneNumberAssociationName {
   String toValue() {
     switch (this) {
       case PhoneNumberAssociationName.accountId:
@@ -12397,7 +12399,7 @@ enum PhoneNumberOrderStatus {
   partial,
 }
 
-extension PhoneNumberOrderStatusValue on PhoneNumberOrderStatus {
+extension PhoneNumberOrderStatusValueExtension on PhoneNumberOrderStatus {
   String toValue() {
     switch (this) {
       case PhoneNumberOrderStatus.processing:
@@ -12433,7 +12435,7 @@ enum PhoneNumberProductType {
   voiceConnector,
 }
 
-extension PhoneNumberProductTypeValue on PhoneNumberProductType {
+extension PhoneNumberProductTypeValueExtension on PhoneNumberProductType {
   String toValue() {
     switch (this) {
       case PhoneNumberProductType.businessCalling:
@@ -12467,7 +12469,7 @@ enum PhoneNumberStatus {
   deleteFailed,
 }
 
-extension PhoneNumberStatusValue on PhoneNumberStatus {
+extension PhoneNumberStatusValueExtension on PhoneNumberStatus {
   String toValue() {
     switch (this) {
       case PhoneNumberStatus.acquireInProgress:
@@ -12519,7 +12521,7 @@ enum PhoneNumberType {
   tollFree,
 }
 
-extension PhoneNumberTypeValue on PhoneNumberType {
+extension PhoneNumberTypeValueExtension on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.local:
@@ -12669,7 +12671,7 @@ enum ProxySessionStatus {
   closed,
 }
 
-extension ProxySessionStatusValue on ProxySessionStatus {
+extension ProxySessionStatusValueExtension on ProxySessionStatus {
   String toValue() {
     switch (this) {
       case ProxySessionStatus.open:
@@ -12961,7 +12963,7 @@ enum RegistrationStatus {
   suspended,
 }
 
-extension RegistrationStatusValue on RegistrationStatus {
+extension RegistrationStatusValueExtension on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.unregistered:
@@ -13140,7 +13142,7 @@ enum RoomMembershipRole {
   member,
 }
 
-extension RoomMembershipRoleValue on RoomMembershipRole {
+extension RoomMembershipRoleValueExtension on RoomMembershipRole {
   String toValue() {
     switch (this) {
       case RoomMembershipRole.administrator:
@@ -13464,7 +13466,7 @@ enum SipRuleTriggerType {
   requestUriHostname,
 }
 
-extension SipRuleTriggerTypeValue on SipRuleTriggerType {
+extension SipRuleTriggerTypeValueExtension on SipRuleTriggerType {
   String toValue() {
     switch (this) {
       case SipRuleTriggerType.toPhoneNumber:
@@ -13492,7 +13494,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -14195,7 +14197,7 @@ enum UserType {
   sharedDevice,
 }
 
-extension UserTypeValue on UserType {
+extension UserTypeValueExtension on UserType {
   String toValue() {
     switch (this) {
       case UserType.privateUser:
@@ -14271,7 +14273,7 @@ enum VoiceConnectorAwsRegion {
   usWest_2,
 }
 
-extension VoiceConnectorAwsRegionValue on VoiceConnectorAwsRegion {
+extension VoiceConnectorAwsRegionValueExtension on VoiceConnectorAwsRegion {
   String toValue() {
     switch (this) {
       case VoiceConnectorAwsRegion.usEast_1:

--- a/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
+++ b/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
@@ -734,7 +734,7 @@ enum ConnectionType {
   connectSsm,
 }
 
-extension ConnectionTypeValue on ConnectionType {
+extension ConnectionTypeValueExtension on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.connectSsh:
@@ -1005,7 +1005,8 @@ enum EnvironmentLifecycleStatus {
   deleteFailed,
 }
 
-extension EnvironmentLifecycleStatusValue on EnvironmentLifecycleStatus {
+extension EnvironmentLifecycleStatusValueExtension
+    on EnvironmentLifecycleStatus {
   String toValue() {
     switch (this) {
       case EnvironmentLifecycleStatus.creating:
@@ -1101,7 +1102,7 @@ enum EnvironmentStatus {
   deleting,
 }
 
-extension EnvironmentStatusValue on EnvironmentStatus {
+extension EnvironmentStatusValueExtension on EnvironmentStatus {
   String toValue() {
     switch (this) {
       case EnvironmentStatus.error:
@@ -1149,7 +1150,7 @@ enum EnvironmentType {
   ec2,
 }
 
-extension EnvironmentTypeValue on EnvironmentType {
+extension EnvironmentTypeValueExtension on EnvironmentType {
   String toValue() {
     switch (this) {
       case EnvironmentType.ssh:
@@ -1219,7 +1220,7 @@ enum MemberPermissions {
   readOnly,
 }
 
-extension MemberPermissionsValue on MemberPermissions {
+extension MemberPermissionsValueExtension on MemberPermissions {
   String toValue() {
     switch (this) {
       case MemberPermissions.readWrite:
@@ -1248,7 +1249,7 @@ enum Permissions {
   readOnly,
 }
 
-extension PermissionsValue on Permissions {
+extension PermissionsValueExtension on Permissions {
   String toValue() {
     switch (this) {
       case Permissions.owner:

--- a/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
+++ b/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
@@ -734,7 +734,7 @@ enum ConnectionType {
   connectSsm,
 }
 
-extension on ConnectionType {
+extension ConnectionTypeValue on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.connectSsh:
@@ -745,7 +745,7 @@ extension on ConnectionType {
   }
 }
 
-extension on String {
+extension ConnectionTypeFromString on String {
   ConnectionType toConnectionType() {
     switch (this) {
       case 'CONNECT_SSH':
@@ -1005,7 +1005,7 @@ enum EnvironmentLifecycleStatus {
   deleteFailed,
 }
 
-extension on EnvironmentLifecycleStatus {
+extension EnvironmentLifecycleStatusValue on EnvironmentLifecycleStatus {
   String toValue() {
     switch (this) {
       case EnvironmentLifecycleStatus.creating:
@@ -1022,7 +1022,7 @@ extension on EnvironmentLifecycleStatus {
   }
 }
 
-extension on String {
+extension EnvironmentLifecycleStatusFromString on String {
   EnvironmentLifecycleStatus toEnvironmentLifecycleStatus() {
     switch (this) {
       case 'CREATING':
@@ -1101,7 +1101,7 @@ enum EnvironmentStatus {
   deleting,
 }
 
-extension on EnvironmentStatus {
+extension EnvironmentStatusValue on EnvironmentStatus {
   String toValue() {
     switch (this) {
       case EnvironmentStatus.error:
@@ -1122,7 +1122,7 @@ extension on EnvironmentStatus {
   }
 }
 
-extension on String {
+extension EnvironmentStatusFromString on String {
   EnvironmentStatus toEnvironmentStatus() {
     switch (this) {
       case 'error':
@@ -1149,7 +1149,7 @@ enum EnvironmentType {
   ec2,
 }
 
-extension on EnvironmentType {
+extension EnvironmentTypeValue on EnvironmentType {
   String toValue() {
     switch (this) {
       case EnvironmentType.ssh:
@@ -1160,7 +1160,7 @@ extension on EnvironmentType {
   }
 }
 
-extension on String {
+extension EnvironmentTypeFromString on String {
   EnvironmentType toEnvironmentType() {
     switch (this) {
       case 'ssh':
@@ -1219,7 +1219,7 @@ enum MemberPermissions {
   readOnly,
 }
 
-extension on MemberPermissions {
+extension MemberPermissionsValue on MemberPermissions {
   String toValue() {
     switch (this) {
       case MemberPermissions.readWrite:
@@ -1230,7 +1230,7 @@ extension on MemberPermissions {
   }
 }
 
-extension on String {
+extension MemberPermissionsFromString on String {
   MemberPermissions toMemberPermissions() {
     switch (this) {
       case 'read-write':
@@ -1248,7 +1248,7 @@ enum Permissions {
   readOnly,
 }
 
-extension on Permissions {
+extension PermissionsValue on Permissions {
   String toValue() {
     switch (this) {
       case Permissions.owner:
@@ -1261,7 +1261,7 @@ extension on Permissions {
   }
 }
 
-extension on String {
+extension PermissionsFromString on String {
   Permissions toPermissions() {
     switch (this) {
       case 'owner':

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
@@ -4920,7 +4920,7 @@ enum BatchReadExceptionType {
   internalServiceException,
 }
 
-extension on BatchReadExceptionType {
+extension BatchReadExceptionTypeValue on BatchReadExceptionType {
   String toValue() {
     switch (this) {
       case BatchReadExceptionType.validationException:
@@ -4953,7 +4953,7 @@ extension on BatchReadExceptionType {
   }
 }
 
-extension on String {
+extension BatchReadExceptionTypeFromString on String {
   BatchReadExceptionType toBatchReadExceptionType() {
     switch (this) {
       case 'ValidationException':
@@ -5426,7 +5426,7 @@ enum BatchWriteExceptionType {
   unsupportedIndexTypeException,
 }
 
-extension on BatchWriteExceptionType {
+extension BatchWriteExceptionTypeValue on BatchWriteExceptionType {
   String toValue() {
     switch (this) {
       case BatchWriteExceptionType.internalServiceException:
@@ -5469,7 +5469,7 @@ extension on BatchWriteExceptionType {
   }
 }
 
-extension on String {
+extension BatchWriteExceptionTypeFromString on String {
   BatchWriteExceptionType toBatchWriteExceptionType() {
     switch (this) {
       case 'InternalServiceException':
@@ -5801,7 +5801,7 @@ enum ConsistencyLevel {
   eventual,
 }
 
-extension on ConsistencyLevel {
+extension ConsistencyLevelValue on ConsistencyLevel {
   String toValue() {
     switch (this) {
       case ConsistencyLevel.serializable:
@@ -5812,7 +5812,7 @@ extension on ConsistencyLevel {
   }
 }
 
-extension on String {
+extension ConsistencyLevelFromString on String {
   ConsistencyLevel toConsistencyLevel() {
     switch (this) {
       case 'SERIALIZABLE':
@@ -6095,7 +6095,7 @@ enum DirectoryState {
   deleted,
 }
 
-extension on DirectoryState {
+extension DirectoryStateValue on DirectoryState {
   String toValue() {
     switch (this) {
       case DirectoryState.enabled:
@@ -6108,7 +6108,7 @@ extension on DirectoryState {
   }
 }
 
-extension on String {
+extension DirectoryStateFromString on String {
   DirectoryState toDirectoryState() {
     switch (this) {
       case 'ENABLED':
@@ -6338,7 +6338,7 @@ enum FacetAttributeType {
   datetime,
 }
 
-extension on FacetAttributeType {
+extension FacetAttributeTypeValue on FacetAttributeType {
   String toValue() {
     switch (this) {
       case FacetAttributeType.string:
@@ -6355,7 +6355,7 @@ extension on FacetAttributeType {
   }
 }
 
-extension on String {
+extension FacetAttributeTypeFromString on String {
   FacetAttributeType toFacetAttributeType() {
     switch (this) {
       case 'STRING':
@@ -7488,7 +7488,7 @@ enum ObjectType {
   $index,
 }
 
-extension on ObjectType {
+extension ObjectTypeValue on ObjectType {
   String toValue() {
     switch (this) {
       case ObjectType.node:
@@ -7503,7 +7503,7 @@ extension on ObjectType {
   }
 }
 
-extension on String {
+extension ObjectTypeFromString on String {
   ObjectType toObjectType() {
     switch (this) {
       case 'NODE':
@@ -7636,7 +7636,7 @@ enum RangeMode {
   exclusive,
 }
 
-extension on RangeMode {
+extension RangeModeValue on RangeMode {
   String toValue() {
     switch (this) {
       case RangeMode.first:
@@ -7653,7 +7653,7 @@ extension on RangeMode {
   }
 }
 
-extension on String {
+extension RangeModeFromString on String {
   RangeMode toRangeMode() {
     switch (this) {
       case 'FIRST':
@@ -7683,7 +7683,7 @@ enum RequiredAttributeBehavior {
   notRequired,
 }
 
-extension on RequiredAttributeBehavior {
+extension RequiredAttributeBehaviorValue on RequiredAttributeBehavior {
   String toValue() {
     switch (this) {
       case RequiredAttributeBehavior.requiredAlways:
@@ -7694,7 +7694,7 @@ extension on RequiredAttributeBehavior {
   }
 }
 
-extension on String {
+extension RequiredAttributeBehaviorFromString on String {
   RequiredAttributeBehavior toRequiredAttributeBehavior() {
     switch (this) {
       case 'REQUIRED_ALWAYS':
@@ -7777,7 +7777,7 @@ enum RuleType {
   stringLength,
 }
 
-extension on RuleType {
+extension RuleTypeValue on RuleType {
   String toValue() {
     switch (this) {
       case RuleType.binaryLength:
@@ -7792,7 +7792,7 @@ extension on RuleType {
   }
 }
 
-extension on String {
+extension RuleTypeFromString on String {
   RuleType toRuleType() {
     switch (this) {
       case 'BINARY_LENGTH':
@@ -8263,7 +8263,7 @@ enum UpdateActionType {
   delete,
 }
 
-extension on UpdateActionType {
+extension UpdateActionTypeValue on UpdateActionType {
   String toValue() {
     switch (this) {
       case UpdateActionType.createOrUpdate:
@@ -8274,7 +8274,7 @@ extension on UpdateActionType {
   }
 }
 
-extension on String {
+extension UpdateActionTypeFromString on String {
   UpdateActionType toUpdateActionType() {
     switch (this) {
       case 'CREATE_OR_UPDATE':

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
@@ -4920,7 +4920,7 @@ enum BatchReadExceptionType {
   internalServiceException,
 }
 
-extension BatchReadExceptionTypeValue on BatchReadExceptionType {
+extension BatchReadExceptionTypeValueExtension on BatchReadExceptionType {
   String toValue() {
     switch (this) {
       case BatchReadExceptionType.validationException:
@@ -5426,7 +5426,7 @@ enum BatchWriteExceptionType {
   unsupportedIndexTypeException,
 }
 
-extension BatchWriteExceptionTypeValue on BatchWriteExceptionType {
+extension BatchWriteExceptionTypeValueExtension on BatchWriteExceptionType {
   String toValue() {
     switch (this) {
       case BatchWriteExceptionType.internalServiceException:
@@ -5801,7 +5801,7 @@ enum ConsistencyLevel {
   eventual,
 }
 
-extension ConsistencyLevelValue on ConsistencyLevel {
+extension ConsistencyLevelValueExtension on ConsistencyLevel {
   String toValue() {
     switch (this) {
       case ConsistencyLevel.serializable:
@@ -6095,7 +6095,7 @@ enum DirectoryState {
   deleted,
 }
 
-extension DirectoryStateValue on DirectoryState {
+extension DirectoryStateValueExtension on DirectoryState {
   String toValue() {
     switch (this) {
       case DirectoryState.enabled:
@@ -6338,7 +6338,7 @@ enum FacetAttributeType {
   datetime,
 }
 
-extension FacetAttributeTypeValue on FacetAttributeType {
+extension FacetAttributeTypeValueExtension on FacetAttributeType {
   String toValue() {
     switch (this) {
       case FacetAttributeType.string:
@@ -7488,7 +7488,7 @@ enum ObjectType {
   $index,
 }
 
-extension ObjectTypeValue on ObjectType {
+extension ObjectTypeValueExtension on ObjectType {
   String toValue() {
     switch (this) {
       case ObjectType.node:
@@ -7636,7 +7636,7 @@ enum RangeMode {
   exclusive,
 }
 
-extension RangeModeValue on RangeMode {
+extension RangeModeValueExtension on RangeMode {
   String toValue() {
     switch (this) {
       case RangeMode.first:
@@ -7683,7 +7683,7 @@ enum RequiredAttributeBehavior {
   notRequired,
 }
 
-extension RequiredAttributeBehaviorValue on RequiredAttributeBehavior {
+extension RequiredAttributeBehaviorValueExtension on RequiredAttributeBehavior {
   String toValue() {
     switch (this) {
       case RequiredAttributeBehavior.requiredAlways:
@@ -7777,7 +7777,7 @@ enum RuleType {
   stringLength,
 }
 
-extension RuleTypeValue on RuleType {
+extension RuleTypeValueExtension on RuleType {
   String toValue() {
     switch (this) {
       case RuleType.binaryLength:
@@ -8263,7 +8263,7 @@ enum UpdateActionType {
   delete,
 }
 
-extension UpdateActionTypeValue on UpdateActionType {
+extension UpdateActionTypeValueExtension on UpdateActionType {
   String toValue() {
     switch (this) {
       case UpdateActionType.createOrUpdate:

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
@@ -5020,7 +5020,7 @@ enum BatchReadExceptionType {
   internalServiceException,
 }
 
-extension BatchReadExceptionTypeValue on BatchReadExceptionType {
+extension BatchReadExceptionTypeValueExtension on BatchReadExceptionType {
   String toValue() {
     switch (this) {
       case BatchReadExceptionType.validationException:
@@ -5769,7 +5769,7 @@ enum ConsistencyLevel {
   eventual,
 }
 
-extension ConsistencyLevelValue on ConsistencyLevel {
+extension ConsistencyLevelValueExtension on ConsistencyLevel {
   String toValue() {
     switch (this) {
       case ConsistencyLevel.serializable:
@@ -6005,7 +6005,7 @@ enum DirectoryState {
   deleted,
 }
 
-extension DirectoryStateValue on DirectoryState {
+extension DirectoryStateValueExtension on DirectoryState {
   String toValue() {
     switch (this) {
       case DirectoryState.enabled:
@@ -6243,7 +6243,7 @@ enum FacetAttributeType {
   variant,
 }
 
-extension FacetAttributeTypeValue on FacetAttributeType {
+extension FacetAttributeTypeValueExtension on FacetAttributeType {
   String toValue() {
     switch (this) {
       case FacetAttributeType.string:
@@ -6309,7 +6309,7 @@ enum FacetStyle {
   dynamic,
 }
 
-extension FacetStyleValue on FacetStyle {
+extension FacetStyleValueExtension on FacetStyle {
   String toValue() {
     switch (this) {
       case FacetStyle.static:
@@ -7177,7 +7177,7 @@ enum ObjectType {
   $index,
 }
 
-extension ObjectTypeValue on ObjectType {
+extension ObjectTypeValueExtension on ObjectType {
   String toValue() {
     switch (this) {
       case ObjectType.node:
@@ -7325,7 +7325,7 @@ enum RangeMode {
   exclusive,
 }
 
-extension RangeModeValue on RangeMode {
+extension RangeModeValueExtension on RangeMode {
   String toValue() {
     switch (this) {
       case RangeMode.first:
@@ -7372,7 +7372,7 @@ enum RequiredAttributeBehavior {
   notRequired,
 }
 
-extension RequiredAttributeBehaviorValue on RequiredAttributeBehavior {
+extension RequiredAttributeBehaviorValueExtension on RequiredAttributeBehavior {
   String toValue() {
     switch (this) {
       case RequiredAttributeBehavior.requiredAlways:
@@ -7433,7 +7433,7 @@ enum RuleType {
   stringLength,
 }
 
-extension RuleTypeValue on RuleType {
+extension RuleTypeValueExtension on RuleType {
   String toValue() {
     switch (this) {
       case RuleType.binaryLength:
@@ -7861,7 +7861,7 @@ enum UpdateActionType {
   delete,
 }
 
-extension UpdateActionTypeValue on UpdateActionType {
+extension UpdateActionTypeValueExtension on UpdateActionType {
   String toValue() {
     switch (this) {
       case UpdateActionType.createOrUpdate:

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
@@ -5020,7 +5020,7 @@ enum BatchReadExceptionType {
   internalServiceException,
 }
 
-extension on BatchReadExceptionType {
+extension BatchReadExceptionTypeValue on BatchReadExceptionType {
   String toValue() {
     switch (this) {
       case BatchReadExceptionType.validationException:
@@ -5053,7 +5053,7 @@ extension on BatchReadExceptionType {
   }
 }
 
-extension on String {
+extension BatchReadExceptionTypeFromString on String {
   BatchReadExceptionType toBatchReadExceptionType() {
     switch (this) {
       case 'ValidationException':
@@ -5769,7 +5769,7 @@ enum ConsistencyLevel {
   eventual,
 }
 
-extension on ConsistencyLevel {
+extension ConsistencyLevelValue on ConsistencyLevel {
   String toValue() {
     switch (this) {
       case ConsistencyLevel.serializable:
@@ -5780,7 +5780,7 @@ extension on ConsistencyLevel {
   }
 }
 
-extension on String {
+extension ConsistencyLevelFromString on String {
   ConsistencyLevel toConsistencyLevel() {
     switch (this) {
       case 'SERIALIZABLE':
@@ -6005,7 +6005,7 @@ enum DirectoryState {
   deleted,
 }
 
-extension on DirectoryState {
+extension DirectoryStateValue on DirectoryState {
   String toValue() {
     switch (this) {
       case DirectoryState.enabled:
@@ -6018,7 +6018,7 @@ extension on DirectoryState {
   }
 }
 
-extension on String {
+extension DirectoryStateFromString on String {
   DirectoryState toDirectoryState() {
     switch (this) {
       case 'ENABLED':
@@ -6243,7 +6243,7 @@ enum FacetAttributeType {
   variant,
 }
 
-extension on FacetAttributeType {
+extension FacetAttributeTypeValue on FacetAttributeType {
   String toValue() {
     switch (this) {
       case FacetAttributeType.string:
@@ -6262,7 +6262,7 @@ extension on FacetAttributeType {
   }
 }
 
-extension on String {
+extension FacetAttributeTypeFromString on String {
   FacetAttributeType toFacetAttributeType() {
     switch (this) {
       case 'STRING':
@@ -6309,7 +6309,7 @@ enum FacetStyle {
   dynamic,
 }
 
-extension on FacetStyle {
+extension FacetStyleValue on FacetStyle {
   String toValue() {
     switch (this) {
       case FacetStyle.static:
@@ -6320,7 +6320,7 @@ extension on FacetStyle {
   }
 }
 
-extension on String {
+extension FacetStyleFromString on String {
   FacetStyle toFacetStyle() {
     switch (this) {
       case 'STATIC':
@@ -7177,7 +7177,7 @@ enum ObjectType {
   $index,
 }
 
-extension on ObjectType {
+extension ObjectTypeValue on ObjectType {
   String toValue() {
     switch (this) {
       case ObjectType.node:
@@ -7192,7 +7192,7 @@ extension on ObjectType {
   }
 }
 
-extension on String {
+extension ObjectTypeFromString on String {
   ObjectType toObjectType() {
     switch (this) {
       case 'NODE':
@@ -7325,7 +7325,7 @@ enum RangeMode {
   exclusive,
 }
 
-extension on RangeMode {
+extension RangeModeValue on RangeMode {
   String toValue() {
     switch (this) {
       case RangeMode.first:
@@ -7342,7 +7342,7 @@ extension on RangeMode {
   }
 }
 
-extension on String {
+extension RangeModeFromString on String {
   RangeMode toRangeMode() {
     switch (this) {
       case 'FIRST':
@@ -7372,7 +7372,7 @@ enum RequiredAttributeBehavior {
   notRequired,
 }
 
-extension on RequiredAttributeBehavior {
+extension RequiredAttributeBehaviorValue on RequiredAttributeBehavior {
   String toValue() {
     switch (this) {
       case RequiredAttributeBehavior.requiredAlways:
@@ -7383,7 +7383,7 @@ extension on RequiredAttributeBehavior {
   }
 }
 
-extension on String {
+extension RequiredAttributeBehaviorFromString on String {
   RequiredAttributeBehavior toRequiredAttributeBehavior() {
     switch (this) {
       case 'REQUIRED_ALWAYS':
@@ -7433,7 +7433,7 @@ enum RuleType {
   stringLength,
 }
 
-extension on RuleType {
+extension RuleTypeValue on RuleType {
   String toValue() {
     switch (this) {
       case RuleType.binaryLength:
@@ -7448,7 +7448,7 @@ extension on RuleType {
   }
 }
 
-extension on String {
+extension RuleTypeFromString on String {
   RuleType toRuleType() {
     switch (this) {
       case 'BINARY_LENGTH':
@@ -7861,7 +7861,7 @@ enum UpdateActionType {
   delete,
 }
 
-extension on UpdateActionType {
+extension UpdateActionTypeValue on UpdateActionType {
   String toValue() {
     switch (this) {
       case UpdateActionType.createOrUpdate:
@@ -7872,7 +7872,7 @@ extension on UpdateActionType {
   }
 }
 
-extension on String {
+extension UpdateActionTypeFromString on String {
   UpdateActionType toUpdateActionType() {
     switch (this) {
       case 'CREATE_OR_UPDATE':

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -5424,7 +5424,7 @@ enum AccountGateStatus {
   skipped,
 }
 
-extension AccountGateStatusValue on AccountGateStatus {
+extension AccountGateStatusValueExtension on AccountGateStatus {
   String toValue() {
     switch (this) {
       case AccountGateStatus.succeeded:
@@ -5538,7 +5538,7 @@ enum Capability {
   capabilityAutoExpand,
 }
 
-extension CapabilityValue on Capability {
+extension CapabilityValueExtension on Capability {
   String toValue() {
     switch (this) {
       case Capability.capabilityIam:
@@ -5598,7 +5598,7 @@ enum ChangeAction {
   dynamic,
 }
 
-extension ChangeActionValue on ChangeAction {
+extension ChangeActionValueExtension on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.add:
@@ -5644,7 +5644,7 @@ enum ChangeSetStatus {
   failed,
 }
 
-extension ChangeSetStatusValue on ChangeSetStatus {
+extension ChangeSetStatusValueExtension on ChangeSetStatus {
   String toValue() {
     switch (this) {
       case ChangeSetStatus.createPending:
@@ -5779,7 +5779,7 @@ enum ChangeSetType {
   import,
 }
 
-extension ChangeSetTypeValue on ChangeSetType {
+extension ChangeSetTypeValueExtension on ChangeSetType {
   String toValue() {
     switch (this) {
       case ChangeSetType.create:
@@ -5814,7 +5814,7 @@ enum ChangeSource {
   automatic,
 }
 
-extension ChangeSourceValue on ChangeSource {
+extension ChangeSourceValueExtension on ChangeSource {
   String toValue() {
     switch (this) {
       case ChangeSource.resourceReference:
@@ -5853,7 +5853,7 @@ enum ChangeType {
   resource,
 }
 
-extension ChangeTypeValue on ChangeType {
+extension ChangeTypeValueExtension on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.resource:
@@ -6026,7 +6026,7 @@ enum DeprecatedStatus {
   deprecated,
 }
 
-extension DeprecatedStatusValue on DeprecatedStatus {
+extension DeprecatedStatusValueExtension on DeprecatedStatus {
   String toValue() {
     switch (this) {
       case DeprecatedStatus.live:
@@ -6761,7 +6761,7 @@ enum DifferenceType {
   notEqual,
 }
 
-extension DifferenceTypeValue on DifferenceType {
+extension DifferenceTypeValueExtension on DifferenceType {
   String toValue() {
     switch (this) {
       case DifferenceType.add:
@@ -6809,7 +6809,7 @@ enum EvaluationType {
   dynamic,
 }
 
-extension EvaluationTypeValue on EvaluationType {
+extension EvaluationTypeValueExtension on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.static:
@@ -6851,7 +6851,7 @@ enum ExecutionStatus {
   obsolete,
 }
 
-extension ExecutionStatusValue on ExecutionStatus {
+extension ExecutionStatusValueExtension on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.unavailable:
@@ -7077,7 +7077,7 @@ enum HandlerErrorCode {
   internalFailure,
 }
 
-extension HandlerErrorCodeValue on HandlerErrorCode {
+extension HandlerErrorCodeValueExtension on HandlerErrorCode {
   String toValue() {
     switch (this) {
       case HandlerErrorCode.notUpdatable:
@@ -7547,7 +7547,7 @@ enum OnFailure {
   delete,
 }
 
-extension OnFailureValue on OnFailure {
+extension OnFailureValueExtension on OnFailure {
   String toValue() {
     switch (this) {
       case OnFailure.doNothing:
@@ -7581,7 +7581,7 @@ enum OperationStatus {
   failed,
 }
 
-extension OperationStatusValue on OperationStatus {
+extension OperationStatusValueExtension on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.pending:
@@ -7759,7 +7759,7 @@ enum PermissionModels {
   selfManaged,
 }
 
-extension PermissionModelsValue on PermissionModels {
+extension PermissionModelsValueExtension on PermissionModels {
   String toValue() {
     switch (this) {
       case PermissionModels.serviceManaged:
@@ -7866,7 +7866,7 @@ enum ProvisioningType {
   fullyMutable,
 }
 
-extension ProvisioningTypeValue on ProvisioningType {
+extension ProvisioningTypeValueExtension on ProvisioningType {
   String toValue() {
     switch (this) {
       case ProvisioningType.nonProvisionable:
@@ -7926,7 +7926,7 @@ enum RegistrationStatus {
   failed,
 }
 
-extension RegistrationStatusValue on RegistrationStatus {
+extension RegistrationStatusValueExtension on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.complete:
@@ -7958,7 +7958,7 @@ enum RegistryType {
   module,
 }
 
-extension RegistryTypeValue on RegistryType {
+extension RegistryTypeValueExtension on RegistryType {
   String toValue() {
     switch (this) {
       case RegistryType.resource:
@@ -7987,7 +7987,7 @@ enum Replacement {
   conditional,
 }
 
-extension ReplacementValue on Replacement {
+extension ReplacementValueExtension on Replacement {
   String toValue() {
     switch (this) {
       case Replacement.$true:
@@ -8020,7 +8020,7 @@ enum RequiresRecreation {
   always,
 }
 
-extension RequiresRecreationValue on RequiresRecreation {
+extension RequiresRecreationValueExtension on RequiresRecreation {
   String toValue() {
     switch (this) {
       case RequiresRecreation.never:
@@ -8056,7 +8056,7 @@ enum ResourceAttribute {
   tags,
 }
 
-extension ResourceAttributeValue on ResourceAttribute {
+extension ResourceAttributeValueExtension on ResourceAttribute {
   String toValue() {
     switch (this) {
       case ResourceAttribute.properties:
@@ -8320,7 +8320,7 @@ enum ResourceSignalStatus {
   failure,
 }
 
-extension ResourceSignalStatusValue on ResourceSignalStatus {
+extension ResourceSignalStatusValueExtension on ResourceSignalStatus {
   String toValue() {
     switch (this) {
       case ResourceSignalStatus.success:
@@ -8362,7 +8362,7 @@ enum ResourceStatus {
   importRollbackComplete,
 }
 
-extension ResourceStatusValue on ResourceStatus {
+extension ResourceStatusValueExtension on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.createInProgress:
@@ -8825,7 +8825,7 @@ enum StackDriftDetectionStatus {
   detectionComplete,
 }
 
-extension StackDriftDetectionStatusValue on StackDriftDetectionStatus {
+extension StackDriftDetectionStatusValueExtension on StackDriftDetectionStatus {
   String toValue() {
     switch (this) {
       case StackDriftDetectionStatus.detectionInProgress:
@@ -8953,7 +8953,7 @@ enum StackDriftStatus {
   notChecked,
 }
 
-extension StackDriftStatusValue on StackDriftStatus {
+extension StackDriftStatusValueExtension on StackDriftStatus {
   String toValue() {
     switch (this) {
       case StackDriftStatus.drifted:
@@ -9267,7 +9267,8 @@ enum StackInstanceDetailedStatus {
   inoperable,
 }
 
-extension StackInstanceDetailedStatusValue on StackInstanceDetailedStatus {
+extension StackInstanceDetailedStatusValueExtension
+    on StackInstanceDetailedStatus {
   String toValue() {
     switch (this) {
       case StackInstanceDetailedStatus.pending:
@@ -9332,7 +9333,7 @@ enum StackInstanceFilterName {
   detailedStatus,
 }
 
-extension StackInstanceFilterNameValue on StackInstanceFilterName {
+extension StackInstanceFilterNameValueExtension on StackInstanceFilterName {
   String toValue() {
     switch (this) {
       case StackInstanceFilterName.detailedStatus:
@@ -9357,7 +9358,7 @@ enum StackInstanceStatus {
   inoperable,
 }
 
-extension StackInstanceStatusValue on StackInstanceStatus {
+extension StackInstanceStatusValueExtension on StackInstanceStatus {
   String toValue() {
     switch (this) {
       case StackInstanceStatus.current:
@@ -9919,7 +9920,7 @@ enum StackResourceDriftStatus {
   notChecked,
 }
 
-extension StackResourceDriftStatusValue on StackResourceDriftStatus {
+extension StackResourceDriftStatusValueExtension on StackResourceDriftStatus {
   String toValue() {
     switch (this) {
       case StackResourceDriftStatus.inSync:
@@ -10311,7 +10312,8 @@ enum StackSetDriftDetectionStatus {
   stopped,
 }
 
-extension StackSetDriftDetectionStatusValue on StackSetDriftDetectionStatus {
+extension StackSetDriftDetectionStatusValueExtension
+    on StackSetDriftDetectionStatus {
   String toValue() {
     switch (this) {
       case StackSetDriftDetectionStatus.completed:
@@ -10352,7 +10354,7 @@ enum StackSetDriftStatus {
   notChecked,
 }
 
-extension StackSetDriftStatusValue on StackSetDriftStatus {
+extension StackSetDriftStatusValueExtension on StackSetDriftStatus {
   String toValue() {
     switch (this) {
       case StackSetDriftStatus.drifted:
@@ -10533,7 +10535,7 @@ enum StackSetOperationAction {
   detectDrift,
 }
 
-extension StackSetOperationActionValue on StackSetOperationAction {
+extension StackSetOperationActionValueExtension on StackSetOperationAction {
   String toValue() {
     switch (this) {
       case StackSetOperationAction.create:
@@ -10674,7 +10676,8 @@ enum StackSetOperationResultStatus {
   cancelled,
 }
 
-extension StackSetOperationResultStatusValue on StackSetOperationResultStatus {
+extension StackSetOperationResultStatusValueExtension
+    on StackSetOperationResultStatus {
   String toValue() {
     switch (this) {
       case StackSetOperationResultStatus.pending:
@@ -10797,7 +10800,7 @@ enum StackSetOperationStatus {
   queued,
 }
 
-extension StackSetOperationStatusValue on StackSetOperationStatus {
+extension StackSetOperationStatusValueExtension on StackSetOperationStatus {
   String toValue() {
     switch (this) {
       case StackSetOperationStatus.running:
@@ -10922,7 +10925,7 @@ enum StackSetStatus {
   deleted,
 }
 
-extension StackSetStatusValue on StackSetStatus {
+extension StackSetStatusValueExtension on StackSetStatus {
   String toValue() {
     switch (this) {
       case StackSetStatus.active:
@@ -11072,7 +11075,7 @@ enum StackStatus {
   importRollbackComplete,
 }
 
-extension StackStatusValue on StackStatus {
+extension StackStatusValueExtension on StackStatus {
   String toValue() {
     switch (this) {
       case StackStatus.createInProgress:
@@ -11339,7 +11342,7 @@ enum TemplateStage {
   processed,
 }
 
-extension TemplateStageValue on TemplateStage {
+extension TemplateStageValueExtension on TemplateStage {
   String toValue() {
     switch (this) {
       case TemplateStage.original:
@@ -11568,7 +11571,7 @@ enum Visibility {
   private,
 }
 
-extension VisibilityValue on Visibility {
+extension VisibilityValueExtension on Visibility {
   String toValue() {
     switch (this) {
       case Visibility.public:

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -5424,7 +5424,7 @@ enum AccountGateStatus {
   skipped,
 }
 
-extension on AccountGateStatus {
+extension AccountGateStatusValue on AccountGateStatus {
   String toValue() {
     switch (this) {
       case AccountGateStatus.succeeded:
@@ -5437,7 +5437,7 @@ extension on AccountGateStatus {
   }
 }
 
-extension on String {
+extension AccountGateStatusFromString on String {
   AccountGateStatus toAccountGateStatus() {
     switch (this) {
       case 'SUCCEEDED':
@@ -5538,7 +5538,7 @@ enum Capability {
   capabilityAutoExpand,
 }
 
-extension on Capability {
+extension CapabilityValue on Capability {
   String toValue() {
     switch (this) {
       case Capability.capabilityIam:
@@ -5551,7 +5551,7 @@ extension on Capability {
   }
 }
 
-extension on String {
+extension CapabilityFromString on String {
   Capability toCapability() {
     switch (this) {
       case 'CAPABILITY_IAM':
@@ -5598,7 +5598,7 @@ enum ChangeAction {
   dynamic,
 }
 
-extension on ChangeAction {
+extension ChangeActionValue on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.add:
@@ -5615,7 +5615,7 @@ extension on ChangeAction {
   }
 }
 
-extension on String {
+extension ChangeActionFromString on String {
   ChangeAction toChangeAction() {
     switch (this) {
       case 'Add':
@@ -5644,7 +5644,7 @@ enum ChangeSetStatus {
   failed,
 }
 
-extension on ChangeSetStatus {
+extension ChangeSetStatusValue on ChangeSetStatus {
   String toValue() {
     switch (this) {
       case ChangeSetStatus.createPending:
@@ -5667,7 +5667,7 @@ extension on ChangeSetStatus {
   }
 }
 
-extension on String {
+extension ChangeSetStatusFromString on String {
   ChangeSetStatus toChangeSetStatus() {
     switch (this) {
       case 'CREATE_PENDING':
@@ -5779,7 +5779,7 @@ enum ChangeSetType {
   import,
 }
 
-extension on ChangeSetType {
+extension ChangeSetTypeValue on ChangeSetType {
   String toValue() {
     switch (this) {
       case ChangeSetType.create:
@@ -5792,7 +5792,7 @@ extension on ChangeSetType {
   }
 }
 
-extension on String {
+extension ChangeSetTypeFromString on String {
   ChangeSetType toChangeSetType() {
     switch (this) {
       case 'CREATE':
@@ -5814,7 +5814,7 @@ enum ChangeSource {
   automatic,
 }
 
-extension on ChangeSource {
+extension ChangeSourceValue on ChangeSource {
   String toValue() {
     switch (this) {
       case ChangeSource.resourceReference:
@@ -5831,7 +5831,7 @@ extension on ChangeSource {
   }
 }
 
-extension on String {
+extension ChangeSourceFromString on String {
   ChangeSource toChangeSource() {
     switch (this) {
       case 'ResourceReference':
@@ -5853,7 +5853,7 @@ enum ChangeType {
   resource,
 }
 
-extension on ChangeType {
+extension ChangeTypeValue on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.resource:
@@ -5862,7 +5862,7 @@ extension on ChangeType {
   }
 }
 
-extension on String {
+extension ChangeTypeFromString on String {
   ChangeType toChangeType() {
     switch (this) {
       case 'Resource':
@@ -6026,7 +6026,7 @@ enum DeprecatedStatus {
   deprecated,
 }
 
-extension on DeprecatedStatus {
+extension DeprecatedStatusValue on DeprecatedStatus {
   String toValue() {
     switch (this) {
       case DeprecatedStatus.live:
@@ -6037,7 +6037,7 @@ extension on DeprecatedStatus {
   }
 }
 
-extension on String {
+extension DeprecatedStatusFromString on String {
   DeprecatedStatus toDeprecatedStatus() {
     switch (this) {
       case 'LIVE':
@@ -6761,7 +6761,7 @@ enum DifferenceType {
   notEqual,
 }
 
-extension on DifferenceType {
+extension DifferenceTypeValue on DifferenceType {
   String toValue() {
     switch (this) {
       case DifferenceType.add:
@@ -6774,7 +6774,7 @@ extension on DifferenceType {
   }
 }
 
-extension on String {
+extension DifferenceTypeFromString on String {
   DifferenceType toDifferenceType() {
     switch (this) {
       case 'ADD':
@@ -6809,7 +6809,7 @@ enum EvaluationType {
   dynamic,
 }
 
-extension on EvaluationType {
+extension EvaluationTypeValue on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.static:
@@ -6820,7 +6820,7 @@ extension on EvaluationType {
   }
 }
 
-extension on String {
+extension EvaluationTypeFromString on String {
   EvaluationType toEvaluationType() {
     switch (this) {
       case 'Static':
@@ -6851,7 +6851,7 @@ enum ExecutionStatus {
   obsolete,
 }
 
-extension on ExecutionStatus {
+extension ExecutionStatusValue on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.unavailable:
@@ -6870,7 +6870,7 @@ extension on ExecutionStatus {
   }
 }
 
-extension on String {
+extension ExecutionStatusFromString on String {
   ExecutionStatus toExecutionStatus() {
     switch (this) {
       case 'UNAVAILABLE':
@@ -7077,7 +7077,7 @@ enum HandlerErrorCode {
   internalFailure,
 }
 
-extension on HandlerErrorCode {
+extension HandlerErrorCodeValue on HandlerErrorCode {
   String toValue() {
     switch (this) {
       case HandlerErrorCode.notUpdatable:
@@ -7112,7 +7112,7 @@ extension on HandlerErrorCode {
   }
 }
 
-extension on String {
+extension HandlerErrorCodeFromString on String {
   HandlerErrorCode toHandlerErrorCode() {
     switch (this) {
       case 'NotUpdatable':
@@ -7547,7 +7547,7 @@ enum OnFailure {
   delete,
 }
 
-extension on OnFailure {
+extension OnFailureValue on OnFailure {
   String toValue() {
     switch (this) {
       case OnFailure.doNothing:
@@ -7560,7 +7560,7 @@ extension on OnFailure {
   }
 }
 
-extension on String {
+extension OnFailureFromString on String {
   OnFailure toOnFailure() {
     switch (this) {
       case 'DO_NOTHING':
@@ -7581,7 +7581,7 @@ enum OperationStatus {
   failed,
 }
 
-extension on OperationStatus {
+extension OperationStatusValue on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.pending:
@@ -7596,7 +7596,7 @@ extension on OperationStatus {
   }
 }
 
-extension on String {
+extension OperationStatusFromString on String {
   OperationStatus toOperationStatus() {
     switch (this) {
       case 'PENDING':
@@ -7759,7 +7759,7 @@ enum PermissionModels {
   selfManaged,
 }
 
-extension on PermissionModels {
+extension PermissionModelsValue on PermissionModels {
   String toValue() {
     switch (this) {
       case PermissionModels.serviceManaged:
@@ -7770,7 +7770,7 @@ extension on PermissionModels {
   }
 }
 
-extension on String {
+extension PermissionModelsFromString on String {
   PermissionModels toPermissionModels() {
     switch (this) {
       case 'SERVICE_MANAGED':
@@ -7866,7 +7866,7 @@ enum ProvisioningType {
   fullyMutable,
 }
 
-extension on ProvisioningType {
+extension ProvisioningTypeValue on ProvisioningType {
   String toValue() {
     switch (this) {
       case ProvisioningType.nonProvisionable:
@@ -7879,7 +7879,7 @@ extension on ProvisioningType {
   }
 }
 
-extension on String {
+extension ProvisioningTypeFromString on String {
   ProvisioningType toProvisioningType() {
     switch (this) {
       case 'NON_PROVISIONABLE':
@@ -7926,7 +7926,7 @@ enum RegistrationStatus {
   failed,
 }
 
-extension on RegistrationStatus {
+extension RegistrationStatusValue on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.complete:
@@ -7939,7 +7939,7 @@ extension on RegistrationStatus {
   }
 }
 
-extension on String {
+extension RegistrationStatusFromString on String {
   RegistrationStatus toRegistrationStatus() {
     switch (this) {
       case 'COMPLETE':
@@ -7958,7 +7958,7 @@ enum RegistryType {
   module,
 }
 
-extension on RegistryType {
+extension RegistryTypeValue on RegistryType {
   String toValue() {
     switch (this) {
       case RegistryType.resource:
@@ -7969,7 +7969,7 @@ extension on RegistryType {
   }
 }
 
-extension on String {
+extension RegistryTypeFromString on String {
   RegistryType toRegistryType() {
     switch (this) {
       case 'RESOURCE':
@@ -7987,7 +7987,7 @@ enum Replacement {
   conditional,
 }
 
-extension on Replacement {
+extension ReplacementValue on Replacement {
   String toValue() {
     switch (this) {
       case Replacement.$true:
@@ -8000,7 +8000,7 @@ extension on Replacement {
   }
 }
 
-extension on String {
+extension ReplacementFromString on String {
   Replacement toReplacement() {
     switch (this) {
       case 'True':
@@ -8020,7 +8020,7 @@ enum RequiresRecreation {
   always,
 }
 
-extension on RequiresRecreation {
+extension RequiresRecreationValue on RequiresRecreation {
   String toValue() {
     switch (this) {
       case RequiresRecreation.never:
@@ -8033,7 +8033,7 @@ extension on RequiresRecreation {
   }
 }
 
-extension on String {
+extension RequiresRecreationFromString on String {
   RequiresRecreation toRequiresRecreation() {
     switch (this) {
       case 'Never':
@@ -8056,7 +8056,7 @@ enum ResourceAttribute {
   tags,
 }
 
-extension on ResourceAttribute {
+extension ResourceAttributeValue on ResourceAttribute {
   String toValue() {
     switch (this) {
       case ResourceAttribute.properties:
@@ -8075,7 +8075,7 @@ extension on ResourceAttribute {
   }
 }
 
-extension on String {
+extension ResourceAttributeFromString on String {
   ResourceAttribute toResourceAttribute() {
     switch (this) {
       case 'Properties':
@@ -8320,7 +8320,7 @@ enum ResourceSignalStatus {
   failure,
 }
 
-extension on ResourceSignalStatus {
+extension ResourceSignalStatusValue on ResourceSignalStatus {
   String toValue() {
     switch (this) {
       case ResourceSignalStatus.success:
@@ -8331,7 +8331,7 @@ extension on ResourceSignalStatus {
   }
 }
 
-extension on String {
+extension ResourceSignalStatusFromString on String {
   ResourceSignalStatus toResourceSignalStatus() {
     switch (this) {
       case 'SUCCESS':
@@ -8362,7 +8362,7 @@ enum ResourceStatus {
   importRollbackComplete,
 }
 
-extension on ResourceStatus {
+extension ResourceStatusValue on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.createInProgress:
@@ -8401,7 +8401,7 @@ extension on ResourceStatus {
   }
 }
 
-extension on String {
+extension ResourceStatusFromString on String {
   ResourceStatus toResourceStatus() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -8825,7 +8825,7 @@ enum StackDriftDetectionStatus {
   detectionComplete,
 }
 
-extension on StackDriftDetectionStatus {
+extension StackDriftDetectionStatusValue on StackDriftDetectionStatus {
   String toValue() {
     switch (this) {
       case StackDriftDetectionStatus.detectionInProgress:
@@ -8838,7 +8838,7 @@ extension on StackDriftDetectionStatus {
   }
 }
 
-extension on String {
+extension StackDriftDetectionStatusFromString on String {
   StackDriftDetectionStatus toStackDriftDetectionStatus() {
     switch (this) {
       case 'DETECTION_IN_PROGRESS':
@@ -8953,7 +8953,7 @@ enum StackDriftStatus {
   notChecked,
 }
 
-extension on StackDriftStatus {
+extension StackDriftStatusValue on StackDriftStatus {
   String toValue() {
     switch (this) {
       case StackDriftStatus.drifted:
@@ -8968,7 +8968,7 @@ extension on StackDriftStatus {
   }
 }
 
-extension on String {
+extension StackDriftStatusFromString on String {
   StackDriftStatus toStackDriftStatus() {
     switch (this) {
       case 'DRIFTED':
@@ -9267,7 +9267,7 @@ enum StackInstanceDetailedStatus {
   inoperable,
 }
 
-extension on StackInstanceDetailedStatus {
+extension StackInstanceDetailedStatusValue on StackInstanceDetailedStatus {
   String toValue() {
     switch (this) {
       case StackInstanceDetailedStatus.pending:
@@ -9286,7 +9286,7 @@ extension on StackInstanceDetailedStatus {
   }
 }
 
-extension on String {
+extension StackInstanceDetailedStatusFromString on String {
   StackInstanceDetailedStatus toStackInstanceDetailedStatus() {
     switch (this) {
       case 'PENDING':
@@ -9332,7 +9332,7 @@ enum StackInstanceFilterName {
   detailedStatus,
 }
 
-extension on StackInstanceFilterName {
+extension StackInstanceFilterNameValue on StackInstanceFilterName {
   String toValue() {
     switch (this) {
       case StackInstanceFilterName.detailedStatus:
@@ -9341,7 +9341,7 @@ extension on StackInstanceFilterName {
   }
 }
 
-extension on String {
+extension StackInstanceFilterNameFromString on String {
   StackInstanceFilterName toStackInstanceFilterName() {
     switch (this) {
       case 'DETAILED_STATUS':
@@ -9357,7 +9357,7 @@ enum StackInstanceStatus {
   inoperable,
 }
 
-extension on StackInstanceStatus {
+extension StackInstanceStatusValue on StackInstanceStatus {
   String toValue() {
     switch (this) {
       case StackInstanceStatus.current:
@@ -9370,7 +9370,7 @@ extension on StackInstanceStatus {
   }
 }
 
-extension on String {
+extension StackInstanceStatusFromString on String {
   StackInstanceStatus toStackInstanceStatus() {
     switch (this) {
       case 'CURRENT':
@@ -9919,7 +9919,7 @@ enum StackResourceDriftStatus {
   notChecked,
 }
 
-extension on StackResourceDriftStatus {
+extension StackResourceDriftStatusValue on StackResourceDriftStatus {
   String toValue() {
     switch (this) {
       case StackResourceDriftStatus.inSync:
@@ -9934,7 +9934,7 @@ extension on StackResourceDriftStatus {
   }
 }
 
-extension on String {
+extension StackResourceDriftStatusFromString on String {
   StackResourceDriftStatus toStackResourceDriftStatus() {
     switch (this) {
       case 'IN_SYNC':
@@ -10311,7 +10311,7 @@ enum StackSetDriftDetectionStatus {
   stopped,
 }
 
-extension on StackSetDriftDetectionStatus {
+extension StackSetDriftDetectionStatusValue on StackSetDriftDetectionStatus {
   String toValue() {
     switch (this) {
       case StackSetDriftDetectionStatus.completed:
@@ -10328,7 +10328,7 @@ extension on StackSetDriftDetectionStatus {
   }
 }
 
-extension on String {
+extension StackSetDriftDetectionStatusFromString on String {
   StackSetDriftDetectionStatus toStackSetDriftDetectionStatus() {
     switch (this) {
       case 'COMPLETED':
@@ -10352,7 +10352,7 @@ enum StackSetDriftStatus {
   notChecked,
 }
 
-extension on StackSetDriftStatus {
+extension StackSetDriftStatusValue on StackSetDriftStatus {
   String toValue() {
     switch (this) {
       case StackSetDriftStatus.drifted:
@@ -10365,7 +10365,7 @@ extension on StackSetDriftStatus {
   }
 }
 
-extension on String {
+extension StackSetDriftStatusFromString on String {
   StackSetDriftStatus toStackSetDriftStatus() {
     switch (this) {
       case 'DRIFTED':
@@ -10533,7 +10533,7 @@ enum StackSetOperationAction {
   detectDrift,
 }
 
-extension on StackSetOperationAction {
+extension StackSetOperationActionValue on StackSetOperationAction {
   String toValue() {
     switch (this) {
       case StackSetOperationAction.create:
@@ -10548,7 +10548,7 @@ extension on StackSetOperationAction {
   }
 }
 
-extension on String {
+extension StackSetOperationActionFromString on String {
   StackSetOperationAction toStackSetOperationAction() {
     switch (this) {
       case 'CREATE':
@@ -10674,7 +10674,7 @@ enum StackSetOperationResultStatus {
   cancelled,
 }
 
-extension on StackSetOperationResultStatus {
+extension StackSetOperationResultStatusValue on StackSetOperationResultStatus {
   String toValue() {
     switch (this) {
       case StackSetOperationResultStatus.pending:
@@ -10691,7 +10691,7 @@ extension on StackSetOperationResultStatus {
   }
 }
 
-extension on String {
+extension StackSetOperationResultStatusFromString on String {
   StackSetOperationResultStatus toStackSetOperationResultStatus() {
     switch (this) {
       case 'PENDING':
@@ -10797,7 +10797,7 @@ enum StackSetOperationStatus {
   queued,
 }
 
-extension on StackSetOperationStatus {
+extension StackSetOperationStatusValue on StackSetOperationStatus {
   String toValue() {
     switch (this) {
       case StackSetOperationStatus.running:
@@ -10816,7 +10816,7 @@ extension on StackSetOperationStatus {
   }
 }
 
-extension on String {
+extension StackSetOperationStatusFromString on String {
   StackSetOperationStatus toStackSetOperationStatus() {
     switch (this) {
       case 'RUNNING':
@@ -10922,7 +10922,7 @@ enum StackSetStatus {
   deleted,
 }
 
-extension on StackSetStatus {
+extension StackSetStatusValue on StackSetStatus {
   String toValue() {
     switch (this) {
       case StackSetStatus.active:
@@ -10933,7 +10933,7 @@ extension on StackSetStatus {
   }
 }
 
-extension on String {
+extension StackSetStatusFromString on String {
   StackSetStatus toStackSetStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -11072,7 +11072,7 @@ enum StackStatus {
   importRollbackComplete,
 }
 
-extension on StackStatus {
+extension StackStatusValue on StackStatus {
   String toValue() {
     switch (this) {
       case StackStatus.createInProgress:
@@ -11123,7 +11123,7 @@ extension on StackStatus {
   }
 }
 
-extension on String {
+extension StackStatusFromString on String {
   StackStatus toStackStatus() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -11339,7 +11339,7 @@ enum TemplateStage {
   processed,
 }
 
-extension on TemplateStage {
+extension TemplateStageValue on TemplateStage {
   String toValue() {
     switch (this) {
       case TemplateStage.original:
@@ -11350,7 +11350,7 @@ extension on TemplateStage {
   }
 }
 
-extension on String {
+extension TemplateStageFromString on String {
   TemplateStage toTemplateStage() {
     switch (this) {
       case 'Original':
@@ -11568,7 +11568,7 @@ enum Visibility {
   private,
 }
 
-extension on Visibility {
+extension VisibilityValue on Visibility {
   String toValue() {
     switch (this) {
       case Visibility.public:
@@ -11579,7 +11579,7 @@ extension on Visibility {
   }
 }
 
-extension on String {
+extension VisibilityFromString on String {
   Visibility toVisibility() {
     switch (this) {
       case 'PUBLIC':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
@@ -1720,7 +1720,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -1733,7 +1733,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -3286,7 +3286,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -3301,7 +3301,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -3496,7 +3496,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -3509,7 +3509,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -3715,7 +3715,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -3726,7 +3726,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -4235,7 +4235,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -4248,7 +4248,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -4544,7 +4544,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -4565,7 +4565,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -4592,7 +4592,7 @@ enum MinimumProtocolVersion {
   tLSv1,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -4603,7 +4603,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -4919,7 +4919,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -4932,7 +4932,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -5101,7 +5101,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -5114,7 +5114,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -5323,7 +5323,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -5334,7 +5334,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -5388,7 +5388,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -5403,7 +5403,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -6602,7 +6602,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -6615,7 +6615,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
@@ -1720,7 +1720,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -3286,7 +3286,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -3496,7 +3496,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -3715,7 +3715,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -4235,7 +4235,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -4544,7 +4544,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -4592,7 +4592,7 @@ enum MinimumProtocolVersion {
   tLSv1,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -4919,7 +4919,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -5101,7 +5101,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -5323,7 +5323,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -5388,7 +5388,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -6602,7 +6602,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
@@ -1809,7 +1809,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -3398,7 +3398,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -3608,7 +3608,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -3839,7 +3839,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -4385,7 +4385,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -4710,7 +4710,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -4761,7 +4761,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -5100,7 +5100,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -5282,7 +5282,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -5517,7 +5517,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -5582,7 +5582,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -6836,7 +6836,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
@@ -1809,7 +1809,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -1822,7 +1822,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -3398,7 +3398,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -3413,7 +3413,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -3608,7 +3608,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -3621,7 +3621,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -3839,7 +3839,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -3850,7 +3850,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -4385,7 +4385,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -4398,7 +4398,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -4710,7 +4710,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -4731,7 +4731,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -4761,7 +4761,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -4778,7 +4778,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -5100,7 +5100,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -5113,7 +5113,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -5282,7 +5282,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -5295,7 +5295,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -5517,7 +5517,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -5528,7 +5528,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -5582,7 +5582,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -5597,7 +5597,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -6836,7 +6836,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -6849,7 +6849,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
@@ -2418,7 +2418,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -4306,7 +4306,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4778,7 +4778,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4976,7 +4976,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -5291,7 +5291,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5854,7 +5854,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -6207,7 +6207,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -6258,7 +6258,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -6639,7 +6639,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6821,7 +6821,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -7367,7 +7367,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -7432,7 +7432,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -8852,7 +8852,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
@@ -2418,7 +2418,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -2431,7 +2431,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -4306,7 +4306,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4321,7 +4321,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -4778,7 +4778,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4787,7 +4787,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'URLEncoded':
@@ -4976,7 +4976,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -4989,7 +4989,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -5291,7 +5291,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5302,7 +5302,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -5854,7 +5854,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5867,7 +5867,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -6207,7 +6207,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -6228,7 +6228,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -6258,7 +6258,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -6275,7 +6275,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -6639,7 +6639,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6652,7 +6652,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -6821,7 +6821,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6834,7 +6834,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -7367,7 +7367,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -7378,7 +7378,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -7432,7 +7432,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -7447,7 +7447,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -8852,7 +8852,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -8865,7 +8865,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
@@ -2401,7 +2401,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -4230,7 +4230,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4632,7 +4632,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4830,7 +4830,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -5145,7 +5145,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5343,7 +5343,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5708,7 +5708,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5759,7 +5759,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -6002,7 +6002,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6169,7 +6169,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6673,7 +6673,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -6738,7 +6738,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -7764,7 +7764,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
@@ -2401,7 +2401,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -2414,7 +2414,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -4230,7 +4230,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4245,7 +4245,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -4632,7 +4632,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4641,7 +4641,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'URLEncoded':
@@ -4830,7 +4830,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -4843,7 +4843,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -5145,7 +5145,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5156,7 +5156,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -5343,7 +5343,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5356,7 +5356,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -5708,7 +5708,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5729,7 +5729,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -5759,7 +5759,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -5776,7 +5776,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -6002,7 +6002,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6015,7 +6015,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -6169,7 +6169,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6182,7 +6182,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -6673,7 +6673,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -6684,7 +6684,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -6738,7 +6738,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -6753,7 +6753,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -7764,7 +7764,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -7777,7 +7777,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
@@ -2404,7 +2404,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -2417,7 +2417,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -4257,7 +4257,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4272,7 +4272,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -4659,7 +4659,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4668,7 +4668,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'URLEncoded':
@@ -4857,7 +4857,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -4870,7 +4870,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -5172,7 +5172,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5183,7 +5183,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -5371,7 +5371,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5384,7 +5384,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -5733,7 +5733,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5754,7 +5754,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -5784,7 +5784,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -5801,7 +5801,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -6234,7 +6234,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6247,7 +6247,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -6403,7 +6403,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6416,7 +6416,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -6907,7 +6907,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -6918,7 +6918,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -6972,7 +6972,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -6987,7 +6987,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -8042,7 +8042,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -8055,7 +8055,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
@@ -2404,7 +2404,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -4257,7 +4257,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4659,7 +4659,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4857,7 +4857,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -5172,7 +5172,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5371,7 +5371,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5733,7 +5733,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5784,7 +5784,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2018,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -6234,7 +6234,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6403,7 +6403,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6907,7 +6907,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -6972,7 +6972,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -8042,7 +8042,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
@@ -2452,7 +2452,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -2465,7 +2465,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -4376,7 +4376,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4391,7 +4391,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -4778,7 +4778,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4787,7 +4787,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'URLEncoded':
@@ -4984,7 +4984,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -4997,7 +4997,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -5299,7 +5299,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5310,7 +5310,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -5328,7 +5328,7 @@ enum ICPRecordalStatus {
   pending,
 }
 
-extension on ICPRecordalStatus {
+extension ICPRecordalStatusValue on ICPRecordalStatus {
   String toValue() {
     switch (this) {
       case ICPRecordalStatus.approved:
@@ -5341,7 +5341,7 @@ extension on ICPRecordalStatus {
   }
 }
 
-extension on String {
+extension ICPRecordalStatusFromString on String {
   ICPRecordalStatus toICPRecordalStatus() {
     switch (this) {
       case 'APPROVED':
@@ -5531,7 +5531,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5544,7 +5544,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -5896,7 +5896,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5917,7 +5917,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -5948,7 +5948,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2019,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -5967,7 +5967,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -6405,7 +6405,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6418,7 +6418,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -6575,7 +6575,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -6588,7 +6588,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -7083,7 +7083,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -7094,7 +7094,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -7148,7 +7148,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -7163,7 +7163,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -8163,7 +8163,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -8176,7 +8176,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
@@ -2452,7 +2452,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -4376,7 +4376,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -4778,7 +4778,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -4984,7 +4984,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -5299,7 +5299,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -5328,7 +5328,7 @@ enum ICPRecordalStatus {
   pending,
 }
 
-extension ICPRecordalStatusValue on ICPRecordalStatus {
+extension ICPRecordalStatusValueExtension on ICPRecordalStatus {
   String toValue() {
     switch (this) {
       case ICPRecordalStatus.approved:
@@ -5531,7 +5531,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -5896,7 +5896,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -5948,7 +5948,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2019,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -6405,7 +6405,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -6575,7 +6575,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -7083,7 +7083,7 @@ enum SSLSupportMethod {
   vip,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -7148,7 +7148,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -8163,7 +8163,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
@@ -4112,7 +4112,7 @@ enum CachePolicyCookieBehavior {
   all,
 }
 
-extension on CachePolicyCookieBehavior {
+extension CachePolicyCookieBehaviorValue on CachePolicyCookieBehavior {
   String toValue() {
     switch (this) {
       case CachePolicyCookieBehavior.none:
@@ -4127,7 +4127,7 @@ extension on CachePolicyCookieBehavior {
   }
 }
 
-extension on String {
+extension CachePolicyCookieBehaviorFromString on String {
   CachePolicyCookieBehavior toCachePolicyCookieBehavior() {
     switch (this) {
       case 'none':
@@ -4217,7 +4217,7 @@ enum CachePolicyHeaderBehavior {
   whitelist,
 }
 
-extension on CachePolicyHeaderBehavior {
+extension CachePolicyHeaderBehaviorValue on CachePolicyHeaderBehavior {
   String toValue() {
     switch (this) {
       case CachePolicyHeaderBehavior.none:
@@ -4228,7 +4228,7 @@ extension on CachePolicyHeaderBehavior {
   }
 }
 
-extension on String {
+extension CachePolicyHeaderBehaviorFromString on String {
   CachePolicyHeaderBehavior toCachePolicyHeaderBehavior() {
     switch (this) {
       case 'none':
@@ -4340,7 +4340,8 @@ enum CachePolicyQueryStringBehavior {
   all,
 }
 
-extension on CachePolicyQueryStringBehavior {
+extension CachePolicyQueryStringBehaviorValue
+    on CachePolicyQueryStringBehavior {
   String toValue() {
     switch (this) {
       case CachePolicyQueryStringBehavior.none:
@@ -4355,7 +4356,7 @@ extension on CachePolicyQueryStringBehavior {
   }
 }
 
-extension on String {
+extension CachePolicyQueryStringBehaviorFromString on String {
   CachePolicyQueryStringBehavior toCachePolicyQueryStringBehavior() {
     switch (this) {
       case 'none':
@@ -4479,7 +4480,7 @@ enum CachePolicyType {
   custom,
 }
 
-extension on CachePolicyType {
+extension CachePolicyTypeValue on CachePolicyType {
   String toValue() {
     switch (this) {
       case CachePolicyType.managed:
@@ -4490,7 +4491,7 @@ extension on CachePolicyType {
   }
 }
 
-extension on String {
+extension CachePolicyTypeFromString on String {
   CachePolicyType toCachePolicyType() {
     switch (this) {
       case 'managed':
@@ -4569,7 +4570,7 @@ enum CertificateSource {
   acm,
 }
 
-extension on CertificateSource {
+extension CertificateSourceValue on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -4582,7 +4583,7 @@ extension on CertificateSource {
   }
 }
 
-extension on String {
+extension CertificateSourceFromString on String {
   CertificateSource toCertificateSource() {
     switch (this) {
       case 'cloudfront':
@@ -6878,7 +6879,7 @@ enum EventType {
   originResponse,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -6893,7 +6894,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'viewer-request':
@@ -7280,7 +7281,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -7289,7 +7290,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'URLEncoded':
@@ -7551,7 +7552,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension on GeoRestrictionType {
+extension GeoRestrictionTypeValue on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -7564,7 +7565,7 @@ extension on GeoRestrictionType {
   }
 }
 
-extension on String {
+extension GeoRestrictionTypeFromString on String {
   GeoRestrictionType toGeoRestrictionType() {
     switch (this) {
       case 'blacklist':
@@ -7943,7 +7944,7 @@ enum HttpVersion {
   http2,
 }
 
-extension on HttpVersion {
+extension HttpVersionValue on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -7954,7 +7955,7 @@ extension on HttpVersion {
   }
 }
 
-extension on String {
+extension HttpVersionFromString on String {
   HttpVersion toHttpVersion() {
     switch (this) {
       case 'http1.1':
@@ -7972,7 +7973,7 @@ enum ICPRecordalStatus {
   pending,
 }
 
-extension on ICPRecordalStatus {
+extension ICPRecordalStatusValue on ICPRecordalStatus {
   String toValue() {
     switch (this) {
       case ICPRecordalStatus.approved:
@@ -7985,7 +7986,7 @@ extension on ICPRecordalStatus {
   }
 }
 
-extension on String {
+extension ICPRecordalStatusFromString on String {
   ICPRecordalStatus toICPRecordalStatus() {
     switch (this) {
       case 'APPROVED':
@@ -8175,7 +8176,7 @@ enum ItemSelection {
   all,
 }
 
-extension on ItemSelection {
+extension ItemSelectionValue on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -8188,7 +8189,7 @@ extension on ItemSelection {
   }
 }
 
-extension on String {
+extension ItemSelectionFromString on String {
   ItemSelection toItemSelection() {
     switch (this) {
       case 'none':
@@ -8846,7 +8847,7 @@ enum Method {
   delete,
 }
 
-extension on Method {
+extension MethodValue on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -8867,7 +8868,7 @@ extension on Method {
   }
 }
 
-extension on String {
+extension MethodFromString on String {
   Method toMethod() {
     switch (this) {
       case 'GET':
@@ -8898,7 +8899,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2019,
 }
 
-extension on MinimumProtocolVersion {
+extension MinimumProtocolVersionValue on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -8917,7 +8918,7 @@ extension on MinimumProtocolVersion {
   }
 }
 
-extension on String {
+extension MinimumProtocolVersionFromString on String {
   MinimumProtocolVersion toMinimumProtocolVersion() {
     switch (this) {
       case 'SSLv3':
@@ -9405,7 +9406,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicy {
+extension OriginProtocolPolicyValue on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -9418,7 +9419,7 @@ extension on OriginProtocolPolicy {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyFromString on String {
   OriginProtocolPolicy toOriginProtocolPolicy() {
     switch (this) {
       case 'http-only':
@@ -9576,7 +9577,8 @@ enum OriginRequestPolicyCookieBehavior {
   all,
 }
 
-extension on OriginRequestPolicyCookieBehavior {
+extension OriginRequestPolicyCookieBehaviorValue
+    on OriginRequestPolicyCookieBehavior {
   String toValue() {
     switch (this) {
       case OriginRequestPolicyCookieBehavior.none:
@@ -9589,7 +9591,7 @@ extension on OriginRequestPolicyCookieBehavior {
   }
 }
 
-extension on String {
+extension OriginRequestPolicyCookieBehaviorFromString on String {
   OriginRequestPolicyCookieBehavior toOriginRequestPolicyCookieBehavior() {
     switch (this) {
       case 'none':
@@ -9670,7 +9672,8 @@ enum OriginRequestPolicyHeaderBehavior {
   allViewerAndWhitelistCloudFront,
 }
 
-extension on OriginRequestPolicyHeaderBehavior {
+extension OriginRequestPolicyHeaderBehaviorValue
+    on OriginRequestPolicyHeaderBehavior {
   String toValue() {
     switch (this) {
       case OriginRequestPolicyHeaderBehavior.none:
@@ -9685,7 +9688,7 @@ extension on OriginRequestPolicyHeaderBehavior {
   }
 }
 
-extension on String {
+extension OriginRequestPolicyHeaderBehaviorFromString on String {
   OriginRequestPolicyHeaderBehavior toOriginRequestPolicyHeaderBehavior() {
     switch (this) {
       case 'none':
@@ -9809,7 +9812,8 @@ enum OriginRequestPolicyQueryStringBehavior {
   all,
 }
 
-extension on OriginRequestPolicyQueryStringBehavior {
+extension OriginRequestPolicyQueryStringBehaviorValue
+    on OriginRequestPolicyQueryStringBehavior {
   String toValue() {
     switch (this) {
       case OriginRequestPolicyQueryStringBehavior.none:
@@ -9822,7 +9826,7 @@ extension on OriginRequestPolicyQueryStringBehavior {
   }
 }
 
-extension on String {
+extension OriginRequestPolicyQueryStringBehaviorFromString on String {
   OriginRequestPolicyQueryStringBehavior
       toOriginRequestPolicyQueryStringBehavior() {
     switch (this) {
@@ -9929,7 +9933,7 @@ enum OriginRequestPolicyType {
   custom,
 }
 
-extension on OriginRequestPolicyType {
+extension OriginRequestPolicyTypeValue on OriginRequestPolicyType {
   String toValue() {
     switch (this) {
       case OriginRequestPolicyType.managed:
@@ -9940,7 +9944,7 @@ extension on OriginRequestPolicyType {
   }
 }
 
-extension on String {
+extension OriginRequestPolicyTypeFromString on String {
   OriginRequestPolicyType toOriginRequestPolicyType() {
     switch (this) {
       case 'managed':
@@ -10309,7 +10313,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension on PriceClass {
+extension PriceClassValue on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -10322,7 +10326,7 @@ extension on PriceClass {
   }
 }
 
-extension on String {
+extension PriceClassFromString on String {
   PriceClass toPriceClass() {
     switch (this) {
       case 'PriceClass_100':
@@ -10863,7 +10867,8 @@ enum RealtimeMetricsSubscriptionStatus {
   disabled,
 }
 
-extension on RealtimeMetricsSubscriptionStatus {
+extension RealtimeMetricsSubscriptionStatusValue
+    on RealtimeMetricsSubscriptionStatus {
   String toValue() {
     switch (this) {
       case RealtimeMetricsSubscriptionStatus.enabled:
@@ -10874,7 +10879,7 @@ extension on RealtimeMetricsSubscriptionStatus {
   }
 }
 
-extension on String {
+extension RealtimeMetricsSubscriptionStatusFromString on String {
   RealtimeMetricsSubscriptionStatus toRealtimeMetricsSubscriptionStatus() {
     switch (this) {
       case 'Enabled':
@@ -11042,7 +11047,7 @@ enum SSLSupportMethod {
   staticIp,
 }
 
-extension on SSLSupportMethod {
+extension SSLSupportMethodValue on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -11055,7 +11060,7 @@ extension on SSLSupportMethod {
   }
 }
 
-extension on String {
+extension SSLSupportMethodFromString on String {
   SSLSupportMethod toSSLSupportMethod() {
     switch (this) {
       case 'sni-only':
@@ -11104,7 +11109,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension on SslProtocol {
+extension SslProtocolValue on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -11119,7 +11124,7 @@ extension on SslProtocol {
   }
 }
 
-extension on String {
+extension SslProtocolFromString on String {
   SslProtocol toSslProtocol() {
     switch (this) {
       case 'SSLv3':
@@ -12266,7 +12271,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:
@@ -12279,7 +12284,7 @@ extension on ViewerProtocolPolicy {
   }
 }
 
-extension on String {
+extension ViewerProtocolPolicyFromString on String {
   ViewerProtocolPolicy toViewerProtocolPolicy() {
     switch (this) {
       case 'allow-all':

--- a/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
@@ -4112,7 +4112,7 @@ enum CachePolicyCookieBehavior {
   all,
 }
 
-extension CachePolicyCookieBehaviorValue on CachePolicyCookieBehavior {
+extension CachePolicyCookieBehaviorValueExtension on CachePolicyCookieBehavior {
   String toValue() {
     switch (this) {
       case CachePolicyCookieBehavior.none:
@@ -4217,7 +4217,7 @@ enum CachePolicyHeaderBehavior {
   whitelist,
 }
 
-extension CachePolicyHeaderBehaviorValue on CachePolicyHeaderBehavior {
+extension CachePolicyHeaderBehaviorValueExtension on CachePolicyHeaderBehavior {
   String toValue() {
     switch (this) {
       case CachePolicyHeaderBehavior.none:
@@ -4340,7 +4340,7 @@ enum CachePolicyQueryStringBehavior {
   all,
 }
 
-extension CachePolicyQueryStringBehaviorValue
+extension CachePolicyQueryStringBehaviorValueExtension
     on CachePolicyQueryStringBehavior {
   String toValue() {
     switch (this) {
@@ -4480,7 +4480,7 @@ enum CachePolicyType {
   custom,
 }
 
-extension CachePolicyTypeValue on CachePolicyType {
+extension CachePolicyTypeValueExtension on CachePolicyType {
   String toValue() {
     switch (this) {
       case CachePolicyType.managed:
@@ -4570,7 +4570,7 @@ enum CertificateSource {
   acm,
 }
 
-extension CertificateSourceValue on CertificateSource {
+extension CertificateSourceValueExtension on CertificateSource {
   String toValue() {
     switch (this) {
       case CertificateSource.cloudfront:
@@ -6879,7 +6879,7 @@ enum EventType {
   originResponse,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.viewerRequest:
@@ -7281,7 +7281,7 @@ enum Format {
   uRLEncoded,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.uRLEncoded:
@@ -7552,7 +7552,7 @@ enum GeoRestrictionType {
   none,
 }
 
-extension GeoRestrictionTypeValue on GeoRestrictionType {
+extension GeoRestrictionTypeValueExtension on GeoRestrictionType {
   String toValue() {
     switch (this) {
       case GeoRestrictionType.blacklist:
@@ -7944,7 +7944,7 @@ enum HttpVersion {
   http2,
 }
 
-extension HttpVersionValue on HttpVersion {
+extension HttpVersionValueExtension on HttpVersion {
   String toValue() {
     switch (this) {
       case HttpVersion.http1_1:
@@ -7973,7 +7973,7 @@ enum ICPRecordalStatus {
   pending,
 }
 
-extension ICPRecordalStatusValue on ICPRecordalStatus {
+extension ICPRecordalStatusValueExtension on ICPRecordalStatus {
   String toValue() {
     switch (this) {
       case ICPRecordalStatus.approved:
@@ -8176,7 +8176,7 @@ enum ItemSelection {
   all,
 }
 
-extension ItemSelectionValue on ItemSelection {
+extension ItemSelectionValueExtension on ItemSelection {
   String toValue() {
     switch (this) {
       case ItemSelection.none:
@@ -8847,7 +8847,7 @@ enum Method {
   delete,
 }
 
-extension MethodValue on Method {
+extension MethodValueExtension on Method {
   String toValue() {
     switch (this) {
       case Method.get:
@@ -8899,7 +8899,7 @@ enum MinimumProtocolVersion {
   tLSv1_2_2019,
 }
 
-extension MinimumProtocolVersionValue on MinimumProtocolVersion {
+extension MinimumProtocolVersionValueExtension on MinimumProtocolVersion {
   String toValue() {
     switch (this) {
       case MinimumProtocolVersion.sSLv3:
@@ -9406,7 +9406,7 @@ enum OriginProtocolPolicy {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyValue on OriginProtocolPolicy {
+extension OriginProtocolPolicyValueExtension on OriginProtocolPolicy {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicy.httpOnly:
@@ -9577,7 +9577,7 @@ enum OriginRequestPolicyCookieBehavior {
   all,
 }
 
-extension OriginRequestPolicyCookieBehaviorValue
+extension OriginRequestPolicyCookieBehaviorValueExtension
     on OriginRequestPolicyCookieBehavior {
   String toValue() {
     switch (this) {
@@ -9672,7 +9672,7 @@ enum OriginRequestPolicyHeaderBehavior {
   allViewerAndWhitelistCloudFront,
 }
 
-extension OriginRequestPolicyHeaderBehaviorValue
+extension OriginRequestPolicyHeaderBehaviorValueExtension
     on OriginRequestPolicyHeaderBehavior {
   String toValue() {
     switch (this) {
@@ -9812,7 +9812,7 @@ enum OriginRequestPolicyQueryStringBehavior {
   all,
 }
 
-extension OriginRequestPolicyQueryStringBehaviorValue
+extension OriginRequestPolicyQueryStringBehaviorValueExtension
     on OriginRequestPolicyQueryStringBehavior {
   String toValue() {
     switch (this) {
@@ -9933,7 +9933,7 @@ enum OriginRequestPolicyType {
   custom,
 }
 
-extension OriginRequestPolicyTypeValue on OriginRequestPolicyType {
+extension OriginRequestPolicyTypeValueExtension on OriginRequestPolicyType {
   String toValue() {
     switch (this) {
       case OriginRequestPolicyType.managed:
@@ -10313,7 +10313,7 @@ enum PriceClass {
   priceClassAll,
 }
 
-extension PriceClassValue on PriceClass {
+extension PriceClassValueExtension on PriceClass {
   String toValue() {
     switch (this) {
       case PriceClass.priceClass_100:
@@ -10867,7 +10867,7 @@ enum RealtimeMetricsSubscriptionStatus {
   disabled,
 }
 
-extension RealtimeMetricsSubscriptionStatusValue
+extension RealtimeMetricsSubscriptionStatusValueExtension
     on RealtimeMetricsSubscriptionStatus {
   String toValue() {
     switch (this) {
@@ -11047,7 +11047,7 @@ enum SSLSupportMethod {
   staticIp,
 }
 
-extension SSLSupportMethodValue on SSLSupportMethod {
+extension SSLSupportMethodValueExtension on SSLSupportMethod {
   String toValue() {
     switch (this) {
       case SSLSupportMethod.sniOnly:
@@ -11109,7 +11109,7 @@ enum SslProtocol {
   tLSv1_2,
 }
 
-extension SslProtocolValue on SslProtocol {
+extension SslProtocolValueExtension on SslProtocol {
   String toValue() {
     switch (this) {
       case SslProtocol.sSLv3:
@@ -12271,7 +12271,7 @@ enum ViewerProtocolPolicy {
   redirectToHttps,
 }
 
-extension ViewerProtocolPolicyValue on ViewerProtocolPolicy {
+extension ViewerProtocolPolicyValueExtension on ViewerProtocolPolicy {
   String toValue() {
     switch (this) {
       case ViewerProtocolPolicy.allowAll:

--- a/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
+++ b/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
@@ -1185,7 +1185,7 @@ enum ClientVersion {
   $5_3,
 }
 
-extension ClientVersionValue on ClientVersion {
+extension ClientVersionValueExtension on ClientVersion {
   String toValue() {
     switch (this) {
       case ClientVersion.$5_1:
@@ -1222,7 +1222,7 @@ enum CloudHsmObjectState {
   degraded,
 }
 
-extension CloudHsmObjectStateValue on CloudHsmObjectState {
+extension CloudHsmObjectStateValueExtension on CloudHsmObjectState {
   String toValue() {
     switch (this) {
       case CloudHsmObjectState.ready:
@@ -1611,7 +1611,7 @@ enum HsmStatus {
   degraded,
 }
 
-extension HsmStatusValue on HsmStatus {
+extension HsmStatusValueExtension on HsmStatus {
   String toValue() {
     switch (this) {
       case HsmStatus.pending:
@@ -1837,7 +1837,7 @@ enum SubscriptionType {
   production,
 }
 
-extension SubscriptionTypeValue on SubscriptionType {
+extension SubscriptionTypeValueExtension on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.production:

--- a/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
+++ b/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
@@ -1185,7 +1185,7 @@ enum ClientVersion {
   $5_3,
 }
 
-extension on ClientVersion {
+extension ClientVersionValue on ClientVersion {
   String toValue() {
     switch (this) {
       case ClientVersion.$5_1:
@@ -1196,7 +1196,7 @@ extension on ClientVersion {
   }
 }
 
-extension on String {
+extension ClientVersionFromString on String {
   ClientVersion toClientVersion() {
     switch (this) {
       case '5.1':
@@ -1222,7 +1222,7 @@ enum CloudHsmObjectState {
   degraded,
 }
 
-extension on CloudHsmObjectState {
+extension CloudHsmObjectStateValue on CloudHsmObjectState {
   String toValue() {
     switch (this) {
       case CloudHsmObjectState.ready:
@@ -1235,7 +1235,7 @@ extension on CloudHsmObjectState {
   }
 }
 
-extension on String {
+extension CloudHsmObjectStateFromString on String {
   CloudHsmObjectState toCloudHsmObjectState() {
     switch (this) {
       case 'READY':
@@ -1611,7 +1611,7 @@ enum HsmStatus {
   degraded,
 }
 
-extension on HsmStatus {
+extension HsmStatusValue on HsmStatus {
   String toValue() {
     switch (this) {
       case HsmStatus.pending:
@@ -1632,7 +1632,7 @@ extension on HsmStatus {
   }
 }
 
-extension on String {
+extension HsmStatusFromString on String {
   HsmStatus toHsmStatus() {
     switch (this) {
       case 'PENDING':
@@ -1837,7 +1837,7 @@ enum SubscriptionType {
   production,
 }
 
-extension on SubscriptionType {
+extension SubscriptionTypeValue on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.production:
@@ -1846,7 +1846,7 @@ extension on SubscriptionType {
   }
 }
 
-extension on String {
+extension SubscriptionTypeFromString on String {
   SubscriptionType toSubscriptionType() {
     switch (this) {
       case 'PRODUCTION':

--- a/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
+++ b/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
@@ -918,7 +918,7 @@ enum BackupPolicy {
   $default,
 }
 
-extension on BackupPolicy {
+extension BackupPolicyValue on BackupPolicy {
   String toValue() {
     switch (this) {
       case BackupPolicy.$default:
@@ -927,7 +927,7 @@ extension on BackupPolicy {
   }
 }
 
-extension on String {
+extension BackupPolicyFromString on String {
   BackupPolicy toBackupPolicy() {
     switch (this) {
       case 'DEFAULT':
@@ -971,7 +971,7 @@ enum BackupRetentionType {
   days,
 }
 
-extension on BackupRetentionType {
+extension BackupRetentionTypeValue on BackupRetentionType {
   String toValue() {
     switch (this) {
       case BackupRetentionType.days:
@@ -980,7 +980,7 @@ extension on BackupRetentionType {
   }
 }
 
-extension on String {
+extension BackupRetentionTypeFromString on String {
   BackupRetentionType toBackupRetentionType() {
     switch (this) {
       case 'DAYS':
@@ -997,7 +997,7 @@ enum BackupState {
   pendingDeletion,
 }
 
-extension on BackupState {
+extension BackupStateValue on BackupState {
   String toValue() {
     switch (this) {
       case BackupState.createInProgress:
@@ -1012,7 +1012,7 @@ extension on BackupState {
   }
 }
 
-extension on String {
+extension BackupStateFromString on String {
   BackupState toBackupState() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -1178,7 +1178,7 @@ enum ClusterState {
   degraded,
 }
 
-extension on ClusterState {
+extension ClusterStateValue on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.createInProgress:
@@ -1203,7 +1203,7 @@ extension on ClusterState {
   }
 }
 
-extension on String {
+extension ClusterStateFromString on String {
   ClusterState toClusterState() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -1472,7 +1472,7 @@ enum HsmState {
   deleted,
 }
 
-extension on HsmState {
+extension HsmStateValue on HsmState {
   String toValue() {
     switch (this) {
       case HsmState.createInProgress:
@@ -1489,7 +1489,7 @@ extension on HsmState {
   }
 }
 
-extension on String {
+extension HsmStateFromString on String {
   HsmState toHsmState() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':

--- a/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
+++ b/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
@@ -918,7 +918,7 @@ enum BackupPolicy {
   $default,
 }
 
-extension BackupPolicyValue on BackupPolicy {
+extension BackupPolicyValueExtension on BackupPolicy {
   String toValue() {
     switch (this) {
       case BackupPolicy.$default:
@@ -971,7 +971,7 @@ enum BackupRetentionType {
   days,
 }
 
-extension BackupRetentionTypeValue on BackupRetentionType {
+extension BackupRetentionTypeValueExtension on BackupRetentionType {
   String toValue() {
     switch (this) {
       case BackupRetentionType.days:
@@ -997,7 +997,7 @@ enum BackupState {
   pendingDeletion,
 }
 
-extension BackupStateValue on BackupState {
+extension BackupStateValueExtension on BackupState {
   String toValue() {
     switch (this) {
       case BackupState.createInProgress:
@@ -1178,7 +1178,7 @@ enum ClusterState {
   degraded,
 }
 
-extension ClusterStateValue on ClusterState {
+extension ClusterStateValueExtension on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.createInProgress:
@@ -1472,7 +1472,7 @@ enum HsmState {
   deleted,
 }
 
-extension HsmStateValue on HsmState {
+extension HsmStateValueExtension on HsmState {
   String toValue() {
     switch (this) {
       case HsmState.createInProgress:

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -1433,7 +1433,7 @@ enum IndexFieldType {
   text,
 }
 
-extension IndexFieldTypeValue on IndexFieldType {
+extension IndexFieldTypeValueExtension on IndexFieldType {
   String toValue() {
     switch (this) {
       case IndexFieldType.uint:
@@ -1616,7 +1616,7 @@ enum OptionState {
   active,
 }
 
-extension OptionStateValue on OptionState {
+extension OptionStateValueExtension on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -1838,7 +1838,7 @@ enum SourceDataFunction {
   map,
 }
 
-extension SourceDataFunctionValue on SourceDataFunction {
+extension SourceDataFunctionValueExtension on SourceDataFunction {
   String toValue() {
     switch (this) {
       case SourceDataFunction.copy:

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -1433,7 +1433,7 @@ enum IndexFieldType {
   text,
 }
 
-extension on IndexFieldType {
+extension IndexFieldTypeValue on IndexFieldType {
   String toValue() {
     switch (this) {
       case IndexFieldType.uint:
@@ -1446,7 +1446,7 @@ extension on IndexFieldType {
   }
 }
 
-extension on String {
+extension IndexFieldTypeFromString on String {
   IndexFieldType toIndexFieldType() {
     switch (this) {
       case 'uint':
@@ -1616,7 +1616,7 @@ enum OptionState {
   active,
 }
 
-extension on OptionState {
+extension OptionStateValue on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -1629,7 +1629,7 @@ extension on OptionState {
   }
 }
 
-extension on String {
+extension OptionStateFromString on String {
   OptionState toOptionState() {
     switch (this) {
       case 'RequiresIndexDocuments':
@@ -1838,7 +1838,7 @@ enum SourceDataFunction {
   map,
 }
 
-extension on SourceDataFunction {
+extension SourceDataFunctionValue on SourceDataFunction {
   String toValue() {
     switch (this) {
       case SourceDataFunction.copy:
@@ -1851,7 +1851,7 @@ extension on SourceDataFunction {
   }
 }
 
-extension on String {
+extension SourceDataFunctionFromString on String {
   SourceDataFunction toSourceDataFunction() {
     switch (this) {
       case 'Copy':

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -1256,7 +1256,7 @@ enum AlgorithmicStemming {
   full,
 }
 
-extension AlgorithmicStemmingValue on AlgorithmicStemming {
+extension AlgorithmicStemmingValueExtension on AlgorithmicStemming {
   String toValue() {
     switch (this) {
       case AlgorithmicStemming.none:
@@ -1449,7 +1449,7 @@ enum AnalysisSchemeLanguage {
   zhHant,
 }
 
-extension AnalysisSchemeLanguageValue on AnalysisSchemeLanguage {
+extension AnalysisSchemeLanguageValueExtension on AnalysisSchemeLanguage {
   String toValue() {
     switch (this) {
       case AnalysisSchemeLanguage.ar:
@@ -2621,7 +2621,7 @@ enum IndexFieldType {
   dateArray,
 }
 
-extension IndexFieldTypeValue on IndexFieldType {
+extension IndexFieldTypeValueExtension on IndexFieldType {
   String toValue() {
     switch (this) {
       case IndexFieldType.int:
@@ -3021,7 +3021,7 @@ enum OptionState {
   failedToValidate,
 }
 
-extension OptionStateValue on OptionState {
+extension OptionStateValueExtension on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -3118,7 +3118,7 @@ enum PartitionInstanceType {
   search_2xlarge,
 }
 
-extension PartitionInstanceTypeValue on PartitionInstanceType {
+extension PartitionInstanceTypeValueExtension on PartitionInstanceType {
   String toValue() {
     switch (this) {
       case PartitionInstanceType.searchM1Small:
@@ -3298,7 +3298,7 @@ enum SuggesterFuzzyMatching {
   high,
 }
 
-extension SuggesterFuzzyMatchingValue on SuggesterFuzzyMatching {
+extension SuggesterFuzzyMatchingValueExtension on SuggesterFuzzyMatching {
   String toValue() {
     switch (this) {
       case SuggesterFuzzyMatching.none:
@@ -3348,7 +3348,7 @@ enum TLSSecurityPolicy {
   policyMinTls_1_2_2019_07,
 }
 
-extension TLSSecurityPolicyValue on TLSSecurityPolicy {
+extension TLSSecurityPolicyValueExtension on TLSSecurityPolicy {
   String toValue() {
     switch (this) {
       case TLSSecurityPolicy.policyMinTls_1_0_2019_07:

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -1256,7 +1256,7 @@ enum AlgorithmicStemming {
   full,
 }
 
-extension on AlgorithmicStemming {
+extension AlgorithmicStemmingValue on AlgorithmicStemming {
   String toValue() {
     switch (this) {
       case AlgorithmicStemming.none:
@@ -1271,7 +1271,7 @@ extension on AlgorithmicStemming {
   }
 }
 
-extension on String {
+extension AlgorithmicStemmingFromString on String {
   AlgorithmicStemming toAlgorithmicStemming() {
     switch (this) {
       case 'none':
@@ -1449,7 +1449,7 @@ enum AnalysisSchemeLanguage {
   zhHant,
 }
 
-extension on AnalysisSchemeLanguage {
+extension AnalysisSchemeLanguageValue on AnalysisSchemeLanguage {
   String toValue() {
     switch (this) {
       case AnalysisSchemeLanguage.ar:
@@ -1526,7 +1526,7 @@ extension on AnalysisSchemeLanguage {
   }
 }
 
-extension on String {
+extension AnalysisSchemeLanguageFromString on String {
   AnalysisSchemeLanguage toAnalysisSchemeLanguage() {
     switch (this) {
       case 'ar':
@@ -2621,7 +2621,7 @@ enum IndexFieldType {
   dateArray,
 }
 
-extension on IndexFieldType {
+extension IndexFieldTypeValue on IndexFieldType {
   String toValue() {
     switch (this) {
       case IndexFieldType.int:
@@ -2650,7 +2650,7 @@ extension on IndexFieldType {
   }
 }
 
-extension on String {
+extension IndexFieldTypeFromString on String {
   IndexFieldType toIndexFieldType() {
     switch (this) {
       case 'int':
@@ -3021,7 +3021,7 @@ enum OptionState {
   failedToValidate,
 }
 
-extension on OptionState {
+extension OptionStateValue on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -3036,7 +3036,7 @@ extension on OptionState {
   }
 }
 
-extension on String {
+extension OptionStateFromString on String {
   OptionState toOptionState() {
     switch (this) {
       case 'RequiresIndexDocuments':
@@ -3118,7 +3118,7 @@ enum PartitionInstanceType {
   search_2xlarge,
 }
 
-extension on PartitionInstanceType {
+extension PartitionInstanceTypeValue on PartitionInstanceType {
   String toValue() {
     switch (this) {
       case PartitionInstanceType.searchM1Small:
@@ -3151,7 +3151,7 @@ extension on PartitionInstanceType {
   }
 }
 
-extension on String {
+extension PartitionInstanceTypeFromString on String {
   PartitionInstanceType toPartitionInstanceType() {
     switch (this) {
       case 'search.m1.small':
@@ -3298,7 +3298,7 @@ enum SuggesterFuzzyMatching {
   high,
 }
 
-extension on SuggesterFuzzyMatching {
+extension SuggesterFuzzyMatchingValue on SuggesterFuzzyMatching {
   String toValue() {
     switch (this) {
       case SuggesterFuzzyMatching.none:
@@ -3311,7 +3311,7 @@ extension on SuggesterFuzzyMatching {
   }
 }
 
-extension on String {
+extension SuggesterFuzzyMatchingFromString on String {
   SuggesterFuzzyMatching toSuggesterFuzzyMatching() {
     switch (this) {
       case 'none':
@@ -3348,7 +3348,7 @@ enum TLSSecurityPolicy {
   policyMinTls_1_2_2019_07,
 }
 
-extension on TLSSecurityPolicy {
+extension TLSSecurityPolicyValue on TLSSecurityPolicy {
   String toValue() {
     switch (this) {
       case TLSSecurityPolicy.policyMinTls_1_0_2019_07:
@@ -3359,7 +3359,7 @@ extension on TLSSecurityPolicy {
   }
 }
 
-extension on String {
+extension TLSSecurityPolicyFromString on String {
   TLSSecurityPolicy toTLSSecurityPolicy() {
     switch (this) {
       case 'Policy-Min-TLS-1-0-2019-07':

--- a/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
+++ b/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
@@ -655,7 +655,7 @@ enum ContentType {
   applicationXml,
 }
 
-extension ContentTypeValue on ContentType {
+extension ContentTypeValueExtension on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.applicationJson:
@@ -868,7 +868,7 @@ enum QueryParser {
   dismax,
 }
 
-extension QueryParserValue on QueryParser {
+extension QueryParserValueExtension on QueryParser {
   String toValue() {
     switch (this) {
       case QueryParser.simple:

--- a/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
+++ b/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
@@ -655,7 +655,7 @@ enum ContentType {
   applicationXml,
 }
 
-extension on ContentType {
+extension ContentTypeValue on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.applicationJson:
@@ -666,7 +666,7 @@ extension on ContentType {
   }
 }
 
-extension on String {
+extension ContentTypeFromString on String {
   ContentType toContentType() {
     switch (this) {
       case 'application/json':
@@ -868,7 +868,7 @@ enum QueryParser {
   dismax,
 }
 
-extension on QueryParser {
+extension QueryParserValue on QueryParser {
   String toValue() {
     switch (this) {
       case QueryParser.simple:
@@ -883,7 +883,7 @@ extension on QueryParser {
   }
 }
 
-extension on String {
+extension QueryParserFromString on String {
   QueryParser toQueryParser() {
     switch (this) {
       case 'simple':

--- a/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
+++ b/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
@@ -1920,7 +1920,7 @@ enum EventCategory {
   insight,
 }
 
-extension on EventCategory {
+extension EventCategoryValue on EventCategory {
   String toValue() {
     switch (this) {
       case EventCategory.insight:
@@ -1929,7 +1929,7 @@ extension on EventCategory {
   }
 }
 
-extension on String {
+extension EventCategoryFromString on String {
   EventCategory toEventCategory() {
     switch (this) {
       case 'insight':
@@ -2263,7 +2263,7 @@ enum InsightType {
   apiCallRateInsight,
 }
 
-extension on InsightType {
+extension InsightTypeValue on InsightType {
   String toValue() {
     switch (this) {
       case InsightType.apiCallRateInsight:
@@ -2272,7 +2272,7 @@ extension on InsightType {
   }
 }
 
-extension on String {
+extension InsightTypeFromString on String {
   InsightType toInsightType() {
     switch (this) {
       case 'ApiCallRateInsight':
@@ -2393,7 +2393,7 @@ enum LookupAttributeKey {
   accessKeyId,
 }
 
-extension on LookupAttributeKey {
+extension LookupAttributeKeyValue on LookupAttributeKey {
   String toValue() {
     switch (this) {
       case LookupAttributeKey.eventId:
@@ -2416,7 +2416,7 @@ extension on LookupAttributeKey {
   }
 }
 
-extension on String {
+extension LookupAttributeKeyFromString on String {
   LookupAttributeKey toLookupAttributeKey() {
     switch (this) {
       case 'EventId':
@@ -2564,7 +2564,7 @@ enum ReadWriteType {
   all,
 }
 
-extension on ReadWriteType {
+extension ReadWriteTypeValue on ReadWriteType {
   String toValue() {
     switch (this) {
       case ReadWriteType.readOnly:
@@ -2577,7 +2577,7 @@ extension on ReadWriteType {
   }
 }
 
-extension on String {
+extension ReadWriteTypeFromString on String {
   ReadWriteType toReadWriteType() {
     switch (this) {
       case 'ReadOnly':

--- a/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
+++ b/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
@@ -1920,7 +1920,7 @@ enum EventCategory {
   insight,
 }
 
-extension EventCategoryValue on EventCategory {
+extension EventCategoryValueExtension on EventCategory {
   String toValue() {
     switch (this) {
       case EventCategory.insight:
@@ -2263,7 +2263,7 @@ enum InsightType {
   apiCallRateInsight,
 }
 
-extension InsightTypeValue on InsightType {
+extension InsightTypeValueExtension on InsightType {
   String toValue() {
     switch (this) {
       case InsightType.apiCallRateInsight:
@@ -2393,7 +2393,7 @@ enum LookupAttributeKey {
   accessKeyId,
 }
 
-extension LookupAttributeKeyValue on LookupAttributeKey {
+extension LookupAttributeKeyValueExtension on LookupAttributeKey {
   String toValue() {
     switch (this) {
       case LookupAttributeKey.eventId:
@@ -2564,7 +2564,7 @@ enum ReadWriteType {
   all,
 }
 
-extension ReadWriteTypeValue on ReadWriteType {
+extension ReadWriteTypeValueExtension on ReadWriteType {
   String toValue() {
     switch (this) {
       case ReadWriteType.readOnly:

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -2872,7 +2872,7 @@ enum AlarmType {
   metricAlarm,
 }
 
-extension AlarmTypeValue on AlarmType {
+extension AlarmTypeValueExtension on AlarmType {
   String toValue() {
     switch (this) {
       case AlarmType.compositeAlarm:
@@ -2997,7 +2997,7 @@ enum AnomalyDetectorStateValue {
   trained,
 }
 
-extension AnomalyDetectorStateValueValue on AnomalyDetectorStateValue {
+extension AnomalyDetectorStateValueValueExtension on AnomalyDetectorStateValue {
   String toValue() {
     switch (this) {
       case AnomalyDetectorStateValue.pendingTraining:
@@ -3034,7 +3034,7 @@ enum ComparisonOperator {
   greaterThanUpperThreshold,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -3691,7 +3691,7 @@ enum HistoryItemType {
   action,
 }
 
-extension HistoryItemTypeValue on HistoryItemType {
+extension HistoryItemTypeValueExtension on HistoryItemType {
   String toValue() {
     switch (this) {
       case HistoryItemType.configurationUpdate:
@@ -4688,7 +4688,7 @@ enum RecentlyActive {
   pt3h,
 }
 
-extension RecentlyActiveValue on RecentlyActive {
+extension RecentlyActiveValueExtension on RecentlyActive {
   String toValue() {
     switch (this) {
       case RecentlyActive.pt3h:
@@ -4712,7 +4712,7 @@ enum ScanBy {
   timestampAscending,
 }
 
-extension ScanByValue on ScanBy {
+extension ScanByValueExtension on ScanBy {
   String toValue() {
     switch (this) {
       case ScanBy.timestampDescending:
@@ -4765,7 +4765,7 @@ enum StandardUnit {
   none,
 }
 
-extension StandardUnitValue on StandardUnit {
+extension StandardUnitValueExtension on StandardUnit {
   String toValue() {
     switch (this) {
       case StandardUnit.seconds:
@@ -4894,7 +4894,7 @@ enum StateValue {
   insufficientData,
 }
 
-extension StateValueValue on StateValue {
+extension StateValueValueExtension on StateValue {
   String toValue() {
     switch (this) {
       case StateValue.ok:
@@ -4929,7 +4929,7 @@ enum Statistic {
   maximum,
 }
 
-extension StatisticValue on Statistic {
+extension StatisticValueExtension on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sampleCount:
@@ -5004,7 +5004,7 @@ enum StatusCode {
   partialData,
 }
 
-extension StatusCodeValue on StatusCode {
+extension StatusCodeValueExtension on StatusCode {
   String toValue() {
     switch (this) {
       case StatusCode.complete:

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -2872,7 +2872,7 @@ enum AlarmType {
   metricAlarm,
 }
 
-extension on AlarmType {
+extension AlarmTypeValue on AlarmType {
   String toValue() {
     switch (this) {
       case AlarmType.compositeAlarm:
@@ -2883,7 +2883,7 @@ extension on AlarmType {
   }
 }
 
-extension on String {
+extension AlarmTypeFromString on String {
   AlarmType toAlarmType() {
     switch (this) {
       case 'CompositeAlarm':
@@ -2997,7 +2997,7 @@ enum AnomalyDetectorStateValue {
   trained,
 }
 
-extension on AnomalyDetectorStateValue {
+extension AnomalyDetectorStateValueValue on AnomalyDetectorStateValue {
   String toValue() {
     switch (this) {
       case AnomalyDetectorStateValue.pendingTraining:
@@ -3010,7 +3010,7 @@ extension on AnomalyDetectorStateValue {
   }
 }
 
-extension on String {
+extension AnomalyDetectorStateValueFromString on String {
   AnomalyDetectorStateValue toAnomalyDetectorStateValue() {
     switch (this) {
       case 'PENDING_TRAINING':
@@ -3034,7 +3034,7 @@ enum ComparisonOperator {
   greaterThanUpperThreshold,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -3055,7 +3055,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'GreaterThanOrEqualToThreshold':
@@ -3691,7 +3691,7 @@ enum HistoryItemType {
   action,
 }
 
-extension on HistoryItemType {
+extension HistoryItemTypeValue on HistoryItemType {
   String toValue() {
     switch (this) {
       case HistoryItemType.configurationUpdate:
@@ -3704,7 +3704,7 @@ extension on HistoryItemType {
   }
 }
 
-extension on String {
+extension HistoryItemTypeFromString on String {
   HistoryItemType toHistoryItemType() {
     switch (this) {
       case 'ConfigurationUpdate':
@@ -4688,7 +4688,7 @@ enum RecentlyActive {
   pt3h,
 }
 
-extension on RecentlyActive {
+extension RecentlyActiveValue on RecentlyActive {
   String toValue() {
     switch (this) {
       case RecentlyActive.pt3h:
@@ -4697,7 +4697,7 @@ extension on RecentlyActive {
   }
 }
 
-extension on String {
+extension RecentlyActiveFromString on String {
   RecentlyActive toRecentlyActive() {
     switch (this) {
       case 'PT3H':
@@ -4712,7 +4712,7 @@ enum ScanBy {
   timestampAscending,
 }
 
-extension on ScanBy {
+extension ScanByValue on ScanBy {
   String toValue() {
     switch (this) {
       case ScanBy.timestampDescending:
@@ -4723,7 +4723,7 @@ extension on ScanBy {
   }
 }
 
-extension on String {
+extension ScanByFromString on String {
   ScanBy toScanBy() {
     switch (this) {
       case 'TimestampDescending':
@@ -4765,7 +4765,7 @@ enum StandardUnit {
   none,
 }
 
-extension on StandardUnit {
+extension StandardUnitValue on StandardUnit {
   String toValue() {
     switch (this) {
       case StandardUnit.seconds:
@@ -4826,7 +4826,7 @@ extension on StandardUnit {
   }
 }
 
-extension on String {
+extension StandardUnitFromString on String {
   StandardUnit toStandardUnit() {
     switch (this) {
       case 'Seconds':
@@ -4894,7 +4894,7 @@ enum StateValue {
   insufficientData,
 }
 
-extension on StateValue {
+extension StateValueValue on StateValue {
   String toValue() {
     switch (this) {
       case StateValue.ok:
@@ -4907,7 +4907,7 @@ extension on StateValue {
   }
 }
 
-extension on String {
+extension StateValueFromString on String {
   StateValue toStateValue() {
     switch (this) {
       case 'OK':
@@ -4929,7 +4929,7 @@ enum Statistic {
   maximum,
 }
 
-extension on Statistic {
+extension StatisticValue on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sampleCount:
@@ -4946,7 +4946,7 @@ extension on Statistic {
   }
 }
 
-extension on String {
+extension StatisticFromString on String {
   Statistic toStatistic() {
     switch (this) {
       case 'SampleCount':
@@ -5004,7 +5004,7 @@ enum StatusCode {
   partialData,
 }
 
-extension on StatusCode {
+extension StatusCodeValue on StatusCode {
   String toValue() {
     switch (this) {
       case StatusCode.complete:
@@ -5017,7 +5017,7 @@ extension on StatusCode {
   }
 }
 
-extension on String {
+extension StatusCodeFromString on String {
   StatusCode toStatusCode() {
     switch (this) {
       case 'Complete':

--- a/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
+++ b/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
@@ -3177,7 +3177,7 @@ enum ArtifactNamespace {
   buildId,
 }
 
-extension on ArtifactNamespace {
+extension ArtifactNamespaceValue on ArtifactNamespace {
   String toValue() {
     switch (this) {
       case ArtifactNamespace.none:
@@ -3188,7 +3188,7 @@ extension on ArtifactNamespace {
   }
 }
 
-extension on String {
+extension ArtifactNamespaceFromString on String {
   ArtifactNamespace toArtifactNamespace() {
     switch (this) {
       case 'NONE':
@@ -3205,7 +3205,7 @@ enum ArtifactPackaging {
   zip,
 }
 
-extension on ArtifactPackaging {
+extension ArtifactPackagingValue on ArtifactPackaging {
   String toValue() {
     switch (this) {
       case ArtifactPackaging.none:
@@ -3216,7 +3216,7 @@ extension on ArtifactPackaging {
   }
 }
 
-extension on String {
+extension ArtifactPackagingFromString on String {
   ArtifactPackaging toArtifactPackaging() {
     switch (this) {
       case 'NONE':
@@ -3234,7 +3234,7 @@ enum ArtifactsType {
   noArtifacts,
 }
 
-extension on ArtifactsType {
+extension ArtifactsTypeValue on ArtifactsType {
   String toValue() {
     switch (this) {
       case ArtifactsType.codepipeline:
@@ -3247,7 +3247,7 @@ extension on ArtifactsType {
   }
 }
 
-extension on String {
+extension ArtifactsTypeFromString on String {
   ArtifactsType toArtifactsType() {
     switch (this) {
       case 'CODEPIPELINE':
@@ -3267,7 +3267,7 @@ enum AuthType {
   personalAccessToken,
 }
 
-extension on AuthType {
+extension AuthTypeValue on AuthType {
   String toValue() {
     switch (this) {
       case AuthType.oauth:
@@ -3280,7 +3280,7 @@ extension on AuthType {
   }
 }
 
-extension on String {
+extension AuthTypeFromString on String {
   AuthType toAuthType() {
     switch (this) {
       case 'OAUTH':
@@ -4211,7 +4211,7 @@ enum BuildBatchPhaseType {
   stopped,
 }
 
-extension on BuildBatchPhaseType {
+extension BuildBatchPhaseTypeValue on BuildBatchPhaseType {
   String toValue() {
     switch (this) {
       case BuildBatchPhaseType.submitted:
@@ -4232,7 +4232,7 @@ extension on BuildBatchPhaseType {
   }
 }
 
-extension on String {
+extension BuildBatchPhaseTypeFromString on String {
   BuildBatchPhaseType toBuildBatchPhaseType() {
     switch (this) {
       case 'SUBMITTED':
@@ -4442,7 +4442,7 @@ enum BuildPhaseType {
   completed,
 }
 
-extension on BuildPhaseType {
+extension BuildPhaseTypeValue on BuildPhaseType {
   String toValue() {
     switch (this) {
       case BuildPhaseType.submitted:
@@ -4471,7 +4471,7 @@ extension on BuildPhaseType {
   }
 }
 
-extension on String {
+extension BuildPhaseTypeFromString on String {
   BuildPhaseType toBuildPhaseType() {
     switch (this) {
       case 'SUBMITTED':
@@ -4617,7 +4617,7 @@ enum CacheMode {
   localCustomCache,
 }
 
-extension on CacheMode {
+extension CacheModeValue on CacheMode {
   String toValue() {
     switch (this) {
       case CacheMode.localDockerLayerCache:
@@ -4630,7 +4630,7 @@ extension on CacheMode {
   }
 }
 
-extension on String {
+extension CacheModeFromString on String {
   CacheMode toCacheMode() {
     switch (this) {
       case 'LOCAL_DOCKER_LAYER_CACHE':
@@ -4650,7 +4650,7 @@ enum CacheType {
   local,
 }
 
-extension on CacheType {
+extension CacheTypeValue on CacheType {
   String toValue() {
     switch (this) {
       case CacheType.noCache:
@@ -4663,7 +4663,7 @@ extension on CacheType {
   }
 }
 
-extension on String {
+extension CacheTypeFromString on String {
   CacheType toCacheType() {
     switch (this) {
       case 'NO_CACHE':
@@ -4852,7 +4852,7 @@ enum ComputeType {
   buildGeneral1_2xlarge,
 }
 
-extension on ComputeType {
+extension ComputeTypeValue on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.buildGeneral1Small:
@@ -4867,7 +4867,7 @@ extension on ComputeType {
   }
 }
 
-extension on String {
+extension ComputeTypeFromString on String {
   ComputeType toComputeType() {
     switch (this) {
       case 'BUILD_GENERAL1_SMALL':
@@ -4936,7 +4936,7 @@ enum CredentialProviderType {
   secretsManager,
 }
 
-extension on CredentialProviderType {
+extension CredentialProviderTypeValue on CredentialProviderType {
   String toValue() {
     switch (this) {
       case CredentialProviderType.secretsManager:
@@ -4945,7 +4945,7 @@ extension on CredentialProviderType {
   }
 }
 
-extension on String {
+extension CredentialProviderTypeFromString on String {
   CredentialProviderType toCredentialProviderType() {
     switch (this) {
       case 'SECRETS_MANAGER':
@@ -5199,7 +5199,7 @@ enum EnvironmentType {
   windowsServer_2019Container,
 }
 
-extension on EnvironmentType {
+extension EnvironmentTypeValue on EnvironmentType {
   String toValue() {
     switch (this) {
       case EnvironmentType.windowsContainer:
@@ -5216,7 +5216,7 @@ extension on EnvironmentType {
   }
 }
 
-extension on String {
+extension EnvironmentTypeFromString on String {
   EnvironmentType toEnvironmentType() {
     switch (this) {
       case 'WINDOWS_CONTAINER':
@@ -5306,7 +5306,7 @@ enum EnvironmentVariableType {
   secretsManager,
 }
 
-extension on EnvironmentVariableType {
+extension EnvironmentVariableTypeValue on EnvironmentVariableType {
   String toValue() {
     switch (this) {
       case EnvironmentVariableType.plaintext:
@@ -5319,7 +5319,7 @@ extension on EnvironmentVariableType {
   }
 }
 
-extension on String {
+extension EnvironmentVariableTypeFromString on String {
   EnvironmentVariableType toEnvironmentVariableType() {
     switch (this) {
       case 'PLAINTEXT':
@@ -5364,7 +5364,7 @@ enum FileSystemType {
   efs,
 }
 
-extension on FileSystemType {
+extension FileSystemTypeValue on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.efs:
@@ -5373,7 +5373,7 @@ extension on FileSystemType {
   }
 }
 
-extension on String {
+extension FileSystemTypeFromString on String {
   FileSystemType toFileSystemType() {
     switch (this) {
       case 'EFS':
@@ -5447,7 +5447,7 @@ enum ImagePullCredentialsType {
   serviceRole,
 }
 
-extension on ImagePullCredentialsType {
+extension ImagePullCredentialsTypeValue on ImagePullCredentialsType {
   String toValue() {
     switch (this) {
       case ImagePullCredentialsType.codebuild:
@@ -5458,7 +5458,7 @@ extension on ImagePullCredentialsType {
   }
 }
 
-extension on String {
+extension ImagePullCredentialsTypeFromString on String {
   ImagePullCredentialsType toImagePullCredentialsType() {
     switch (this) {
       case 'CODEBUILD':
@@ -5504,7 +5504,7 @@ enum LanguageType {
   php,
 }
 
-extension on LanguageType {
+extension LanguageTypeValue on LanguageType {
   String toValue() {
     switch (this) {
       case LanguageType.java:
@@ -5531,7 +5531,7 @@ extension on LanguageType {
   }
 }
 
-extension on String {
+extension LanguageTypeFromString on String {
   LanguageType toLanguageType() {
     switch (this) {
       case 'JAVA':
@@ -5906,7 +5906,7 @@ enum LogsConfigStatusType {
   disabled,
 }
 
-extension on LogsConfigStatusType {
+extension LogsConfigStatusTypeValue on LogsConfigStatusType {
   String toValue() {
     switch (this) {
       case LogsConfigStatusType.enabled:
@@ -5917,7 +5917,7 @@ extension on LogsConfigStatusType {
   }
 }
 
-extension on String {
+extension LogsConfigStatusTypeFromString on String {
   LogsConfigStatusType toLogsConfigStatusType() {
     switch (this) {
       case 'ENABLED':
@@ -6041,7 +6041,7 @@ enum PlatformType {
   windowsServer,
 }
 
-extension on PlatformType {
+extension PlatformTypeValue on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.debian:
@@ -6056,7 +6056,7 @@ extension on PlatformType {
   }
 }
 
-extension on String {
+extension PlatformTypeFromString on String {
   PlatformType toPlatformType() {
     switch (this) {
       case 'DEBIAN':
@@ -7006,7 +7006,7 @@ enum ProjectSortByType {
   lastModifiedTime,
 }
 
-extension on ProjectSortByType {
+extension ProjectSortByTypeValue on ProjectSortByType {
   String toValue() {
     switch (this) {
       case ProjectSortByType.name:
@@ -7019,7 +7019,7 @@ extension on ProjectSortByType {
   }
 }
 
-extension on String {
+extension ProjectSortByTypeFromString on String {
   ProjectSortByType toProjectSortByType() {
     switch (this) {
       case 'NAME':
@@ -7459,7 +7459,7 @@ enum ReportCodeCoverageSortByType {
   filePath,
 }
 
-extension on ReportCodeCoverageSortByType {
+extension ReportCodeCoverageSortByTypeValue on ReportCodeCoverageSortByType {
   String toValue() {
     switch (this) {
       case ReportCodeCoverageSortByType.lineCoveragePercentage:
@@ -7470,7 +7470,7 @@ extension on ReportCodeCoverageSortByType {
   }
 }
 
-extension on String {
+extension ReportCodeCoverageSortByTypeFromString on String {
   ReportCodeCoverageSortByType toReportCodeCoverageSortByType() {
     switch (this) {
       case 'LINE_COVERAGE_PERCENTAGE':
@@ -7531,7 +7531,7 @@ enum ReportExportConfigType {
   noExport,
 }
 
-extension on ReportExportConfigType {
+extension ReportExportConfigTypeValue on ReportExportConfigType {
   String toValue() {
     switch (this) {
       case ReportExportConfigType.s3:
@@ -7542,7 +7542,7 @@ extension on ReportExportConfigType {
   }
 }
 
-extension on String {
+extension ReportExportConfigTypeFromString on String {
   ReportExportConfigType toReportExportConfigType() {
     switch (this) {
       case 'S3':
@@ -7639,7 +7639,7 @@ enum ReportGroupSortByType {
   lastModifiedTime,
 }
 
-extension on ReportGroupSortByType {
+extension ReportGroupSortByTypeValue on ReportGroupSortByType {
   String toValue() {
     switch (this) {
       case ReportGroupSortByType.name:
@@ -7652,7 +7652,7 @@ extension on ReportGroupSortByType {
   }
 }
 
-extension on String {
+extension ReportGroupSortByTypeFromString on String {
   ReportGroupSortByType toReportGroupSortByType() {
     switch (this) {
       case 'NAME':
@@ -7671,7 +7671,7 @@ enum ReportGroupStatusType {
   deleting,
 }
 
-extension on ReportGroupStatusType {
+extension ReportGroupStatusTypeValue on ReportGroupStatusType {
   String toValue() {
     switch (this) {
       case ReportGroupStatusType.active:
@@ -7682,7 +7682,7 @@ extension on ReportGroupStatusType {
   }
 }
 
-extension on String {
+extension ReportGroupStatusTypeFromString on String {
   ReportGroupStatusType toReportGroupStatusType() {
     switch (this) {
       case 'ACTIVE':
@@ -7706,7 +7706,7 @@ enum ReportGroupTrendFieldType {
   branchesMissed,
 }
 
-extension on ReportGroupTrendFieldType {
+extension ReportGroupTrendFieldTypeValue on ReportGroupTrendFieldType {
   String toValue() {
     switch (this) {
       case ReportGroupTrendFieldType.passRate:
@@ -7731,7 +7731,7 @@ extension on ReportGroupTrendFieldType {
   }
 }
 
-extension on String {
+extension ReportGroupTrendFieldTypeFromString on String {
   ReportGroupTrendFieldType toReportGroupTrendFieldType() {
     switch (this) {
       case 'PASS_RATE':
@@ -7781,7 +7781,7 @@ enum ReportPackagingType {
   none,
 }
 
-extension on ReportPackagingType {
+extension ReportPackagingTypeValue on ReportPackagingType {
   String toValue() {
     switch (this) {
       case ReportPackagingType.zip:
@@ -7792,7 +7792,7 @@ extension on ReportPackagingType {
   }
 }
 
-extension on String {
+extension ReportPackagingTypeFromString on String {
   ReportPackagingType toReportPackagingType() {
     switch (this) {
       case 'ZIP':
@@ -7812,7 +7812,7 @@ enum ReportStatusType {
   deleting,
 }
 
-extension on ReportStatusType {
+extension ReportStatusTypeValue on ReportStatusType {
   String toValue() {
     switch (this) {
       case ReportStatusType.generating:
@@ -7829,7 +7829,7 @@ extension on ReportStatusType {
   }
 }
 
-extension on String {
+extension ReportStatusTypeFromString on String {
   ReportStatusType toReportStatusType() {
     switch (this) {
       case 'GENERATING':
@@ -7852,7 +7852,7 @@ enum ReportType {
   codeCoverage,
 }
 
-extension on ReportType {
+extension ReportTypeValue on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.test:
@@ -7863,7 +7863,7 @@ extension on ReportType {
   }
 }
 
-extension on String {
+extension ReportTypeFromString on String {
   ReportType toReportType() {
     switch (this) {
       case 'TEST':
@@ -7938,7 +7938,7 @@ enum RetryBuildBatchType {
   retryFailedBuilds,
 }
 
-extension on RetryBuildBatchType {
+extension RetryBuildBatchTypeValue on RetryBuildBatchType {
   String toValue() {
     switch (this) {
       case RetryBuildBatchType.retryAllBuilds:
@@ -7949,7 +7949,7 @@ extension on RetryBuildBatchType {
   }
 }
 
-extension on String {
+extension RetryBuildBatchTypeFromString on String {
   RetryBuildBatchType toRetryBuildBatchType() {
     switch (this) {
       case 'RETRY_ALL_BUILDS':
@@ -8093,7 +8093,7 @@ enum ServerType {
   githubEnterprise,
 }
 
-extension on ServerType {
+extension ServerTypeValue on ServerType {
   String toValue() {
     switch (this) {
       case ServerType.github:
@@ -8106,7 +8106,7 @@ extension on ServerType {
   }
 }
 
-extension on String {
+extension ServerTypeFromString on String {
   ServerType toServerType() {
     switch (this) {
       case 'GITHUB':
@@ -8125,7 +8125,7 @@ enum SharedResourceSortByType {
   modifiedTime,
 }
 
-extension on SharedResourceSortByType {
+extension SharedResourceSortByTypeValue on SharedResourceSortByType {
   String toValue() {
     switch (this) {
       case SharedResourceSortByType.arn:
@@ -8136,7 +8136,7 @@ extension on SharedResourceSortByType {
   }
 }
 
-extension on String {
+extension SharedResourceSortByTypeFromString on String {
   SharedResourceSortByType toSharedResourceSortByType() {
     switch (this) {
       case 'ARN':
@@ -8153,7 +8153,7 @@ enum SortOrderType {
   descending,
 }
 
-extension on SortOrderType {
+extension SortOrderTypeValue on SortOrderType {
   String toValue() {
     switch (this) {
       case SortOrderType.ascending:
@@ -8164,7 +8164,7 @@ extension on SortOrderType {
   }
 }
 
-extension on String {
+extension SortOrderTypeFromString on String {
   SortOrderType toSortOrderType() {
     switch (this) {
       case 'ASCENDING':
@@ -8217,7 +8217,7 @@ enum SourceAuthType {
   oauth,
 }
 
-extension on SourceAuthType {
+extension SourceAuthTypeValue on SourceAuthType {
   String toValue() {
     switch (this) {
       case SourceAuthType.oauth:
@@ -8226,7 +8226,7 @@ extension on SourceAuthType {
   }
 }
 
-extension on String {
+extension SourceAuthTypeFromString on String {
   SourceAuthType toSourceAuthType() {
     switch (this) {
       case 'OAUTH':
@@ -8274,7 +8274,7 @@ enum SourceType {
   noSource,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.codecommit:
@@ -8295,7 +8295,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'CODECOMMIT':
@@ -8359,7 +8359,7 @@ enum StatusType {
   stopped,
 }
 
-extension on StatusType {
+extension StatusTypeValue on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.succeeded:
@@ -8378,7 +8378,7 @@ extension on StatusType {
   }
 }
 
-extension on String {
+extension StatusTypeFromString on String {
   StatusType toStatusType() {
     switch (this) {
       case 'SUCCEEDED':
@@ -8757,7 +8757,7 @@ enum WebhookBuildType {
   buildBatch,
 }
 
-extension on WebhookBuildType {
+extension WebhookBuildTypeValue on WebhookBuildType {
   String toValue() {
     switch (this) {
       case WebhookBuildType.build:
@@ -8768,7 +8768,7 @@ extension on WebhookBuildType {
   }
 }
 
-extension on String {
+extension WebhookBuildTypeFromString on String {
   WebhookBuildType toWebhookBuildType() {
     switch (this) {
       case 'BUILD':
@@ -8884,7 +8884,7 @@ enum WebhookFilterType {
   commitMessage,
 }
 
-extension on WebhookFilterType {
+extension WebhookFilterTypeValue on WebhookFilterType {
   String toValue() {
     switch (this) {
       case WebhookFilterType.event:
@@ -8903,7 +8903,7 @@ extension on WebhookFilterType {
   }
 }
 
-extension on String {
+extension WebhookFilterTypeFromString on String {
   WebhookFilterType toWebhookFilterType() {
     switch (this) {
       case 'EVENT':

--- a/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
+++ b/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
@@ -3177,7 +3177,7 @@ enum ArtifactNamespace {
   buildId,
 }
 
-extension ArtifactNamespaceValue on ArtifactNamespace {
+extension ArtifactNamespaceValueExtension on ArtifactNamespace {
   String toValue() {
     switch (this) {
       case ArtifactNamespace.none:
@@ -3205,7 +3205,7 @@ enum ArtifactPackaging {
   zip,
 }
 
-extension ArtifactPackagingValue on ArtifactPackaging {
+extension ArtifactPackagingValueExtension on ArtifactPackaging {
   String toValue() {
     switch (this) {
       case ArtifactPackaging.none:
@@ -3234,7 +3234,7 @@ enum ArtifactsType {
   noArtifacts,
 }
 
-extension ArtifactsTypeValue on ArtifactsType {
+extension ArtifactsTypeValueExtension on ArtifactsType {
   String toValue() {
     switch (this) {
       case ArtifactsType.codepipeline:
@@ -3267,7 +3267,7 @@ enum AuthType {
   personalAccessToken,
 }
 
-extension AuthTypeValue on AuthType {
+extension AuthTypeValueExtension on AuthType {
   String toValue() {
     switch (this) {
       case AuthType.oauth:
@@ -4211,7 +4211,7 @@ enum BuildBatchPhaseType {
   stopped,
 }
 
-extension BuildBatchPhaseTypeValue on BuildBatchPhaseType {
+extension BuildBatchPhaseTypeValueExtension on BuildBatchPhaseType {
   String toValue() {
     switch (this) {
       case BuildBatchPhaseType.submitted:
@@ -4442,7 +4442,7 @@ enum BuildPhaseType {
   completed,
 }
 
-extension BuildPhaseTypeValue on BuildPhaseType {
+extension BuildPhaseTypeValueExtension on BuildPhaseType {
   String toValue() {
     switch (this) {
       case BuildPhaseType.submitted:
@@ -4617,7 +4617,7 @@ enum CacheMode {
   localCustomCache,
 }
 
-extension CacheModeValue on CacheMode {
+extension CacheModeValueExtension on CacheMode {
   String toValue() {
     switch (this) {
       case CacheMode.localDockerLayerCache:
@@ -4650,7 +4650,7 @@ enum CacheType {
   local,
 }
 
-extension CacheTypeValue on CacheType {
+extension CacheTypeValueExtension on CacheType {
   String toValue() {
     switch (this) {
       case CacheType.noCache:
@@ -4852,7 +4852,7 @@ enum ComputeType {
   buildGeneral1_2xlarge,
 }
 
-extension ComputeTypeValue on ComputeType {
+extension ComputeTypeValueExtension on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.buildGeneral1Small:
@@ -4936,7 +4936,7 @@ enum CredentialProviderType {
   secretsManager,
 }
 
-extension CredentialProviderTypeValue on CredentialProviderType {
+extension CredentialProviderTypeValueExtension on CredentialProviderType {
   String toValue() {
     switch (this) {
       case CredentialProviderType.secretsManager:
@@ -5199,7 +5199,7 @@ enum EnvironmentType {
   windowsServer_2019Container,
 }
 
-extension EnvironmentTypeValue on EnvironmentType {
+extension EnvironmentTypeValueExtension on EnvironmentType {
   String toValue() {
     switch (this) {
       case EnvironmentType.windowsContainer:
@@ -5306,7 +5306,7 @@ enum EnvironmentVariableType {
   secretsManager,
 }
 
-extension EnvironmentVariableTypeValue on EnvironmentVariableType {
+extension EnvironmentVariableTypeValueExtension on EnvironmentVariableType {
   String toValue() {
     switch (this) {
       case EnvironmentVariableType.plaintext:
@@ -5364,7 +5364,7 @@ enum FileSystemType {
   efs,
 }
 
-extension FileSystemTypeValue on FileSystemType {
+extension FileSystemTypeValueExtension on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.efs:
@@ -5447,7 +5447,7 @@ enum ImagePullCredentialsType {
   serviceRole,
 }
 
-extension ImagePullCredentialsTypeValue on ImagePullCredentialsType {
+extension ImagePullCredentialsTypeValueExtension on ImagePullCredentialsType {
   String toValue() {
     switch (this) {
       case ImagePullCredentialsType.codebuild:
@@ -5504,7 +5504,7 @@ enum LanguageType {
   php,
 }
 
-extension LanguageTypeValue on LanguageType {
+extension LanguageTypeValueExtension on LanguageType {
   String toValue() {
     switch (this) {
       case LanguageType.java:
@@ -5906,7 +5906,7 @@ enum LogsConfigStatusType {
   disabled,
 }
 
-extension LogsConfigStatusTypeValue on LogsConfigStatusType {
+extension LogsConfigStatusTypeValueExtension on LogsConfigStatusType {
   String toValue() {
     switch (this) {
       case LogsConfigStatusType.enabled:
@@ -6041,7 +6041,7 @@ enum PlatformType {
   windowsServer,
 }
 
-extension PlatformTypeValue on PlatformType {
+extension PlatformTypeValueExtension on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.debian:
@@ -7006,7 +7006,7 @@ enum ProjectSortByType {
   lastModifiedTime,
 }
 
-extension ProjectSortByTypeValue on ProjectSortByType {
+extension ProjectSortByTypeValueExtension on ProjectSortByType {
   String toValue() {
     switch (this) {
       case ProjectSortByType.name:
@@ -7459,7 +7459,8 @@ enum ReportCodeCoverageSortByType {
   filePath,
 }
 
-extension ReportCodeCoverageSortByTypeValue on ReportCodeCoverageSortByType {
+extension ReportCodeCoverageSortByTypeValueExtension
+    on ReportCodeCoverageSortByType {
   String toValue() {
     switch (this) {
       case ReportCodeCoverageSortByType.lineCoveragePercentage:
@@ -7531,7 +7532,7 @@ enum ReportExportConfigType {
   noExport,
 }
 
-extension ReportExportConfigTypeValue on ReportExportConfigType {
+extension ReportExportConfigTypeValueExtension on ReportExportConfigType {
   String toValue() {
     switch (this) {
       case ReportExportConfigType.s3:
@@ -7639,7 +7640,7 @@ enum ReportGroupSortByType {
   lastModifiedTime,
 }
 
-extension ReportGroupSortByTypeValue on ReportGroupSortByType {
+extension ReportGroupSortByTypeValueExtension on ReportGroupSortByType {
   String toValue() {
     switch (this) {
       case ReportGroupSortByType.name:
@@ -7671,7 +7672,7 @@ enum ReportGroupStatusType {
   deleting,
 }
 
-extension ReportGroupStatusTypeValue on ReportGroupStatusType {
+extension ReportGroupStatusTypeValueExtension on ReportGroupStatusType {
   String toValue() {
     switch (this) {
       case ReportGroupStatusType.active:
@@ -7706,7 +7707,7 @@ enum ReportGroupTrendFieldType {
   branchesMissed,
 }
 
-extension ReportGroupTrendFieldTypeValue on ReportGroupTrendFieldType {
+extension ReportGroupTrendFieldTypeValueExtension on ReportGroupTrendFieldType {
   String toValue() {
     switch (this) {
       case ReportGroupTrendFieldType.passRate:
@@ -7781,7 +7782,7 @@ enum ReportPackagingType {
   none,
 }
 
-extension ReportPackagingTypeValue on ReportPackagingType {
+extension ReportPackagingTypeValueExtension on ReportPackagingType {
   String toValue() {
     switch (this) {
       case ReportPackagingType.zip:
@@ -7812,7 +7813,7 @@ enum ReportStatusType {
   deleting,
 }
 
-extension ReportStatusTypeValue on ReportStatusType {
+extension ReportStatusTypeValueExtension on ReportStatusType {
   String toValue() {
     switch (this) {
       case ReportStatusType.generating:
@@ -7852,7 +7853,7 @@ enum ReportType {
   codeCoverage,
 }
 
-extension ReportTypeValue on ReportType {
+extension ReportTypeValueExtension on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.test:
@@ -7938,7 +7939,7 @@ enum RetryBuildBatchType {
   retryFailedBuilds,
 }
 
-extension RetryBuildBatchTypeValue on RetryBuildBatchType {
+extension RetryBuildBatchTypeValueExtension on RetryBuildBatchType {
   String toValue() {
     switch (this) {
       case RetryBuildBatchType.retryAllBuilds:
@@ -8093,7 +8094,7 @@ enum ServerType {
   githubEnterprise,
 }
 
-extension ServerTypeValue on ServerType {
+extension ServerTypeValueExtension on ServerType {
   String toValue() {
     switch (this) {
       case ServerType.github:
@@ -8125,7 +8126,7 @@ enum SharedResourceSortByType {
   modifiedTime,
 }
 
-extension SharedResourceSortByTypeValue on SharedResourceSortByType {
+extension SharedResourceSortByTypeValueExtension on SharedResourceSortByType {
   String toValue() {
     switch (this) {
       case SharedResourceSortByType.arn:
@@ -8153,7 +8154,7 @@ enum SortOrderType {
   descending,
 }
 
-extension SortOrderTypeValue on SortOrderType {
+extension SortOrderTypeValueExtension on SortOrderType {
   String toValue() {
     switch (this) {
       case SortOrderType.ascending:
@@ -8217,7 +8218,7 @@ enum SourceAuthType {
   oauth,
 }
 
-extension SourceAuthTypeValue on SourceAuthType {
+extension SourceAuthTypeValueExtension on SourceAuthType {
   String toValue() {
     switch (this) {
       case SourceAuthType.oauth:
@@ -8274,7 +8275,7 @@ enum SourceType {
   noSource,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.codecommit:
@@ -8359,7 +8360,7 @@ enum StatusType {
   stopped,
 }
 
-extension StatusTypeValue on StatusType {
+extension StatusTypeValueExtension on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.succeeded:
@@ -8757,7 +8758,7 @@ enum WebhookBuildType {
   buildBatch,
 }
 
-extension WebhookBuildTypeValue on WebhookBuildType {
+extension WebhookBuildTypeValueExtension on WebhookBuildType {
   String toValue() {
     switch (this) {
       case WebhookBuildType.build:
@@ -8884,7 +8885,7 @@ enum WebhookFilterType {
   commitMessage,
 }
 
-extension WebhookFilterTypeValue on WebhookFilterType {
+extension WebhookFilterTypeValueExtension on WebhookFilterType {
   String toValue() {
     switch (this) {
       case WebhookFilterType.event:

--- a/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
+++ b/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
@@ -5728,7 +5728,7 @@ enum ApprovalState {
   revoke,
 }
 
-extension ApprovalStateValue on ApprovalState {
+extension ApprovalStateValueExtension on ApprovalState {
   String toValue() {
     switch (this) {
       case ApprovalState.approve:
@@ -6116,7 +6116,7 @@ enum ChangeTypeEnum {
   d,
 }
 
-extension ChangeTypeEnumValue on ChangeTypeEnum {
+extension ChangeTypeEnumValueExtension on ChangeTypeEnum {
   String toValue() {
     switch (this) {
       case ChangeTypeEnum.a:
@@ -6428,7 +6428,8 @@ enum ConflictDetailLevelTypeEnum {
   lineLevel,
 }
 
-extension ConflictDetailLevelTypeEnumValue on ConflictDetailLevelTypeEnum {
+extension ConflictDetailLevelTypeEnumValueExtension
+    on ConflictDetailLevelTypeEnum {
   String toValue() {
     switch (this) {
       case ConflictDetailLevelTypeEnum.fileLevel:
@@ -6566,7 +6567,7 @@ enum ConflictResolutionStrategyTypeEnum {
   automerge,
 }
 
-extension ConflictResolutionStrategyTypeEnumValue
+extension ConflictResolutionStrategyTypeEnumValueExtension
     on ConflictResolutionStrategyTypeEnum {
   String toValue() {
     switch (this) {
@@ -7082,7 +7083,7 @@ enum FileModeTypeEnum {
   symlink,
 }
 
-extension FileModeTypeEnumValue on FileModeTypeEnum {
+extension FileModeTypeEnumValueExtension on FileModeTypeEnum {
   String toValue() {
     switch (this) {
       case FileModeTypeEnum.executable:
@@ -8100,7 +8101,7 @@ enum MergeOptionTypeEnum {
   threeWayMerge,
 }
 
-extension MergeOptionTypeEnumValue on MergeOptionTypeEnum {
+extension MergeOptionTypeEnumValueExtension on MergeOptionTypeEnum {
   String toValue() {
     switch (this) {
       case MergeOptionTypeEnum.fastForwardMerge:
@@ -8181,7 +8182,7 @@ enum ObjectTypeEnum {
   symbolicLink,
 }
 
-extension ObjectTypeEnumValue on ObjectTypeEnum {
+extension ObjectTypeEnumValueExtension on ObjectTypeEnum {
   String toValue() {
     switch (this) {
       case ObjectTypeEnum.file:
@@ -8242,7 +8243,7 @@ enum OrderEnum {
   descending,
 }
 
-extension OrderEnumValue on OrderEnum {
+extension OrderEnumValueExtension on OrderEnum {
   String toValue() {
     switch (this) {
       case OrderEnum.ascending:
@@ -8291,7 +8292,7 @@ enum OverrideStatus {
   revoke,
 }
 
-extension OverrideStatusValue on OverrideStatus {
+extension OverrideStatusValueExtension on OverrideStatus {
   String toValue() {
     switch (this) {
       case OverrideStatus.override:
@@ -8672,7 +8673,7 @@ enum PullRequestEventType {
   pullRequestApprovalStateChanged,
 }
 
-extension PullRequestEventTypeValue on PullRequestEventType {
+extension PullRequestEventTypeValueExtension on PullRequestEventType {
   String toValue() {
     switch (this) {
       case PullRequestEventType.pullRequestCreated:
@@ -8809,7 +8810,7 @@ enum PullRequestStatusEnum {
   closed,
 }
 
-extension PullRequestStatusEnumValue on PullRequestStatusEnum {
+extension PullRequestStatusEnumValueExtension on PullRequestStatusEnum {
   String toValue() {
     switch (this) {
       case PullRequestStatusEnum.open:
@@ -9034,7 +9035,7 @@ enum RelativeFileVersionEnum {
   after,
 }
 
-extension RelativeFileVersionEnumValue on RelativeFileVersionEnum {
+extension RelativeFileVersionEnumValueExtension on RelativeFileVersionEnum {
   String toValue() {
     switch (this) {
       case RelativeFileVersionEnum.before:
@@ -9100,7 +9101,7 @@ enum ReplacementTypeEnum {
   useNewContent,
 }
 
-extension ReplacementTypeEnumValue on ReplacementTypeEnum {
+extension ReplacementTypeEnumValueExtension on ReplacementTypeEnum {
   String toValue() {
     switch (this) {
       case ReplacementTypeEnum.keepBase:
@@ -9285,7 +9286,8 @@ enum RepositoryTriggerEventEnum {
   deleteReference,
 }
 
-extension RepositoryTriggerEventEnumValue on RepositoryTriggerEventEnum {
+extension RepositoryTriggerEventEnumValueExtension
+    on RepositoryTriggerEventEnum {
   String toValue() {
     switch (this) {
       case RepositoryTriggerEventEnum.all:
@@ -9364,7 +9366,7 @@ enum SortByEnum {
   lastModifiedDate,
 }
 
-extension SortByEnumValue on SortByEnum {
+extension SortByEnumValueExtension on SortByEnum {
   String toValue() {
     switch (this) {
       case SortByEnum.repositoryName:

--- a/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
+++ b/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
@@ -5728,7 +5728,7 @@ enum ApprovalState {
   revoke,
 }
 
-extension on ApprovalState {
+extension ApprovalStateValue on ApprovalState {
   String toValue() {
     switch (this) {
       case ApprovalState.approve:
@@ -5739,7 +5739,7 @@ extension on ApprovalState {
   }
 }
 
-extension on String {
+extension ApprovalStateFromString on String {
   ApprovalState toApprovalState() {
     switch (this) {
       case 'APPROVE':
@@ -6116,7 +6116,7 @@ enum ChangeTypeEnum {
   d,
 }
 
-extension on ChangeTypeEnum {
+extension ChangeTypeEnumValue on ChangeTypeEnum {
   String toValue() {
     switch (this) {
       case ChangeTypeEnum.a:
@@ -6129,7 +6129,7 @@ extension on ChangeTypeEnum {
   }
 }
 
-extension on String {
+extension ChangeTypeEnumFromString on String {
   ChangeTypeEnum toChangeTypeEnum() {
     switch (this) {
       case 'A':
@@ -6428,7 +6428,7 @@ enum ConflictDetailLevelTypeEnum {
   lineLevel,
 }
 
-extension on ConflictDetailLevelTypeEnum {
+extension ConflictDetailLevelTypeEnumValue on ConflictDetailLevelTypeEnum {
   String toValue() {
     switch (this) {
       case ConflictDetailLevelTypeEnum.fileLevel:
@@ -6439,7 +6439,7 @@ extension on ConflictDetailLevelTypeEnum {
   }
 }
 
-extension on String {
+extension ConflictDetailLevelTypeEnumFromString on String {
   ConflictDetailLevelTypeEnum toConflictDetailLevelTypeEnum() {
     switch (this) {
       case 'FILE_LEVEL':
@@ -6566,7 +6566,8 @@ enum ConflictResolutionStrategyTypeEnum {
   automerge,
 }
 
-extension on ConflictResolutionStrategyTypeEnum {
+extension ConflictResolutionStrategyTypeEnumValue
+    on ConflictResolutionStrategyTypeEnum {
   String toValue() {
     switch (this) {
       case ConflictResolutionStrategyTypeEnum.none:
@@ -6581,7 +6582,7 @@ extension on ConflictResolutionStrategyTypeEnum {
   }
 }
 
-extension on String {
+extension ConflictResolutionStrategyTypeEnumFromString on String {
   ConflictResolutionStrategyTypeEnum toConflictResolutionStrategyTypeEnum() {
     switch (this) {
       case 'NONE':
@@ -7081,7 +7082,7 @@ enum FileModeTypeEnum {
   symlink,
 }
 
-extension on FileModeTypeEnum {
+extension FileModeTypeEnumValue on FileModeTypeEnum {
   String toValue() {
     switch (this) {
       case FileModeTypeEnum.executable:
@@ -7094,7 +7095,7 @@ extension on FileModeTypeEnum {
   }
 }
 
-extension on String {
+extension FileModeTypeEnumFromString on String {
   FileModeTypeEnum toFileModeTypeEnum() {
     switch (this) {
       case 'EXECUTABLE':
@@ -8099,7 +8100,7 @@ enum MergeOptionTypeEnum {
   threeWayMerge,
 }
 
-extension on MergeOptionTypeEnum {
+extension MergeOptionTypeEnumValue on MergeOptionTypeEnum {
   String toValue() {
     switch (this) {
       case MergeOptionTypeEnum.fastForwardMerge:
@@ -8112,7 +8113,7 @@ extension on MergeOptionTypeEnum {
   }
 }
 
-extension on String {
+extension MergeOptionTypeEnumFromString on String {
   MergeOptionTypeEnum toMergeOptionTypeEnum() {
     switch (this) {
       case 'FAST_FORWARD_MERGE':
@@ -8180,7 +8181,7 @@ enum ObjectTypeEnum {
   symbolicLink,
 }
 
-extension on ObjectTypeEnum {
+extension ObjectTypeEnumValue on ObjectTypeEnum {
   String toValue() {
     switch (this) {
       case ObjectTypeEnum.file:
@@ -8195,7 +8196,7 @@ extension on ObjectTypeEnum {
   }
 }
 
-extension on String {
+extension ObjectTypeEnumFromString on String {
   ObjectTypeEnum toObjectTypeEnum() {
     switch (this) {
       case 'FILE':
@@ -8241,7 +8242,7 @@ enum OrderEnum {
   descending,
 }
 
-extension on OrderEnum {
+extension OrderEnumValue on OrderEnum {
   String toValue() {
     switch (this) {
       case OrderEnum.ascending:
@@ -8252,7 +8253,7 @@ extension on OrderEnum {
   }
 }
 
-extension on String {
+extension OrderEnumFromString on String {
   OrderEnum toOrderEnum() {
     switch (this) {
       case 'ascending':
@@ -8290,7 +8291,7 @@ enum OverrideStatus {
   revoke,
 }
 
-extension on OverrideStatus {
+extension OverrideStatusValue on OverrideStatus {
   String toValue() {
     switch (this) {
       case OverrideStatus.override:
@@ -8301,7 +8302,7 @@ extension on OverrideStatus {
   }
 }
 
-extension on String {
+extension OverrideStatusFromString on String {
   OverrideStatus toOverrideStatus() {
     switch (this) {
       case 'OVERRIDE':
@@ -8671,7 +8672,7 @@ enum PullRequestEventType {
   pullRequestApprovalStateChanged,
 }
 
-extension on PullRequestEventType {
+extension PullRequestEventTypeValue on PullRequestEventType {
   String toValue() {
     switch (this) {
       case PullRequestEventType.pullRequestCreated:
@@ -8696,7 +8697,7 @@ extension on PullRequestEventType {
   }
 }
 
-extension on String {
+extension PullRequestEventTypeFromString on String {
   PullRequestEventType toPullRequestEventType() {
     switch (this) {
       case 'PULL_REQUEST_CREATED':
@@ -8808,7 +8809,7 @@ enum PullRequestStatusEnum {
   closed,
 }
 
-extension on PullRequestStatusEnum {
+extension PullRequestStatusEnumValue on PullRequestStatusEnum {
   String toValue() {
     switch (this) {
       case PullRequestStatusEnum.open:
@@ -8819,7 +8820,7 @@ extension on PullRequestStatusEnum {
   }
 }
 
-extension on String {
+extension PullRequestStatusEnumFromString on String {
   PullRequestStatusEnum toPullRequestStatusEnum() {
     switch (this) {
       case 'OPEN':
@@ -9033,7 +9034,7 @@ enum RelativeFileVersionEnum {
   after,
 }
 
-extension on RelativeFileVersionEnum {
+extension RelativeFileVersionEnumValue on RelativeFileVersionEnum {
   String toValue() {
     switch (this) {
       case RelativeFileVersionEnum.before:
@@ -9044,7 +9045,7 @@ extension on RelativeFileVersionEnum {
   }
 }
 
-extension on String {
+extension RelativeFileVersionEnumFromString on String {
   RelativeFileVersionEnum toRelativeFileVersionEnum() {
     switch (this) {
       case 'BEFORE':
@@ -9099,7 +9100,7 @@ enum ReplacementTypeEnum {
   useNewContent,
 }
 
-extension on ReplacementTypeEnum {
+extension ReplacementTypeEnumValue on ReplacementTypeEnum {
   String toValue() {
     switch (this) {
       case ReplacementTypeEnum.keepBase:
@@ -9114,7 +9115,7 @@ extension on ReplacementTypeEnum {
   }
 }
 
-extension on String {
+extension ReplacementTypeEnumFromString on String {
   ReplacementTypeEnum toReplacementTypeEnum() {
     switch (this) {
       case 'KEEP_BASE':
@@ -9284,7 +9285,7 @@ enum RepositoryTriggerEventEnum {
   deleteReference,
 }
 
-extension on RepositoryTriggerEventEnum {
+extension RepositoryTriggerEventEnumValue on RepositoryTriggerEventEnum {
   String toValue() {
     switch (this) {
       case RepositoryTriggerEventEnum.all:
@@ -9299,7 +9300,7 @@ extension on RepositoryTriggerEventEnum {
   }
 }
 
-extension on String {
+extension RepositoryTriggerEventEnumFromString on String {
   RepositoryTriggerEventEnum toRepositoryTriggerEventEnum() {
     switch (this) {
       case 'all':
@@ -9363,7 +9364,7 @@ enum SortByEnum {
   lastModifiedDate,
 }
 
-extension on SortByEnum {
+extension SortByEnumValue on SortByEnum {
   String toValue() {
     switch (this) {
       case SortByEnum.repositoryName:
@@ -9374,7 +9375,7 @@ extension on SortByEnum {
   }
 }
 
-extension on String {
+extension SortByEnumFromString on String {
   SortByEnum toSortByEnum() {
     switch (this) {
       case 'repositoryName':

--- a/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
+++ b/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
@@ -1431,7 +1431,7 @@ enum JobState {
   deleting,
 }
 
-extension on JobState {
+extension JobStateValue on JobState {
   String toValue() {
     switch (this) {
       case JobState.completed:
@@ -1446,7 +1446,7 @@ extension on JobState {
   }
 }
 
-extension on String {
+extension JobStateFromString on String {
   JobState toJobState() {
     switch (this) {
       case 'Completed':
@@ -1660,7 +1660,7 @@ enum ProviderType {
   gitHubEnterpriseServer,
 }
 
-extension on ProviderType {
+extension ProviderTypeValue on ProviderType {
   String toValue() {
     switch (this) {
       case ProviderType.codeCommit:
@@ -1675,7 +1675,7 @@ extension on ProviderType {
   }
 }
 
-extension on String {
+extension ProviderTypeFromString on String {
   ProviderType toProviderType() {
     switch (this) {
       case 'CodeCommit':
@@ -1703,7 +1703,7 @@ enum Reaction {
   thumbsDown,
 }
 
-extension on Reaction {
+extension ReactionValue on Reaction {
   String toValue() {
     switch (this) {
       case Reaction.thumbsUp:
@@ -1714,7 +1714,7 @@ extension on Reaction {
   }
 }
 
-extension on String {
+extension ReactionFromString on String {
   Reaction toReaction() {
     switch (this) {
       case 'ThumbsUp':
@@ -2035,7 +2035,7 @@ enum RepositoryAssociationState {
   disassociated,
 }
 
-extension on RepositoryAssociationState {
+extension RepositoryAssociationStateValue on RepositoryAssociationState {
   String toValue() {
     switch (this) {
       case RepositoryAssociationState.associated:
@@ -2052,7 +2052,7 @@ extension on RepositoryAssociationState {
   }
 }
 
-extension on String {
+extension RepositoryAssociationStateFromString on String {
   RepositoryAssociationState toRepositoryAssociationState() {
     switch (this) {
       case 'Associated':
@@ -2285,7 +2285,7 @@ enum Type {
   repositoryAnalysis,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.pullRequest:
@@ -2296,7 +2296,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'PullRequest':

--- a/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
+++ b/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
@@ -1431,7 +1431,7 @@ enum JobState {
   deleting,
 }
 
-extension JobStateValue on JobState {
+extension JobStateValueExtension on JobState {
   String toValue() {
     switch (this) {
       case JobState.completed:
@@ -1660,7 +1660,7 @@ enum ProviderType {
   gitHubEnterpriseServer,
 }
 
-extension ProviderTypeValue on ProviderType {
+extension ProviderTypeValueExtension on ProviderType {
   String toValue() {
     switch (this) {
       case ProviderType.codeCommit:
@@ -1703,7 +1703,7 @@ enum Reaction {
   thumbsDown,
 }
 
-extension ReactionValue on Reaction {
+extension ReactionValueExtension on Reaction {
   String toValue() {
     switch (this) {
       case Reaction.thumbsUp:
@@ -2035,7 +2035,8 @@ enum RepositoryAssociationState {
   disassociated,
 }
 
-extension RepositoryAssociationStateValue on RepositoryAssociationState {
+extension RepositoryAssociationStateValueExtension
+    on RepositoryAssociationState {
   String toValue() {
     switch (this) {
       case RepositoryAssociationState.associated:
@@ -2285,7 +2286,7 @@ enum Type {
   repositoryAnalysis,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.pullRequest:

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -1519,7 +1519,7 @@ enum ActionGroup {
   agentPermissions,
 }
 
-extension ActionGroupValue on ActionGroup {
+extension ActionGroupValueExtension on ActionGroup {
   String toValue() {
     switch (this) {
       case ActionGroup.agentPermissions:
@@ -1654,7 +1654,7 @@ enum AgentParameterField {
   samplingIntervalInMilliseconds,
 }
 
-extension AgentParameterFieldValue on AgentParameterField {
+extension AgentParameterFieldValueExtension on AgentParameterField {
   String toValue() {
     switch (this) {
       case AgentParameterField.maxStackDepth:
@@ -1741,7 +1741,7 @@ enum AggregationPeriod {
   pt5m,
 }
 
-extension AggregationPeriodValue on AggregationPeriod {
+extension AggregationPeriodValueExtension on AggregationPeriod {
   String toValue() {
     switch (this) {
       case AggregationPeriod.p1d:
@@ -1969,7 +1969,7 @@ enum ComputePlatform {
   $default,
 }
 
-extension ComputePlatformValue on ComputePlatform {
+extension ComputePlatformValueExtension on ComputePlatform {
   String toValue() {
     switch (this) {
       case ComputePlatform.awsLambda:
@@ -2043,7 +2043,7 @@ enum EventPublisher {
   anomalyDetection,
 }
 
-extension EventPublisherValue on EventPublisher {
+extension EventPublisherValueExtension on EventPublisher {
   String toValue() {
     switch (this) {
       case EventPublisher.anomalyDetection:
@@ -2067,7 +2067,7 @@ enum FeedbackType {
   positive,
 }
 
-extension FeedbackTypeValue on FeedbackType {
+extension FeedbackTypeValueExtension on FeedbackType {
   String toValue() {
     switch (this) {
       case FeedbackType.negative:
@@ -2492,7 +2492,7 @@ enum MetadataField {
   lambdaTimeGapBetweenInvokesInMilliseconds,
 }
 
-extension MetadataFieldValue on MetadataField {
+extension MetadataFieldValueExtension on MetadataField {
   String toValue() {
     switch (this) {
       case MetadataField.agentId:
@@ -2582,7 +2582,7 @@ enum MetricType {
   aggregatedRelativeTotalTime,
 }
 
-extension MetricTypeValue on MetricType {
+extension MetricTypeValueExtension on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.aggregatedRelativeTotalTime:
@@ -2627,7 +2627,7 @@ enum OrderBy {
   timestampDescending,
 }
 
-extension OrderByValue on OrderBy {
+extension OrderByValueExtension on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.timestampAscending:

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -1519,7 +1519,7 @@ enum ActionGroup {
   agentPermissions,
 }
 
-extension on ActionGroup {
+extension ActionGroupValue on ActionGroup {
   String toValue() {
     switch (this) {
       case ActionGroup.agentPermissions:
@@ -1528,7 +1528,7 @@ extension on ActionGroup {
   }
 }
 
-extension on String {
+extension ActionGroupFromString on String {
   ActionGroup toActionGroup() {
     switch (this) {
       case 'agentPermissions':
@@ -1654,7 +1654,7 @@ enum AgentParameterField {
   samplingIntervalInMilliseconds,
 }
 
-extension on AgentParameterField {
+extension AgentParameterFieldValue on AgentParameterField {
   String toValue() {
     switch (this) {
       case AgentParameterField.maxStackDepth:
@@ -1671,7 +1671,7 @@ extension on AgentParameterField {
   }
 }
 
-extension on String {
+extension AgentParameterFieldFromString on String {
   AgentParameterField toAgentParameterField() {
     switch (this) {
       case 'MaxStackDepth':
@@ -1741,7 +1741,7 @@ enum AggregationPeriod {
   pt5m,
 }
 
-extension on AggregationPeriod {
+extension AggregationPeriodValue on AggregationPeriod {
   String toValue() {
     switch (this) {
       case AggregationPeriod.p1d:
@@ -1754,7 +1754,7 @@ extension on AggregationPeriod {
   }
 }
 
-extension on String {
+extension AggregationPeriodFromString on String {
   AggregationPeriod toAggregationPeriod() {
     switch (this) {
       case 'P1D':
@@ -1969,7 +1969,7 @@ enum ComputePlatform {
   $default,
 }
 
-extension on ComputePlatform {
+extension ComputePlatformValue on ComputePlatform {
   String toValue() {
     switch (this) {
       case ComputePlatform.awsLambda:
@@ -1980,7 +1980,7 @@ extension on ComputePlatform {
   }
 }
 
-extension on String {
+extension ComputePlatformFromString on String {
   ComputePlatform toComputePlatform() {
     switch (this) {
       case 'AWSLambda':
@@ -2043,7 +2043,7 @@ enum EventPublisher {
   anomalyDetection,
 }
 
-extension on EventPublisher {
+extension EventPublisherValue on EventPublisher {
   String toValue() {
     switch (this) {
       case EventPublisher.anomalyDetection:
@@ -2052,7 +2052,7 @@ extension on EventPublisher {
   }
 }
 
-extension on String {
+extension EventPublisherFromString on String {
   EventPublisher toEventPublisher() {
     switch (this) {
       case 'AnomalyDetection':
@@ -2067,7 +2067,7 @@ enum FeedbackType {
   positive,
 }
 
-extension on FeedbackType {
+extension FeedbackTypeValue on FeedbackType {
   String toValue() {
     switch (this) {
       case FeedbackType.negative:
@@ -2078,7 +2078,7 @@ extension on FeedbackType {
   }
 }
 
-extension on String {
+extension FeedbackTypeFromString on String {
   FeedbackType toFeedbackType() {
     switch (this) {
       case 'Negative':
@@ -2492,7 +2492,7 @@ enum MetadataField {
   lambdaTimeGapBetweenInvokesInMilliseconds,
 }
 
-extension on MetadataField {
+extension MetadataFieldValue on MetadataField {
   String toValue() {
     switch (this) {
       case MetadataField.agentId:
@@ -2517,7 +2517,7 @@ extension on MetadataField {
   }
 }
 
-extension on String {
+extension MetadataFieldFromString on String {
   MetadataField toMetadataField() {
     switch (this) {
       case 'AgentId':
@@ -2582,7 +2582,7 @@ enum MetricType {
   aggregatedRelativeTotalTime,
 }
 
-extension on MetricType {
+extension MetricTypeValue on MetricType {
   String toValue() {
     switch (this) {
       case MetricType.aggregatedRelativeTotalTime:
@@ -2591,7 +2591,7 @@ extension on MetricType {
   }
 }
 
-extension on String {
+extension MetricTypeFromString on String {
   MetricType toMetricType() {
     switch (this) {
       case 'AggregatedRelativeTotalTime':
@@ -2627,7 +2627,7 @@ enum OrderBy {
   timestampDescending,
 }
 
-extension on OrderBy {
+extension OrderByValue on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.timestampAscending:
@@ -2638,7 +2638,7 @@ extension on OrderBy {
   }
 }
 
-extension on String {
+extension OrderByFromString on String {
   OrderBy toOrderBy() {
     switch (this) {
       case 'TimestampAscending':

--- a/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
+++ b/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
@@ -2135,7 +2135,7 @@ enum ActionCategory {
   approval,
 }
 
-extension on ActionCategory {
+extension ActionCategoryValue on ActionCategory {
   String toValue() {
     switch (this) {
       case ActionCategory.source:
@@ -2154,7 +2154,7 @@ extension on ActionCategory {
   }
 }
 
-extension on String {
+extension ActionCategoryFromString on String {
   ActionCategory toActionCategory() {
     switch (this) {
       case 'Source':
@@ -2275,7 +2275,8 @@ enum ActionConfigurationPropertyType {
   boolean,
 }
 
-extension on ActionConfigurationPropertyType {
+extension ActionConfigurationPropertyTypeValue
+    on ActionConfigurationPropertyType {
   String toValue() {
     switch (this) {
       case ActionConfigurationPropertyType.string:
@@ -2288,7 +2289,7 @@ extension on ActionConfigurationPropertyType {
   }
 }
 
-extension on String {
+extension ActionConfigurationPropertyTypeFromString on String {
   ActionConfigurationPropertyType toActionConfigurationPropertyType() {
     switch (this) {
       case 'String':
@@ -2715,7 +2716,7 @@ enum ActionExecutionStatus {
   failed,
 }
 
-extension on ActionExecutionStatus {
+extension ActionExecutionStatusValue on ActionExecutionStatus {
   String toValue() {
     switch (this) {
       case ActionExecutionStatus.inProgress:
@@ -2730,7 +2731,7 @@ extension on ActionExecutionStatus {
   }
 }
 
-extension on String {
+extension ActionExecutionStatusFromString on String {
   ActionExecutionStatus toActionExecutionStatus() {
     switch (this) {
       case 'InProgress':
@@ -2752,7 +2753,7 @@ enum ActionOwner {
   custom,
 }
 
-extension on ActionOwner {
+extension ActionOwnerValue on ActionOwner {
   String toValue() {
     switch (this) {
       case ActionOwner.aws:
@@ -2765,7 +2766,7 @@ extension on ActionOwner {
   }
 }
 
-extension on String {
+extension ActionOwnerFromString on String {
   ActionOwner toActionOwner() {
     switch (this) {
       case 'AWS':
@@ -3065,7 +3066,7 @@ enum ApprovalStatus {
   rejected,
 }
 
-extension on ApprovalStatus {
+extension ApprovalStatusValue on ApprovalStatus {
   String toValue() {
     switch (this) {
       case ApprovalStatus.approved:
@@ -3076,7 +3077,7 @@ extension on ApprovalStatus {
   }
 }
 
-extension on String {
+extension ApprovalStatusFromString on String {
   ApprovalStatus toApprovalStatus() {
     switch (this) {
       case 'Approved':
@@ -3195,7 +3196,7 @@ enum ArtifactLocationType {
   s3,
 }
 
-extension on ArtifactLocationType {
+extension ArtifactLocationTypeValue on ArtifactLocationType {
   String toValue() {
     switch (this) {
       case ArtifactLocationType.s3:
@@ -3204,7 +3205,7 @@ extension on ArtifactLocationType {
   }
 }
 
-extension on String {
+extension ArtifactLocationTypeFromString on String {
   ArtifactLocationType toArtifactLocationType() {
     switch (this) {
       case 'S3':
@@ -3318,7 +3319,7 @@ enum ArtifactStoreType {
   s3,
 }
 
-extension on ArtifactStoreType {
+extension ArtifactStoreTypeValue on ArtifactStoreType {
   String toValue() {
     switch (this) {
       case ArtifactStoreType.s3:
@@ -3327,7 +3328,7 @@ extension on ArtifactStoreType {
   }
 }
 
-extension on String {
+extension ArtifactStoreTypeFromString on String {
   ArtifactStoreType toArtifactStoreType() {
     switch (this) {
       case 'S3':
@@ -3370,7 +3371,7 @@ enum BlockerType {
   schedule,
 }
 
-extension on BlockerType {
+extension BlockerTypeValue on BlockerType {
   String toValue() {
     switch (this) {
       case BlockerType.schedule:
@@ -3379,7 +3380,7 @@ extension on BlockerType {
   }
 }
 
-extension on String {
+extension BlockerTypeFromString on String {
   BlockerType toBlockerType() {
     switch (this) {
       case 'Schedule':
@@ -3531,7 +3532,7 @@ enum EncryptionKeyType {
   kms,
 }
 
-extension on EncryptionKeyType {
+extension EncryptionKeyTypeValue on EncryptionKeyType {
   String toValue() {
     switch (this) {
       case EncryptionKeyType.kms:
@@ -3540,7 +3541,7 @@ extension on EncryptionKeyType {
   }
 }
 
-extension on String {
+extension EncryptionKeyTypeFromString on String {
   EncryptionKeyType toEncryptionKeyType() {
     switch (this) {
       case 'KMS':
@@ -3663,7 +3664,7 @@ enum FailureType {
   systemUnavailable,
 }
 
-extension on FailureType {
+extension FailureTypeValue on FailureType {
   String toValue() {
     switch (this) {
       case FailureType.jobFailed:
@@ -3682,7 +3683,7 @@ extension on FailureType {
   }
 }
 
-extension on String {
+extension FailureTypeFromString on String {
   FailureType toFailureType() {
     switch (this) {
       case 'JobFailed':
@@ -4011,7 +4012,7 @@ enum JobStatus {
   failed,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -4032,7 +4033,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'Created':
@@ -4501,7 +4502,7 @@ enum PipelineExecutionStatus {
   failed,
 }
 
-extension on PipelineExecutionStatus {
+extension PipelineExecutionStatusValue on PipelineExecutionStatus {
   String toValue() {
     switch (this) {
       case PipelineExecutionStatus.inProgress:
@@ -4520,7 +4521,7 @@ extension on PipelineExecutionStatus {
   }
 }
 
-extension on String {
+extension PipelineExecutionStatusFromString on String {
   PipelineExecutionStatus toPipelineExecutionStatus() {
     switch (this) {
       case 'InProgress':
@@ -4959,7 +4960,7 @@ enum StageExecutionStatus {
   succeeded,
 }
 
-extension on StageExecutionStatus {
+extension StageExecutionStatusValue on StageExecutionStatus {
   String toValue() {
     switch (this) {
       case StageExecutionStatus.inProgress:
@@ -4976,7 +4977,7 @@ extension on StageExecutionStatus {
   }
 }
 
-extension on String {
+extension StageExecutionStatusFromString on String {
   StageExecutionStatus toStageExecutionStatus() {
     switch (this) {
       case 'InProgress':
@@ -4998,7 +4999,7 @@ enum StageRetryMode {
   failedActions,
 }
 
-extension on StageRetryMode {
+extension StageRetryModeValue on StageRetryMode {
   String toValue() {
     switch (this) {
       case StageRetryMode.failedActions:
@@ -5007,7 +5008,7 @@ extension on StageRetryMode {
   }
 }
 
-extension on String {
+extension StageRetryModeFromString on String {
   StageRetryMode toStageRetryMode() {
     switch (this) {
       case 'FAILED_ACTIONS':
@@ -5068,7 +5069,7 @@ enum StageTransitionType {
   outbound,
 }
 
-extension on StageTransitionType {
+extension StageTransitionTypeValue on StageTransitionType {
   String toValue() {
     switch (this) {
       case StageTransitionType.inbound:
@@ -5079,7 +5080,7 @@ extension on StageTransitionType {
   }
 }
 
-extension on String {
+extension StageTransitionTypeFromString on String {
   StageTransitionType toStageTransitionType() {
     switch (this) {
       case 'Inbound':
@@ -5351,7 +5352,7 @@ enum TriggerType {
   putActionRevision,
 }
 
-extension on TriggerType {
+extension TriggerTypeValue on TriggerType {
   String toValue() {
     switch (this) {
       case TriggerType.createPipeline:
@@ -5370,7 +5371,7 @@ extension on TriggerType {
   }
 }
 
-extension on String {
+extension TriggerTypeFromString on String {
   TriggerType toTriggerType() {
     switch (this) {
       case 'CreatePipeline':
@@ -5453,7 +5454,7 @@ enum WebhookAuthenticationType {
   unauthenticated,
 }
 
-extension on WebhookAuthenticationType {
+extension WebhookAuthenticationTypeValue on WebhookAuthenticationType {
   String toValue() {
     switch (this) {
       case WebhookAuthenticationType.githubHmac:
@@ -5466,7 +5467,7 @@ extension on WebhookAuthenticationType {
   }
 }
 
-extension on String {
+extension WebhookAuthenticationTypeFromString on String {
   WebhookAuthenticationType toWebhookAuthenticationType() {
     switch (this) {
       case 'GITHUB_HMAC':

--- a/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
+++ b/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
@@ -2135,7 +2135,7 @@ enum ActionCategory {
   approval,
 }
 
-extension ActionCategoryValue on ActionCategory {
+extension ActionCategoryValueExtension on ActionCategory {
   String toValue() {
     switch (this) {
       case ActionCategory.source:
@@ -2275,7 +2275,7 @@ enum ActionConfigurationPropertyType {
   boolean,
 }
 
-extension ActionConfigurationPropertyTypeValue
+extension ActionConfigurationPropertyTypeValueExtension
     on ActionConfigurationPropertyType {
   String toValue() {
     switch (this) {
@@ -2716,7 +2716,7 @@ enum ActionExecutionStatus {
   failed,
 }
 
-extension ActionExecutionStatusValue on ActionExecutionStatus {
+extension ActionExecutionStatusValueExtension on ActionExecutionStatus {
   String toValue() {
     switch (this) {
       case ActionExecutionStatus.inProgress:
@@ -2753,7 +2753,7 @@ enum ActionOwner {
   custom,
 }
 
-extension ActionOwnerValue on ActionOwner {
+extension ActionOwnerValueExtension on ActionOwner {
   String toValue() {
     switch (this) {
       case ActionOwner.aws:
@@ -3066,7 +3066,7 @@ enum ApprovalStatus {
   rejected,
 }
 
-extension ApprovalStatusValue on ApprovalStatus {
+extension ApprovalStatusValueExtension on ApprovalStatus {
   String toValue() {
     switch (this) {
       case ApprovalStatus.approved:
@@ -3196,7 +3196,7 @@ enum ArtifactLocationType {
   s3,
 }
 
-extension ArtifactLocationTypeValue on ArtifactLocationType {
+extension ArtifactLocationTypeValueExtension on ArtifactLocationType {
   String toValue() {
     switch (this) {
       case ArtifactLocationType.s3:
@@ -3319,7 +3319,7 @@ enum ArtifactStoreType {
   s3,
 }
 
-extension ArtifactStoreTypeValue on ArtifactStoreType {
+extension ArtifactStoreTypeValueExtension on ArtifactStoreType {
   String toValue() {
     switch (this) {
       case ArtifactStoreType.s3:
@@ -3371,7 +3371,7 @@ enum BlockerType {
   schedule,
 }
 
-extension BlockerTypeValue on BlockerType {
+extension BlockerTypeValueExtension on BlockerType {
   String toValue() {
     switch (this) {
       case BlockerType.schedule:
@@ -3532,7 +3532,7 @@ enum EncryptionKeyType {
   kms,
 }
 
-extension EncryptionKeyTypeValue on EncryptionKeyType {
+extension EncryptionKeyTypeValueExtension on EncryptionKeyType {
   String toValue() {
     switch (this) {
       case EncryptionKeyType.kms:
@@ -3664,7 +3664,7 @@ enum FailureType {
   systemUnavailable,
 }
 
-extension FailureTypeValue on FailureType {
+extension FailureTypeValueExtension on FailureType {
   String toValue() {
     switch (this) {
       case FailureType.jobFailed:
@@ -4012,7 +4012,7 @@ enum JobStatus {
   failed,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -4502,7 +4502,7 @@ enum PipelineExecutionStatus {
   failed,
 }
 
-extension PipelineExecutionStatusValue on PipelineExecutionStatus {
+extension PipelineExecutionStatusValueExtension on PipelineExecutionStatus {
   String toValue() {
     switch (this) {
       case PipelineExecutionStatus.inProgress:
@@ -4960,7 +4960,7 @@ enum StageExecutionStatus {
   succeeded,
 }
 
-extension StageExecutionStatusValue on StageExecutionStatus {
+extension StageExecutionStatusValueExtension on StageExecutionStatus {
   String toValue() {
     switch (this) {
       case StageExecutionStatus.inProgress:
@@ -4999,7 +4999,7 @@ enum StageRetryMode {
   failedActions,
 }
 
-extension StageRetryModeValue on StageRetryMode {
+extension StageRetryModeValueExtension on StageRetryMode {
   String toValue() {
     switch (this) {
       case StageRetryMode.failedActions:
@@ -5069,7 +5069,7 @@ enum StageTransitionType {
   outbound,
 }
 
-extension StageTransitionTypeValue on StageTransitionType {
+extension StageTransitionTypeValueExtension on StageTransitionType {
   String toValue() {
     switch (this) {
       case StageTransitionType.inbound:
@@ -5352,7 +5352,7 @@ enum TriggerType {
   putActionRevision,
 }
 
-extension TriggerTypeValue on TriggerType {
+extension TriggerTypeValueExtension on TriggerType {
   String toValue() {
     switch (this) {
       case TriggerType.createPipeline:
@@ -5454,7 +5454,7 @@ enum WebhookAuthenticationType {
   unauthenticated,
 }
 
-extension WebhookAuthenticationTypeValue on WebhookAuthenticationType {
+extension WebhookAuthenticationTypeValueExtension on WebhookAuthenticationType {
   String toValue() {
     switch (this) {
       case WebhookAuthenticationType.githubHmac:

--- a/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
+++ b/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
@@ -690,7 +690,7 @@ enum ConnectionStatus {
   error,
 }
 
-extension on ConnectionStatus {
+extension ConnectionStatusValue on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.pending:
@@ -703,7 +703,7 @@ extension on ConnectionStatus {
   }
 }
 
-extension on String {
+extension ConnectionStatusFromString on String {
   ConnectionStatus toConnectionStatus() {
     switch (this) {
       case 'PENDING':
@@ -956,7 +956,7 @@ enum ProviderType {
   gitHubEnterpriseServer,
 }
 
-extension on ProviderType {
+extension ProviderTypeValue on ProviderType {
   String toValue() {
     switch (this) {
       case ProviderType.bitbucket:
@@ -969,7 +969,7 @@ extension on ProviderType {
   }
 }
 
-extension on String {
+extension ProviderTypeFromString on String {
   ProviderType toProviderType() {
     switch (this) {
       case 'Bitbucket':

--- a/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
+++ b/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
@@ -690,7 +690,7 @@ enum ConnectionStatus {
   error,
 }
 
-extension ConnectionStatusValue on ConnectionStatus {
+extension ConnectionStatusValueExtension on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.pending:
@@ -956,7 +956,7 @@ enum ProviderType {
   gitHubEnterpriseServer,
 }
 
-extension ProviderTypeValue on ProviderType {
+extension ProviderTypeValueExtension on ProviderType {
   String toValue() {
     switch (this) {
       case ProviderType.bitbucket:

--- a/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
+++ b/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
@@ -787,7 +787,7 @@ enum DetailType {
   full,
 }
 
-extension DetailTypeValue on DetailType {
+extension DetailTypeValueExtension on DetailType {
   String toValue() {
     switch (this) {
       case DetailType.basic:
@@ -869,7 +869,7 @@ enum ListEventTypesFilterName {
   serviceName,
 }
 
-extension ListEventTypesFilterNameValue on ListEventTypesFilterName {
+extension ListEventTypesFilterNameValueExtension on ListEventTypesFilterName {
   String toValue() {
     switch (this) {
       case ListEventTypesFilterName.resourceType:
@@ -950,7 +950,7 @@ enum ListNotificationRulesFilterName {
   targetAddress,
 }
 
-extension ListNotificationRulesFilterNameValue
+extension ListNotificationRulesFilterNameValueExtension
     on ListNotificationRulesFilterName {
   String toValue() {
     switch (this) {
@@ -1057,7 +1057,7 @@ enum ListTargetsFilterName {
   targetStatus,
 }
 
-extension ListTargetsFilterNameValue on ListTargetsFilterName {
+extension ListTargetsFilterNameValueExtension on ListTargetsFilterName {
   String toValue() {
     switch (this) {
       case ListTargetsFilterName.targetType:
@@ -1112,7 +1112,7 @@ enum NotificationRuleStatus {
   disabled,
 }
 
-extension NotificationRuleStatusValue on NotificationRuleStatus {
+extension NotificationRuleStatusValueExtension on NotificationRuleStatus {
   String toValue() {
     switch (this) {
       case NotificationRuleStatus.enabled:
@@ -1215,7 +1215,7 @@ enum TargetStatus {
   deactivated,
 }
 
-extension TargetStatusValue on TargetStatus {
+extension TargetStatusValueExtension on TargetStatus {
   String toValue() {
     switch (this) {
       case TargetStatus.pending:

--- a/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
+++ b/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
@@ -787,7 +787,7 @@ enum DetailType {
   full,
 }
 
-extension on DetailType {
+extension DetailTypeValue on DetailType {
   String toValue() {
     switch (this) {
       case DetailType.basic:
@@ -798,7 +798,7 @@ extension on DetailType {
   }
 }
 
-extension on String {
+extension DetailTypeFromString on String {
   DetailType toDetailType() {
     switch (this) {
       case 'BASIC':
@@ -869,7 +869,7 @@ enum ListEventTypesFilterName {
   serviceName,
 }
 
-extension on ListEventTypesFilterName {
+extension ListEventTypesFilterNameValue on ListEventTypesFilterName {
   String toValue() {
     switch (this) {
       case ListEventTypesFilterName.resourceType:
@@ -880,7 +880,7 @@ extension on ListEventTypesFilterName {
   }
 }
 
-extension on String {
+extension ListEventTypesFilterNameFromString on String {
   ListEventTypesFilterName toListEventTypesFilterName() {
     switch (this) {
       case 'RESOURCE_TYPE':
@@ -950,7 +950,8 @@ enum ListNotificationRulesFilterName {
   targetAddress,
 }
 
-extension on ListNotificationRulesFilterName {
+extension ListNotificationRulesFilterNameValue
+    on ListNotificationRulesFilterName {
   String toValue() {
     switch (this) {
       case ListNotificationRulesFilterName.eventTypeId:
@@ -965,7 +966,7 @@ extension on ListNotificationRulesFilterName {
   }
 }
 
-extension on String {
+extension ListNotificationRulesFilterNameFromString on String {
   ListNotificationRulesFilterName toListNotificationRulesFilterName() {
     switch (this) {
       case 'EVENT_TYPE_ID':
@@ -1056,7 +1057,7 @@ enum ListTargetsFilterName {
   targetStatus,
 }
 
-extension on ListTargetsFilterName {
+extension ListTargetsFilterNameValue on ListTargetsFilterName {
   String toValue() {
     switch (this) {
       case ListTargetsFilterName.targetType:
@@ -1069,7 +1070,7 @@ extension on ListTargetsFilterName {
   }
 }
 
-extension on String {
+extension ListTargetsFilterNameFromString on String {
   ListTargetsFilterName toListTargetsFilterName() {
     switch (this) {
       case 'TARGET_TYPE':
@@ -1111,7 +1112,7 @@ enum NotificationRuleStatus {
   disabled,
 }
 
-extension on NotificationRuleStatus {
+extension NotificationRuleStatusValue on NotificationRuleStatus {
   String toValue() {
     switch (this) {
       case NotificationRuleStatus.enabled:
@@ -1122,7 +1123,7 @@ extension on NotificationRuleStatus {
   }
 }
 
-extension on String {
+extension NotificationRuleStatusFromString on String {
   NotificationRuleStatus toNotificationRuleStatus() {
     switch (this) {
       case 'ENABLED':
@@ -1214,7 +1215,7 @@ enum TargetStatus {
   deactivated,
 }
 
-extension on TargetStatus {
+extension TargetStatusValue on TargetStatus {
   String toValue() {
     switch (this) {
       case TargetStatus.pending:
@@ -1231,7 +1232,7 @@ extension on TargetStatus {
   }
 }
 
-extension on String {
+extension TargetStatusFromString on String {
   TargetStatus toTargetStatus() {
     switch (this) {
       case 'PENDING':

--- a/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
+++ b/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
@@ -1521,7 +1521,7 @@ enum AmbiguousRoleResolutionType {
   deny,
 }
 
-extension on AmbiguousRoleResolutionType {
+extension AmbiguousRoleResolutionTypeValue on AmbiguousRoleResolutionType {
   String toValue() {
     switch (this) {
       case AmbiguousRoleResolutionType.authenticatedRole:
@@ -1532,7 +1532,7 @@ extension on AmbiguousRoleResolutionType {
   }
 }
 
-extension on String {
+extension AmbiguousRoleResolutionTypeFromString on String {
   AmbiguousRoleResolutionType toAmbiguousRoleResolutionType() {
     switch (this) {
       case 'AuthenticatedRole':
@@ -1646,7 +1646,7 @@ enum ErrorCode {
   internalServerError,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.accessDenied:
@@ -1657,7 +1657,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'AccessDenied':
@@ -2076,7 +2076,7 @@ enum MappingRuleMatchType {
   notEqual,
 }
 
-extension on MappingRuleMatchType {
+extension MappingRuleMatchTypeValue on MappingRuleMatchType {
   String toValue() {
     switch (this) {
       case MappingRuleMatchType.equals:
@@ -2091,7 +2091,7 @@ extension on MappingRuleMatchType {
   }
 }
 
-extension on String {
+extension MappingRuleMatchTypeFromString on String {
   MappingRuleMatchType toMappingRuleMatchType() {
     switch (this) {
       case 'Equals':
@@ -2181,7 +2181,7 @@ enum RoleMappingType {
   rules,
 }
 
-extension on RoleMappingType {
+extension RoleMappingTypeValue on RoleMappingType {
   String toValue() {
     switch (this) {
       case RoleMappingType.token:
@@ -2192,7 +2192,7 @@ extension on RoleMappingType {
   }
 }
 
-extension on String {
+extension RoleMappingTypeFromString on String {
   RoleMappingType toRoleMappingType() {
     switch (this) {
       case 'Token':

--- a/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
+++ b/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
@@ -1521,7 +1521,8 @@ enum AmbiguousRoleResolutionType {
   deny,
 }
 
-extension AmbiguousRoleResolutionTypeValue on AmbiguousRoleResolutionType {
+extension AmbiguousRoleResolutionTypeValueExtension
+    on AmbiguousRoleResolutionType {
   String toValue() {
     switch (this) {
       case AmbiguousRoleResolutionType.authenticatedRole:
@@ -1646,7 +1647,7 @@ enum ErrorCode {
   internalServerError,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.accessDenied:
@@ -2076,7 +2077,7 @@ enum MappingRuleMatchType {
   notEqual,
 }
 
-extension MappingRuleMatchTypeValue on MappingRuleMatchType {
+extension MappingRuleMatchTypeValueExtension on MappingRuleMatchType {
   String toValue() {
     switch (this) {
       case MappingRuleMatchType.equals:
@@ -2181,7 +2182,7 @@ enum RoleMappingType {
   rules,
 }
 
-extension RoleMappingTypeValue on RoleMappingType {
+extension RoleMappingTypeValueExtension on RoleMappingType {
   String toValue() {
     switch (this) {
       case RoleMappingType.token:

--- a/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
+++ b/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
@@ -8656,7 +8656,8 @@ enum AccountTakeoverEventActionType {
   noAction,
 }
 
-extension on AccountTakeoverEventActionType {
+extension AccountTakeoverEventActionTypeValue
+    on AccountTakeoverEventActionType {
   String toValue() {
     switch (this) {
       case AccountTakeoverEventActionType.block:
@@ -8671,7 +8672,7 @@ extension on AccountTakeoverEventActionType {
   }
 }
 
-extension on String {
+extension AccountTakeoverEventActionTypeFromString on String {
   AccountTakeoverEventActionType toAccountTakeoverEventActionType() {
     switch (this) {
       case 'BLOCK':
@@ -9259,7 +9260,7 @@ enum AdvancedSecurityModeType {
   enforced,
 }
 
-extension on AdvancedSecurityModeType {
+extension AdvancedSecurityModeTypeValue on AdvancedSecurityModeType {
   String toValue() {
     switch (this) {
       case AdvancedSecurityModeType.off:
@@ -9272,7 +9273,7 @@ extension on AdvancedSecurityModeType {
   }
 }
 
-extension on String {
+extension AdvancedSecurityModeTypeFromString on String {
   AdvancedSecurityModeType toAdvancedSecurityModeType() {
     switch (this) {
       case 'OFF':
@@ -9292,7 +9293,7 @@ enum AliasAttributeType {
   preferredUsername,
 }
 
-extension on AliasAttributeType {
+extension AliasAttributeTypeValue on AliasAttributeType {
   String toValue() {
     switch (this) {
       case AliasAttributeType.phoneNumber:
@@ -9305,7 +9306,7 @@ extension on AliasAttributeType {
   }
 }
 
-extension on String {
+extension AliasAttributeTypeFromString on String {
   AliasAttributeType toAliasAttributeType() {
     switch (this) {
       case 'phone_number':
@@ -9435,7 +9436,7 @@ enum AttributeDataType {
   boolean,
 }
 
-extension on AttributeDataType {
+extension AttributeDataTypeValue on AttributeDataType {
   String toValue() {
     switch (this) {
       case AttributeDataType.string:
@@ -9450,7 +9451,7 @@ extension on AttributeDataType {
   }
 }
 
-extension on String {
+extension AttributeDataTypeFromString on String {
   AttributeDataType toAttributeDataType() {
     switch (this) {
       case 'String':
@@ -9569,7 +9570,7 @@ enum AuthFlowType {
   adminUserPasswordAuth,
 }
 
-extension on AuthFlowType {
+extension AuthFlowTypeValue on AuthFlowType {
   String toValue() {
     switch (this) {
       case AuthFlowType.userSrpAuth:
@@ -9590,7 +9591,7 @@ extension on AuthFlowType {
   }
 }
 
-extension on String {
+extension AuthFlowTypeFromString on String {
   AuthFlowType toAuthFlowType() {
     switch (this) {
       case 'USER_SRP_AUTH':
@@ -9660,7 +9661,7 @@ enum ChallengeName {
   mfa,
 }
 
-extension on ChallengeName {
+extension ChallengeNameValue on ChallengeName {
   String toValue() {
     switch (this) {
       case ChallengeName.password:
@@ -9671,7 +9672,7 @@ extension on ChallengeName {
   }
 }
 
-extension on String {
+extension ChallengeNameFromString on String {
   ChallengeName toChallengeName() {
     switch (this) {
       case 'Password':
@@ -9696,7 +9697,7 @@ enum ChallengeNameType {
   newPasswordRequired,
 }
 
-extension on ChallengeNameType {
+extension ChallengeNameTypeValue on ChallengeNameType {
   String toValue() {
     switch (this) {
       case ChallengeNameType.smsMfa:
@@ -9723,7 +9724,7 @@ extension on ChallengeNameType {
   }
 }
 
-extension on String {
+extension ChallengeNameTypeFromString on String {
   ChallengeNameType toChallengeNameType() {
     switch (this) {
       case 'SMS_MFA':
@@ -9756,7 +9757,7 @@ enum ChallengeResponse {
   failure,
 }
 
-extension on ChallengeResponse {
+extension ChallengeResponseValue on ChallengeResponse {
   String toValue() {
     switch (this) {
       case ChallengeResponse.success:
@@ -9767,7 +9768,7 @@ extension on ChallengeResponse {
   }
 }
 
-extension on String {
+extension ChallengeResponseFromString on String {
   ChallengeResponse toChallengeResponse() {
     switch (this) {
       case 'Success':
@@ -9863,7 +9864,8 @@ enum CompromisedCredentialsEventActionType {
   noAction,
 }
 
-extension on CompromisedCredentialsEventActionType {
+extension CompromisedCredentialsEventActionTypeValue
+    on CompromisedCredentialsEventActionType {
   String toValue() {
     switch (this) {
       case CompromisedCredentialsEventActionType.block:
@@ -9874,7 +9876,7 @@ extension on CompromisedCredentialsEventActionType {
   }
 }
 
-extension on String {
+extension CompromisedCredentialsEventActionTypeFromString on String {
   CompromisedCredentialsEventActionType
       toCompromisedCredentialsEventActionType() {
     switch (this) {
@@ -10178,7 +10180,8 @@ enum CustomEmailSenderLambdaVersionType {
   v1_0,
 }
 
-extension on CustomEmailSenderLambdaVersionType {
+extension CustomEmailSenderLambdaVersionTypeValue
+    on CustomEmailSenderLambdaVersionType {
   String toValue() {
     switch (this) {
       case CustomEmailSenderLambdaVersionType.v1_0:
@@ -10187,7 +10190,7 @@ extension on CustomEmailSenderLambdaVersionType {
   }
 }
 
-extension on String {
+extension CustomEmailSenderLambdaVersionTypeFromString on String {
   CustomEmailSenderLambdaVersionType toCustomEmailSenderLambdaVersionType() {
     switch (this) {
       case 'V1_0':
@@ -10235,7 +10238,8 @@ enum CustomSMSSenderLambdaVersionType {
   v1_0,
 }
 
-extension on CustomSMSSenderLambdaVersionType {
+extension CustomSMSSenderLambdaVersionTypeValue
+    on CustomSMSSenderLambdaVersionType {
   String toValue() {
     switch (this) {
       case CustomSMSSenderLambdaVersionType.v1_0:
@@ -10244,7 +10248,7 @@ extension on CustomSMSSenderLambdaVersionType {
   }
 }
 
-extension on String {
+extension CustomSMSSenderLambdaVersionTypeFromString on String {
   CustomSMSSenderLambdaVersionType toCustomSMSSenderLambdaVersionType() {
     switch (this) {
       case 'V1_0':
@@ -10260,7 +10264,7 @@ enum DefaultEmailOptionType {
   confirmWithCode,
 }
 
-extension on DefaultEmailOptionType {
+extension DefaultEmailOptionTypeValue on DefaultEmailOptionType {
   String toValue() {
     switch (this) {
       case DefaultEmailOptionType.confirmWithLink:
@@ -10271,7 +10275,7 @@ extension on DefaultEmailOptionType {
   }
 }
 
-extension on String {
+extension DefaultEmailOptionTypeFromString on String {
   DefaultEmailOptionType toDefaultEmailOptionType() {
     switch (this) {
       case 'CONFIRM_WITH_LINK':
@@ -10303,7 +10307,7 @@ enum DeliveryMediumType {
   email,
 }
 
-extension on DeliveryMediumType {
+extension DeliveryMediumTypeValue on DeliveryMediumType {
   String toValue() {
     switch (this) {
       case DeliveryMediumType.sms:
@@ -10314,7 +10318,7 @@ extension on DeliveryMediumType {
   }
 }
 
-extension on String {
+extension DeliveryMediumTypeFromString on String {
   DeliveryMediumType toDeliveryMediumType() {
     switch (this) {
       case 'SMS':
@@ -10485,7 +10489,7 @@ enum DeviceRememberedStatusType {
   notRemembered,
 }
 
-extension on DeviceRememberedStatusType {
+extension DeviceRememberedStatusTypeValue on DeviceRememberedStatusType {
   String toValue() {
     switch (this) {
       case DeviceRememberedStatusType.remembered:
@@ -10496,7 +10500,7 @@ extension on DeviceRememberedStatusType {
   }
 }
 
-extension on String {
+extension DeviceRememberedStatusTypeFromString on String {
   DeviceRememberedStatusType toDeviceRememberedStatusType() {
     switch (this) {
       case 'remembered':
@@ -10631,7 +10635,7 @@ enum DomainStatusType {
   failed,
 }
 
-extension on DomainStatusType {
+extension DomainStatusTypeValue on DomainStatusType {
   String toValue() {
     switch (this) {
       case DomainStatusType.creating:
@@ -10648,7 +10652,7 @@ extension on DomainStatusType {
   }
 }
 
-extension on String {
+extension DomainStatusTypeFromString on String {
   DomainStatusType toDomainStatusType() {
     switch (this) {
       case 'CREATING':
@@ -10835,7 +10839,7 @@ enum EmailSendingAccountType {
   developer,
 }
 
-extension on EmailSendingAccountType {
+extension EmailSendingAccountTypeValue on EmailSendingAccountType {
   String toValue() {
     switch (this) {
       case EmailSendingAccountType.cognitoDefault:
@@ -10846,7 +10850,7 @@ extension on EmailSendingAccountType {
   }
 }
 
-extension on String {
+extension EmailSendingAccountTypeFromString on String {
   EmailSendingAccountType toEmailSendingAccountType() {
     switch (this) {
       case 'COGNITO_DEFAULT':
@@ -10924,7 +10928,7 @@ enum EventFilterType {
   signUp,
 }
 
-extension on EventFilterType {
+extension EventFilterTypeValue on EventFilterType {
   String toValue() {
     switch (this) {
       case EventFilterType.signIn:
@@ -10937,7 +10941,7 @@ extension on EventFilterType {
   }
 }
 
-extension on String {
+extension EventFilterTypeFromString on String {
   EventFilterType toEventFilterType() {
     switch (this) {
       case 'SIGN_IN':
@@ -10956,7 +10960,7 @@ enum EventResponseType {
   failure,
 }
 
-extension on EventResponseType {
+extension EventResponseTypeValue on EventResponseType {
   String toValue() {
     switch (this) {
       case EventResponseType.success:
@@ -10967,7 +10971,7 @@ extension on EventResponseType {
   }
 }
 
-extension on String {
+extension EventResponseTypeFromString on String {
   EventResponseType toEventResponseType() {
     switch (this) {
       case 'Success':
@@ -11012,7 +11016,7 @@ enum EventType {
   forgotPassword,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.signIn:
@@ -11025,7 +11029,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'SignIn':
@@ -11050,7 +11054,7 @@ enum ExplicitAuthFlowsType {
   allowRefreshTokenAuth,
 }
 
-extension on ExplicitAuthFlowsType {
+extension ExplicitAuthFlowsTypeValue on ExplicitAuthFlowsType {
   String toValue() {
     switch (this) {
       case ExplicitAuthFlowsType.adminNoSrpAuth:
@@ -11073,7 +11077,7 @@ extension on ExplicitAuthFlowsType {
   }
 }
 
-extension on String {
+extension ExplicitAuthFlowsTypeFromString on String {
   ExplicitAuthFlowsType toExplicitAuthFlowsType() {
     switch (this) {
       case 'ADMIN_NO_SRP_AUTH':
@@ -11102,7 +11106,7 @@ enum FeedbackValueType {
   invalid,
 }
 
-extension on FeedbackValueType {
+extension FeedbackValueTypeValue on FeedbackValueType {
   String toValue() {
     switch (this) {
       case FeedbackValueType.valid:
@@ -11113,7 +11117,7 @@ extension on FeedbackValueType {
   }
 }
 
-extension on String {
+extension FeedbackValueTypeFromString on String {
   FeedbackValueType toFeedbackValueType() {
     switch (this) {
       case 'Valid':
@@ -11626,7 +11630,7 @@ enum IdentityProviderTypeType {
   oidc,
 }
 
-extension on IdentityProviderTypeType {
+extension IdentityProviderTypeTypeValue on IdentityProviderTypeType {
   String toValue() {
     switch (this) {
       case IdentityProviderTypeType.saml:
@@ -11645,7 +11649,7 @@ extension on IdentityProviderTypeType {
   }
 }
 
-extension on String {
+extension IdentityProviderTypeTypeFromString on String {
   IdentityProviderTypeType toIdentityProviderTypeType() {
     switch (this) {
       case 'SAML':
@@ -12136,7 +12140,7 @@ enum MessageActionType {
   suppress,
 }
 
-extension on MessageActionType {
+extension MessageActionTypeValue on MessageActionType {
   String toValue() {
     switch (this) {
       case MessageActionType.resend:
@@ -12147,7 +12151,7 @@ extension on MessageActionType {
   }
 }
 
-extension on String {
+extension MessageActionTypeFromString on String {
   MessageActionType toMessageActionType() {
     switch (this) {
       case 'RESEND':
@@ -12360,7 +12364,7 @@ enum OAuthFlowType {
   clientCredentials,
 }
 
-extension on OAuthFlowType {
+extension OAuthFlowTypeValue on OAuthFlowType {
   String toValue() {
     switch (this) {
       case OAuthFlowType.code:
@@ -12373,7 +12377,7 @@ extension on OAuthFlowType {
   }
 }
 
-extension on String {
+extension OAuthFlowTypeFromString on String {
   OAuthFlowType toOAuthFlowType() {
     switch (this) {
       case 'code':
@@ -12463,7 +12467,8 @@ enum PreventUserExistenceErrorTypes {
   enabled,
 }
 
-extension on PreventUserExistenceErrorTypes {
+extension PreventUserExistenceErrorTypesValue
+    on PreventUserExistenceErrorTypes {
   String toValue() {
     switch (this) {
       case PreventUserExistenceErrorTypes.legacy:
@@ -12474,7 +12479,7 @@ extension on PreventUserExistenceErrorTypes {
   }
 }
 
-extension on String {
+extension PreventUserExistenceErrorTypesFromString on String {
   PreventUserExistenceErrorTypes toPreventUserExistenceErrorTypes() {
     switch (this) {
       case 'LEGACY':
@@ -12557,7 +12562,7 @@ enum RecoveryOptionNameType {
   adminOnly,
 }
 
-extension on RecoveryOptionNameType {
+extension RecoveryOptionNameTypeValue on RecoveryOptionNameType {
   String toValue() {
     switch (this) {
       case RecoveryOptionNameType.verifiedEmail:
@@ -12570,7 +12575,7 @@ extension on RecoveryOptionNameType {
   }
 }
 
-extension on String {
+extension RecoveryOptionNameTypeFromString on String {
   RecoveryOptionNameType toRecoveryOptionNameType() {
     switch (this) {
       case 'verified_email':
@@ -12801,7 +12806,7 @@ enum RiskDecisionType {
   block,
 }
 
-extension on RiskDecisionType {
+extension RiskDecisionTypeValue on RiskDecisionType {
   String toValue() {
     switch (this) {
       case RiskDecisionType.noRisk:
@@ -12814,7 +12819,7 @@ extension on RiskDecisionType {
   }
 }
 
-extension on String {
+extension RiskDecisionTypeFromString on String {
   RiskDecisionType toRiskDecisionType() {
     switch (this) {
       case 'NoRisk':
@@ -12872,7 +12877,7 @@ enum RiskLevelType {
   high,
 }
 
-extension on RiskLevelType {
+extension RiskLevelTypeValue on RiskLevelType {
   String toValue() {
     switch (this) {
       case RiskLevelType.low:
@@ -12885,7 +12890,7 @@ extension on RiskLevelType {
   }
 }
 
-extension on String {
+extension RiskLevelTypeFromString on String {
   RiskLevelType toRiskLevelType() {
     switch (this) {
       case 'Low':
@@ -13299,7 +13304,7 @@ enum StatusType {
   disabled,
 }
 
-extension on StatusType {
+extension StatusTypeValue on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.enabled:
@@ -13310,7 +13315,7 @@ extension on StatusType {
   }
 }
 
-extension on String {
+extension StatusTypeFromString on String {
   StatusType toStatusType() {
     switch (this) {
       case 'Enabled':
@@ -13384,7 +13389,7 @@ enum TimeUnitsType {
   days,
 }
 
-extension on TimeUnitsType {
+extension TimeUnitsTypeValue on TimeUnitsType {
   String toValue() {
     switch (this) {
       case TimeUnitsType.seconds:
@@ -13399,7 +13404,7 @@ extension on TimeUnitsType {
   }
 }
 
-extension on String {
+extension TimeUnitsTypeFromString on String {
   TimeUnitsType toTimeUnitsType() {
     switch (this) {
       case 'seconds':
@@ -13666,7 +13671,7 @@ enum UserImportJobStatusType {
   succeeded,
 }
 
-extension on UserImportJobStatusType {
+extension UserImportJobStatusTypeValue on UserImportJobStatusType {
   String toValue() {
     switch (this) {
       case UserImportJobStatusType.created:
@@ -13689,7 +13694,7 @@ extension on UserImportJobStatusType {
   }
 }
 
-extension on String {
+extension UserImportJobStatusTypeFromString on String {
   UserImportJobStatusType toUserImportJobStatusType() {
     switch (this) {
       case 'Created':
@@ -14196,7 +14201,7 @@ enum UserPoolMfaType {
   optional,
 }
 
-extension on UserPoolMfaType {
+extension UserPoolMfaTypeValue on UserPoolMfaType {
   String toValue() {
     switch (this) {
       case UserPoolMfaType.off:
@@ -14209,7 +14214,7 @@ extension on UserPoolMfaType {
   }
 }
 
-extension on String {
+extension UserPoolMfaTypeFromString on String {
   UserPoolMfaType toUserPoolMfaType() {
     switch (this) {
       case 'OFF':
@@ -14503,7 +14508,7 @@ enum UserStatusType {
   forceChangePassword,
 }
 
-extension on UserStatusType {
+extension UserStatusTypeValue on UserStatusType {
   String toValue() {
     switch (this) {
       case UserStatusType.unconfirmed:
@@ -14524,7 +14529,7 @@ extension on UserStatusType {
   }
 }
 
-extension on String {
+extension UserStatusTypeFromString on String {
   UserStatusType toUserStatusType() {
     switch (this) {
       case 'UNCONFIRMED':
@@ -14629,7 +14634,7 @@ enum UsernameAttributeType {
   email,
 }
 
-extension on UsernameAttributeType {
+extension UsernameAttributeTypeValue on UsernameAttributeType {
   String toValue() {
     switch (this) {
       case UsernameAttributeType.phoneNumber:
@@ -14640,7 +14645,7 @@ extension on UsernameAttributeType {
   }
 }
 
-extension on String {
+extension UsernameAttributeTypeFromString on String {
   UsernameAttributeType toUsernameAttributeType() {
     switch (this) {
       case 'phone_number':
@@ -14769,7 +14774,7 @@ enum VerifiedAttributeType {
   email,
 }
 
-extension on VerifiedAttributeType {
+extension VerifiedAttributeTypeValue on VerifiedAttributeType {
   String toValue() {
     switch (this) {
       case VerifiedAttributeType.phoneNumber:
@@ -14780,7 +14785,7 @@ extension on VerifiedAttributeType {
   }
 }
 
-extension on String {
+extension VerifiedAttributeTypeFromString on String {
   VerifiedAttributeType toVerifiedAttributeType() {
     switch (this) {
       case 'phone_number':
@@ -14817,7 +14822,8 @@ enum VerifySoftwareTokenResponseType {
   error,
 }
 
-extension on VerifySoftwareTokenResponseType {
+extension VerifySoftwareTokenResponseTypeValue
+    on VerifySoftwareTokenResponseType {
   String toValue() {
     switch (this) {
       case VerifySoftwareTokenResponseType.success:
@@ -14828,7 +14834,7 @@ extension on VerifySoftwareTokenResponseType {
   }
 }
 
-extension on String {
+extension VerifySoftwareTokenResponseTypeFromString on String {
   VerifySoftwareTokenResponseType toVerifySoftwareTokenResponseType() {
     switch (this) {
       case 'SUCCESS':

--- a/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
+++ b/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
@@ -8656,7 +8656,7 @@ enum AccountTakeoverEventActionType {
   noAction,
 }
 
-extension AccountTakeoverEventActionTypeValue
+extension AccountTakeoverEventActionTypeValueExtension
     on AccountTakeoverEventActionType {
   String toValue() {
     switch (this) {
@@ -9260,7 +9260,7 @@ enum AdvancedSecurityModeType {
   enforced,
 }
 
-extension AdvancedSecurityModeTypeValue on AdvancedSecurityModeType {
+extension AdvancedSecurityModeTypeValueExtension on AdvancedSecurityModeType {
   String toValue() {
     switch (this) {
       case AdvancedSecurityModeType.off:
@@ -9293,7 +9293,7 @@ enum AliasAttributeType {
   preferredUsername,
 }
 
-extension AliasAttributeTypeValue on AliasAttributeType {
+extension AliasAttributeTypeValueExtension on AliasAttributeType {
   String toValue() {
     switch (this) {
       case AliasAttributeType.phoneNumber:
@@ -9436,7 +9436,7 @@ enum AttributeDataType {
   boolean,
 }
 
-extension AttributeDataTypeValue on AttributeDataType {
+extension AttributeDataTypeValueExtension on AttributeDataType {
   String toValue() {
     switch (this) {
       case AttributeDataType.string:
@@ -9570,7 +9570,7 @@ enum AuthFlowType {
   adminUserPasswordAuth,
 }
 
-extension AuthFlowTypeValue on AuthFlowType {
+extension AuthFlowTypeValueExtension on AuthFlowType {
   String toValue() {
     switch (this) {
       case AuthFlowType.userSrpAuth:
@@ -9661,7 +9661,7 @@ enum ChallengeName {
   mfa,
 }
 
-extension ChallengeNameValue on ChallengeName {
+extension ChallengeNameValueExtension on ChallengeName {
   String toValue() {
     switch (this) {
       case ChallengeName.password:
@@ -9697,7 +9697,7 @@ enum ChallengeNameType {
   newPasswordRequired,
 }
 
-extension ChallengeNameTypeValue on ChallengeNameType {
+extension ChallengeNameTypeValueExtension on ChallengeNameType {
   String toValue() {
     switch (this) {
       case ChallengeNameType.smsMfa:
@@ -9757,7 +9757,7 @@ enum ChallengeResponse {
   failure,
 }
 
-extension ChallengeResponseValue on ChallengeResponse {
+extension ChallengeResponseValueExtension on ChallengeResponse {
   String toValue() {
     switch (this) {
       case ChallengeResponse.success:
@@ -9864,7 +9864,7 @@ enum CompromisedCredentialsEventActionType {
   noAction,
 }
 
-extension CompromisedCredentialsEventActionTypeValue
+extension CompromisedCredentialsEventActionTypeValueExtension
     on CompromisedCredentialsEventActionType {
   String toValue() {
     switch (this) {
@@ -10180,7 +10180,7 @@ enum CustomEmailSenderLambdaVersionType {
   v1_0,
 }
 
-extension CustomEmailSenderLambdaVersionTypeValue
+extension CustomEmailSenderLambdaVersionTypeValueExtension
     on CustomEmailSenderLambdaVersionType {
   String toValue() {
     switch (this) {
@@ -10238,7 +10238,7 @@ enum CustomSMSSenderLambdaVersionType {
   v1_0,
 }
 
-extension CustomSMSSenderLambdaVersionTypeValue
+extension CustomSMSSenderLambdaVersionTypeValueExtension
     on CustomSMSSenderLambdaVersionType {
   String toValue() {
     switch (this) {
@@ -10264,7 +10264,7 @@ enum DefaultEmailOptionType {
   confirmWithCode,
 }
 
-extension DefaultEmailOptionTypeValue on DefaultEmailOptionType {
+extension DefaultEmailOptionTypeValueExtension on DefaultEmailOptionType {
   String toValue() {
     switch (this) {
       case DefaultEmailOptionType.confirmWithLink:
@@ -10307,7 +10307,7 @@ enum DeliveryMediumType {
   email,
 }
 
-extension DeliveryMediumTypeValue on DeliveryMediumType {
+extension DeliveryMediumTypeValueExtension on DeliveryMediumType {
   String toValue() {
     switch (this) {
       case DeliveryMediumType.sms:
@@ -10489,7 +10489,8 @@ enum DeviceRememberedStatusType {
   notRemembered,
 }
 
-extension DeviceRememberedStatusTypeValue on DeviceRememberedStatusType {
+extension DeviceRememberedStatusTypeValueExtension
+    on DeviceRememberedStatusType {
   String toValue() {
     switch (this) {
       case DeviceRememberedStatusType.remembered:
@@ -10635,7 +10636,7 @@ enum DomainStatusType {
   failed,
 }
 
-extension DomainStatusTypeValue on DomainStatusType {
+extension DomainStatusTypeValueExtension on DomainStatusType {
   String toValue() {
     switch (this) {
       case DomainStatusType.creating:
@@ -10839,7 +10840,7 @@ enum EmailSendingAccountType {
   developer,
 }
 
-extension EmailSendingAccountTypeValue on EmailSendingAccountType {
+extension EmailSendingAccountTypeValueExtension on EmailSendingAccountType {
   String toValue() {
     switch (this) {
       case EmailSendingAccountType.cognitoDefault:
@@ -10928,7 +10929,7 @@ enum EventFilterType {
   signUp,
 }
 
-extension EventFilterTypeValue on EventFilterType {
+extension EventFilterTypeValueExtension on EventFilterType {
   String toValue() {
     switch (this) {
       case EventFilterType.signIn:
@@ -10960,7 +10961,7 @@ enum EventResponseType {
   failure,
 }
 
-extension EventResponseTypeValue on EventResponseType {
+extension EventResponseTypeValueExtension on EventResponseType {
   String toValue() {
     switch (this) {
       case EventResponseType.success:
@@ -11016,7 +11017,7 @@ enum EventType {
   forgotPassword,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.signIn:
@@ -11054,7 +11055,7 @@ enum ExplicitAuthFlowsType {
   allowRefreshTokenAuth,
 }
 
-extension ExplicitAuthFlowsTypeValue on ExplicitAuthFlowsType {
+extension ExplicitAuthFlowsTypeValueExtension on ExplicitAuthFlowsType {
   String toValue() {
     switch (this) {
       case ExplicitAuthFlowsType.adminNoSrpAuth:
@@ -11106,7 +11107,7 @@ enum FeedbackValueType {
   invalid,
 }
 
-extension FeedbackValueTypeValue on FeedbackValueType {
+extension FeedbackValueTypeValueExtension on FeedbackValueType {
   String toValue() {
     switch (this) {
       case FeedbackValueType.valid:
@@ -11630,7 +11631,7 @@ enum IdentityProviderTypeType {
   oidc,
 }
 
-extension IdentityProviderTypeTypeValue on IdentityProviderTypeType {
+extension IdentityProviderTypeTypeValueExtension on IdentityProviderTypeType {
   String toValue() {
     switch (this) {
       case IdentityProviderTypeType.saml:
@@ -12140,7 +12141,7 @@ enum MessageActionType {
   suppress,
 }
 
-extension MessageActionTypeValue on MessageActionType {
+extension MessageActionTypeValueExtension on MessageActionType {
   String toValue() {
     switch (this) {
       case MessageActionType.resend:
@@ -12364,7 +12365,7 @@ enum OAuthFlowType {
   clientCredentials,
 }
 
-extension OAuthFlowTypeValue on OAuthFlowType {
+extension OAuthFlowTypeValueExtension on OAuthFlowType {
   String toValue() {
     switch (this) {
       case OAuthFlowType.code:
@@ -12467,7 +12468,7 @@ enum PreventUserExistenceErrorTypes {
   enabled,
 }
 
-extension PreventUserExistenceErrorTypesValue
+extension PreventUserExistenceErrorTypesValueExtension
     on PreventUserExistenceErrorTypes {
   String toValue() {
     switch (this) {
@@ -12562,7 +12563,7 @@ enum RecoveryOptionNameType {
   adminOnly,
 }
 
-extension RecoveryOptionNameTypeValue on RecoveryOptionNameType {
+extension RecoveryOptionNameTypeValueExtension on RecoveryOptionNameType {
   String toValue() {
     switch (this) {
       case RecoveryOptionNameType.verifiedEmail:
@@ -12806,7 +12807,7 @@ enum RiskDecisionType {
   block,
 }
 
-extension RiskDecisionTypeValue on RiskDecisionType {
+extension RiskDecisionTypeValueExtension on RiskDecisionType {
   String toValue() {
     switch (this) {
       case RiskDecisionType.noRisk:
@@ -12877,7 +12878,7 @@ enum RiskLevelType {
   high,
 }
 
-extension RiskLevelTypeValue on RiskLevelType {
+extension RiskLevelTypeValueExtension on RiskLevelType {
   String toValue() {
     switch (this) {
       case RiskLevelType.low:
@@ -13304,7 +13305,7 @@ enum StatusType {
   disabled,
 }
 
-extension StatusTypeValue on StatusType {
+extension StatusTypeValueExtension on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.enabled:
@@ -13389,7 +13390,7 @@ enum TimeUnitsType {
   days,
 }
 
-extension TimeUnitsTypeValue on TimeUnitsType {
+extension TimeUnitsTypeValueExtension on TimeUnitsType {
   String toValue() {
     switch (this) {
       case TimeUnitsType.seconds:
@@ -13671,7 +13672,7 @@ enum UserImportJobStatusType {
   succeeded,
 }
 
-extension UserImportJobStatusTypeValue on UserImportJobStatusType {
+extension UserImportJobStatusTypeValueExtension on UserImportJobStatusType {
   String toValue() {
     switch (this) {
       case UserImportJobStatusType.created:
@@ -14201,7 +14202,7 @@ enum UserPoolMfaType {
   optional,
 }
 
-extension UserPoolMfaTypeValue on UserPoolMfaType {
+extension UserPoolMfaTypeValueExtension on UserPoolMfaType {
   String toValue() {
     switch (this) {
       case UserPoolMfaType.off:
@@ -14508,7 +14509,7 @@ enum UserStatusType {
   forceChangePassword,
 }
 
-extension UserStatusTypeValue on UserStatusType {
+extension UserStatusTypeValueExtension on UserStatusType {
   String toValue() {
     switch (this) {
       case UserStatusType.unconfirmed:
@@ -14634,7 +14635,7 @@ enum UsernameAttributeType {
   email,
 }
 
-extension UsernameAttributeTypeValue on UsernameAttributeType {
+extension UsernameAttributeTypeValueExtension on UsernameAttributeType {
   String toValue() {
     switch (this) {
       case UsernameAttributeType.phoneNumber:
@@ -14774,7 +14775,7 @@ enum VerifiedAttributeType {
   email,
 }
 
-extension VerifiedAttributeTypeValue on VerifiedAttributeType {
+extension VerifiedAttributeTypeValueExtension on VerifiedAttributeType {
   String toValue() {
     switch (this) {
       case VerifiedAttributeType.phoneNumber:
@@ -14822,7 +14823,7 @@ enum VerifySoftwareTokenResponseType {
   error,
 }
 
-extension VerifySoftwareTokenResponseTypeValue
+extension VerifySoftwareTokenResponseTypeValueExtension
     on VerifySoftwareTokenResponseType {
   String toValue() {
     switch (this) {

--- a/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
+++ b/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
@@ -1070,7 +1070,7 @@ enum BulkPublishStatus {
   succeeded,
 }
 
-extension on BulkPublishStatus {
+extension BulkPublishStatusValue on BulkPublishStatus {
   String toValue() {
     switch (this) {
       case BulkPublishStatus.notStarted:
@@ -1085,7 +1085,7 @@ extension on BulkPublishStatus {
   }
 }
 
-extension on String {
+extension BulkPublishStatusFromString on String {
   BulkPublishStatus toBulkPublishStatus() {
     switch (this) {
       case 'NOT_STARTED':
@@ -1711,7 +1711,7 @@ enum Operation {
   remove,
 }
 
-extension on Operation {
+extension OperationValue on Operation {
   String toValue() {
     switch (this) {
       case Operation.replace:
@@ -1722,7 +1722,7 @@ extension on Operation {
   }
 }
 
-extension on String {
+extension OperationFromString on String {
   Operation toOperation() {
     switch (this) {
       case 'replace':
@@ -1741,7 +1741,7 @@ enum Platform {
   adm,
 }
 
-extension on Platform {
+extension PlatformValue on Platform {
   String toValue() {
     switch (this) {
       case Platform.apns:
@@ -1756,7 +1756,7 @@ extension on Platform {
   }
 }
 
-extension on String {
+extension PlatformFromString on String {
   Platform toPlatform() {
     switch (this) {
       case 'APNS':
@@ -1968,7 +1968,7 @@ enum StreamingStatus {
   disabled,
 }
 
-extension on StreamingStatus {
+extension StreamingStatusValue on StreamingStatus {
   String toValue() {
     switch (this) {
       case StreamingStatus.enabled:
@@ -1979,7 +1979,7 @@ extension on StreamingStatus {
   }
 }
 
-extension on String {
+extension StreamingStatusFromString on String {
   StreamingStatus toStreamingStatus() {
     switch (this) {
       case 'ENABLED':

--- a/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
+++ b/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
@@ -1070,7 +1070,7 @@ enum BulkPublishStatus {
   succeeded,
 }
 
-extension BulkPublishStatusValue on BulkPublishStatus {
+extension BulkPublishStatusValueExtension on BulkPublishStatus {
   String toValue() {
     switch (this) {
       case BulkPublishStatus.notStarted:
@@ -1711,7 +1711,7 @@ enum Operation {
   remove,
 }
 
-extension OperationValue on Operation {
+extension OperationValueExtension on Operation {
   String toValue() {
     switch (this) {
       case Operation.replace:
@@ -1741,7 +1741,7 @@ enum Platform {
   adm,
 }
 
-extension PlatformValue on Platform {
+extension PlatformValueExtension on Platform {
   String toValue() {
     switch (this) {
       case Platform.apns:
@@ -1968,7 +1968,7 @@ enum StreamingStatus {
   disabled,
 }
 
-extension StreamingStatusValue on StreamingStatus {
+extension StreamingStatusValueExtension on StreamingStatus {
   String toValue() {
     switch (this) {
       case StreamingStatus.enabled:

--- a/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
+++ b/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
@@ -4739,7 +4739,7 @@ enum DocumentClassifierDataFormat {
   augmentedManifest,
 }
 
-extension on DocumentClassifierDataFormat {
+extension DocumentClassifierDataFormatValue on DocumentClassifierDataFormat {
   String toValue() {
     switch (this) {
       case DocumentClassifierDataFormat.comprehendCsv:
@@ -4750,7 +4750,7 @@ extension on DocumentClassifierDataFormat {
   }
 }
 
-extension on String {
+extension DocumentClassifierDataFormatFromString on String {
   DocumentClassifierDataFormat toDocumentClassifierDataFormat() {
     switch (this) {
       case 'COMPREHEND_CSV':
@@ -4899,7 +4899,7 @@ enum DocumentClassifierMode {
   multiLabel,
 }
 
-extension on DocumentClassifierMode {
+extension DocumentClassifierModeValue on DocumentClassifierMode {
   String toValue() {
     switch (this) {
       case DocumentClassifierMode.multiClass:
@@ -4910,7 +4910,7 @@ extension on DocumentClassifierMode {
   }
 }
 
-extension on String {
+extension DocumentClassifierModeFromString on String {
   DocumentClassifierMode toDocumentClassifierMode() {
     switch (this) {
       case 'MULTI_CLASS':
@@ -5400,7 +5400,7 @@ enum EndpointStatus {
   updating,
 }
 
-extension on EndpointStatus {
+extension EndpointStatusValue on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.creating:
@@ -5417,7 +5417,7 @@ extension on EndpointStatus {
   }
 }
 
-extension on String {
+extension EndpointStatusFromString on String {
   EndpointStatus toEndpointStatus() {
     switch (this) {
       case 'CREATING':
@@ -5657,7 +5657,7 @@ enum EntityRecognizerDataFormat {
   augmentedManifest,
 }
 
-extension on EntityRecognizerDataFormat {
+extension EntityRecognizerDataFormatValue on EntityRecognizerDataFormat {
   String toValue() {
     switch (this) {
       case EntityRecognizerDataFormat.comprehendCsv:
@@ -5668,7 +5668,7 @@ extension on EntityRecognizerDataFormat {
   }
 }
 
-extension on String {
+extension EntityRecognizerDataFormatFromString on String {
   EntityRecognizerDataFormat toEntityRecognizerDataFormat() {
     switch (this) {
       case 'COMPREHEND_CSV':
@@ -6098,7 +6098,7 @@ enum EntityType {
   other,
 }
 
-extension on EntityType {
+extension EntityTypeValue on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.person:
@@ -6123,7 +6123,7 @@ extension on EntityType {
   }
 }
 
-extension on String {
+extension EntityTypeFromString on String {
   EntityType toEntityType() {
     switch (this) {
       case 'PERSON':
@@ -6382,7 +6382,7 @@ enum InputFormat {
   oneDocPerLine,
 }
 
-extension on InputFormat {
+extension InputFormatValue on InputFormat {
   String toValue() {
     switch (this) {
       case InputFormat.oneDocPerFile:
@@ -6393,7 +6393,7 @@ extension on InputFormat {
   }
 }
 
-extension on String {
+extension InputFormatFromString on String {
   InputFormat toInputFormat() {
     switch (this) {
       case 'ONE_DOC_PER_FILE':
@@ -6414,7 +6414,7 @@ enum JobStatus {
   stopped,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -6433,7 +6433,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -6649,7 +6649,7 @@ enum LanguageCode {
   zhTw,
 }
 
-extension on LanguageCode {
+extension LanguageCodeValue on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.en:
@@ -6680,7 +6680,7 @@ extension on LanguageCode {
   }
 }
 
-extension on String {
+extension LanguageCodeFromString on String {
   LanguageCode toLanguageCode() {
     switch (this) {
       case 'en':
@@ -7023,7 +7023,7 @@ enum ModelStatus {
   trained,
 }
 
-extension on ModelStatus {
+extension ModelStatusValue on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.submitted:
@@ -7044,7 +7044,7 @@ extension on ModelStatus {
   }
 }
 
-extension on String {
+extension ModelStatusFromString on String {
   ModelStatus toModelStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -7169,7 +7169,7 @@ enum PartOfSpeechTagType {
   verb,
 }
 
-extension on PartOfSpeechTagType {
+extension PartOfSpeechTagTypeValue on PartOfSpeechTagType {
   String toValue() {
     switch (this) {
       case PartOfSpeechTagType.adj:
@@ -7212,7 +7212,7 @@ extension on PartOfSpeechTagType {
   }
 }
 
-extension on String {
+extension PartOfSpeechTagTypeFromString on String {
   PartOfSpeechTagType toPartOfSpeechTagType() {
     switch (this) {
       case 'ADJ':
@@ -7392,7 +7392,7 @@ enum PiiEntitiesDetectionMaskMode {
   replaceWithPiiEntityType,
 }
 
-extension on PiiEntitiesDetectionMaskMode {
+extension PiiEntitiesDetectionMaskModeValue on PiiEntitiesDetectionMaskMode {
   String toValue() {
     switch (this) {
       case PiiEntitiesDetectionMaskMode.mask:
@@ -7403,7 +7403,7 @@ extension on PiiEntitiesDetectionMaskMode {
   }
 }
 
-extension on String {
+extension PiiEntitiesDetectionMaskModeFromString on String {
   PiiEntitiesDetectionMaskMode toPiiEntitiesDetectionMaskMode() {
     switch (this) {
       case 'MASK':
@@ -7420,7 +7420,7 @@ enum PiiEntitiesDetectionMode {
   onlyOffsets,
 }
 
-extension on PiiEntitiesDetectionMode {
+extension PiiEntitiesDetectionModeValue on PiiEntitiesDetectionMode {
   String toValue() {
     switch (this) {
       case PiiEntitiesDetectionMode.onlyRedaction:
@@ -7431,7 +7431,7 @@ extension on PiiEntitiesDetectionMode {
   }
 }
 
-extension on String {
+extension PiiEntitiesDetectionModeFromString on String {
   PiiEntitiesDetectionMode toPiiEntitiesDetectionMode() {
     switch (this) {
       case 'ONLY_REDACTION':
@@ -7508,7 +7508,7 @@ enum PiiEntityType {
   all,
 }
 
-extension on PiiEntityType {
+extension PiiEntityTypeValue on PiiEntityType {
   String toValue() {
     switch (this) {
       case PiiEntityType.bankAccountNumber:
@@ -7561,7 +7561,7 @@ extension on PiiEntityType {
   }
 }
 
-extension on String {
+extension PiiEntityTypeFromString on String {
   PiiEntityType toPiiEntityType() {
     switch (this) {
       case 'BANK_ACCOUNT_NUMBER':
@@ -7865,7 +7865,7 @@ enum SentimentType {
   mixed,
 }
 
-extension on SentimentType {
+extension SentimentTypeValue on SentimentType {
   String toValue() {
     switch (this) {
       case SentimentType.positive:
@@ -7880,7 +7880,7 @@ extension on SentimentType {
   }
 }
 
-extension on String {
+extension SentimentTypeFromString on String {
   SentimentType toSentimentType() {
     switch (this) {
       case 'POSITIVE':
@@ -8317,7 +8317,7 @@ enum SyntaxLanguageCode {
   pt,
 }
 
-extension on SyntaxLanguageCode {
+extension SyntaxLanguageCodeValue on SyntaxLanguageCode {
   String toValue() {
     switch (this) {
       case SyntaxLanguageCode.en:
@@ -8336,7 +8336,7 @@ extension on SyntaxLanguageCode {
   }
 }
 
-extension on String {
+extension SyntaxLanguageCodeFromString on String {
   SyntaxLanguageCode toSyntaxLanguageCode() {
     switch (this) {
       case 'en':

--- a/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
+++ b/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
@@ -4739,7 +4739,8 @@ enum DocumentClassifierDataFormat {
   augmentedManifest,
 }
 
-extension DocumentClassifierDataFormatValue on DocumentClassifierDataFormat {
+extension DocumentClassifierDataFormatValueExtension
+    on DocumentClassifierDataFormat {
   String toValue() {
     switch (this) {
       case DocumentClassifierDataFormat.comprehendCsv:
@@ -4899,7 +4900,7 @@ enum DocumentClassifierMode {
   multiLabel,
 }
 
-extension DocumentClassifierModeValue on DocumentClassifierMode {
+extension DocumentClassifierModeValueExtension on DocumentClassifierMode {
   String toValue() {
     switch (this) {
       case DocumentClassifierMode.multiClass:
@@ -5400,7 +5401,7 @@ enum EndpointStatus {
   updating,
 }
 
-extension EndpointStatusValue on EndpointStatus {
+extension EndpointStatusValueExtension on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.creating:
@@ -5657,7 +5658,8 @@ enum EntityRecognizerDataFormat {
   augmentedManifest,
 }
 
-extension EntityRecognizerDataFormatValue on EntityRecognizerDataFormat {
+extension EntityRecognizerDataFormatValueExtension
+    on EntityRecognizerDataFormat {
   String toValue() {
     switch (this) {
       case EntityRecognizerDataFormat.comprehendCsv:
@@ -6098,7 +6100,7 @@ enum EntityType {
   other,
 }
 
-extension EntityTypeValue on EntityType {
+extension EntityTypeValueExtension on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.person:
@@ -6382,7 +6384,7 @@ enum InputFormat {
   oneDocPerLine,
 }
 
-extension InputFormatValue on InputFormat {
+extension InputFormatValueExtension on InputFormat {
   String toValue() {
     switch (this) {
       case InputFormat.oneDocPerFile:
@@ -6414,7 +6416,7 @@ enum JobStatus {
   stopped,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -6649,7 +6651,7 @@ enum LanguageCode {
   zhTw,
 }
 
-extension LanguageCodeValue on LanguageCode {
+extension LanguageCodeValueExtension on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.en:
@@ -7023,7 +7025,7 @@ enum ModelStatus {
   trained,
 }
 
-extension ModelStatusValue on ModelStatus {
+extension ModelStatusValueExtension on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.submitted:
@@ -7169,7 +7171,7 @@ enum PartOfSpeechTagType {
   verb,
 }
 
-extension PartOfSpeechTagTypeValue on PartOfSpeechTagType {
+extension PartOfSpeechTagTypeValueExtension on PartOfSpeechTagType {
   String toValue() {
     switch (this) {
       case PartOfSpeechTagType.adj:
@@ -7392,7 +7394,8 @@ enum PiiEntitiesDetectionMaskMode {
   replaceWithPiiEntityType,
 }
 
-extension PiiEntitiesDetectionMaskModeValue on PiiEntitiesDetectionMaskMode {
+extension PiiEntitiesDetectionMaskModeValueExtension
+    on PiiEntitiesDetectionMaskMode {
   String toValue() {
     switch (this) {
       case PiiEntitiesDetectionMaskMode.mask:
@@ -7420,7 +7423,7 @@ enum PiiEntitiesDetectionMode {
   onlyOffsets,
 }
 
-extension PiiEntitiesDetectionModeValue on PiiEntitiesDetectionMode {
+extension PiiEntitiesDetectionModeValueExtension on PiiEntitiesDetectionMode {
   String toValue() {
     switch (this) {
       case PiiEntitiesDetectionMode.onlyRedaction:
@@ -7508,7 +7511,7 @@ enum PiiEntityType {
   all,
 }
 
-extension PiiEntityTypeValue on PiiEntityType {
+extension PiiEntityTypeValueExtension on PiiEntityType {
   String toValue() {
     switch (this) {
       case PiiEntityType.bankAccountNumber:
@@ -7865,7 +7868,7 @@ enum SentimentType {
   mixed,
 }
 
-extension SentimentTypeValue on SentimentType {
+extension SentimentTypeValueExtension on SentimentType {
   String toValue() {
     switch (this) {
       case SentimentType.positive:
@@ -8317,7 +8320,7 @@ enum SyntaxLanguageCode {
   pt,
 }
 
-extension SyntaxLanguageCodeValue on SyntaxLanguageCode {
+extension SyntaxLanguageCodeValueExtension on SyntaxLanguageCode {
   String toValue() {
     switch (this) {
       case SyntaxLanguageCode.en:

--- a/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
+++ b/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
@@ -1292,7 +1292,7 @@ enum AttributeName {
   negation,
 }
 
-extension AttributeNameValue on AttributeName {
+extension AttributeNameValueExtension on AttributeName {
   String toValue() {
     switch (this) {
       case AttributeName.sign:
@@ -1769,7 +1769,7 @@ enum EntitySubType {
   timeToTreatmentName,
 }
 
-extension EntitySubTypeValue on EntitySubType {
+extension EntitySubTypeValueExtension on EntitySubType {
   String toValue() {
     switch (this) {
       case EntitySubType.name:
@@ -1929,7 +1929,7 @@ enum EntityType {
   timeExpression,
 }
 
-extension EntityTypeValue on EntityType {
+extension EntityTypeValueExtension on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.medication:
@@ -2042,7 +2042,7 @@ enum ICD10CMAttributeType {
   quantity,
 }
 
-extension ICD10CMAttributeTypeValue on ICD10CMAttributeType {
+extension ICD10CMAttributeTypeValueExtension on ICD10CMAttributeType {
   String toValue() {
     switch (this) {
       case ICD10CMAttributeType.acuity:
@@ -2193,7 +2193,7 @@ enum ICD10CMEntityCategory {
   medicalCondition,
 }
 
-extension ICD10CMEntityCategoryValue on ICD10CMEntityCategory {
+extension ICD10CMEntityCategoryValueExtension on ICD10CMEntityCategory {
   String toValue() {
     switch (this) {
       case ICD10CMEntityCategory.medicalCondition:
@@ -2216,7 +2216,7 @@ enum ICD10CMEntityType {
   dxName,
 }
 
-extension ICD10CMEntityTypeValue on ICD10CMEntityType {
+extension ICD10CMEntityTypeValueExtension on ICD10CMEntityType {
   String toValue() {
     switch (this) {
       case ICD10CMEntityType.dxName:
@@ -2265,7 +2265,7 @@ enum ICD10CMTraitName {
   symptom,
 }
 
-extension ICD10CMTraitNameValue on ICD10CMTraitName {
+extension ICD10CMTraitNameValueExtension on ICD10CMTraitName {
   String toValue() {
     switch (this) {
       case ICD10CMTraitName.negation:
@@ -2407,7 +2407,7 @@ enum JobStatus {
   stopped,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -2454,7 +2454,7 @@ enum LanguageCode {
   en,
 }
 
-extension LanguageCodeValue on LanguageCode {
+extension LanguageCodeValueExtension on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.en:
@@ -2630,7 +2630,7 @@ enum RelationshipType {
   systemOrganSite,
 }
 
-extension RelationshipTypeValue on RelationshipType {
+extension RelationshipTypeValueExtension on RelationshipType {
   String toValue() {
     switch (this) {
       case RelationshipType.every:
@@ -2792,7 +2792,7 @@ enum RxNormAttributeType {
   strength,
 }
 
-extension RxNormAttributeTypeValue on RxNormAttributeType {
+extension RxNormAttributeTypeValueExtension on RxNormAttributeType {
   String toValue() {
     switch (this) {
       case RxNormAttributeType.dosage:
@@ -2949,7 +2949,7 @@ enum RxNormEntityCategory {
   medication,
 }
 
-extension RxNormEntityCategoryValue on RxNormEntityCategory {
+extension RxNormEntityCategoryValueExtension on RxNormEntityCategory {
   String toValue() {
     switch (this) {
       case RxNormEntityCategory.medication:
@@ -2973,7 +2973,7 @@ enum RxNormEntityType {
   genericName,
 }
 
-extension RxNormEntityTypeValue on RxNormEntityType {
+extension RxNormEntityTypeValueExtension on RxNormEntityType {
   String toValue() {
     switch (this) {
       case RxNormEntityType.brandName:
@@ -3023,7 +3023,7 @@ enum RxNormTraitName {
   negation,
 }
 
-extension RxNormTraitNameValue on RxNormTraitName {
+extension RxNormTraitNameValueExtension on RxNormTraitName {
   String toValue() {
     switch (this) {
       case RxNormTraitName.negation:

--- a/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
+++ b/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
@@ -1292,7 +1292,7 @@ enum AttributeName {
   negation,
 }
 
-extension on AttributeName {
+extension AttributeNameValue on AttributeName {
   String toValue() {
     switch (this) {
       case AttributeName.sign:
@@ -1307,7 +1307,7 @@ extension on AttributeName {
   }
 }
 
-extension on String {
+extension AttributeNameFromString on String {
   AttributeName toAttributeName() {
     switch (this) {
       case 'SIGN':
@@ -1769,7 +1769,7 @@ enum EntitySubType {
   timeToTreatmentName,
 }
 
-extension on EntitySubType {
+extension EntitySubTypeValue on EntitySubType {
   String toValue() {
     switch (this) {
       case EntitySubType.name:
@@ -1844,7 +1844,7 @@ extension on EntitySubType {
   }
 }
 
-extension on String {
+extension EntitySubTypeFromString on String {
   EntitySubType toEntitySubType() {
     switch (this) {
       case 'NAME':
@@ -1929,7 +1929,7 @@ enum EntityType {
   timeExpression,
 }
 
-extension on EntityType {
+extension EntityTypeValue on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.medication:
@@ -1948,7 +1948,7 @@ extension on EntityType {
   }
 }
 
-extension on String {
+extension EntityTypeFromString on String {
   EntityType toEntityType() {
     switch (this) {
       case 'MEDICATION':
@@ -2042,7 +2042,7 @@ enum ICD10CMAttributeType {
   quantity,
 }
 
-extension on ICD10CMAttributeType {
+extension ICD10CMAttributeTypeValue on ICD10CMAttributeType {
   String toValue() {
     switch (this) {
       case ICD10CMAttributeType.acuity:
@@ -2059,7 +2059,7 @@ extension on ICD10CMAttributeType {
   }
 }
 
-extension on String {
+extension ICD10CMAttributeTypeFromString on String {
   ICD10CMAttributeType toICD10CMAttributeType() {
     switch (this) {
       case 'ACUITY':
@@ -2193,7 +2193,7 @@ enum ICD10CMEntityCategory {
   medicalCondition,
 }
 
-extension on ICD10CMEntityCategory {
+extension ICD10CMEntityCategoryValue on ICD10CMEntityCategory {
   String toValue() {
     switch (this) {
       case ICD10CMEntityCategory.medicalCondition:
@@ -2202,7 +2202,7 @@ extension on ICD10CMEntityCategory {
   }
 }
 
-extension on String {
+extension ICD10CMEntityCategoryFromString on String {
   ICD10CMEntityCategory toICD10CMEntityCategory() {
     switch (this) {
       case 'MEDICAL_CONDITION':
@@ -2216,7 +2216,7 @@ enum ICD10CMEntityType {
   dxName,
 }
 
-extension on ICD10CMEntityType {
+extension ICD10CMEntityTypeValue on ICD10CMEntityType {
   String toValue() {
     switch (this) {
       case ICD10CMEntityType.dxName:
@@ -2225,7 +2225,7 @@ extension on ICD10CMEntityType {
   }
 }
 
-extension on String {
+extension ICD10CMEntityTypeFromString on String {
   ICD10CMEntityType toICD10CMEntityType() {
     switch (this) {
       case 'DX_NAME':
@@ -2265,7 +2265,7 @@ enum ICD10CMTraitName {
   symptom,
 }
 
-extension on ICD10CMTraitName {
+extension ICD10CMTraitNameValue on ICD10CMTraitName {
   String toValue() {
     switch (this) {
       case ICD10CMTraitName.negation:
@@ -2280,7 +2280,7 @@ extension on ICD10CMTraitName {
   }
 }
 
-extension on String {
+extension ICD10CMTraitNameFromString on String {
   ICD10CMTraitName toICD10CMTraitName() {
     switch (this) {
       case 'NEGATION':
@@ -2407,7 +2407,7 @@ enum JobStatus {
   stopped,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -2428,7 +2428,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -2454,7 +2454,7 @@ enum LanguageCode {
   en,
 }
 
-extension on LanguageCode {
+extension LanguageCodeValue on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.en:
@@ -2463,7 +2463,7 @@ extension on LanguageCode {
   }
 }
 
-extension on String {
+extension LanguageCodeFromString on String {
   LanguageCode toLanguageCode() {
     switch (this) {
       case 'en':
@@ -2630,7 +2630,7 @@ enum RelationshipType {
   systemOrganSite,
 }
 
-extension on RelationshipType {
+extension RelationshipTypeValue on RelationshipType {
   String toValue() {
     switch (this) {
       case RelationshipType.every:
@@ -2673,7 +2673,7 @@ extension on RelationshipType {
   }
 }
 
-extension on String {
+extension RelationshipTypeFromString on String {
   RelationshipType toRelationshipType() {
     switch (this) {
       case 'EVERY':
@@ -2792,7 +2792,7 @@ enum RxNormAttributeType {
   strength,
 }
 
-extension on RxNormAttributeType {
+extension RxNormAttributeTypeValue on RxNormAttributeType {
   String toValue() {
     switch (this) {
       case RxNormAttributeType.dosage:
@@ -2813,7 +2813,7 @@ extension on RxNormAttributeType {
   }
 }
 
-extension on String {
+extension RxNormAttributeTypeFromString on String {
   RxNormAttributeType toRxNormAttributeType() {
     switch (this) {
       case 'DOSAGE':
@@ -2949,7 +2949,7 @@ enum RxNormEntityCategory {
   medication,
 }
 
-extension on RxNormEntityCategory {
+extension RxNormEntityCategoryValue on RxNormEntityCategory {
   String toValue() {
     switch (this) {
       case RxNormEntityCategory.medication:
@@ -2958,7 +2958,7 @@ extension on RxNormEntityCategory {
   }
 }
 
-extension on String {
+extension RxNormEntityCategoryFromString on String {
   RxNormEntityCategory toRxNormEntityCategory() {
     switch (this) {
       case 'MEDICATION':
@@ -2973,7 +2973,7 @@ enum RxNormEntityType {
   genericName,
 }
 
-extension on RxNormEntityType {
+extension RxNormEntityTypeValue on RxNormEntityType {
   String toValue() {
     switch (this) {
       case RxNormEntityType.brandName:
@@ -2984,7 +2984,7 @@ extension on RxNormEntityType {
   }
 }
 
-extension on String {
+extension RxNormEntityTypeFromString on String {
   RxNormEntityType toRxNormEntityType() {
     switch (this) {
       case 'BRAND_NAME':
@@ -3023,7 +3023,7 @@ enum RxNormTraitName {
   negation,
 }
 
-extension on RxNormTraitName {
+extension RxNormTraitNameValue on RxNormTraitName {
   String toValue() {
     switch (this) {
       case RxNormTraitName.negation:
@@ -3032,7 +3032,7 @@ extension on RxNormTraitName {
   }
 }
 
-extension on String {
+extension RxNormTraitNameFromString on String {
   RxNormTraitName toRxNormTraitName() {
     switch (this) {
       case 'NEGATION':

--- a/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
+++ b/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
@@ -1111,7 +1111,7 @@ enum EBSFilterName {
   finding,
 }
 
-extension EBSFilterNameValue on EBSFilterName {
+extension EBSFilterNameValueExtension on EBSFilterName {
   String toValue() {
     switch (this) {
       case EBSFilterName.finding:
@@ -1135,7 +1135,7 @@ enum EBSFinding {
   notOptimized,
 }
 
-extension EBSFindingValue on EBSFinding {
+extension EBSFindingValueExtension on EBSFinding {
   String toValue() {
     switch (this) {
       case EBSFinding.optimized:
@@ -1165,7 +1165,7 @@ enum EBSMetricName {
   volumeWriteBytesPerSecond,
 }
 
-extension EBSMetricNameValue on EBSMetricName {
+extension EBSMetricNameValueExtension on EBSMetricName {
   String toValue() {
     switch (this) {
       case EBSMetricName.volumeReadOpsPerSecond:
@@ -1382,7 +1382,7 @@ enum ExportableAutoScalingGroupField {
   lastRefreshTimestamp,
 }
 
-extension ExportableAutoScalingGroupFieldValue
+extension ExportableAutoScalingGroupFieldValueExtension
     on ExportableAutoScalingGroupField {
   String toValue() {
     switch (this) {
@@ -1614,7 +1614,7 @@ enum ExportableInstanceField {
   lastRefreshTimestamp,
 }
 
-extension ExportableInstanceFieldValue on ExportableInstanceField {
+extension ExportableInstanceFieldValueExtension on ExportableInstanceField {
   String toValue() {
     switch (this) {
       case ExportableInstanceField.accountId:
@@ -1787,7 +1787,7 @@ enum FileFormat {
   csv,
 }
 
-extension FileFormatValue on FileFormat {
+extension FileFormatValueExtension on FileFormat {
   String toValue() {
     switch (this) {
       case FileFormat.csv:
@@ -1864,7 +1864,7 @@ enum FilterName {
   recommendationSourceType,
 }
 
-extension FilterNameValue on FilterName {
+extension FilterNameValueExtension on FilterName {
   String toValue() {
     switch (this) {
       case FilterName.finding:
@@ -1894,7 +1894,7 @@ enum Finding {
   notOptimized,
 }
 
-extension FindingValue on Finding {
+extension FindingValueExtension on Finding {
   String toValue() {
     switch (this) {
       case Finding.underprovisioned:
@@ -1930,7 +1930,7 @@ enum FindingReasonCode {
   memoryUnderprovisioned,
 }
 
-extension FindingReasonCodeValue on FindingReasonCode {
+extension FindingReasonCodeValueExtension on FindingReasonCode {
   String toValue() {
     switch (this) {
       case FindingReasonCode.memoryOverprovisioned:
@@ -2409,7 +2409,7 @@ enum JobFilterName {
   jobStatus,
 }
 
-extension JobFilterNameValue on JobFilterName {
+extension JobFilterNameValueExtension on JobFilterName {
   String toValue() {
     switch (this) {
       case JobFilterName.resourceType:
@@ -2439,7 +2439,7 @@ enum JobStatus {
   failed,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.queued:
@@ -2474,7 +2474,7 @@ enum LambdaFunctionMemoryMetricName {
   duration,
 }
 
-extension LambdaFunctionMemoryMetricNameValue
+extension LambdaFunctionMemoryMetricNameValueExtension
     on LambdaFunctionMemoryMetricName {
   String toValue() {
     switch (this) {
@@ -2501,7 +2501,7 @@ enum LambdaFunctionMemoryMetricStatistic {
   expected,
 }
 
-extension LambdaFunctionMemoryMetricStatisticValue
+extension LambdaFunctionMemoryMetricStatisticValueExtension
     on LambdaFunctionMemoryMetricStatistic {
   String toValue() {
     switch (this) {
@@ -2597,7 +2597,7 @@ enum LambdaFunctionMetricName {
   memory,
 }
 
-extension LambdaFunctionMetricNameValue on LambdaFunctionMetricName {
+extension LambdaFunctionMetricNameValueExtension on LambdaFunctionMetricName {
   String toValue() {
     switch (this) {
       case LambdaFunctionMetricName.duration:
@@ -2625,7 +2625,8 @@ enum LambdaFunctionMetricStatistic {
   average,
 }
 
-extension LambdaFunctionMetricStatisticValue on LambdaFunctionMetricStatistic {
+extension LambdaFunctionMetricStatisticValueExtension
+    on LambdaFunctionMetricStatistic {
   String toValue() {
     switch (this) {
       case LambdaFunctionMetricStatistic.maximum:
@@ -2850,7 +2851,7 @@ enum LambdaFunctionRecommendationFilterName {
   findingReasonCode,
 }
 
-extension LambdaFunctionRecommendationFilterNameValue
+extension LambdaFunctionRecommendationFilterNameValueExtension
     on LambdaFunctionRecommendationFilterName {
   String toValue() {
     switch (this) {
@@ -2882,7 +2883,7 @@ enum LambdaFunctionRecommendationFinding {
   unavailable,
 }
 
-extension LambdaFunctionRecommendationFindingValue
+extension LambdaFunctionRecommendationFindingValueExtension
     on LambdaFunctionRecommendationFinding {
   String toValue() {
     switch (this) {
@@ -2918,7 +2919,7 @@ enum LambdaFunctionRecommendationFindingReasonCode {
   inconclusive,
 }
 
-extension LambdaFunctionRecommendationFindingReasonCodeValue
+extension LambdaFunctionRecommendationFindingReasonCodeValueExtension
     on LambdaFunctionRecommendationFindingReasonCode {
   String toValue() {
     switch (this) {
@@ -2989,7 +2990,7 @@ enum MetricName {
   ebsWriteBytesPerSecond,
 }
 
-extension MetricNameValue on MetricName {
+extension MetricNameValueExtension on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.cpu:
@@ -3033,7 +3034,7 @@ enum MetricStatistic {
   average,
 }
 
-extension MetricStatisticValue on MetricStatistic {
+extension MetricStatisticValueExtension on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.maximum:
@@ -3236,7 +3237,7 @@ enum RecommendationSourceType {
   lambdaFunction,
 }
 
-extension RecommendationSourceTypeValue on RecommendationSourceType {
+extension RecommendationSourceTypeValueExtension on RecommendationSourceType {
   String toValue() {
     switch (this) {
       case RecommendationSourceType.ec2Instance:
@@ -3346,7 +3347,7 @@ enum ResourceType {
   autoScalingGroup,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.ec2Instance:
@@ -3442,7 +3443,7 @@ enum Status {
   failed,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.active:

--- a/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
+++ b/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
@@ -1111,7 +1111,7 @@ enum EBSFilterName {
   finding,
 }
 
-extension on EBSFilterName {
+extension EBSFilterNameValue on EBSFilterName {
   String toValue() {
     switch (this) {
       case EBSFilterName.finding:
@@ -1120,7 +1120,7 @@ extension on EBSFilterName {
   }
 }
 
-extension on String {
+extension EBSFilterNameFromString on String {
   EBSFilterName toEBSFilterName() {
     switch (this) {
       case 'Finding':
@@ -1135,7 +1135,7 @@ enum EBSFinding {
   notOptimized,
 }
 
-extension on EBSFinding {
+extension EBSFindingValue on EBSFinding {
   String toValue() {
     switch (this) {
       case EBSFinding.optimized:
@@ -1146,7 +1146,7 @@ extension on EBSFinding {
   }
 }
 
-extension on String {
+extension EBSFindingFromString on String {
   EBSFinding toEBSFinding() {
     switch (this) {
       case 'Optimized':
@@ -1165,7 +1165,7 @@ enum EBSMetricName {
   volumeWriteBytesPerSecond,
 }
 
-extension on EBSMetricName {
+extension EBSMetricNameValue on EBSMetricName {
   String toValue() {
     switch (this) {
       case EBSMetricName.volumeReadOpsPerSecond:
@@ -1180,7 +1180,7 @@ extension on EBSMetricName {
   }
 }
 
-extension on String {
+extension EBSMetricNameFromString on String {
   EBSMetricName toEBSMetricName() {
     switch (this) {
       case 'VolumeReadOpsPerSecond':
@@ -1382,7 +1382,8 @@ enum ExportableAutoScalingGroupField {
   lastRefreshTimestamp,
 }
 
-extension on ExportableAutoScalingGroupField {
+extension ExportableAutoScalingGroupFieldValue
+    on ExportableAutoScalingGroupField {
   String toValue() {
     switch (this) {
       case ExportableAutoScalingGroupField.accountId:
@@ -1477,7 +1478,7 @@ extension on ExportableAutoScalingGroupField {
   }
 }
 
-extension on String {
+extension ExportableAutoScalingGroupFieldFromString on String {
   ExportableAutoScalingGroupField toExportableAutoScalingGroupField() {
     switch (this) {
       case 'AccountId':
@@ -1613,7 +1614,7 @@ enum ExportableInstanceField {
   lastRefreshTimestamp,
 }
 
-extension on ExportableInstanceField {
+extension ExportableInstanceFieldValue on ExportableInstanceField {
   String toValue() {
     switch (this) {
       case ExportableInstanceField.accountId:
@@ -1696,7 +1697,7 @@ extension on ExportableInstanceField {
   }
 }
 
-extension on String {
+extension ExportableInstanceFieldFromString on String {
   ExportableInstanceField toExportableInstanceField() {
     switch (this) {
       case 'AccountId':
@@ -1786,7 +1787,7 @@ enum FileFormat {
   csv,
 }
 
-extension on FileFormat {
+extension FileFormatValue on FileFormat {
   String toValue() {
     switch (this) {
       case FileFormat.csv:
@@ -1795,7 +1796,7 @@ extension on FileFormat {
   }
 }
 
-extension on String {
+extension FileFormatFromString on String {
   FileFormat toFileFormat() {
     switch (this) {
       case 'Csv':
@@ -1863,7 +1864,7 @@ enum FilterName {
   recommendationSourceType,
 }
 
-extension on FilterName {
+extension FilterNameValue on FilterName {
   String toValue() {
     switch (this) {
       case FilterName.finding:
@@ -1874,7 +1875,7 @@ extension on FilterName {
   }
 }
 
-extension on String {
+extension FilterNameFromString on String {
   FilterName toFilterName() {
     switch (this) {
       case 'Finding':
@@ -1893,7 +1894,7 @@ enum Finding {
   notOptimized,
 }
 
-extension on Finding {
+extension FindingValue on Finding {
   String toValue() {
     switch (this) {
       case Finding.underprovisioned:
@@ -1908,7 +1909,7 @@ extension on Finding {
   }
 }
 
-extension on String {
+extension FindingFromString on String {
   Finding toFinding() {
     switch (this) {
       case 'Underprovisioned':
@@ -1929,7 +1930,7 @@ enum FindingReasonCode {
   memoryUnderprovisioned,
 }
 
-extension on FindingReasonCode {
+extension FindingReasonCodeValue on FindingReasonCode {
   String toValue() {
     switch (this) {
       case FindingReasonCode.memoryOverprovisioned:
@@ -1940,7 +1941,7 @@ extension on FindingReasonCode {
   }
 }
 
-extension on String {
+extension FindingReasonCodeFromString on String {
   FindingReasonCode toFindingReasonCode() {
     switch (this) {
       case 'MemoryOverprovisioned':
@@ -2408,7 +2409,7 @@ enum JobFilterName {
   jobStatus,
 }
 
-extension on JobFilterName {
+extension JobFilterNameValue on JobFilterName {
   String toValue() {
     switch (this) {
       case JobFilterName.resourceType:
@@ -2419,7 +2420,7 @@ extension on JobFilterName {
   }
 }
 
-extension on String {
+extension JobFilterNameFromString on String {
   JobFilterName toJobFilterName() {
     switch (this) {
       case 'ResourceType':
@@ -2438,7 +2439,7 @@ enum JobStatus {
   failed,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.queued:
@@ -2453,7 +2454,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'Queued':
@@ -2473,7 +2474,8 @@ enum LambdaFunctionMemoryMetricName {
   duration,
 }
 
-extension on LambdaFunctionMemoryMetricName {
+extension LambdaFunctionMemoryMetricNameValue
+    on LambdaFunctionMemoryMetricName {
   String toValue() {
     switch (this) {
       case LambdaFunctionMemoryMetricName.duration:
@@ -2482,7 +2484,7 @@ extension on LambdaFunctionMemoryMetricName {
   }
 }
 
-extension on String {
+extension LambdaFunctionMemoryMetricNameFromString on String {
   LambdaFunctionMemoryMetricName toLambdaFunctionMemoryMetricName() {
     switch (this) {
       case 'Duration':
@@ -2499,7 +2501,8 @@ enum LambdaFunctionMemoryMetricStatistic {
   expected,
 }
 
-extension on LambdaFunctionMemoryMetricStatistic {
+extension LambdaFunctionMemoryMetricStatisticValue
+    on LambdaFunctionMemoryMetricStatistic {
   String toValue() {
     switch (this) {
       case LambdaFunctionMemoryMetricStatistic.lowerBound:
@@ -2512,7 +2515,7 @@ extension on LambdaFunctionMemoryMetricStatistic {
   }
 }
 
-extension on String {
+extension LambdaFunctionMemoryMetricStatisticFromString on String {
   LambdaFunctionMemoryMetricStatistic toLambdaFunctionMemoryMetricStatistic() {
     switch (this) {
       case 'LowerBound':
@@ -2594,7 +2597,7 @@ enum LambdaFunctionMetricName {
   memory,
 }
 
-extension on LambdaFunctionMetricName {
+extension LambdaFunctionMetricNameValue on LambdaFunctionMetricName {
   String toValue() {
     switch (this) {
       case LambdaFunctionMetricName.duration:
@@ -2605,7 +2608,7 @@ extension on LambdaFunctionMetricName {
   }
 }
 
-extension on String {
+extension LambdaFunctionMetricNameFromString on String {
   LambdaFunctionMetricName toLambdaFunctionMetricName() {
     switch (this) {
       case 'Duration':
@@ -2622,7 +2625,7 @@ enum LambdaFunctionMetricStatistic {
   average,
 }
 
-extension on LambdaFunctionMetricStatistic {
+extension LambdaFunctionMetricStatisticValue on LambdaFunctionMetricStatistic {
   String toValue() {
     switch (this) {
       case LambdaFunctionMetricStatistic.maximum:
@@ -2633,7 +2636,7 @@ extension on LambdaFunctionMetricStatistic {
   }
 }
 
-extension on String {
+extension LambdaFunctionMetricStatisticFromString on String {
   LambdaFunctionMetricStatistic toLambdaFunctionMetricStatistic() {
     switch (this) {
       case 'Maximum':
@@ -2847,7 +2850,8 @@ enum LambdaFunctionRecommendationFilterName {
   findingReasonCode,
 }
 
-extension on LambdaFunctionRecommendationFilterName {
+extension LambdaFunctionRecommendationFilterNameValue
+    on LambdaFunctionRecommendationFilterName {
   String toValue() {
     switch (this) {
       case LambdaFunctionRecommendationFilterName.finding:
@@ -2858,7 +2862,7 @@ extension on LambdaFunctionRecommendationFilterName {
   }
 }
 
-extension on String {
+extension LambdaFunctionRecommendationFilterNameFromString on String {
   LambdaFunctionRecommendationFilterName
       toLambdaFunctionRecommendationFilterName() {
     switch (this) {
@@ -2878,7 +2882,8 @@ enum LambdaFunctionRecommendationFinding {
   unavailable,
 }
 
-extension on LambdaFunctionRecommendationFinding {
+extension LambdaFunctionRecommendationFindingValue
+    on LambdaFunctionRecommendationFinding {
   String toValue() {
     switch (this) {
       case LambdaFunctionRecommendationFinding.optimized:
@@ -2891,7 +2896,7 @@ extension on LambdaFunctionRecommendationFinding {
   }
 }
 
-extension on String {
+extension LambdaFunctionRecommendationFindingFromString on String {
   LambdaFunctionRecommendationFinding toLambdaFunctionRecommendationFinding() {
     switch (this) {
       case 'Optimized':
@@ -2913,7 +2918,8 @@ enum LambdaFunctionRecommendationFindingReasonCode {
   inconclusive,
 }
 
-extension on LambdaFunctionRecommendationFindingReasonCode {
+extension LambdaFunctionRecommendationFindingReasonCodeValue
+    on LambdaFunctionRecommendationFindingReasonCode {
   String toValue() {
     switch (this) {
       case LambdaFunctionRecommendationFindingReasonCode.memoryOverprovisioned:
@@ -2928,7 +2934,7 @@ extension on LambdaFunctionRecommendationFindingReasonCode {
   }
 }
 
-extension on String {
+extension LambdaFunctionRecommendationFindingReasonCodeFromString on String {
   LambdaFunctionRecommendationFindingReasonCode
       toLambdaFunctionRecommendationFindingReasonCode() {
     switch (this) {
@@ -2983,7 +2989,7 @@ enum MetricName {
   ebsWriteBytesPerSecond,
 }
 
-extension on MetricName {
+extension MetricNameValue on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.cpu:
@@ -3002,7 +3008,7 @@ extension on MetricName {
   }
 }
 
-extension on String {
+extension MetricNameFromString on String {
   MetricName toMetricName() {
     switch (this) {
       case 'Cpu':
@@ -3027,7 +3033,7 @@ enum MetricStatistic {
   average,
 }
 
-extension on MetricStatistic {
+extension MetricStatisticValue on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.maximum:
@@ -3038,7 +3044,7 @@ extension on MetricStatistic {
   }
 }
 
-extension on String {
+extension MetricStatisticFromString on String {
   MetricStatistic toMetricStatistic() {
     switch (this) {
       case 'Maximum':
@@ -3230,7 +3236,7 @@ enum RecommendationSourceType {
   lambdaFunction,
 }
 
-extension on RecommendationSourceType {
+extension RecommendationSourceTypeValue on RecommendationSourceType {
   String toValue() {
     switch (this) {
       case RecommendationSourceType.ec2Instance:
@@ -3245,7 +3251,7 @@ extension on RecommendationSourceType {
   }
 }
 
-extension on String {
+extension RecommendationSourceTypeFromString on String {
   RecommendationSourceType toRecommendationSourceType() {
     switch (this) {
       case 'Ec2Instance':
@@ -3340,7 +3346,7 @@ enum ResourceType {
   autoScalingGroup,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.ec2Instance:
@@ -3351,7 +3357,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'Ec2Instance':
@@ -3436,7 +3442,7 @@ enum Status {
   failed,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.active:
@@ -3451,7 +3457,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'Active':

--- a/generated/aws_configservice_api/lib/config-2014-11-12.dart
+++ b/generated/aws_configservice_api/lib/config-2014-11-12.dart
@@ -5194,7 +5194,8 @@ enum AggregatedSourceStatusType {
   outdated,
 }
 
-extension AggregatedSourceStatusTypeValue on AggregatedSourceStatusType {
+extension AggregatedSourceStatusTypeValueExtension
+    on AggregatedSourceStatusType {
   String toValue() {
     switch (this) {
       case AggregatedSourceStatusType.failed:
@@ -5226,7 +5227,7 @@ enum AggregatedSourceType {
   organization,
 }
 
-extension AggregatedSourceTypeValue on AggregatedSourceType {
+extension AggregatedSourceTypeValueExtension on AggregatedSourceType {
   String toValue() {
     switch (this) {
       case AggregatedSourceType.account:
@@ -5454,7 +5455,7 @@ enum ChronologicalOrder {
   forward,
 }
 
-extension ChronologicalOrderValue on ChronologicalOrder {
+extension ChronologicalOrderValueExtension on ChronologicalOrder {
   String toValue() {
     switch (this) {
       case ChronologicalOrder.reverse:
@@ -5661,7 +5662,7 @@ enum ComplianceType {
   insufficientData,
 }
 
-extension ComplianceTypeValue on ComplianceType {
+extension ComplianceTypeValueExtension on ComplianceType {
   String toValue() {
     switch (this) {
       case ComplianceType.compliant:
@@ -5951,7 +5952,7 @@ enum ConfigRuleComplianceSummaryGroupKey {
   awsRegion,
 }
 
-extension ConfigRuleComplianceSummaryGroupKeyValue
+extension ConfigRuleComplianceSummaryGroupKeyValueExtension
     on ConfigRuleComplianceSummaryGroupKey {
   String toValue() {
     switch (this) {
@@ -6078,7 +6079,7 @@ enum ConfigRuleState {
   evaluating,
 }
 
-extension ConfigRuleStateValue on ConfigRuleState {
+extension ConfigRuleStateValueExtension on ConfigRuleState {
   String toValue() {
     switch (this) {
       case ConfigRuleState.active:
@@ -6434,7 +6435,7 @@ enum ConfigurationItemStatus {
   resourceDeletedNotRecorded,
 }
 
-extension ConfigurationItemStatusValue on ConfigurationItemStatus {
+extension ConfigurationItemStatusValueExtension on ConfigurationItemStatus {
   String toValue() {
     switch (this) {
       case ConfigurationItemStatus.ok:
@@ -6616,7 +6617,8 @@ enum ConformancePackComplianceType {
   nonCompliant,
 }
 
-extension ConformancePackComplianceTypeValue on ConformancePackComplianceType {
+extension ConformancePackComplianceTypeValueExtension
+    on ConformancePackComplianceType {
   String toValue() {
     switch (this) {
       case ConformancePackComplianceType.compliant:
@@ -6847,7 +6849,7 @@ enum ConformancePackState {
   deleteFailed,
 }
 
-extension ConformancePackStateValue on ConformancePackState {
+extension ConformancePackStateValueExtension on ConformancePackState {
   String toValue() {
     switch (this) {
       case ConformancePackState.createInProgress:
@@ -7143,7 +7145,7 @@ enum DeliveryStatus {
   notApplicable,
 }
 
-extension DeliveryStatusValue on DeliveryStatus {
+extension DeliveryStatusValueExtension on DeliveryStatus {
   String toValue() {
     switch (this) {
       case DeliveryStatus.success:
@@ -7937,7 +7939,7 @@ enum EventSource {
   awsConfig,
 }
 
-extension EventSourceValue on EventSource {
+extension EventSourceValueExtension on EventSource {
   String toValue() {
     switch (this) {
       case EventSource.awsConfig:
@@ -8633,7 +8635,7 @@ enum MaximumExecutionFrequency {
   twentyFourHours,
 }
 
-extension MaximumExecutionFrequencyValue on MaximumExecutionFrequency {
+extension MaximumExecutionFrequencyValueExtension on MaximumExecutionFrequency {
   String toValue() {
     switch (this) {
       case MaximumExecutionFrequency.oneHour:
@@ -8680,7 +8682,7 @@ enum MemberAccountRuleStatus {
   updateFailed,
 }
 
-extension MemberAccountRuleStatusValue on MemberAccountRuleStatus {
+extension MemberAccountRuleStatusValueExtension on MemberAccountRuleStatus {
   String toValue() {
     switch (this) {
       case MemberAccountRuleStatus.createSuccessful:
@@ -8831,7 +8833,7 @@ enum MessageType {
   oversizedConfigurationItemChangeNotification,
 }
 
-extension MessageTypeValue on MessageType {
+extension MessageTypeValueExtension on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.configurationItemChangeNotification:
@@ -9049,7 +9051,7 @@ enum OrganizationConfigRuleTriggerType {
   scheduledNotification,
 }
 
-extension OrganizationConfigRuleTriggerTypeValue
+extension OrganizationConfigRuleTriggerTypeValueExtension
     on OrganizationConfigRuleTriggerType {
   String toValue() {
     switch (this) {
@@ -9550,7 +9552,7 @@ enum OrganizationResourceDetailedStatus {
   updateFailed,
 }
 
-extension OrganizationResourceDetailedStatusValue
+extension OrganizationResourceDetailedStatusValueExtension
     on OrganizationResourceDetailedStatus {
   String toValue() {
     switch (this) {
@@ -9686,7 +9688,8 @@ enum OrganizationResourceStatus {
   updateFailed,
 }
 
-extension OrganizationResourceStatusValue on OrganizationResourceStatus {
+extension OrganizationResourceStatusValueExtension
+    on OrganizationResourceStatus {
   String toValue() {
     switch (this) {
       case OrganizationResourceStatus.createSuccessful:
@@ -9749,7 +9752,7 @@ enum OrganizationRuleStatus {
   updateFailed,
 }
 
-extension OrganizationRuleStatusValue on OrganizationRuleStatus {
+extension OrganizationRuleStatusValueExtension on OrganizationRuleStatus {
   String toValue() {
     switch (this) {
       case OrganizationRuleStatus.createSuccessful:
@@ -9805,7 +9808,7 @@ enum Owner {
   aws,
 }
 
-extension OwnerValue on Owner {
+extension OwnerValueExtension on Owner {
   String toValue() {
     switch (this) {
       case Owner.customLambda:
@@ -10050,7 +10053,7 @@ enum RecorderStatus {
   failure,
 }
 
-extension RecorderStatusValue on RecorderStatus {
+extension RecorderStatusValueExtension on RecorderStatus {
   String toValue() {
     switch (this) {
       case RecorderStatus.pending:
@@ -10415,7 +10418,7 @@ enum RemediationExecutionState {
   failed,
 }
 
-extension RemediationExecutionStateValue on RemediationExecutionState {
+extension RemediationExecutionStateValueExtension on RemediationExecutionState {
   String toValue() {
     switch (this) {
       case RemediationExecutionState.queued:
@@ -10527,7 +10530,8 @@ enum RemediationExecutionStepState {
   failed,
 }
 
-extension RemediationExecutionStepStateValue on RemediationExecutionStepState {
+extension RemediationExecutionStepStateValueExtension
+    on RemediationExecutionStepState {
   String toValue() {
     switch (this) {
       case RemediationExecutionStepState.succeeded:
@@ -10593,7 +10597,7 @@ enum RemediationTargetType {
   ssmDocument,
 }
 
-extension RemediationTargetTypeValue on RemediationTargetType {
+extension RemediationTargetTypeValueExtension on RemediationTargetType {
   String toValue() {
     switch (this) {
       case RemediationTargetType.ssmDocument:
@@ -10666,7 +10670,7 @@ enum ResourceCountGroupKey {
   awsRegion,
 }
 
-extension ResourceCountGroupKeyValue on ResourceCountGroupKey {
+extension ResourceCountGroupKeyValueExtension on ResourceCountGroupKey {
   String toValue() {
     switch (this) {
       case ResourceCountGroupKey.resourceType:
@@ -10889,7 +10893,7 @@ enum ResourceType {
   awsSsmFileData,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.awsEc2CustomerGateway:
@@ -11314,7 +11318,7 @@ enum ResourceValueType {
   resourceId,
 }
 
-extension ResourceValueTypeValue on ResourceValueType {
+extension ResourceValueTypeValueExtension on ResourceValueType {
   String toValue() {
     switch (this) {
       case ResourceValueType.resourceId:

--- a/generated/aws_configservice_api/lib/config-2014-11-12.dart
+++ b/generated/aws_configservice_api/lib/config-2014-11-12.dart
@@ -5194,7 +5194,7 @@ enum AggregatedSourceStatusType {
   outdated,
 }
 
-extension on AggregatedSourceStatusType {
+extension AggregatedSourceStatusTypeValue on AggregatedSourceStatusType {
   String toValue() {
     switch (this) {
       case AggregatedSourceStatusType.failed:
@@ -5207,7 +5207,7 @@ extension on AggregatedSourceStatusType {
   }
 }
 
-extension on String {
+extension AggregatedSourceStatusTypeFromString on String {
   AggregatedSourceStatusType toAggregatedSourceStatusType() {
     switch (this) {
       case 'FAILED':
@@ -5226,7 +5226,7 @@ enum AggregatedSourceType {
   organization,
 }
 
-extension on AggregatedSourceType {
+extension AggregatedSourceTypeValue on AggregatedSourceType {
   String toValue() {
     switch (this) {
       case AggregatedSourceType.account:
@@ -5237,7 +5237,7 @@ extension on AggregatedSourceType {
   }
 }
 
-extension on String {
+extension AggregatedSourceTypeFromString on String {
   AggregatedSourceType toAggregatedSourceType() {
     switch (this) {
       case 'ACCOUNT':
@@ -5454,7 +5454,7 @@ enum ChronologicalOrder {
   forward,
 }
 
-extension on ChronologicalOrder {
+extension ChronologicalOrderValue on ChronologicalOrder {
   String toValue() {
     switch (this) {
       case ChronologicalOrder.reverse:
@@ -5465,7 +5465,7 @@ extension on ChronologicalOrder {
   }
 }
 
-extension on String {
+extension ChronologicalOrderFromString on String {
   ChronologicalOrder toChronologicalOrder() {
     switch (this) {
       case 'Reverse':
@@ -5661,7 +5661,7 @@ enum ComplianceType {
   insufficientData,
 }
 
-extension on ComplianceType {
+extension ComplianceTypeValue on ComplianceType {
   String toValue() {
     switch (this) {
       case ComplianceType.compliant:
@@ -5676,7 +5676,7 @@ extension on ComplianceType {
   }
 }
 
-extension on String {
+extension ComplianceTypeFromString on String {
   ComplianceType toComplianceType() {
     switch (this) {
       case 'COMPLIANT':
@@ -5951,7 +5951,8 @@ enum ConfigRuleComplianceSummaryGroupKey {
   awsRegion,
 }
 
-extension on ConfigRuleComplianceSummaryGroupKey {
+extension ConfigRuleComplianceSummaryGroupKeyValue
+    on ConfigRuleComplianceSummaryGroupKey {
   String toValue() {
     switch (this) {
       case ConfigRuleComplianceSummaryGroupKey.accountId:
@@ -5962,7 +5963,7 @@ extension on ConfigRuleComplianceSummaryGroupKey {
   }
 }
 
-extension on String {
+extension ConfigRuleComplianceSummaryGroupKeyFromString on String {
   ConfigRuleComplianceSummaryGroupKey toConfigRuleComplianceSummaryGroupKey() {
     switch (this) {
       case 'ACCOUNT_ID':
@@ -6077,7 +6078,7 @@ enum ConfigRuleState {
   evaluating,
 }
 
-extension on ConfigRuleState {
+extension ConfigRuleStateValue on ConfigRuleState {
   String toValue() {
     switch (this) {
       case ConfigRuleState.active:
@@ -6092,7 +6093,7 @@ extension on ConfigRuleState {
   }
 }
 
-extension on String {
+extension ConfigRuleStateFromString on String {
   ConfigRuleState toConfigRuleState() {
     switch (this) {
       case 'ACTIVE':
@@ -6433,7 +6434,7 @@ enum ConfigurationItemStatus {
   resourceDeletedNotRecorded,
 }
 
-extension on ConfigurationItemStatus {
+extension ConfigurationItemStatusValue on ConfigurationItemStatus {
   String toValue() {
     switch (this) {
       case ConfigurationItemStatus.ok:
@@ -6450,7 +6451,7 @@ extension on ConfigurationItemStatus {
   }
 }
 
-extension on String {
+extension ConfigurationItemStatusFromString on String {
   ConfigurationItemStatus toConfigurationItemStatus() {
     switch (this) {
       case 'OK':
@@ -6615,7 +6616,7 @@ enum ConformancePackComplianceType {
   nonCompliant,
 }
 
-extension on ConformancePackComplianceType {
+extension ConformancePackComplianceTypeValue on ConformancePackComplianceType {
   String toValue() {
     switch (this) {
       case ConformancePackComplianceType.compliant:
@@ -6626,7 +6627,7 @@ extension on ConformancePackComplianceType {
   }
 }
 
-extension on String {
+extension ConformancePackComplianceTypeFromString on String {
   ConformancePackComplianceType toConformancePackComplianceType() {
     switch (this) {
       case 'COMPLIANT':
@@ -6846,7 +6847,7 @@ enum ConformancePackState {
   deleteFailed,
 }
 
-extension on ConformancePackState {
+extension ConformancePackStateValue on ConformancePackState {
   String toValue() {
     switch (this) {
       case ConformancePackState.createInProgress:
@@ -6863,7 +6864,7 @@ extension on ConformancePackState {
   }
 }
 
-extension on String {
+extension ConformancePackStateFromString on String {
   ConformancePackState toConformancePackState() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -7142,7 +7143,7 @@ enum DeliveryStatus {
   notApplicable,
 }
 
-extension on DeliveryStatus {
+extension DeliveryStatusValue on DeliveryStatus {
   String toValue() {
     switch (this) {
       case DeliveryStatus.success:
@@ -7155,7 +7156,7 @@ extension on DeliveryStatus {
   }
 }
 
-extension on String {
+extension DeliveryStatusFromString on String {
   DeliveryStatus toDeliveryStatus() {
     switch (this) {
       case 'Success':
@@ -7936,7 +7937,7 @@ enum EventSource {
   awsConfig,
 }
 
-extension on EventSource {
+extension EventSourceValue on EventSource {
   String toValue() {
     switch (this) {
       case EventSource.awsConfig:
@@ -7945,7 +7946,7 @@ extension on EventSource {
   }
 }
 
-extension on String {
+extension EventSourceFromString on String {
   EventSource toEventSource() {
     switch (this) {
       case 'aws.config':
@@ -8632,7 +8633,7 @@ enum MaximumExecutionFrequency {
   twentyFourHours,
 }
 
-extension on MaximumExecutionFrequency {
+extension MaximumExecutionFrequencyValue on MaximumExecutionFrequency {
   String toValue() {
     switch (this) {
       case MaximumExecutionFrequency.oneHour:
@@ -8649,7 +8650,7 @@ extension on MaximumExecutionFrequency {
   }
 }
 
-extension on String {
+extension MaximumExecutionFrequencyFromString on String {
   MaximumExecutionFrequency toMaximumExecutionFrequency() {
     switch (this) {
       case 'One_Hour':
@@ -8679,7 +8680,7 @@ enum MemberAccountRuleStatus {
   updateFailed,
 }
 
-extension on MemberAccountRuleStatus {
+extension MemberAccountRuleStatusValue on MemberAccountRuleStatus {
   String toValue() {
     switch (this) {
       case MemberAccountRuleStatus.createSuccessful:
@@ -8704,7 +8705,7 @@ extension on MemberAccountRuleStatus {
   }
 }
 
-extension on String {
+extension MemberAccountRuleStatusFromString on String {
   MemberAccountRuleStatus toMemberAccountRuleStatus() {
     switch (this) {
       case 'CREATE_SUCCESSFUL':
@@ -8830,7 +8831,7 @@ enum MessageType {
   oversizedConfigurationItemChangeNotification,
 }
 
-extension on MessageType {
+extension MessageTypeValue on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.configurationItemChangeNotification:
@@ -8845,7 +8846,7 @@ extension on MessageType {
   }
 }
 
-extension on String {
+extension MessageTypeFromString on String {
   MessageType toMessageType() {
     switch (this) {
       case 'ConfigurationItemChangeNotification':
@@ -9048,7 +9049,8 @@ enum OrganizationConfigRuleTriggerType {
   scheduledNotification,
 }
 
-extension on OrganizationConfigRuleTriggerType {
+extension OrganizationConfigRuleTriggerTypeValue
+    on OrganizationConfigRuleTriggerType {
   String toValue() {
     switch (this) {
       case OrganizationConfigRuleTriggerType
@@ -9063,7 +9065,7 @@ extension on OrganizationConfigRuleTriggerType {
   }
 }
 
-extension on String {
+extension OrganizationConfigRuleTriggerTypeFromString on String {
   OrganizationConfigRuleTriggerType toOrganizationConfigRuleTriggerType() {
     switch (this) {
       case 'ConfigurationItemChangeNotification':
@@ -9548,7 +9550,8 @@ enum OrganizationResourceDetailedStatus {
   updateFailed,
 }
 
-extension on OrganizationResourceDetailedStatus {
+extension OrganizationResourceDetailedStatusValue
+    on OrganizationResourceDetailedStatus {
   String toValue() {
     switch (this) {
       case OrganizationResourceDetailedStatus.createSuccessful:
@@ -9573,7 +9576,7 @@ extension on OrganizationResourceDetailedStatus {
   }
 }
 
-extension on String {
+extension OrganizationResourceDetailedStatusFromString on String {
   OrganizationResourceDetailedStatus toOrganizationResourceDetailedStatus() {
     switch (this) {
       case 'CREATE_SUCCESSFUL':
@@ -9683,7 +9686,7 @@ enum OrganizationResourceStatus {
   updateFailed,
 }
 
-extension on OrganizationResourceStatus {
+extension OrganizationResourceStatusValue on OrganizationResourceStatus {
   String toValue() {
     switch (this) {
       case OrganizationResourceStatus.createSuccessful:
@@ -9708,7 +9711,7 @@ extension on OrganizationResourceStatus {
   }
 }
 
-extension on String {
+extension OrganizationResourceStatusFromString on String {
   OrganizationResourceStatus toOrganizationResourceStatus() {
     switch (this) {
       case 'CREATE_SUCCESSFUL':
@@ -9746,7 +9749,7 @@ enum OrganizationRuleStatus {
   updateFailed,
 }
 
-extension on OrganizationRuleStatus {
+extension OrganizationRuleStatusValue on OrganizationRuleStatus {
   String toValue() {
     switch (this) {
       case OrganizationRuleStatus.createSuccessful:
@@ -9771,7 +9774,7 @@ extension on OrganizationRuleStatus {
   }
 }
 
-extension on String {
+extension OrganizationRuleStatusFromString on String {
   OrganizationRuleStatus toOrganizationRuleStatus() {
     switch (this) {
       case 'CREATE_SUCCESSFUL':
@@ -9802,7 +9805,7 @@ enum Owner {
   aws,
 }
 
-extension on Owner {
+extension OwnerValue on Owner {
   String toValue() {
     switch (this) {
       case Owner.customLambda:
@@ -9813,7 +9816,7 @@ extension on Owner {
   }
 }
 
-extension on String {
+extension OwnerFromString on String {
   Owner toOwner() {
     switch (this) {
       case 'CUSTOM_LAMBDA':
@@ -10047,7 +10050,7 @@ enum RecorderStatus {
   failure,
 }
 
-extension on RecorderStatus {
+extension RecorderStatusValue on RecorderStatus {
   String toValue() {
     switch (this) {
       case RecorderStatus.pending:
@@ -10060,7 +10063,7 @@ extension on RecorderStatus {
   }
 }
 
-extension on String {
+extension RecorderStatusFromString on String {
   RecorderStatus toRecorderStatus() {
     switch (this) {
       case 'Pending':
@@ -10412,7 +10415,7 @@ enum RemediationExecutionState {
   failed,
 }
 
-extension on RemediationExecutionState {
+extension RemediationExecutionStateValue on RemediationExecutionState {
   String toValue() {
     switch (this) {
       case RemediationExecutionState.queued:
@@ -10427,7 +10430,7 @@ extension on RemediationExecutionState {
   }
 }
 
-extension on String {
+extension RemediationExecutionStateFromString on String {
   RemediationExecutionState toRemediationExecutionState() {
     switch (this) {
       case 'QUEUED':
@@ -10524,7 +10527,7 @@ enum RemediationExecutionStepState {
   failed,
 }
 
-extension on RemediationExecutionStepState {
+extension RemediationExecutionStepStateValue on RemediationExecutionStepState {
   String toValue() {
     switch (this) {
       case RemediationExecutionStepState.succeeded:
@@ -10537,7 +10540,7 @@ extension on RemediationExecutionStepState {
   }
 }
 
-extension on String {
+extension RemediationExecutionStepStateFromString on String {
   RemediationExecutionStepState toRemediationExecutionStepState() {
     switch (this) {
       case 'SUCCEEDED':
@@ -10590,7 +10593,7 @@ enum RemediationTargetType {
   ssmDocument,
 }
 
-extension on RemediationTargetType {
+extension RemediationTargetTypeValue on RemediationTargetType {
   String toValue() {
     switch (this) {
       case RemediationTargetType.ssmDocument:
@@ -10599,7 +10602,7 @@ extension on RemediationTargetType {
   }
 }
 
-extension on String {
+extension RemediationTargetTypeFromString on String {
   RemediationTargetType toRemediationTargetType() {
     switch (this) {
       case 'SSM_DOCUMENT':
@@ -10663,7 +10666,7 @@ enum ResourceCountGroupKey {
   awsRegion,
 }
 
-extension on ResourceCountGroupKey {
+extension ResourceCountGroupKeyValue on ResourceCountGroupKey {
   String toValue() {
     switch (this) {
       case ResourceCountGroupKey.resourceType:
@@ -10676,7 +10679,7 @@ extension on ResourceCountGroupKey {
   }
 }
 
-extension on String {
+extension ResourceCountGroupKeyFromString on String {
   ResourceCountGroupKey toResourceCountGroupKey() {
     switch (this) {
       case 'RESOURCE_TYPE':
@@ -10886,7 +10889,7 @@ enum ResourceType {
   awsSsmFileData,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.awsEc2CustomerGateway:
@@ -11085,7 +11088,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'AWS::EC2::CustomerGateway':
@@ -11311,7 +11314,7 @@ enum ResourceValueType {
   resourceId,
 }
 
-extension on ResourceValueType {
+extension ResourceValueTypeValue on ResourceValueType {
   String toValue() {
     switch (this) {
       case ResourceValueType.resourceId:
@@ -11320,7 +11323,7 @@ extension on ResourceValueType {
   }
 }
 
-extension on String {
+extension ResourceValueTypeFromString on String {
   ResourceValueType toResourceValueType() {
     switch (this) {
       case 'RESOURCE_ID':

--- a/generated/aws_connect_api/lib/connect-2017-08-08.dart
+++ b/generated/aws_connect_api/lib/connect-2017-08-08.dart
@@ -5233,7 +5233,7 @@ enum Channel {
   task,
 }
 
-extension ChannelValue on Channel {
+extension ChannelValueExtension on Channel {
   String toValue() {
     switch (this) {
       case Channel.voice:
@@ -5286,7 +5286,7 @@ enum Comparison {
   lt,
 }
 
-extension ComparisonValue on Comparison {
+extension ComparisonValueExtension on Comparison {
   String toValue() {
     switch (this) {
       case Comparison.lt:
@@ -5401,7 +5401,7 @@ enum ContactFlowType {
   queueTransfer,
 }
 
-extension ContactFlowTypeValue on ContactFlowType {
+extension ContactFlowTypeValueExtension on ContactFlowType {
   String toValue() {
     switch (this) {
       case ContactFlowType.contactFlow:
@@ -5707,7 +5707,7 @@ enum CurrentMetricName {
   slotsAvailable,
 }
 
-extension CurrentMetricNameValue on CurrentMetricName {
+extension CurrentMetricNameValueExtension on CurrentMetricName {
   String toValue() {
     switch (this) {
       case CurrentMetricName.agentsOnline:
@@ -5979,7 +5979,7 @@ enum DirectoryType {
   existingDirectory,
 }
 
-extension DirectoryTypeValue on DirectoryType {
+extension DirectoryTypeValueExtension on DirectoryType {
   String toValue() {
     switch (this) {
       case DirectoryType.saml:
@@ -6039,7 +6039,7 @@ enum EncryptionType {
   kms,
 }
 
-extension EncryptionTypeValue on EncryptionType {
+extension EncryptionTypeValueExtension on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.kms:
@@ -6180,7 +6180,7 @@ enum Grouping {
   channel,
 }
 
-extension GroupingValue on Grouping {
+extension GroupingValueExtension on Grouping {
   String toValue() {
     switch (this) {
       case Grouping.queue:
@@ -6541,7 +6541,7 @@ enum HistoricalMetricName {
   serviceLevel,
 }
 
-extension HistoricalMetricNameValue on HistoricalMetricName {
+extension HistoricalMetricNameValueExtension on HistoricalMetricName {
   String toValue() {
     switch (this) {
       case HistoricalMetricName.contactsQueued:
@@ -6780,7 +6780,7 @@ enum InstanceAttributeType {
   earlyMedia,
 }
 
-extension InstanceAttributeTypeValue on InstanceAttributeType {
+extension InstanceAttributeTypeValueExtension on InstanceAttributeType {
   String toValue() {
     switch (this) {
       case InstanceAttributeType.inboundCalls:
@@ -6829,7 +6829,7 @@ enum InstanceStatus {
   creationFailed,
 }
 
-extension InstanceStatusValue on InstanceStatus {
+extension InstanceStatusValueExtension on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.creationInProgress:
@@ -6952,7 +6952,8 @@ enum InstanceStorageResourceType {
   agentEvents,
 }
 
-extension InstanceStorageResourceTypeValue on InstanceStorageResourceType {
+extension InstanceStorageResourceTypeValueExtension
+    on InstanceStorageResourceType {
   String toValue() {
     switch (this) {
       case InstanceStorageResourceType.chatTranscripts:
@@ -7102,7 +7103,7 @@ enum IntegrationType {
   event,
 }
 
-extension IntegrationTypeValue on IntegrationType {
+extension IntegrationTypeValueExtension on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.event:
@@ -8007,7 +8008,7 @@ enum PhoneNumberCountryCode {
   zw,
 }
 
-extension PhoneNumberCountryCodeValue on PhoneNumberCountryCode {
+extension PhoneNumberCountryCodeValueExtension on PhoneNumberCountryCode {
   String toValue() {
     switch (this) {
       case PhoneNumberCountryCode.af:
@@ -9034,7 +9035,7 @@ enum PhoneNumberType {
   did,
 }
 
-extension PhoneNumberTypeValue on PhoneNumberType {
+extension PhoneNumberTypeValueExtension on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.tollFree:
@@ -9062,7 +9063,7 @@ enum PhoneType {
   deskPhone,
 }
 
-extension PhoneTypeValue on PhoneType {
+extension PhoneTypeValueExtension on PhoneType {
   String toValue() {
     switch (this) {
       case PhoneType.softPhone:
@@ -9195,7 +9196,7 @@ enum QueueType {
   agent,
 }
 
-extension QueueTypeValue on QueueType {
+extension QueueTypeValueExtension on QueueType {
   String toValue() {
     switch (this) {
       case QueueType.standard:
@@ -9357,7 +9358,7 @@ enum QuickConnectType {
   phoneNumber,
 }
 
-extension QuickConnectTypeValue on QuickConnectType {
+extension QuickConnectTypeValueExtension on QuickConnectType {
   String toValue() {
     switch (this) {
       case QuickConnectType.user:
@@ -9412,7 +9413,7 @@ enum ReferenceType {
   url,
 }
 
-extension ReferenceTypeValue on ReferenceType {
+extension ReferenceTypeValueExtension on ReferenceType {
   String toValue() {
     switch (this) {
       case ReferenceType.url:
@@ -9717,7 +9718,7 @@ enum SourceType {
   zendesk,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.salesforce:
@@ -9809,7 +9810,7 @@ enum Statistic {
   avg,
 }
 
-extension StatisticValue on Statistic {
+extension StatisticValueExtension on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sum:
@@ -9857,7 +9858,7 @@ enum StorageType {
   kinesisFirehose,
 }
 
-extension StorageTypeValue on StorageType {
+extension StorageTypeValueExtension on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.s3:
@@ -9930,7 +9931,7 @@ enum Unit {
   percent,
 }
 
-extension UnitValue on Unit {
+extension UnitValueExtension on Unit {
   String toValue() {
     switch (this) {
       case Unit.seconds:
@@ -9994,7 +9995,7 @@ enum UseCaseType {
   rulesEvaluation,
 }
 
-extension UseCaseTypeValue on UseCaseType {
+extension UseCaseTypeValueExtension on UseCaseType {
   String toValue() {
     switch (this) {
       case UseCaseType.rulesEvaluation:
@@ -10245,7 +10246,7 @@ enum VoiceRecordingTrack {
   all,
 }
 
-extension VoiceRecordingTrackValue on VoiceRecordingTrack {
+extension VoiceRecordingTrackValueExtension on VoiceRecordingTrack {
   String toValue() {
     switch (this) {
       case VoiceRecordingTrack.fromAgent:

--- a/generated/aws_connect_api/lib/connect-2017-08-08.dart
+++ b/generated/aws_connect_api/lib/connect-2017-08-08.dart
@@ -5233,7 +5233,7 @@ enum Channel {
   task,
 }
 
-extension on Channel {
+extension ChannelValue on Channel {
   String toValue() {
     switch (this) {
       case Channel.voice:
@@ -5246,7 +5246,7 @@ extension on Channel {
   }
 }
 
-extension on String {
+extension ChannelFromString on String {
   Channel toChannel() {
     switch (this) {
       case 'VOICE':
@@ -5286,7 +5286,7 @@ enum Comparison {
   lt,
 }
 
-extension on Comparison {
+extension ComparisonValue on Comparison {
   String toValue() {
     switch (this) {
       case Comparison.lt:
@@ -5295,7 +5295,7 @@ extension on Comparison {
   }
 }
 
-extension on String {
+extension ComparisonFromString on String {
   Comparison toComparison() {
     switch (this) {
       case 'LT':
@@ -5401,7 +5401,7 @@ enum ContactFlowType {
   queueTransfer,
 }
 
-extension on ContactFlowType {
+extension ContactFlowTypeValue on ContactFlowType {
   String toValue() {
     switch (this) {
       case ContactFlowType.contactFlow:
@@ -5426,7 +5426,7 @@ extension on ContactFlowType {
   }
 }
 
-extension on String {
+extension ContactFlowTypeFromString on String {
   ContactFlowType toContactFlowType() {
     switch (this) {
       case 'CONTACT_FLOW':
@@ -5707,7 +5707,7 @@ enum CurrentMetricName {
   slotsAvailable,
 }
 
-extension on CurrentMetricName {
+extension CurrentMetricNameValue on CurrentMetricName {
   String toValue() {
     switch (this) {
       case CurrentMetricName.agentsOnline:
@@ -5740,7 +5740,7 @@ extension on CurrentMetricName {
   }
 }
 
-extension on String {
+extension CurrentMetricNameFromString on String {
   CurrentMetricName toCurrentMetricName() {
     switch (this) {
       case 'AGENTS_ONLINE':
@@ -5979,7 +5979,7 @@ enum DirectoryType {
   existingDirectory,
 }
 
-extension on DirectoryType {
+extension DirectoryTypeValue on DirectoryType {
   String toValue() {
     switch (this) {
       case DirectoryType.saml:
@@ -5992,7 +5992,7 @@ extension on DirectoryType {
   }
 }
 
-extension on String {
+extension DirectoryTypeFromString on String {
   DirectoryType toDirectoryType() {
     switch (this) {
       case 'SAML':
@@ -6039,7 +6039,7 @@ enum EncryptionType {
   kms,
 }
 
-extension on EncryptionType {
+extension EncryptionTypeValue on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.kms:
@@ -6048,7 +6048,7 @@ extension on EncryptionType {
   }
 }
 
-extension on String {
+extension EncryptionTypeFromString on String {
   EncryptionType toEncryptionType() {
     switch (this) {
       case 'KMS':
@@ -6180,7 +6180,7 @@ enum Grouping {
   channel,
 }
 
-extension on Grouping {
+extension GroupingValue on Grouping {
   String toValue() {
     switch (this) {
       case Grouping.queue:
@@ -6191,7 +6191,7 @@ extension on Grouping {
   }
 }
 
-extension on String {
+extension GroupingFromString on String {
   Grouping toGrouping() {
     switch (this) {
       case 'QUEUE':
@@ -6541,7 +6541,7 @@ enum HistoricalMetricName {
   serviceLevel,
 }
 
-extension on HistoricalMetricName {
+extension HistoricalMetricNameValue on HistoricalMetricName {
   String toValue() {
     switch (this) {
       case HistoricalMetricName.contactsQueued:
@@ -6598,7 +6598,7 @@ extension on HistoricalMetricName {
   }
 }
 
-extension on String {
+extension HistoricalMetricNameFromString on String {
   HistoricalMetricName toHistoricalMetricName() {
     switch (this) {
       case 'CONTACTS_QUEUED':
@@ -6780,7 +6780,7 @@ enum InstanceAttributeType {
   earlyMedia,
 }
 
-extension on InstanceAttributeType {
+extension InstanceAttributeTypeValue on InstanceAttributeType {
   String toValue() {
     switch (this) {
       case InstanceAttributeType.inboundCalls:
@@ -6801,7 +6801,7 @@ extension on InstanceAttributeType {
   }
 }
 
-extension on String {
+extension InstanceAttributeTypeFromString on String {
   InstanceAttributeType toInstanceAttributeType() {
     switch (this) {
       case 'INBOUND_CALLS':
@@ -6829,7 +6829,7 @@ enum InstanceStatus {
   creationFailed,
 }
 
-extension on InstanceStatus {
+extension InstanceStatusValue on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.creationInProgress:
@@ -6842,7 +6842,7 @@ extension on InstanceStatus {
   }
 }
 
-extension on String {
+extension InstanceStatusFromString on String {
   InstanceStatus toInstanceStatus() {
     switch (this) {
       case 'CREATION_IN_PROGRESS':
@@ -6952,7 +6952,7 @@ enum InstanceStorageResourceType {
   agentEvents,
 }
 
-extension on InstanceStorageResourceType {
+extension InstanceStorageResourceTypeValue on InstanceStorageResourceType {
   String toValue() {
     switch (this) {
       case InstanceStorageResourceType.chatTranscripts:
@@ -6971,7 +6971,7 @@ extension on InstanceStorageResourceType {
   }
 }
 
-extension on String {
+extension InstanceStorageResourceTypeFromString on String {
   InstanceStorageResourceType toInstanceStorageResourceType() {
     switch (this) {
       case 'CHAT_TRANSCRIPTS':
@@ -7102,7 +7102,7 @@ enum IntegrationType {
   event,
 }
 
-extension on IntegrationType {
+extension IntegrationTypeValue on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.event:
@@ -7111,7 +7111,7 @@ extension on IntegrationType {
   }
 }
 
-extension on String {
+extension IntegrationTypeFromString on String {
   IntegrationType toIntegrationType() {
     switch (this) {
       case 'EVENT':
@@ -8007,7 +8007,7 @@ enum PhoneNumberCountryCode {
   zw,
 }
 
-extension on PhoneNumberCountryCode {
+extension PhoneNumberCountryCodeValue on PhoneNumberCountryCode {
   String toValue() {
     switch (this) {
       case PhoneNumberCountryCode.af:
@@ -8488,7 +8488,7 @@ extension on PhoneNumberCountryCode {
   }
 }
 
-extension on String {
+extension PhoneNumberCountryCodeFromString on String {
   PhoneNumberCountryCode toPhoneNumberCountryCode() {
     switch (this) {
       case 'AF':
@@ -9034,7 +9034,7 @@ enum PhoneNumberType {
   did,
 }
 
-extension on PhoneNumberType {
+extension PhoneNumberTypeValue on PhoneNumberType {
   String toValue() {
     switch (this) {
       case PhoneNumberType.tollFree:
@@ -9045,7 +9045,7 @@ extension on PhoneNumberType {
   }
 }
 
-extension on String {
+extension PhoneNumberTypeFromString on String {
   PhoneNumberType toPhoneNumberType() {
     switch (this) {
       case 'TOLL_FREE':
@@ -9062,7 +9062,7 @@ enum PhoneType {
   deskPhone,
 }
 
-extension on PhoneType {
+extension PhoneTypeValue on PhoneType {
   String toValue() {
     switch (this) {
       case PhoneType.softPhone:
@@ -9073,7 +9073,7 @@ extension on PhoneType {
   }
 }
 
-extension on String {
+extension PhoneTypeFromString on String {
   PhoneType toPhoneType() {
     switch (this) {
       case 'SOFT_PHONE':
@@ -9195,7 +9195,7 @@ enum QueueType {
   agent,
 }
 
-extension on QueueType {
+extension QueueTypeValue on QueueType {
   String toValue() {
     switch (this) {
       case QueueType.standard:
@@ -9206,7 +9206,7 @@ extension on QueueType {
   }
 }
 
-extension on String {
+extension QueueTypeFromString on String {
   QueueType toQueueType() {
     switch (this) {
       case 'STANDARD':
@@ -9357,7 +9357,7 @@ enum QuickConnectType {
   phoneNumber,
 }
 
-extension on QuickConnectType {
+extension QuickConnectTypeValue on QuickConnectType {
   String toValue() {
     switch (this) {
       case QuickConnectType.user:
@@ -9370,7 +9370,7 @@ extension on QuickConnectType {
   }
 }
 
-extension on String {
+extension QuickConnectTypeFromString on String {
   QuickConnectType toQuickConnectType() {
     switch (this) {
       case 'USER':
@@ -9412,7 +9412,7 @@ enum ReferenceType {
   url,
 }
 
-extension on ReferenceType {
+extension ReferenceTypeValue on ReferenceType {
   String toValue() {
     switch (this) {
       case ReferenceType.url:
@@ -9421,7 +9421,7 @@ extension on ReferenceType {
   }
 }
 
-extension on String {
+extension ReferenceTypeFromString on String {
   ReferenceType toReferenceType() {
     switch (this) {
       case 'URL':
@@ -9717,7 +9717,7 @@ enum SourceType {
   zendesk,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.salesforce:
@@ -9728,7 +9728,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'SALESFORCE':
@@ -9809,7 +9809,7 @@ enum Statistic {
   avg,
 }
 
-extension on Statistic {
+extension StatisticValue on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sum:
@@ -9822,7 +9822,7 @@ extension on Statistic {
   }
 }
 
-extension on String {
+extension StatisticFromString on String {
   Statistic toStatistic() {
     switch (this) {
       case 'SUM':
@@ -9857,7 +9857,7 @@ enum StorageType {
   kinesisFirehose,
 }
 
-extension on StorageType {
+extension StorageTypeValue on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.s3:
@@ -9872,7 +9872,7 @@ extension on StorageType {
   }
 }
 
-extension on String {
+extension StorageTypeFromString on String {
   StorageType toStorageType() {
     switch (this) {
       case 'S3':
@@ -9930,7 +9930,7 @@ enum Unit {
   percent,
 }
 
-extension on Unit {
+extension UnitValue on Unit {
   String toValue() {
     switch (this) {
       case Unit.seconds:
@@ -9943,7 +9943,7 @@ extension on Unit {
   }
 }
 
-extension on String {
+extension UnitFromString on String {
   Unit toUnit() {
     switch (this) {
       case 'SECONDS':
@@ -9994,7 +9994,7 @@ enum UseCaseType {
   rulesEvaluation,
 }
 
-extension on UseCaseType {
+extension UseCaseTypeValue on UseCaseType {
   String toValue() {
     switch (this) {
       case UseCaseType.rulesEvaluation:
@@ -10003,7 +10003,7 @@ extension on UseCaseType {
   }
 }
 
-extension on String {
+extension UseCaseTypeFromString on String {
   UseCaseType toUseCaseType() {
     switch (this) {
       case 'RULES_EVALUATION':
@@ -10245,7 +10245,7 @@ enum VoiceRecordingTrack {
   all,
 }
 
-extension on VoiceRecordingTrack {
+extension VoiceRecordingTrackValue on VoiceRecordingTrack {
   String toValue() {
     switch (this) {
       case VoiceRecordingTrack.fromAgent:
@@ -10258,7 +10258,7 @@ extension on VoiceRecordingTrack {
   }
 }
 
-extension on String {
+extension VoiceRecordingTrackFromString on String {
   VoiceRecordingTrack toVoiceRecordingTrack() {
     switch (this) {
       case 'FROM_AGENT':

--- a/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
+++ b/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
@@ -631,7 +631,7 @@ enum ArtifactStatus {
   inProgress,
 }
 
-extension on ArtifactStatus {
+extension ArtifactStatusValue on ArtifactStatus {
   String toValue() {
     switch (this) {
       case ArtifactStatus.approved:
@@ -644,7 +644,7 @@ extension on ArtifactStatus {
   }
 }
 
-extension on String {
+extension ArtifactStatusFromString on String {
   ArtifactStatus toArtifactStatus() {
     switch (this) {
       case 'APPROVED':
@@ -705,7 +705,7 @@ enum ChatItemType {
   connectionAck,
 }
 
-extension on ChatItemType {
+extension ChatItemTypeValue on ChatItemType {
   String toValue() {
     switch (this) {
       case ChatItemType.typing:
@@ -732,7 +732,7 @@ extension on ChatItemType {
   }
 }
 
-extension on String {
+extension ChatItemTypeFromString on String {
   ChatItemType toChatItemType() {
     switch (this) {
       case 'TYPING':
@@ -795,7 +795,7 @@ enum ConnectionType {
   connectionCredentials,
 }
 
-extension on ConnectionType {
+extension ConnectionTypeValue on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.websocket:
@@ -806,7 +806,7 @@ extension on ConnectionType {
   }
 }
 
-extension on String {
+extension ConnectionTypeFromString on String {
   ConnectionType toConnectionType() {
     switch (this) {
       case 'WEBSOCKET':
@@ -968,7 +968,7 @@ enum ParticipantRole {
   system,
 }
 
-extension on ParticipantRole {
+extension ParticipantRoleValue on ParticipantRole {
   String toValue() {
     switch (this) {
       case ParticipantRole.agent:
@@ -981,7 +981,7 @@ extension on ParticipantRole {
   }
 }
 
-extension on String {
+extension ParticipantRoleFromString on String {
   ParticipantRole toParticipantRole() {
     switch (this) {
       case 'AGENT':
@@ -1000,7 +1000,7 @@ enum ScanDirection {
   backward,
 }
 
-extension on ScanDirection {
+extension ScanDirectionValue on ScanDirection {
   String toValue() {
     switch (this) {
       case ScanDirection.forward:
@@ -1011,7 +1011,7 @@ extension on ScanDirection {
   }
 }
 
-extension on String {
+extension ScanDirectionFromString on String {
   ScanDirection toScanDirection() {
     switch (this) {
       case 'FORWARD':
@@ -1072,7 +1072,7 @@ enum SortKey {
   ascending,
 }
 
-extension on SortKey {
+extension SortKeyValue on SortKey {
   String toValue() {
     switch (this) {
       case SortKey.descending:
@@ -1083,7 +1083,7 @@ extension on SortKey {
   }
 }
 
-extension on String {
+extension SortKeyFromString on String {
   SortKey toSortKey() {
     switch (this) {
       case 'DESCENDING':

--- a/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
+++ b/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
@@ -631,7 +631,7 @@ enum ArtifactStatus {
   inProgress,
 }
 
-extension ArtifactStatusValue on ArtifactStatus {
+extension ArtifactStatusValueExtension on ArtifactStatus {
   String toValue() {
     switch (this) {
       case ArtifactStatus.approved:
@@ -705,7 +705,7 @@ enum ChatItemType {
   connectionAck,
 }
 
-extension ChatItemTypeValue on ChatItemType {
+extension ChatItemTypeValueExtension on ChatItemType {
   String toValue() {
     switch (this) {
       case ChatItemType.typing:
@@ -795,7 +795,7 @@ enum ConnectionType {
   connectionCredentials,
 }
 
-extension ConnectionTypeValue on ConnectionType {
+extension ConnectionTypeValueExtension on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.websocket:
@@ -968,7 +968,7 @@ enum ParticipantRole {
   system,
 }
 
-extension ParticipantRoleValue on ParticipantRole {
+extension ParticipantRoleValueExtension on ParticipantRole {
   String toValue() {
     switch (this) {
       case ParticipantRole.agent:
@@ -1000,7 +1000,7 @@ enum ScanDirection {
   backward,
 }
 
-extension ScanDirectionValue on ScanDirection {
+extension ScanDirectionValueExtension on ScanDirection {
   String toValue() {
     switch (this) {
       case ScanDirection.forward:
@@ -1072,7 +1072,7 @@ enum SortKey {
   ascending,
 }
 
-extension SortKeyValue on SortKey {
+extension SortKeyValueExtension on SortKey {
   String toValue() {
     switch (this) {
       case SortKey.descending:

--- a/generated/aws_cur_api/lib/cur-2017-01-06.dart
+++ b/generated/aws_cur_api/lib/cur-2017-01-06.dart
@@ -231,7 +231,7 @@ enum AWSRegion {
   cnNorthwest_1,
 }
 
-extension AWSRegionValue on AWSRegion {
+extension AWSRegionValueExtension on AWSRegion {
   String toValue() {
     switch (this) {
       case AWSRegion.afSouth_1:
@@ -345,7 +345,7 @@ enum AdditionalArtifact {
   athena,
 }
 
-extension AdditionalArtifactValue on AdditionalArtifact {
+extension AdditionalArtifactValueExtension on AdditionalArtifact {
   String toValue() {
     switch (this) {
       case AdditionalArtifact.redshift:
@@ -379,7 +379,7 @@ enum CompressionFormat {
   parquet,
 }
 
-extension CompressionFormatValue on CompressionFormat {
+extension CompressionFormatValueExtension on CompressionFormat {
   String toValue() {
     switch (this) {
       case CompressionFormat.zip:
@@ -562,7 +562,7 @@ enum ReportFormat {
   parquet,
 }
 
-extension ReportFormatValue on ReportFormat {
+extension ReportFormatValueExtension on ReportFormat {
   String toValue() {
     switch (this) {
       case ReportFormat.textORcsv:
@@ -590,7 +590,7 @@ enum ReportVersioning {
   overwriteReport,
 }
 
-extension ReportVersioningValue on ReportVersioning {
+extension ReportVersioningValueExtension on ReportVersioning {
   String toValue() {
     switch (this) {
       case ReportVersioning.createNewReport:
@@ -618,7 +618,7 @@ enum SchemaElement {
   resources,
 }
 
-extension SchemaElementValue on SchemaElement {
+extension SchemaElementValueExtension on SchemaElement {
   String toValue() {
     switch (this) {
       case SchemaElement.resources:
@@ -644,7 +644,7 @@ enum TimeUnit {
   monthly,
 }
 
-extension TimeUnitValue on TimeUnit {
+extension TimeUnitValueExtension on TimeUnit {
   String toValue() {
     switch (this) {
       case TimeUnit.hourly:

--- a/generated/aws_cur_api/lib/cur-2017-01-06.dart
+++ b/generated/aws_cur_api/lib/cur-2017-01-06.dart
@@ -231,7 +231,7 @@ enum AWSRegion {
   cnNorthwest_1,
 }
 
-extension on AWSRegion {
+extension AWSRegionValue on AWSRegion {
   String toValue() {
     switch (this) {
       case AWSRegion.afSouth_1:
@@ -284,7 +284,7 @@ extension on AWSRegion {
   }
 }
 
-extension on String {
+extension AWSRegionFromString on String {
   AWSRegion toAWSRegion() {
     switch (this) {
       case 'af-south-1':
@@ -345,7 +345,7 @@ enum AdditionalArtifact {
   athena,
 }
 
-extension on AdditionalArtifact {
+extension AdditionalArtifactValue on AdditionalArtifact {
   String toValue() {
     switch (this) {
       case AdditionalArtifact.redshift:
@@ -358,7 +358,7 @@ extension on AdditionalArtifact {
   }
 }
 
-extension on String {
+extension AdditionalArtifactFromString on String {
   AdditionalArtifact toAdditionalArtifact() {
     switch (this) {
       case 'REDSHIFT':
@@ -379,7 +379,7 @@ enum CompressionFormat {
   parquet,
 }
 
-extension on CompressionFormat {
+extension CompressionFormatValue on CompressionFormat {
   String toValue() {
     switch (this) {
       case CompressionFormat.zip:
@@ -392,7 +392,7 @@ extension on CompressionFormat {
   }
 }
 
-extension on String {
+extension CompressionFormatFromString on String {
   CompressionFormat toCompressionFormat() {
     switch (this) {
       case 'ZIP':
@@ -562,7 +562,7 @@ enum ReportFormat {
   parquet,
 }
 
-extension on ReportFormat {
+extension ReportFormatValue on ReportFormat {
   String toValue() {
     switch (this) {
       case ReportFormat.textORcsv:
@@ -573,7 +573,7 @@ extension on ReportFormat {
   }
 }
 
-extension on String {
+extension ReportFormatFromString on String {
   ReportFormat toReportFormat() {
     switch (this) {
       case 'textORcsv':
@@ -590,7 +590,7 @@ enum ReportVersioning {
   overwriteReport,
 }
 
-extension on ReportVersioning {
+extension ReportVersioningValue on ReportVersioning {
   String toValue() {
     switch (this) {
       case ReportVersioning.createNewReport:
@@ -601,7 +601,7 @@ extension on ReportVersioning {
   }
 }
 
-extension on String {
+extension ReportVersioningFromString on String {
   ReportVersioning toReportVersioning() {
     switch (this) {
       case 'CREATE_NEW_REPORT':
@@ -618,7 +618,7 @@ enum SchemaElement {
   resources,
 }
 
-extension on SchemaElement {
+extension SchemaElementValue on SchemaElement {
   String toValue() {
     switch (this) {
       case SchemaElement.resources:
@@ -627,7 +627,7 @@ extension on SchemaElement {
   }
 }
 
-extension on String {
+extension SchemaElementFromString on String {
   SchemaElement toSchemaElement() {
     switch (this) {
       case 'RESOURCES':
@@ -644,7 +644,7 @@ enum TimeUnit {
   monthly,
 }
 
-extension on TimeUnit {
+extension TimeUnitValue on TimeUnit {
   String toValue() {
     switch (this) {
       case TimeUnit.hourly:
@@ -657,7 +657,7 @@ extension on TimeUnit {
   }
 }
 
-extension on String {
+extension TimeUnitFromString on String {
   TimeUnit toTimeUnit() {
     switch (this) {
       case 'HOURLY':

--- a/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
+++ b/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
@@ -968,7 +968,7 @@ enum AssetType {
   s3Snapshot,
 }
 
-extension on AssetType {
+extension AssetTypeValue on AssetType {
   String toValue() {
     switch (this) {
       case AssetType.s3Snapshot:
@@ -977,7 +977,7 @@ extension on AssetType {
   }
 }
 
-extension on String {
+extension AssetTypeFromString on String {
   AssetType toAssetType() {
     switch (this) {
       case 'S3_SNAPSHOT':
@@ -997,7 +997,7 @@ enum Code {
   malwareScanEncryptedFile,
 }
 
-extension on Code {
+extension CodeValue on Code {
   String toValue() {
     switch (this) {
       case Code.accessDeniedException:
@@ -1018,7 +1018,7 @@ extension on Code {
   }
 }
 
-extension on String {
+extension CodeFromString on String {
   Code toCode() {
     switch (this) {
       case 'ACCESS_DENIED_EXCEPTION':
@@ -2012,7 +2012,7 @@ enum JobErrorLimitName {
   assetSizeInGb,
 }
 
-extension on JobErrorLimitName {
+extension JobErrorLimitNameValue on JobErrorLimitName {
   String toValue() {
     switch (this) {
       case JobErrorLimitName.assetsPerRevision:
@@ -2023,7 +2023,7 @@ extension on JobErrorLimitName {
   }
 }
 
-extension on String {
+extension JobErrorLimitNameFromString on String {
   JobErrorLimitName toJobErrorLimitName() {
     switch (this) {
       case 'Assets per revision':
@@ -2041,7 +2041,7 @@ enum JobErrorResourceTypes {
   asset,
 }
 
-extension on JobErrorResourceTypes {
+extension JobErrorResourceTypesValue on JobErrorResourceTypes {
   String toValue() {
     switch (this) {
       case JobErrorResourceTypes.revision:
@@ -2052,7 +2052,7 @@ extension on JobErrorResourceTypes {
   }
 }
 
-extension on String {
+extension JobErrorResourceTypesFromString on String {
   JobErrorResourceTypes toJobErrorResourceTypes() {
     switch (this) {
       case 'REVISION':
@@ -2180,7 +2180,7 @@ enum Origin {
   entitled,
 }
 
-extension on Origin {
+extension OriginValue on Origin {
   String toValue() {
     switch (this) {
       case Origin.owned:
@@ -2191,7 +2191,7 @@ extension on Origin {
   }
 }
 
-extension on String {
+extension OriginFromString on String {
   Origin toOrigin() {
     switch (this) {
       case 'OWNED':
@@ -2375,7 +2375,7 @@ enum ServerSideEncryptionTypes {
   aes256,
 }
 
-extension on ServerSideEncryptionTypes {
+extension ServerSideEncryptionTypesValue on ServerSideEncryptionTypes {
   String toValue() {
     switch (this) {
       case ServerSideEncryptionTypes.awsKms:
@@ -2386,7 +2386,7 @@ extension on ServerSideEncryptionTypes {
   }
 }
 
-extension on String {
+extension ServerSideEncryptionTypesFromString on String {
   ServerSideEncryptionTypes toServerSideEncryptionTypes() {
     switch (this) {
       case 'aws:kms':
@@ -2414,7 +2414,7 @@ enum State {
   timedOut,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.waiting:
@@ -2433,7 +2433,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'WAITING':
@@ -2460,7 +2460,7 @@ enum Type {
   exportAssetToSignedUrl,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.importAssetsFromS3:
@@ -2475,7 +2475,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'IMPORT_ASSETS_FROM_S3':

--- a/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
+++ b/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
@@ -968,7 +968,7 @@ enum AssetType {
   s3Snapshot,
 }
 
-extension AssetTypeValue on AssetType {
+extension AssetTypeValueExtension on AssetType {
   String toValue() {
     switch (this) {
       case AssetType.s3Snapshot:
@@ -997,7 +997,7 @@ enum Code {
   malwareScanEncryptedFile,
 }
 
-extension CodeValue on Code {
+extension CodeValueExtension on Code {
   String toValue() {
     switch (this) {
       case Code.accessDeniedException:
@@ -2012,7 +2012,7 @@ enum JobErrorLimitName {
   assetSizeInGb,
 }
 
-extension JobErrorLimitNameValue on JobErrorLimitName {
+extension JobErrorLimitNameValueExtension on JobErrorLimitName {
   String toValue() {
     switch (this) {
       case JobErrorLimitName.assetsPerRevision:
@@ -2041,7 +2041,7 @@ enum JobErrorResourceTypes {
   asset,
 }
 
-extension JobErrorResourceTypesValue on JobErrorResourceTypes {
+extension JobErrorResourceTypesValueExtension on JobErrorResourceTypes {
   String toValue() {
     switch (this) {
       case JobErrorResourceTypes.revision:
@@ -2180,7 +2180,7 @@ enum Origin {
   entitled,
 }
 
-extension OriginValue on Origin {
+extension OriginValueExtension on Origin {
   String toValue() {
     switch (this) {
       case Origin.owned:
@@ -2375,7 +2375,7 @@ enum ServerSideEncryptionTypes {
   aes256,
 }
 
-extension ServerSideEncryptionTypesValue on ServerSideEncryptionTypes {
+extension ServerSideEncryptionTypesValueExtension on ServerSideEncryptionTypes {
   String toValue() {
     switch (this) {
       case ServerSideEncryptionTypes.awsKms:
@@ -2414,7 +2414,7 @@ enum State {
   timedOut,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.waiting:
@@ -2460,7 +2460,7 @@ enum Type {
   exportAssetToSignedUrl,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.importAssetsFromS3:

--- a/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
+++ b/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
@@ -1561,7 +1561,7 @@ enum OperatorType {
   between,
 }
 
-extension OperatorTypeValue on OperatorType {
+extension OperatorTypeValueExtension on OperatorType {
   String toValue() {
     switch (this) {
       case OperatorType.eq:
@@ -2098,7 +2098,7 @@ enum TaskStatus {
   $false,
 }
 
-extension TaskStatusValue on TaskStatus {
+extension TaskStatusValueExtension on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.finished:

--- a/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
+++ b/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
@@ -1561,7 +1561,7 @@ enum OperatorType {
   between,
 }
 
-extension on OperatorType {
+extension OperatorTypeValue on OperatorType {
   String toValue() {
     switch (this) {
       case OperatorType.eq:
@@ -1578,7 +1578,7 @@ extension on OperatorType {
   }
 }
 
-extension on String {
+extension OperatorTypeFromString on String {
   OperatorType toOperatorType() {
     switch (this) {
       case 'EQ':
@@ -2098,7 +2098,7 @@ enum TaskStatus {
   $false,
 }
 
-extension on TaskStatus {
+extension TaskStatusValue on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.finished:
@@ -2111,7 +2111,7 @@ extension on TaskStatus {
   }
 }
 
-extension on String {
+extension TaskStatusFromString on String {
   TaskStatus toTaskStatus() {
     switch (this) {
       case 'FINISHED':

--- a/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
+++ b/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
@@ -2059,7 +2059,7 @@ enum AgentStatus {
   offline,
 }
 
-extension on AgentStatus {
+extension AgentStatusValue on AgentStatus {
   String toValue() {
     switch (this) {
       case AgentStatus.online:
@@ -2070,7 +2070,7 @@ extension on AgentStatus {
   }
 }
 
-extension on String {
+extension AgentStatusFromString on String {
   AgentStatus toAgentStatus() {
     switch (this) {
       case 'ONLINE':
@@ -2087,7 +2087,7 @@ enum Atime {
   bestEffort,
 }
 
-extension on Atime {
+extension AtimeValue on Atime {
   String toValue() {
     switch (this) {
       case Atime.none:
@@ -2098,7 +2098,7 @@ extension on Atime {
   }
 }
 
-extension on String {
+extension AtimeFromString on String {
   Atime toAtime() {
     switch (this) {
       case 'NONE':
@@ -2875,7 +2875,7 @@ enum EndpointType {
   fips,
 }
 
-extension on EndpointType {
+extension EndpointTypeValue on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.public:
@@ -2888,7 +2888,7 @@ extension on EndpointType {
   }
 }
 
-extension on String {
+extension EndpointTypeFromString on String {
   EndpointType toEndpointType() {
     switch (this) {
       case 'PUBLIC':
@@ -2941,7 +2941,7 @@ enum FilterType {
   simplePattern,
 }
 
-extension on FilterType {
+extension FilterTypeValue on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.simplePattern:
@@ -2950,7 +2950,7 @@ extension on FilterType {
   }
 }
 
-extension on String {
+extension FilterTypeFromString on String {
   FilterType toFilterType() {
     switch (this) {
       case 'SIMPLE_PATTERN':
@@ -2967,7 +2967,7 @@ enum Gid {
   both,
 }
 
-extension on Gid {
+extension GidValue on Gid {
   String toValue() {
     switch (this) {
       case Gid.none:
@@ -2982,7 +2982,7 @@ extension on Gid {
   }
 }
 
-extension on String {
+extension GidFromString on String {
   Gid toGid() {
     switch (this) {
       case 'NONE':
@@ -3161,7 +3161,7 @@ enum LocationFilterName {
   creationTime,
 }
 
-extension on LocationFilterName {
+extension LocationFilterNameValue on LocationFilterName {
   String toValue() {
     switch (this) {
       case LocationFilterName.locationUri:
@@ -3174,7 +3174,7 @@ extension on LocationFilterName {
   }
 }
 
-extension on String {
+extension LocationFilterNameFromString on String {
   LocationFilterName toLocationFilterName() {
     switch (this) {
       case 'LocationUri':
@@ -3237,7 +3237,7 @@ enum LogLevel {
   transfer,
 }
 
-extension on LogLevel {
+extension LogLevelValue on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.off:
@@ -3250,7 +3250,7 @@ extension on LogLevel {
   }
 }
 
-extension on String {
+extension LogLevelFromString on String {
   LogLevel toLogLevel() {
     switch (this) {
       case 'OFF':
@@ -3269,7 +3269,7 @@ enum Mtime {
   preserve,
 }
 
-extension on Mtime {
+extension MtimeValue on Mtime {
   String toValue() {
     switch (this) {
       case Mtime.none:
@@ -3280,7 +3280,7 @@ extension on Mtime {
   }
 }
 
-extension on String {
+extension MtimeFromString on String {
   Mtime toMtime() {
     switch (this) {
       case 'NONE':
@@ -3346,7 +3346,7 @@ enum NfsVersion {
   nfs4_1,
 }
 
-extension on NfsVersion {
+extension NfsVersionValue on NfsVersion {
   String toValue() {
     switch (this) {
       case NfsVersion.automatic:
@@ -3361,7 +3361,7 @@ extension on NfsVersion {
   }
 }
 
-extension on String {
+extension NfsVersionFromString on String {
   NfsVersion toNfsVersion() {
     switch (this) {
       case 'AUTOMATIC':
@@ -3382,7 +3382,7 @@ enum ObjectStorageServerProtocol {
   http,
 }
 
-extension on ObjectStorageServerProtocol {
+extension ObjectStorageServerProtocolValue on ObjectStorageServerProtocol {
   String toValue() {
     switch (this) {
       case ObjectStorageServerProtocol.https:
@@ -3393,7 +3393,7 @@ extension on ObjectStorageServerProtocol {
   }
 }
 
-extension on String {
+extension ObjectStorageServerProtocolFromString on String {
   ObjectStorageServerProtocol toObjectStorageServerProtocol() {
     switch (this) {
       case 'HTTPS':
@@ -3444,7 +3444,7 @@ enum Operator {
   beginsWith,
 }
 
-extension on Operator {
+extension OperatorValue on Operator {
   String toValue() {
     switch (this) {
       case Operator.equals:
@@ -3471,7 +3471,7 @@ extension on Operator {
   }
 }
 
-extension on String {
+extension OperatorFromString on String {
   Operator toOperator() {
     switch (this) {
       case 'Equals':
@@ -3750,7 +3750,7 @@ enum OverwriteMode {
   never,
 }
 
-extension on OverwriteMode {
+extension OverwriteModeValue on OverwriteMode {
   String toValue() {
     switch (this) {
       case OverwriteMode.always:
@@ -3761,7 +3761,7 @@ extension on OverwriteMode {
   }
 }
 
-extension on String {
+extension OverwriteModeFromString on String {
   OverwriteMode toOverwriteMode() {
     switch (this) {
       case 'ALWAYS':
@@ -3779,7 +3779,7 @@ enum PhaseStatus {
   error,
 }
 
-extension on PhaseStatus {
+extension PhaseStatusValue on PhaseStatus {
   String toValue() {
     switch (this) {
       case PhaseStatus.pending:
@@ -3792,7 +3792,7 @@ extension on PhaseStatus {
   }
 }
 
-extension on String {
+extension PhaseStatusFromString on String {
   PhaseStatus toPhaseStatus() {
     switch (this) {
       case 'PENDING':
@@ -3811,7 +3811,7 @@ enum PosixPermissions {
   preserve,
 }
 
-extension on PosixPermissions {
+extension PosixPermissionsValue on PosixPermissions {
   String toValue() {
     switch (this) {
       case PosixPermissions.none:
@@ -3822,7 +3822,7 @@ extension on PosixPermissions {
   }
 }
 
-extension on String {
+extension PosixPermissionsFromString on String {
   PosixPermissions toPosixPermissions() {
     switch (this) {
       case 'NONE':
@@ -3839,7 +3839,7 @@ enum PreserveDeletedFiles {
   remove,
 }
 
-extension on PreserveDeletedFiles {
+extension PreserveDeletedFilesValue on PreserveDeletedFiles {
   String toValue() {
     switch (this) {
       case PreserveDeletedFiles.preserve:
@@ -3850,7 +3850,7 @@ extension on PreserveDeletedFiles {
   }
 }
 
-extension on String {
+extension PreserveDeletedFilesFromString on String {
   PreserveDeletedFiles toPreserveDeletedFiles() {
     switch (this) {
       case 'PRESERVE':
@@ -3867,7 +3867,7 @@ enum PreserveDevices {
   preserve,
 }
 
-extension on PreserveDevices {
+extension PreserveDevicesValue on PreserveDevices {
   String toValue() {
     switch (this) {
       case PreserveDevices.none:
@@ -3878,7 +3878,7 @@ extension on PreserveDevices {
   }
 }
 
-extension on String {
+extension PreserveDevicesFromString on String {
   PreserveDevices toPreserveDevices() {
     switch (this) {
       case 'NONE':
@@ -3973,7 +3973,7 @@ enum S3StorageClass {
   outposts,
 }
 
-extension on S3StorageClass {
+extension S3StorageClassValue on S3StorageClass {
   String toValue() {
     switch (this) {
       case S3StorageClass.standard:
@@ -3994,7 +3994,7 @@ extension on S3StorageClass {
   }
 }
 
-extension on String {
+extension S3StorageClassFromString on String {
   S3StorageClass toS3StorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -4048,7 +4048,7 @@ enum SmbVersion {
   smb3,
 }
 
-extension on SmbVersion {
+extension SmbVersionValue on SmbVersion {
   String toValue() {
     switch (this) {
       case SmbVersion.automatic:
@@ -4061,7 +4061,7 @@ extension on SmbVersion {
   }
 }
 
-extension on String {
+extension SmbVersionFromString on String {
   SmbVersion toSmbVersion() {
     switch (this) {
       case 'AUTOMATIC':
@@ -4225,7 +4225,7 @@ enum TaskExecutionStatus {
   error,
 }
 
-extension on TaskExecutionStatus {
+extension TaskExecutionStatusValue on TaskExecutionStatus {
   String toValue() {
     switch (this) {
       case TaskExecutionStatus.queued:
@@ -4246,7 +4246,7 @@ extension on TaskExecutionStatus {
   }
 }
 
-extension on String {
+extension TaskExecutionStatusFromString on String {
   TaskExecutionStatus toTaskExecutionStatus() {
     switch (this) {
       case 'QUEUED':
@@ -4310,7 +4310,7 @@ enum TaskFilterName {
   creationTime,
 }
 
-extension on TaskFilterName {
+extension TaskFilterNameValue on TaskFilterName {
   String toValue() {
     switch (this) {
       case TaskFilterName.locationId:
@@ -4321,7 +4321,7 @@ extension on TaskFilterName {
   }
 }
 
-extension on String {
+extension TaskFilterNameFromString on String {
   TaskFilterName toTaskFilterName() {
     switch (this) {
       case 'LocationId':
@@ -4366,7 +4366,7 @@ enum TaskQueueing {
   disabled,
 }
 
-extension on TaskQueueing {
+extension TaskQueueingValue on TaskQueueing {
   String toValue() {
     switch (this) {
       case TaskQueueing.enabled:
@@ -4377,7 +4377,7 @@ extension on TaskQueueing {
   }
 }
 
-extension on String {
+extension TaskQueueingFromString on String {
   TaskQueueing toTaskQueueing() {
     switch (this) {
       case 'ENABLED':
@@ -4423,7 +4423,7 @@ enum TaskStatus {
   unavailable,
 }
 
-extension on TaskStatus {
+extension TaskStatusValue on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.available:
@@ -4440,7 +4440,7 @@ extension on TaskStatus {
   }
 }
 
-extension on String {
+extension TaskStatusFromString on String {
   TaskStatus toTaskStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -4463,7 +4463,7 @@ enum TransferMode {
   all,
 }
 
-extension on TransferMode {
+extension TransferModeValue on TransferMode {
   String toValue() {
     switch (this) {
       case TransferMode.changed:
@@ -4474,7 +4474,7 @@ extension on TransferMode {
   }
 }
 
-extension on String {
+extension TransferModeFromString on String {
   TransferMode toTransferMode() {
     switch (this) {
       case 'CHANGED':
@@ -4493,7 +4493,7 @@ enum Uid {
   both,
 }
 
-extension on Uid {
+extension UidValue on Uid {
   String toValue() {
     switch (this) {
       case Uid.none:
@@ -4508,7 +4508,7 @@ extension on Uid {
   }
 }
 
-extension on String {
+extension UidFromString on String {
   Uid toUid() {
     switch (this) {
       case 'NONE':
@@ -4558,7 +4558,7 @@ enum VerifyMode {
   none,
 }
 
-extension on VerifyMode {
+extension VerifyModeValue on VerifyMode {
   String toValue() {
     switch (this) {
       case VerifyMode.pointInTimeConsistent:
@@ -4571,7 +4571,7 @@ extension on VerifyMode {
   }
 }
 
-extension on String {
+extension VerifyModeFromString on String {
   VerifyMode toVerifyMode() {
     switch (this) {
       case 'POINT_IN_TIME_CONSISTENT':

--- a/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
+++ b/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
@@ -2059,7 +2059,7 @@ enum AgentStatus {
   offline,
 }
 
-extension AgentStatusValue on AgentStatus {
+extension AgentStatusValueExtension on AgentStatus {
   String toValue() {
     switch (this) {
       case AgentStatus.online:
@@ -2087,7 +2087,7 @@ enum Atime {
   bestEffort,
 }
 
-extension AtimeValue on Atime {
+extension AtimeValueExtension on Atime {
   String toValue() {
     switch (this) {
       case Atime.none:
@@ -2875,7 +2875,7 @@ enum EndpointType {
   fips,
 }
 
-extension EndpointTypeValue on EndpointType {
+extension EndpointTypeValueExtension on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.public:
@@ -2941,7 +2941,7 @@ enum FilterType {
   simplePattern,
 }
 
-extension FilterTypeValue on FilterType {
+extension FilterTypeValueExtension on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.simplePattern:
@@ -2967,7 +2967,7 @@ enum Gid {
   both,
 }
 
-extension GidValue on Gid {
+extension GidValueExtension on Gid {
   String toValue() {
     switch (this) {
       case Gid.none:
@@ -3161,7 +3161,7 @@ enum LocationFilterName {
   creationTime,
 }
 
-extension LocationFilterNameValue on LocationFilterName {
+extension LocationFilterNameValueExtension on LocationFilterName {
   String toValue() {
     switch (this) {
       case LocationFilterName.locationUri:
@@ -3237,7 +3237,7 @@ enum LogLevel {
   transfer,
 }
 
-extension LogLevelValue on LogLevel {
+extension LogLevelValueExtension on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.off:
@@ -3269,7 +3269,7 @@ enum Mtime {
   preserve,
 }
 
-extension MtimeValue on Mtime {
+extension MtimeValueExtension on Mtime {
   String toValue() {
     switch (this) {
       case Mtime.none:
@@ -3346,7 +3346,7 @@ enum NfsVersion {
   nfs4_1,
 }
 
-extension NfsVersionValue on NfsVersion {
+extension NfsVersionValueExtension on NfsVersion {
   String toValue() {
     switch (this) {
       case NfsVersion.automatic:
@@ -3382,7 +3382,8 @@ enum ObjectStorageServerProtocol {
   http,
 }
 
-extension ObjectStorageServerProtocolValue on ObjectStorageServerProtocol {
+extension ObjectStorageServerProtocolValueExtension
+    on ObjectStorageServerProtocol {
   String toValue() {
     switch (this) {
       case ObjectStorageServerProtocol.https:
@@ -3444,7 +3445,7 @@ enum Operator {
   beginsWith,
 }
 
-extension OperatorValue on Operator {
+extension OperatorValueExtension on Operator {
   String toValue() {
     switch (this) {
       case Operator.equals:
@@ -3750,7 +3751,7 @@ enum OverwriteMode {
   never,
 }
 
-extension OverwriteModeValue on OverwriteMode {
+extension OverwriteModeValueExtension on OverwriteMode {
   String toValue() {
     switch (this) {
       case OverwriteMode.always:
@@ -3779,7 +3780,7 @@ enum PhaseStatus {
   error,
 }
 
-extension PhaseStatusValue on PhaseStatus {
+extension PhaseStatusValueExtension on PhaseStatus {
   String toValue() {
     switch (this) {
       case PhaseStatus.pending:
@@ -3811,7 +3812,7 @@ enum PosixPermissions {
   preserve,
 }
 
-extension PosixPermissionsValue on PosixPermissions {
+extension PosixPermissionsValueExtension on PosixPermissions {
   String toValue() {
     switch (this) {
       case PosixPermissions.none:
@@ -3839,7 +3840,7 @@ enum PreserveDeletedFiles {
   remove,
 }
 
-extension PreserveDeletedFilesValue on PreserveDeletedFiles {
+extension PreserveDeletedFilesValueExtension on PreserveDeletedFiles {
   String toValue() {
     switch (this) {
       case PreserveDeletedFiles.preserve:
@@ -3867,7 +3868,7 @@ enum PreserveDevices {
   preserve,
 }
 
-extension PreserveDevicesValue on PreserveDevices {
+extension PreserveDevicesValueExtension on PreserveDevices {
   String toValue() {
     switch (this) {
       case PreserveDevices.none:
@@ -3973,7 +3974,7 @@ enum S3StorageClass {
   outposts,
 }
 
-extension S3StorageClassValue on S3StorageClass {
+extension S3StorageClassValueExtension on S3StorageClass {
   String toValue() {
     switch (this) {
       case S3StorageClass.standard:
@@ -4048,7 +4049,7 @@ enum SmbVersion {
   smb3,
 }
 
-extension SmbVersionValue on SmbVersion {
+extension SmbVersionValueExtension on SmbVersion {
   String toValue() {
     switch (this) {
       case SmbVersion.automatic:
@@ -4225,7 +4226,7 @@ enum TaskExecutionStatus {
   error,
 }
 
-extension TaskExecutionStatusValue on TaskExecutionStatus {
+extension TaskExecutionStatusValueExtension on TaskExecutionStatus {
   String toValue() {
     switch (this) {
       case TaskExecutionStatus.queued:
@@ -4310,7 +4311,7 @@ enum TaskFilterName {
   creationTime,
 }
 
-extension TaskFilterNameValue on TaskFilterName {
+extension TaskFilterNameValueExtension on TaskFilterName {
   String toValue() {
     switch (this) {
       case TaskFilterName.locationId:
@@ -4366,7 +4367,7 @@ enum TaskQueueing {
   disabled,
 }
 
-extension TaskQueueingValue on TaskQueueing {
+extension TaskQueueingValueExtension on TaskQueueing {
   String toValue() {
     switch (this) {
       case TaskQueueing.enabled:
@@ -4423,7 +4424,7 @@ enum TaskStatus {
   unavailable,
 }
 
-extension TaskStatusValue on TaskStatus {
+extension TaskStatusValueExtension on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.available:
@@ -4463,7 +4464,7 @@ enum TransferMode {
   all,
 }
 
-extension TransferModeValue on TransferMode {
+extension TransferModeValueExtension on TransferMode {
   String toValue() {
     switch (this) {
       case TransferMode.changed:
@@ -4493,7 +4494,7 @@ enum Uid {
   both,
 }
 
-extension UidValue on Uid {
+extension UidValueExtension on Uid {
   String toValue() {
     switch (this) {
       case Uid.none:
@@ -4558,7 +4559,7 @@ enum VerifyMode {
   none,
 }
 
-extension VerifyModeValue on VerifyMode {
+extension VerifyModeValueExtension on VerifyMode {
   String toValue() {
     switch (this) {
       case VerifyMode.pointInTimeConsistent:

--- a/generated/aws_dax_api/lib/dax-2017-04-19.dart
+++ b/generated/aws_dax_api/lib/dax-2017-04-19.dart
@@ -1187,7 +1187,7 @@ enum ChangeType {
   requiresReboot,
 }
 
-extension on ChangeType {
+extension ChangeTypeValue on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.immediate:
@@ -1198,7 +1198,7 @@ extension on ChangeType {
   }
 }
 
-extension on String {
+extension ChangeTypeFromString on String {
   ChangeType toChangeType() {
     switch (this) {
       case 'IMMEDIATE':
@@ -1670,7 +1670,7 @@ enum IsModifiable {
   conditional,
 }
 
-extension on IsModifiable {
+extension IsModifiableValue on IsModifiable {
   String toValue() {
     switch (this) {
       case IsModifiable.$true:
@@ -1683,7 +1683,7 @@ extension on IsModifiable {
   }
 }
 
-extension on String {
+extension IsModifiableFromString on String {
   IsModifiable toIsModifiable() {
     switch (this) {
       case 'TRUE':
@@ -1952,7 +1952,7 @@ enum ParameterType {
   nodeTypeSpecific,
 }
 
-extension on ParameterType {
+extension ParameterTypeValue on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.$default:
@@ -1963,7 +1963,7 @@ extension on ParameterType {
   }
 }
 
-extension on String {
+extension ParameterTypeFromString on String {
   ParameterType toParameterType() {
     switch (this) {
       case 'DEFAULT':
@@ -2046,7 +2046,7 @@ enum SSEStatus {
   disabled,
 }
 
-extension on SSEStatus {
+extension SSEStatusValue on SSEStatus {
   String toValue() {
     switch (this) {
       case SSEStatus.enabling:
@@ -2061,7 +2061,7 @@ extension on SSEStatus {
   }
 }
 
-extension on String {
+extension SSEStatusFromString on String {
   SSEStatus toSSEStatus() {
     switch (this) {
       case 'ENABLING':
@@ -2103,7 +2103,7 @@ enum SourceType {
   subnetGroup,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cluster:
@@ -2116,7 +2116,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'CLUSTER':

--- a/generated/aws_dax_api/lib/dax-2017-04-19.dart
+++ b/generated/aws_dax_api/lib/dax-2017-04-19.dart
@@ -1187,7 +1187,7 @@ enum ChangeType {
   requiresReboot,
 }
 
-extension ChangeTypeValue on ChangeType {
+extension ChangeTypeValueExtension on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.immediate:
@@ -1670,7 +1670,7 @@ enum IsModifiable {
   conditional,
 }
 
-extension IsModifiableValue on IsModifiable {
+extension IsModifiableValueExtension on IsModifiable {
   String toValue() {
     switch (this) {
       case IsModifiable.$true:
@@ -1952,7 +1952,7 @@ enum ParameterType {
   nodeTypeSpecific,
 }
 
-extension ParameterTypeValue on ParameterType {
+extension ParameterTypeValueExtension on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.$default:
@@ -2046,7 +2046,7 @@ enum SSEStatus {
   disabled,
 }
 
-extension SSEStatusValue on SSEStatus {
+extension SSEStatusValueExtension on SSEStatus {
   String toValue() {
     switch (this) {
       case SSEStatus.enabling:
@@ -2103,7 +2103,7 @@ enum SourceType {
   subnetGroup,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cluster:

--- a/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
+++ b/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
@@ -2950,7 +2950,7 @@ enum ApplicationRevisionSortBy {
   lastUsedTime,
 }
 
-extension ApplicationRevisionSortByValue on ApplicationRevisionSortBy {
+extension ApplicationRevisionSortByValueExtension on ApplicationRevisionSortBy {
   String toValue() {
     switch (this) {
       case ApplicationRevisionSortBy.registerTime:
@@ -3018,7 +3018,7 @@ enum AutoRollbackEvent {
   deploymentStopOnRequest,
 }
 
-extension AutoRollbackEventValue on AutoRollbackEvent {
+extension AutoRollbackEventValueExtension on AutoRollbackEvent {
   String toValue() {
     switch (this) {
       case AutoRollbackEvent.deploymentFailure:
@@ -3354,7 +3354,7 @@ enum BundleType {
   json,
 }
 
-extension BundleTypeValue on BundleType {
+extension BundleTypeValueExtension on BundleType {
   String toValue() {
     switch (this) {
       case BundleType.tar:
@@ -3450,7 +3450,7 @@ enum ComputePlatform {
   ecs,
 }
 
-extension ComputePlatformValue on ComputePlatform {
+extension ComputePlatformValueExtension on ComputePlatform {
   String toValue() {
     switch (this) {
       case ComputePlatform.server:
@@ -3640,7 +3640,7 @@ enum DeploymentCreator {
   cloudFormationRollback,
 }
 
-extension DeploymentCreatorValue on DeploymentCreator {
+extension DeploymentCreatorValueExtension on DeploymentCreator {
   String toValue() {
     switch (this) {
       case DeploymentCreator.user:
@@ -4128,7 +4128,7 @@ enum DeploymentOption {
   withoutTrafficControl,
 }
 
-extension DeploymentOptionValue on DeploymentOption {
+extension DeploymentOptionValueExtension on DeploymentOption {
   String toValue() {
     switch (this) {
       case DeploymentOption.withTrafficControl:
@@ -4198,7 +4198,7 @@ enum DeploymentReadyAction {
   stopDeployment,
 }
 
-extension DeploymentReadyActionValue on DeploymentReadyAction {
+extension DeploymentReadyActionValueExtension on DeploymentReadyAction {
   String toValue() {
     switch (this) {
       case DeploymentReadyAction.continueDeployment:
@@ -4280,7 +4280,7 @@ enum DeploymentStatus {
   ready,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.created:
@@ -4415,7 +4415,7 @@ enum DeploymentTargetType {
   cloudFormationTarget,
 }
 
-extension DeploymentTargetTypeValue on DeploymentTargetType {
+extension DeploymentTargetTypeValueExtension on DeploymentTargetType {
   String toValue() {
     switch (this) {
       case DeploymentTargetType.instanceTarget:
@@ -4451,7 +4451,7 @@ enum DeploymentType {
   blueGreen,
 }
 
-extension DeploymentTypeValue on DeploymentType {
+extension DeploymentTypeValueExtension on DeploymentType {
   String toValue() {
     switch (this) {
       case DeploymentType.inPlace:
@@ -4479,7 +4479,7 @@ enum DeploymentWaitType {
   terminationWait,
 }
 
-extension DeploymentWaitTypeValue on DeploymentWaitType {
+extension DeploymentWaitTypeValueExtension on DeploymentWaitType {
   String toValue() {
     switch (this) {
       case DeploymentWaitType.readyWait:
@@ -4613,7 +4613,7 @@ enum EC2TagFilterType {
   keyAndValue,
 }
 
-extension EC2TagFilterTypeValue on EC2TagFilterType {
+extension EC2TagFilterTypeValueExtension on EC2TagFilterType {
   String toValue() {
     switch (this) {
       case EC2TagFilterType.keyOnly:
@@ -4904,7 +4904,7 @@ enum ErrorCode {
   cloudformationStackFailure,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.agentIssue:
@@ -5139,7 +5139,7 @@ enum FileExistsBehavior {
   retain,
 }
 
-extension FileExistsBehaviorValue on FileExistsBehavior {
+extension FileExistsBehaviorValueExtension on FileExistsBehavior {
   String toValue() {
     switch (this) {
       case FileExistsBehavior.disallow:
@@ -5400,7 +5400,8 @@ enum GreenFleetProvisioningAction {
   copyAutoScalingGroup,
 }
 
-extension GreenFleetProvisioningActionValue on GreenFleetProvisioningAction {
+extension GreenFleetProvisioningActionValueExtension
+    on GreenFleetProvisioningAction {
   String toValue() {
     switch (this) {
       case GreenFleetProvisioningAction.discoverExisting:
@@ -5462,7 +5463,7 @@ enum InstanceAction {
   keepAlive,
 }
 
-extension InstanceActionValue on InstanceAction {
+extension InstanceActionValueExtension on InstanceAction {
   String toValue() {
     switch (this) {
       case InstanceAction.terminate:
@@ -5545,7 +5546,7 @@ enum InstanceStatus {
   ready,
 }
 
-extension InstanceStatusValue on InstanceStatus {
+extension InstanceStatusValueExtension on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.pending:
@@ -5719,7 +5720,7 @@ enum InstanceType {
   green,
 }
 
-extension InstanceTypeValue on InstanceType {
+extension InstanceTypeValueExtension on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.blue:
@@ -5878,7 +5879,7 @@ enum LifecycleErrorCode {
   unknownError,
 }
 
-extension LifecycleErrorCodeValue on LifecycleErrorCode {
+extension LifecycleErrorCodeValueExtension on LifecycleErrorCode {
   String toValue() {
     switch (this) {
       case LifecycleErrorCode.success:
@@ -5986,7 +5987,7 @@ enum LifecycleEventStatus {
   unknown,
 }
 
-extension LifecycleEventStatusValue on LifecycleEventStatus {
+extension LifecycleEventStatusValueExtension on LifecycleEventStatus {
   String toValue() {
     switch (this) {
       case LifecycleEventStatus.pending:
@@ -6264,7 +6265,7 @@ enum ListStateFilterAction {
   ignore,
 }
 
-extension ListStateFilterActionValue on ListStateFilterAction {
+extension ListStateFilterActionValueExtension on ListStateFilterAction {
   String toValue() {
     switch (this) {
       case ListStateFilterAction.include:
@@ -6442,7 +6443,7 @@ enum MinimumHealthyHostsType {
   fleetPercent,
 }
 
-extension MinimumHealthyHostsTypeValue on MinimumHealthyHostsType {
+extension MinimumHealthyHostsTypeValueExtension on MinimumHealthyHostsType {
   String toValue() {
     switch (this) {
       case MinimumHealthyHostsType.hostCount:
@@ -6552,7 +6553,7 @@ enum RegistrationStatus {
   deregistered,
 }
 
-extension RegistrationStatusValue on RegistrationStatus {
+extension RegistrationStatusValueExtension on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.registered:
@@ -6690,7 +6691,7 @@ enum RevisionLocationType {
   appSpecContent,
 }
 
-extension RevisionLocationTypeValue on RevisionLocationType {
+extension RevisionLocationTypeValueExtension on RevisionLocationType {
   String toValue() {
     switch (this) {
       case RevisionLocationType.s3:
@@ -6826,7 +6827,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -6883,7 +6884,7 @@ enum StopStatus {
   succeeded,
 }
 
-extension StopStatusValue on StopStatus {
+extension StopStatusValueExtension on StopStatus {
   String toValue() {
     switch (this) {
       case StopStatus.pending:
@@ -6989,7 +6990,7 @@ enum TagFilterType {
   keyAndValue,
 }
 
-extension TagFilterTypeValue on TagFilterType {
+extension TagFilterTypeValueExtension on TagFilterType {
   String toValue() {
     switch (this) {
       case TagFilterType.keyOnly:
@@ -7028,7 +7029,7 @@ enum TargetFilterName {
   serverInstanceLabel,
 }
 
-extension TargetFilterNameValue on TargetFilterName {
+extension TargetFilterNameValueExtension on TargetFilterName {
   String toValue() {
     switch (this) {
       case TargetFilterName.targetStatus:
@@ -7187,7 +7188,7 @@ enum TargetLabel {
   green,
 }
 
-extension TargetLabelValue on TargetLabel {
+extension TargetLabelValueExtension on TargetLabel {
   String toValue() {
     switch (this) {
       case TargetLabel.blue:
@@ -7220,7 +7221,7 @@ enum TargetStatus {
   ready,
 }
 
-extension TargetStatusValue on TargetStatus {
+extension TargetStatusValueExtension on TargetStatus {
   String toValue() {
     switch (this) {
       case TargetStatus.pending:
@@ -7444,7 +7445,7 @@ enum TrafficRoutingType {
   allAtOnce,
 }
 
-extension TrafficRoutingTypeValue on TrafficRoutingType {
+extension TrafficRoutingTypeValueExtension on TrafficRoutingType {
   String toValue() {
     switch (this) {
       case TrafficRoutingType.timeBasedCanary:
@@ -7526,7 +7527,7 @@ enum TriggerEventType {
   instanceReady,
 }
 
-extension TriggerEventTypeValue on TriggerEventType {
+extension TriggerEventTypeValueExtension on TriggerEventType {
   String toValue() {
     switch (this) {
       case TriggerEventType.deploymentStart:

--- a/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
+++ b/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
@@ -2950,7 +2950,7 @@ enum ApplicationRevisionSortBy {
   lastUsedTime,
 }
 
-extension on ApplicationRevisionSortBy {
+extension ApplicationRevisionSortByValue on ApplicationRevisionSortBy {
   String toValue() {
     switch (this) {
       case ApplicationRevisionSortBy.registerTime:
@@ -2963,7 +2963,7 @@ extension on ApplicationRevisionSortBy {
   }
 }
 
-extension on String {
+extension ApplicationRevisionSortByFromString on String {
   ApplicationRevisionSortBy toApplicationRevisionSortBy() {
     switch (this) {
       case 'registerTime':
@@ -3018,7 +3018,7 @@ enum AutoRollbackEvent {
   deploymentStopOnRequest,
 }
 
-extension on AutoRollbackEvent {
+extension AutoRollbackEventValue on AutoRollbackEvent {
   String toValue() {
     switch (this) {
       case AutoRollbackEvent.deploymentFailure:
@@ -3031,7 +3031,7 @@ extension on AutoRollbackEvent {
   }
 }
 
-extension on String {
+extension AutoRollbackEventFromString on String {
   AutoRollbackEvent toAutoRollbackEvent() {
     switch (this) {
       case 'DEPLOYMENT_FAILURE':
@@ -3354,7 +3354,7 @@ enum BundleType {
   json,
 }
 
-extension on BundleType {
+extension BundleTypeValue on BundleType {
   String toValue() {
     switch (this) {
       case BundleType.tar:
@@ -3371,7 +3371,7 @@ extension on BundleType {
   }
 }
 
-extension on String {
+extension BundleTypeFromString on String {
   BundleType toBundleType() {
     switch (this) {
       case 'tar':
@@ -3450,7 +3450,7 @@ enum ComputePlatform {
   ecs,
 }
 
-extension on ComputePlatform {
+extension ComputePlatformValue on ComputePlatform {
   String toValue() {
     switch (this) {
       case ComputePlatform.server:
@@ -3463,7 +3463,7 @@ extension on ComputePlatform {
   }
 }
 
-extension on String {
+extension ComputePlatformFromString on String {
   ComputePlatform toComputePlatform() {
     switch (this) {
       case 'Server':
@@ -3640,7 +3640,7 @@ enum DeploymentCreator {
   cloudFormationRollback,
 }
 
-extension on DeploymentCreator {
+extension DeploymentCreatorValue on DeploymentCreator {
   String toValue() {
     switch (this) {
       case DeploymentCreator.user:
@@ -3659,7 +3659,7 @@ extension on DeploymentCreator {
   }
 }
 
-extension on String {
+extension DeploymentCreatorFromString on String {
   DeploymentCreator toDeploymentCreator() {
     switch (this) {
       case 'user':
@@ -4128,7 +4128,7 @@ enum DeploymentOption {
   withoutTrafficControl,
 }
 
-extension on DeploymentOption {
+extension DeploymentOptionValue on DeploymentOption {
   String toValue() {
     switch (this) {
       case DeploymentOption.withTrafficControl:
@@ -4139,7 +4139,7 @@ extension on DeploymentOption {
   }
 }
 
-extension on String {
+extension DeploymentOptionFromString on String {
   DeploymentOption toDeploymentOption() {
     switch (this) {
       case 'WITH_TRAFFIC_CONTROL':
@@ -4198,7 +4198,7 @@ enum DeploymentReadyAction {
   stopDeployment,
 }
 
-extension on DeploymentReadyAction {
+extension DeploymentReadyActionValue on DeploymentReadyAction {
   String toValue() {
     switch (this) {
       case DeploymentReadyAction.continueDeployment:
@@ -4209,7 +4209,7 @@ extension on DeploymentReadyAction {
   }
 }
 
-extension on String {
+extension DeploymentReadyActionFromString on String {
   DeploymentReadyAction toDeploymentReadyAction() {
     switch (this) {
       case 'CONTINUE_DEPLOYMENT':
@@ -4280,7 +4280,7 @@ enum DeploymentStatus {
   ready,
 }
 
-extension on DeploymentStatus {
+extension DeploymentStatusValue on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.created:
@@ -4303,7 +4303,7 @@ extension on DeploymentStatus {
   }
 }
 
-extension on String {
+extension DeploymentStatusFromString on String {
   DeploymentStatus toDeploymentStatus() {
     switch (this) {
       case 'Created':
@@ -4415,7 +4415,7 @@ enum DeploymentTargetType {
   cloudFormationTarget,
 }
 
-extension on DeploymentTargetType {
+extension DeploymentTargetTypeValue on DeploymentTargetType {
   String toValue() {
     switch (this) {
       case DeploymentTargetType.instanceTarget:
@@ -4430,7 +4430,7 @@ extension on DeploymentTargetType {
   }
 }
 
-extension on String {
+extension DeploymentTargetTypeFromString on String {
   DeploymentTargetType toDeploymentTargetType() {
     switch (this) {
       case 'InstanceTarget':
@@ -4451,7 +4451,7 @@ enum DeploymentType {
   blueGreen,
 }
 
-extension on DeploymentType {
+extension DeploymentTypeValue on DeploymentType {
   String toValue() {
     switch (this) {
       case DeploymentType.inPlace:
@@ -4462,7 +4462,7 @@ extension on DeploymentType {
   }
 }
 
-extension on String {
+extension DeploymentTypeFromString on String {
   DeploymentType toDeploymentType() {
     switch (this) {
       case 'IN_PLACE':
@@ -4479,7 +4479,7 @@ enum DeploymentWaitType {
   terminationWait,
 }
 
-extension on DeploymentWaitType {
+extension DeploymentWaitTypeValue on DeploymentWaitType {
   String toValue() {
     switch (this) {
       case DeploymentWaitType.readyWait:
@@ -4490,7 +4490,7 @@ extension on DeploymentWaitType {
   }
 }
 
-extension on String {
+extension DeploymentWaitTypeFromString on String {
   DeploymentWaitType toDeploymentWaitType() {
     switch (this) {
       case 'READY_WAIT':
@@ -4613,7 +4613,7 @@ enum EC2TagFilterType {
   keyAndValue,
 }
 
-extension on EC2TagFilterType {
+extension EC2TagFilterTypeValue on EC2TagFilterType {
   String toValue() {
     switch (this) {
       case EC2TagFilterType.keyOnly:
@@ -4626,7 +4626,7 @@ extension on EC2TagFilterType {
   }
 }
 
-extension on String {
+extension EC2TagFilterTypeFromString on String {
   EC2TagFilterType toEC2TagFilterType() {
     switch (this) {
       case 'KEY_ONLY':
@@ -4904,7 +4904,7 @@ enum ErrorCode {
   cloudformationStackFailure,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.agentIssue:
@@ -4979,7 +4979,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'AGENT_ISSUE':
@@ -5139,7 +5139,7 @@ enum FileExistsBehavior {
   retain,
 }
 
-extension on FileExistsBehavior {
+extension FileExistsBehaviorValue on FileExistsBehavior {
   String toValue() {
     switch (this) {
       case FileExistsBehavior.disallow:
@@ -5152,7 +5152,7 @@ extension on FileExistsBehavior {
   }
 }
 
-extension on String {
+extension FileExistsBehaviorFromString on String {
   FileExistsBehavior toFileExistsBehavior() {
     switch (this) {
       case 'DISALLOW':
@@ -5400,7 +5400,7 @@ enum GreenFleetProvisioningAction {
   copyAutoScalingGroup,
 }
 
-extension on GreenFleetProvisioningAction {
+extension GreenFleetProvisioningActionValue on GreenFleetProvisioningAction {
   String toValue() {
     switch (this) {
       case GreenFleetProvisioningAction.discoverExisting:
@@ -5411,7 +5411,7 @@ extension on GreenFleetProvisioningAction {
   }
 }
 
-extension on String {
+extension GreenFleetProvisioningActionFromString on String {
   GreenFleetProvisioningAction toGreenFleetProvisioningAction() {
     switch (this) {
       case 'DISCOVER_EXISTING':
@@ -5462,7 +5462,7 @@ enum InstanceAction {
   keepAlive,
 }
 
-extension on InstanceAction {
+extension InstanceActionValue on InstanceAction {
   String toValue() {
     switch (this) {
       case InstanceAction.terminate:
@@ -5473,7 +5473,7 @@ extension on InstanceAction {
   }
 }
 
-extension on String {
+extension InstanceActionFromString on String {
   InstanceAction toInstanceAction() {
     switch (this) {
       case 'TERMINATE':
@@ -5545,7 +5545,7 @@ enum InstanceStatus {
   ready,
 }
 
-extension on InstanceStatus {
+extension InstanceStatusValue on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.pending:
@@ -5566,7 +5566,7 @@ extension on InstanceStatus {
   }
 }
 
-extension on String {
+extension InstanceStatusFromString on String {
   InstanceStatus toInstanceStatus() {
     switch (this) {
       case 'Pending':
@@ -5719,7 +5719,7 @@ enum InstanceType {
   green,
 }
 
-extension on InstanceType {
+extension InstanceTypeValue on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.blue:
@@ -5730,7 +5730,7 @@ extension on InstanceType {
   }
 }
 
-extension on String {
+extension InstanceTypeFromString on String {
   InstanceType toInstanceType() {
     switch (this) {
       case 'Blue':
@@ -5878,7 +5878,7 @@ enum LifecycleErrorCode {
   unknownError,
 }
 
-extension on LifecycleErrorCode {
+extension LifecycleErrorCodeValue on LifecycleErrorCode {
   String toValue() {
     switch (this) {
       case LifecycleErrorCode.success:
@@ -5897,7 +5897,7 @@ extension on LifecycleErrorCode {
   }
 }
 
-extension on String {
+extension LifecycleErrorCodeFromString on String {
   LifecycleErrorCode toLifecycleErrorCode() {
     switch (this) {
       case 'Success':
@@ -5986,7 +5986,7 @@ enum LifecycleEventStatus {
   unknown,
 }
 
-extension on LifecycleEventStatus {
+extension LifecycleEventStatusValue on LifecycleEventStatus {
   String toValue() {
     switch (this) {
       case LifecycleEventStatus.pending:
@@ -6005,7 +6005,7 @@ extension on LifecycleEventStatus {
   }
 }
 
-extension on String {
+extension LifecycleEventStatusFromString on String {
   LifecycleEventStatus toLifecycleEventStatus() {
     switch (this) {
       case 'Pending':
@@ -6264,7 +6264,7 @@ enum ListStateFilterAction {
   ignore,
 }
 
-extension on ListStateFilterAction {
+extension ListStateFilterActionValue on ListStateFilterAction {
   String toValue() {
     switch (this) {
       case ListStateFilterAction.include:
@@ -6277,7 +6277,7 @@ extension on ListStateFilterAction {
   }
 }
 
-extension on String {
+extension ListStateFilterActionFromString on String {
   ListStateFilterAction toListStateFilterAction() {
     switch (this) {
       case 'include':
@@ -6442,7 +6442,7 @@ enum MinimumHealthyHostsType {
   fleetPercent,
 }
 
-extension on MinimumHealthyHostsType {
+extension MinimumHealthyHostsTypeValue on MinimumHealthyHostsType {
   String toValue() {
     switch (this) {
       case MinimumHealthyHostsType.hostCount:
@@ -6453,7 +6453,7 @@ extension on MinimumHealthyHostsType {
   }
 }
 
-extension on String {
+extension MinimumHealthyHostsTypeFromString on String {
   MinimumHealthyHostsType toMinimumHealthyHostsType() {
     switch (this) {
       case 'HOST_COUNT':
@@ -6552,7 +6552,7 @@ enum RegistrationStatus {
   deregistered,
 }
 
-extension on RegistrationStatus {
+extension RegistrationStatusValue on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.registered:
@@ -6563,7 +6563,7 @@ extension on RegistrationStatus {
   }
 }
 
-extension on String {
+extension RegistrationStatusFromString on String {
   RegistrationStatus toRegistrationStatus() {
     switch (this) {
       case 'Registered':
@@ -6690,7 +6690,7 @@ enum RevisionLocationType {
   appSpecContent,
 }
 
-extension on RevisionLocationType {
+extension RevisionLocationTypeValue on RevisionLocationType {
   String toValue() {
     switch (this) {
       case RevisionLocationType.s3:
@@ -6705,7 +6705,7 @@ extension on RevisionLocationType {
   }
 }
 
-extension on String {
+extension RevisionLocationTypeFromString on String {
   RevisionLocationType toRevisionLocationType() {
     switch (this) {
       case 'S3':
@@ -6826,7 +6826,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -6837,7 +6837,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ascending':
@@ -6883,7 +6883,7 @@ enum StopStatus {
   succeeded,
 }
 
-extension on StopStatus {
+extension StopStatusValue on StopStatus {
   String toValue() {
     switch (this) {
       case StopStatus.pending:
@@ -6894,7 +6894,7 @@ extension on StopStatus {
   }
 }
 
-extension on String {
+extension StopStatusFromString on String {
   StopStatus toStopStatus() {
     switch (this) {
       case 'Pending':
@@ -6989,7 +6989,7 @@ enum TagFilterType {
   keyAndValue,
 }
 
-extension on TagFilterType {
+extension TagFilterTypeValue on TagFilterType {
   String toValue() {
     switch (this) {
       case TagFilterType.keyOnly:
@@ -7002,7 +7002,7 @@ extension on TagFilterType {
   }
 }
 
-extension on String {
+extension TagFilterTypeFromString on String {
   TagFilterType toTagFilterType() {
     switch (this) {
       case 'KEY_ONLY':
@@ -7028,7 +7028,7 @@ enum TargetFilterName {
   serverInstanceLabel,
 }
 
-extension on TargetFilterName {
+extension TargetFilterNameValue on TargetFilterName {
   String toValue() {
     switch (this) {
       case TargetFilterName.targetStatus:
@@ -7039,7 +7039,7 @@ extension on TargetFilterName {
   }
 }
 
-extension on String {
+extension TargetFilterNameFromString on String {
   TargetFilterName toTargetFilterName() {
     switch (this) {
       case 'TargetStatus':
@@ -7187,7 +7187,7 @@ enum TargetLabel {
   green,
 }
 
-extension on TargetLabel {
+extension TargetLabelValue on TargetLabel {
   String toValue() {
     switch (this) {
       case TargetLabel.blue:
@@ -7198,7 +7198,7 @@ extension on TargetLabel {
   }
 }
 
-extension on String {
+extension TargetLabelFromString on String {
   TargetLabel toTargetLabel() {
     switch (this) {
       case 'Blue':
@@ -7220,7 +7220,7 @@ enum TargetStatus {
   ready,
 }
 
-extension on TargetStatus {
+extension TargetStatusValue on TargetStatus {
   String toValue() {
     switch (this) {
       case TargetStatus.pending:
@@ -7241,7 +7241,7 @@ extension on TargetStatus {
   }
 }
 
-extension on String {
+extension TargetStatusFromString on String {
   TargetStatus toTargetStatus() {
     switch (this) {
       case 'Pending':
@@ -7444,7 +7444,7 @@ enum TrafficRoutingType {
   allAtOnce,
 }
 
-extension on TrafficRoutingType {
+extension TrafficRoutingTypeValue on TrafficRoutingType {
   String toValue() {
     switch (this) {
       case TrafficRoutingType.timeBasedCanary:
@@ -7457,7 +7457,7 @@ extension on TrafficRoutingType {
   }
 }
 
-extension on String {
+extension TrafficRoutingTypeFromString on String {
   TrafficRoutingType toTrafficRoutingType() {
     switch (this) {
       case 'TimeBasedCanary':
@@ -7526,7 +7526,7 @@ enum TriggerEventType {
   instanceReady,
 }
 
-extension on TriggerEventType {
+extension TriggerEventTypeValue on TriggerEventType {
   String toValue() {
     switch (this) {
       case TriggerEventType.deploymentStart:
@@ -7553,7 +7553,7 @@ extension on TriggerEventType {
   }
 }
 
-extension on String {
+extension TriggerEventTypeFromString on String {
   TriggerEventType toTriggerEventType() {
     switch (this) {
       case 'DeploymentStart':

--- a/generated/aws_detective_api/lib/detective-2018-10-26.dart
+++ b/generated/aws_detective_api/lib/detective-2018-10-26.dart
@@ -945,7 +945,7 @@ enum MemberDisabledReason {
   volumeUnknown,
 }
 
-extension on MemberDisabledReason {
+extension MemberDisabledReasonValue on MemberDisabledReason {
   String toValue() {
     switch (this) {
       case MemberDisabledReason.volumeTooHigh:
@@ -956,7 +956,7 @@ extension on MemberDisabledReason {
   }
 }
 
-extension on String {
+extension MemberDisabledReasonFromString on String {
   MemberDisabledReason toMemberDisabledReason() {
     switch (this) {
       case 'VOLUME_TOO_HIGH':
@@ -976,7 +976,7 @@ enum MemberStatus {
   acceptedButDisabled,
 }
 
-extension on MemberStatus {
+extension MemberStatusValue on MemberStatus {
   String toValue() {
     switch (this) {
       case MemberStatus.invited:
@@ -993,7 +993,7 @@ extension on MemberStatus {
   }
 }
 
-extension on String {
+extension MemberStatusFromString on String {
   MemberStatus toMemberStatus() {
     switch (this) {
       case 'INVITED':

--- a/generated/aws_detective_api/lib/detective-2018-10-26.dart
+++ b/generated/aws_detective_api/lib/detective-2018-10-26.dart
@@ -945,7 +945,7 @@ enum MemberDisabledReason {
   volumeUnknown,
 }
 
-extension MemberDisabledReasonValue on MemberDisabledReason {
+extension MemberDisabledReasonValueExtension on MemberDisabledReason {
   String toValue() {
     switch (this) {
       case MemberDisabledReason.volumeTooHigh:
@@ -976,7 +976,7 @@ enum MemberStatus {
   acceptedButDisabled,
 }
 
-extension MemberStatusValue on MemberStatus {
+extension MemberStatusValueExtension on MemberStatus {
   String toValue() {
     switch (this) {
       case MemberStatus.invited:

--- a/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
+++ b/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
@@ -4862,7 +4862,7 @@ enum ArtifactCategory {
   log,
 }
 
-extension ArtifactCategoryValue on ArtifactCategory {
+extension ArtifactCategoryValueExtension on ArtifactCategory {
   String toValue() {
     switch (this) {
       case ArtifactCategory.screenshot:
@@ -4920,7 +4920,7 @@ enum ArtifactType {
   testspecOutput,
 }
 
-extension ArtifactTypeValue on ArtifactType {
+extension ArtifactTypeValueExtension on ArtifactType {
   String toValue() {
     switch (this) {
       case ArtifactType.unknown:
@@ -5052,7 +5052,7 @@ enum BillingMethod {
   unmetered,
 }
 
-extension BillingMethodValue on BillingMethod {
+extension BillingMethodValueExtension on BillingMethod {
   String toValue() {
     switch (this) {
       case BillingMethod.metered:
@@ -5335,7 +5335,7 @@ enum CurrencyCode {
   usd,
 }
 
-extension CurrencyCodeValue on CurrencyCode {
+extension CurrencyCodeValueExtension on CurrencyCode {
   String toValue() {
     switch (this) {
       case CurrencyCode.usd:
@@ -5645,7 +5645,7 @@ enum DeviceAttribute {
   availability,
 }
 
-extension DeviceAttributeValue on DeviceAttribute {
+extension DeviceAttributeValueExtension on DeviceAttribute {
   String toValue() {
     switch (this) {
       case DeviceAttribute.arn:
@@ -5719,7 +5719,7 @@ enum DeviceAvailability {
   highlyAvailable,
 }
 
-extension DeviceAvailabilityValue on DeviceAvailability {
+extension DeviceAvailabilityValueExtension on DeviceAvailability {
   String toValue() {
     switch (this) {
       case DeviceAvailability.temporaryNotAvailable:
@@ -5908,7 +5908,7 @@ enum DeviceFilterAttribute {
   fleetType,
 }
 
-extension DeviceFilterAttributeValue on DeviceFilterAttribute {
+extension DeviceFilterAttributeValueExtension on DeviceFilterAttribute {
   String toValue() {
     switch (this) {
       case DeviceFilterAttribute.arn:
@@ -5976,7 +5976,7 @@ enum DeviceFormFactor {
   tablet,
 }
 
-extension DeviceFormFactorValue on DeviceFormFactor {
+extension DeviceFormFactorValueExtension on DeviceFormFactor {
   String toValue() {
     switch (this) {
       case DeviceFormFactor.phone:
@@ -6079,7 +6079,7 @@ enum DevicePlatform {
   ios,
 }
 
-extension DevicePlatformValue on DevicePlatform {
+extension DevicePlatformValueExtension on DevicePlatform {
   String toValue() {
     switch (this) {
       case DevicePlatform.android:
@@ -6200,7 +6200,7 @@ enum DevicePoolType {
   private,
 }
 
-extension DevicePoolTypeValue on DevicePoolType {
+extension DevicePoolTypeValueExtension on DevicePoolType {
   String toValue() {
     switch (this) {
       case DevicePoolType.curated:
@@ -6448,7 +6448,7 @@ enum ExecutionResult {
   stopped,
 }
 
-extension ExecutionResultValue on ExecutionResult {
+extension ExecutionResultValueExtension on ExecutionResult {
   String toValue() {
     switch (this) {
       case ExecutionResult.pending:
@@ -6496,7 +6496,7 @@ enum ExecutionResultCode {
   vpcEndpointSetupFailed,
 }
 
-extension ExecutionResultCodeValue on ExecutionResultCode {
+extension ExecutionResultCodeValueExtension on ExecutionResultCode {
   String toValue() {
     switch (this) {
       case ExecutionResultCode.parsingFailed:
@@ -6531,7 +6531,7 @@ enum ExecutionStatus {
   stopping,
 }
 
-extension ExecutionStatusValue on ExecutionStatus {
+extension ExecutionStatusValueExtension on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.pending:
@@ -7033,7 +7033,7 @@ enum InstanceStatus {
   notAvailable,
 }
 
-extension InstanceStatusValue on InstanceStatus {
+extension InstanceStatusValueExtension on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.inUse:
@@ -7070,7 +7070,7 @@ enum InteractionMode {
   videoOnly,
 }
 
-extension InteractionModeValue on InteractionMode {
+extension InteractionModeValueExtension on InteractionMode {
   String toValue() {
     switch (this) {
       case InteractionMode.interactive:
@@ -8048,7 +8048,7 @@ enum NetworkProfileType {
   private,
 }
 
-extension NetworkProfileTypeValue on NetworkProfileType {
+extension NetworkProfileTypeValueExtension on NetworkProfileType {
   String toValue() {
     switch (this) {
       case NetworkProfileType.curated:
@@ -8208,7 +8208,7 @@ enum OfferingTransactionType {
   system,
 }
 
-extension OfferingTransactionTypeValue on OfferingTransactionType {
+extension OfferingTransactionTypeValueExtension on OfferingTransactionType {
   String toValue() {
     switch (this) {
       case OfferingTransactionType.purchase:
@@ -8239,7 +8239,7 @@ enum OfferingType {
   recurring,
 }
 
-extension OfferingTypeValue on OfferingType {
+extension OfferingTypeValueExtension on OfferingType {
   String toValue() {
     switch (this) {
       case OfferingType.recurring:
@@ -8479,7 +8479,7 @@ enum RecurringChargeFrequency {
   monthly,
 }
 
-extension RecurringChargeFrequencyValue on RecurringChargeFrequency {
+extension RecurringChargeFrequencyValueExtension on RecurringChargeFrequency {
   String toValue() {
     switch (this) {
       case RecurringChargeFrequency.monthly:
@@ -8884,7 +8884,7 @@ enum RuleOperator {
   contains,
 }
 
-extension RuleOperatorValue on RuleOperator {
+extension RuleOperatorValueExtension on RuleOperator {
   String toValue() {
     switch (this) {
       case RuleOperator.equals:
@@ -9372,7 +9372,7 @@ enum SampleType {
   openglMaxDrawtime,
 }
 
-extension SampleTypeValue on SampleType {
+extension SampleTypeValueExtension on SampleType {
   String toValue() {
     switch (this) {
       case SampleType.cpu:
@@ -10398,7 +10398,7 @@ enum TestGridSessionArtifactCategory {
   log,
 }
 
-extension TestGridSessionArtifactCategoryValue
+extension TestGridSessionArtifactCategoryValueExtension
     on TestGridSessionArtifactCategory {
   String toValue() {
     switch (this) {
@@ -10429,7 +10429,8 @@ enum TestGridSessionArtifactType {
   seleniumLog,
 }
 
-extension TestGridSessionArtifactTypeValue on TestGridSessionArtifactType {
+extension TestGridSessionArtifactTypeValueExtension
+    on TestGridSessionArtifactType {
   String toValue() {
     switch (this) {
       case TestGridSessionArtifactType.unknown:
@@ -10462,7 +10463,7 @@ enum TestGridSessionStatus {
   errored,
 }
 
-extension TestGridSessionStatusValue on TestGridSessionStatus {
+extension TestGridSessionStatusValueExtension on TestGridSessionStatus {
   String toValue() {
     switch (this) {
       case TestGridSessionStatus.active:
@@ -10513,7 +10514,7 @@ enum TestType {
   remoteAccessReplay,
 }
 
-extension TestTypeValue on TestType {
+extension TestTypeValueExtension on TestType {
   String toValue() {
     switch (this) {
       case TestType.builtinFuzz:
@@ -10993,7 +10994,7 @@ enum UploadCategory {
   private,
 }
 
-extension UploadCategoryValue on UploadCategory {
+extension UploadCategoryValueExtension on UploadCategory {
   String toValue() {
     switch (this) {
       case UploadCategory.curated:
@@ -11023,7 +11024,7 @@ enum UploadStatus {
   failed,
 }
 
-extension UploadStatusValue on UploadStatus {
+extension UploadStatusValueExtension on UploadStatus {
   String toValue() {
     switch (this) {
       case UploadStatus.initialized:
@@ -11089,7 +11090,7 @@ enum UploadType {
   xctestUiTestSpec,
 }
 
-extension UploadTypeValue on UploadType {
+extension UploadTypeValueExtension on UploadType {
   String toValue() {
     switch (this) {
       case UploadType.androidApp:

--- a/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
+++ b/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
@@ -4862,7 +4862,7 @@ enum ArtifactCategory {
   log,
 }
 
-extension on ArtifactCategory {
+extension ArtifactCategoryValue on ArtifactCategory {
   String toValue() {
     switch (this) {
       case ArtifactCategory.screenshot:
@@ -4875,7 +4875,7 @@ extension on ArtifactCategory {
   }
 }
 
-extension on String {
+extension ArtifactCategoryFromString on String {
   ArtifactCategory toArtifactCategory() {
     switch (this) {
       case 'SCREENSHOT':
@@ -4920,7 +4920,7 @@ enum ArtifactType {
   testspecOutput,
 }
 
-extension on ArtifactType {
+extension ArtifactTypeValue on ArtifactType {
   String toValue() {
     switch (this) {
       case ArtifactType.unknown:
@@ -4983,7 +4983,7 @@ extension on ArtifactType {
   }
 }
 
-extension on String {
+extension ArtifactTypeFromString on String {
   ArtifactType toArtifactType() {
     switch (this) {
       case 'UNKNOWN':
@@ -5052,7 +5052,7 @@ enum BillingMethod {
   unmetered,
 }
 
-extension on BillingMethod {
+extension BillingMethodValue on BillingMethod {
   String toValue() {
     switch (this) {
       case BillingMethod.metered:
@@ -5063,7 +5063,7 @@ extension on BillingMethod {
   }
 }
 
-extension on String {
+extension BillingMethodFromString on String {
   BillingMethod toBillingMethod() {
     switch (this) {
       case 'METERED':
@@ -5335,7 +5335,7 @@ enum CurrencyCode {
   usd,
 }
 
-extension on CurrencyCode {
+extension CurrencyCodeValue on CurrencyCode {
   String toValue() {
     switch (this) {
       case CurrencyCode.usd:
@@ -5344,7 +5344,7 @@ extension on CurrencyCode {
   }
 }
 
-extension on String {
+extension CurrencyCodeFromString on String {
   CurrencyCode toCurrencyCode() {
     switch (this) {
       case 'USD':
@@ -5645,7 +5645,7 @@ enum DeviceAttribute {
   availability,
 }
 
-extension on DeviceAttribute {
+extension DeviceAttributeValue on DeviceAttribute {
   String toValue() {
     switch (this) {
       case DeviceAttribute.arn:
@@ -5678,7 +5678,7 @@ extension on DeviceAttribute {
   }
 }
 
-extension on String {
+extension DeviceAttributeFromString on String {
   DeviceAttribute toDeviceAttribute() {
     switch (this) {
       case 'ARN':
@@ -5719,7 +5719,7 @@ enum DeviceAvailability {
   highlyAvailable,
 }
 
-extension on DeviceAvailability {
+extension DeviceAvailabilityValue on DeviceAvailability {
   String toValue() {
     switch (this) {
       case DeviceAvailability.temporaryNotAvailable:
@@ -5734,7 +5734,7 @@ extension on DeviceAvailability {
   }
 }
 
-extension on String {
+extension DeviceAvailabilityFromString on String {
   DeviceAvailability toDeviceAvailability() {
     switch (this) {
       case 'TEMPORARY_NOT_AVAILABLE':
@@ -5908,7 +5908,7 @@ enum DeviceFilterAttribute {
   fleetType,
 }
 
-extension on DeviceFilterAttribute {
+extension DeviceFilterAttributeValue on DeviceFilterAttribute {
   String toValue() {
     switch (this) {
       case DeviceFilterAttribute.arn:
@@ -5939,7 +5939,7 @@ extension on DeviceFilterAttribute {
   }
 }
 
-extension on String {
+extension DeviceFilterAttributeFromString on String {
   DeviceFilterAttribute toDeviceFilterAttribute() {
     switch (this) {
       case 'ARN':
@@ -5976,7 +5976,7 @@ enum DeviceFormFactor {
   tablet,
 }
 
-extension on DeviceFormFactor {
+extension DeviceFormFactorValue on DeviceFormFactor {
   String toValue() {
     switch (this) {
       case DeviceFormFactor.phone:
@@ -5987,7 +5987,7 @@ extension on DeviceFormFactor {
   }
 }
 
-extension on String {
+extension DeviceFormFactorFromString on String {
   DeviceFormFactor toDeviceFormFactor() {
     switch (this) {
       case 'PHONE':
@@ -6079,7 +6079,7 @@ enum DevicePlatform {
   ios,
 }
 
-extension on DevicePlatform {
+extension DevicePlatformValue on DevicePlatform {
   String toValue() {
     switch (this) {
       case DevicePlatform.android:
@@ -6090,7 +6090,7 @@ extension on DevicePlatform {
   }
 }
 
-extension on String {
+extension DevicePlatformFromString on String {
   DevicePlatform toDevicePlatform() {
     switch (this) {
       case 'ANDROID':
@@ -6200,7 +6200,7 @@ enum DevicePoolType {
   private,
 }
 
-extension on DevicePoolType {
+extension DevicePoolTypeValue on DevicePoolType {
   String toValue() {
     switch (this) {
       case DevicePoolType.curated:
@@ -6211,7 +6211,7 @@ extension on DevicePoolType {
   }
 }
 
-extension on String {
+extension DevicePoolTypeFromString on String {
   DevicePoolType toDevicePoolType() {
     switch (this) {
       case 'CURATED':
@@ -6448,7 +6448,7 @@ enum ExecutionResult {
   stopped,
 }
 
-extension on ExecutionResult {
+extension ExecutionResultValue on ExecutionResult {
   String toValue() {
     switch (this) {
       case ExecutionResult.pending:
@@ -6469,7 +6469,7 @@ extension on ExecutionResult {
   }
 }
 
-extension on String {
+extension ExecutionResultFromString on String {
   ExecutionResult toExecutionResult() {
     switch (this) {
       case 'PENDING':
@@ -6496,7 +6496,7 @@ enum ExecutionResultCode {
   vpcEndpointSetupFailed,
 }
 
-extension on ExecutionResultCode {
+extension ExecutionResultCodeValue on ExecutionResultCode {
   String toValue() {
     switch (this) {
       case ExecutionResultCode.parsingFailed:
@@ -6507,7 +6507,7 @@ extension on ExecutionResultCode {
   }
 }
 
-extension on String {
+extension ExecutionResultCodeFromString on String {
   ExecutionResultCode toExecutionResultCode() {
     switch (this) {
       case 'PARSING_FAILED':
@@ -6531,7 +6531,7 @@ enum ExecutionStatus {
   stopping,
 }
 
-extension on ExecutionStatus {
+extension ExecutionStatusValue on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.pending:
@@ -6556,7 +6556,7 @@ extension on ExecutionStatus {
   }
 }
 
-extension on String {
+extension ExecutionStatusFromString on String {
   ExecutionStatus toExecutionStatus() {
     switch (this) {
       case 'PENDING':
@@ -7033,7 +7033,7 @@ enum InstanceStatus {
   notAvailable,
 }
 
-extension on InstanceStatus {
+extension InstanceStatusValue on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.inUse:
@@ -7048,7 +7048,7 @@ extension on InstanceStatus {
   }
 }
 
-extension on String {
+extension InstanceStatusFromString on String {
   InstanceStatus toInstanceStatus() {
     switch (this) {
       case 'IN_USE':
@@ -7070,7 +7070,7 @@ enum InteractionMode {
   videoOnly,
 }
 
-extension on InteractionMode {
+extension InteractionModeValue on InteractionMode {
   String toValue() {
     switch (this) {
       case InteractionMode.interactive:
@@ -7083,7 +7083,7 @@ extension on InteractionMode {
   }
 }
 
-extension on String {
+extension InteractionModeFromString on String {
   InteractionMode toInteractionMode() {
     switch (this) {
       case 'INTERACTIVE':
@@ -8048,7 +8048,7 @@ enum NetworkProfileType {
   private,
 }
 
-extension on NetworkProfileType {
+extension NetworkProfileTypeValue on NetworkProfileType {
   String toValue() {
     switch (this) {
       case NetworkProfileType.curated:
@@ -8059,7 +8059,7 @@ extension on NetworkProfileType {
   }
 }
 
-extension on String {
+extension NetworkProfileTypeFromString on String {
   NetworkProfileType toNetworkProfileType() {
     switch (this) {
       case 'CURATED':
@@ -8208,7 +8208,7 @@ enum OfferingTransactionType {
   system,
 }
 
-extension on OfferingTransactionType {
+extension OfferingTransactionTypeValue on OfferingTransactionType {
   String toValue() {
     switch (this) {
       case OfferingTransactionType.purchase:
@@ -8221,7 +8221,7 @@ extension on OfferingTransactionType {
   }
 }
 
-extension on String {
+extension OfferingTransactionTypeFromString on String {
   OfferingTransactionType toOfferingTransactionType() {
     switch (this) {
       case 'PURCHASE':
@@ -8239,7 +8239,7 @@ enum OfferingType {
   recurring,
 }
 
-extension on OfferingType {
+extension OfferingTypeValue on OfferingType {
   String toValue() {
     switch (this) {
       case OfferingType.recurring:
@@ -8248,7 +8248,7 @@ extension on OfferingType {
   }
 }
 
-extension on String {
+extension OfferingTypeFromString on String {
   OfferingType toOfferingType() {
     switch (this) {
       case 'RECURRING':
@@ -8479,7 +8479,7 @@ enum RecurringChargeFrequency {
   monthly,
 }
 
-extension on RecurringChargeFrequency {
+extension RecurringChargeFrequencyValue on RecurringChargeFrequency {
   String toValue() {
     switch (this) {
       case RecurringChargeFrequency.monthly:
@@ -8488,7 +8488,7 @@ extension on RecurringChargeFrequency {
   }
 }
 
-extension on String {
+extension RecurringChargeFrequencyFromString on String {
   RecurringChargeFrequency toRecurringChargeFrequency() {
     switch (this) {
       case 'MONTHLY':
@@ -8884,7 +8884,7 @@ enum RuleOperator {
   contains,
 }
 
-extension on RuleOperator {
+extension RuleOperatorValue on RuleOperator {
   String toValue() {
     switch (this) {
       case RuleOperator.equals:
@@ -8907,7 +8907,7 @@ extension on RuleOperator {
   }
 }
 
-extension on String {
+extension RuleOperatorFromString on String {
   RuleOperator toRuleOperator() {
     switch (this) {
       case 'EQUALS':
@@ -9372,7 +9372,7 @@ enum SampleType {
   openglMaxDrawtime,
 }
 
-extension on SampleType {
+extension SampleTypeValue on SampleType {
   String toValue() {
     switch (this) {
       case SampleType.cpu:
@@ -9413,7 +9413,7 @@ extension on SampleType {
   }
 }
 
-extension on String {
+extension SampleTypeFromString on String {
   SampleType toSampleType() {
     switch (this) {
       case 'CPU':
@@ -10398,7 +10398,8 @@ enum TestGridSessionArtifactCategory {
   log,
 }
 
-extension on TestGridSessionArtifactCategory {
+extension TestGridSessionArtifactCategoryValue
+    on TestGridSessionArtifactCategory {
   String toValue() {
     switch (this) {
       case TestGridSessionArtifactCategory.video:
@@ -10409,7 +10410,7 @@ extension on TestGridSessionArtifactCategory {
   }
 }
 
-extension on String {
+extension TestGridSessionArtifactCategoryFromString on String {
   TestGridSessionArtifactCategory toTestGridSessionArtifactCategory() {
     switch (this) {
       case 'VIDEO':
@@ -10428,7 +10429,7 @@ enum TestGridSessionArtifactType {
   seleniumLog,
 }
 
-extension on TestGridSessionArtifactType {
+extension TestGridSessionArtifactTypeValue on TestGridSessionArtifactType {
   String toValue() {
     switch (this) {
       case TestGridSessionArtifactType.unknown:
@@ -10441,7 +10442,7 @@ extension on TestGridSessionArtifactType {
   }
 }
 
-extension on String {
+extension TestGridSessionArtifactTypeFromString on String {
   TestGridSessionArtifactType toTestGridSessionArtifactType() {
     switch (this) {
       case 'UNKNOWN':
@@ -10461,7 +10462,7 @@ enum TestGridSessionStatus {
   errored,
 }
 
-extension on TestGridSessionStatus {
+extension TestGridSessionStatusValue on TestGridSessionStatus {
   String toValue() {
     switch (this) {
       case TestGridSessionStatus.active:
@@ -10474,7 +10475,7 @@ extension on TestGridSessionStatus {
   }
 }
 
-extension on String {
+extension TestGridSessionStatusFromString on String {
   TestGridSessionStatus toTestGridSessionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -10512,7 +10513,7 @@ enum TestType {
   remoteAccessReplay,
 }
 
-extension on TestType {
+extension TestTypeValue on TestType {
   String toValue() {
     switch (this) {
       case TestType.builtinFuzz:
@@ -10561,7 +10562,7 @@ extension on TestType {
   }
 }
 
-extension on String {
+extension TestTypeFromString on String {
   TestType toTestType() {
     switch (this) {
       case 'BUILTIN_FUZZ':
@@ -10992,7 +10993,7 @@ enum UploadCategory {
   private,
 }
 
-extension on UploadCategory {
+extension UploadCategoryValue on UploadCategory {
   String toValue() {
     switch (this) {
       case UploadCategory.curated:
@@ -11003,7 +11004,7 @@ extension on UploadCategory {
   }
 }
 
-extension on String {
+extension UploadCategoryFromString on String {
   UploadCategory toUploadCategory() {
     switch (this) {
       case 'CURATED':
@@ -11022,7 +11023,7 @@ enum UploadStatus {
   failed,
 }
 
-extension on UploadStatus {
+extension UploadStatusValue on UploadStatus {
   String toValue() {
     switch (this) {
       case UploadStatus.initialized:
@@ -11037,7 +11038,7 @@ extension on UploadStatus {
   }
 }
 
-extension on String {
+extension UploadStatusFromString on String {
   UploadStatus toUploadStatus() {
     switch (this) {
       case 'INITIALIZED':
@@ -11088,7 +11089,7 @@ enum UploadType {
   xctestUiTestSpec,
 }
 
-extension on UploadType {
+extension UploadTypeValue on UploadType {
   String toValue() {
     switch (this) {
       case UploadType.androidApp:
@@ -11159,7 +11160,7 @@ extension on UploadType {
   }
 }
 
-extension on String {
+extension UploadTypeFromString on String {
   UploadType toUploadType() {
     switch (this) {
       case 'ANDROID_APP':

--- a/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
+++ b/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
@@ -2730,7 +2730,7 @@ enum AddressFamily {
   ipv6,
 }
 
-extension AddressFamilyValue on AddressFamily {
+extension AddressFamilyValueExtension on AddressFamily {
   String toValue() {
     switch (this) {
       case AddressFamily.ipv4:
@@ -2901,7 +2901,7 @@ enum BGPPeerState {
   deleted,
 }
 
-extension BGPPeerStateValue on BGPPeerState {
+extension BGPPeerStateValueExtension on BGPPeerState {
   String toValue() {
     switch (this) {
       case BGPPeerState.verifying:
@@ -2942,7 +2942,7 @@ enum BGPStatus {
   unknown,
 }
 
-extension BGPStatusValue on BGPStatus {
+extension BGPStatusValueExtension on BGPStatus {
   String toValue() {
     switch (this) {
       case BGPStatus.up:
@@ -3348,7 +3348,7 @@ enum ConnectionState {
   unknown,
 }
 
-extension ConnectionStateValue on ConnectionState {
+extension ConnectionStateValueExtension on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.ordering:
@@ -4068,7 +4068,7 @@ enum DirectConnectGatewayAssociationProposalState {
   deleted,
 }
 
-extension DirectConnectGatewayAssociationProposalStateValue
+extension DirectConnectGatewayAssociationProposalStateValueExtension
     on DirectConnectGatewayAssociationProposalState {
   String toValue() {
     switch (this) {
@@ -4106,7 +4106,7 @@ enum DirectConnectGatewayAssociationState {
   updating,
 }
 
-extension DirectConnectGatewayAssociationStateValue
+extension DirectConnectGatewayAssociationStateValueExtension
     on DirectConnectGatewayAssociationState {
   String toValue() {
     switch (this) {
@@ -4220,7 +4220,7 @@ enum DirectConnectGatewayAttachmentState {
   detached,
 }
 
-extension DirectConnectGatewayAttachmentStateValue
+extension DirectConnectGatewayAttachmentStateValueExtension
     on DirectConnectGatewayAttachmentState {
   String toValue() {
     switch (this) {
@@ -4258,7 +4258,7 @@ enum DirectConnectGatewayAttachmentType {
   privateVirtualInterface,
 }
 
-extension DirectConnectGatewayAttachmentTypeValue
+extension DirectConnectGatewayAttachmentTypeValueExtension
     on DirectConnectGatewayAttachmentType {
   String toValue() {
     switch (this) {
@@ -4290,7 +4290,7 @@ enum DirectConnectGatewayState {
   deleted,
 }
 
-extension DirectConnectGatewayStateValue on DirectConnectGatewayState {
+extension DirectConnectGatewayStateValueExtension on DirectConnectGatewayState {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayState.pending:
@@ -4326,7 +4326,7 @@ enum GatewayType {
   transitGateway,
 }
 
-extension GatewayTypeValue on GatewayType {
+extension GatewayTypeValueExtension on GatewayType {
   String toValue() {
     switch (this) {
       case GatewayType.virtualPrivateGateway:
@@ -4355,7 +4355,7 @@ enum HasLogicalRedundancy {
   no,
 }
 
-extension HasLogicalRedundancyValue on HasLogicalRedundancy {
+extension HasLogicalRedundancyValueExtension on HasLogicalRedundancy {
   String toValue() {
     switch (this) {
       case HasLogicalRedundancy.unknown:
@@ -4506,7 +4506,7 @@ enum InterconnectState {
   unknown,
 }
 
-extension InterconnectStateValue on InterconnectState {
+extension InterconnectStateValueExtension on InterconnectState {
   String toValue() {
     switch (this) {
       case InterconnectState.requested:
@@ -4708,7 +4708,7 @@ enum LagState {
   unknown,
 }
 
-extension LagStateValue on LagState {
+extension LagStateValueExtension on LagState {
   String toValue() {
     switch (this) {
       case LagState.requested:
@@ -4820,7 +4820,7 @@ enum LoaContentType {
   applicationPdf,
 }
 
-extension LoaContentTypeValue on LoaContentType {
+extension LoaContentTypeValueExtension on LoaContentType {
   String toValue() {
     switch (this) {
       case LoaContentType.applicationPdf:
@@ -5796,7 +5796,7 @@ enum VirtualInterfaceState {
   unknown,
 }
 
-extension VirtualInterfaceStateValue on VirtualInterfaceState {
+extension VirtualInterfaceStateValueExtension on VirtualInterfaceState {
   String toValue() {
     switch (this) {
       case VirtualInterfaceState.confirming:

--- a/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
+++ b/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
@@ -2730,7 +2730,7 @@ enum AddressFamily {
   ipv6,
 }
 
-extension on AddressFamily {
+extension AddressFamilyValue on AddressFamily {
   String toValue() {
     switch (this) {
       case AddressFamily.ipv4:
@@ -2741,7 +2741,7 @@ extension on AddressFamily {
   }
 }
 
-extension on String {
+extension AddressFamilyFromString on String {
   AddressFamily toAddressFamily() {
     switch (this) {
       case 'ipv4':
@@ -2901,7 +2901,7 @@ enum BGPPeerState {
   deleted,
 }
 
-extension on BGPPeerState {
+extension BGPPeerStateValue on BGPPeerState {
   String toValue() {
     switch (this) {
       case BGPPeerState.verifying:
@@ -2918,7 +2918,7 @@ extension on BGPPeerState {
   }
 }
 
-extension on String {
+extension BGPPeerStateFromString on String {
   BGPPeerState toBGPPeerState() {
     switch (this) {
       case 'verifying':
@@ -2942,7 +2942,7 @@ enum BGPStatus {
   unknown,
 }
 
-extension on BGPStatus {
+extension BGPStatusValue on BGPStatus {
   String toValue() {
     switch (this) {
       case BGPStatus.up:
@@ -2955,7 +2955,7 @@ extension on BGPStatus {
   }
 }
 
-extension on String {
+extension BGPStatusFromString on String {
   BGPStatus toBGPStatus() {
     switch (this) {
       case 'up':
@@ -3348,7 +3348,7 @@ enum ConnectionState {
   unknown,
 }
 
-extension on ConnectionState {
+extension ConnectionStateValue on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.ordering:
@@ -3373,7 +3373,7 @@ extension on ConnectionState {
   }
 }
 
-extension on String {
+extension ConnectionStateFromString on String {
   ConnectionState toConnectionState() {
     switch (this) {
       case 'ordering':
@@ -4068,7 +4068,8 @@ enum DirectConnectGatewayAssociationProposalState {
   deleted,
 }
 
-extension on DirectConnectGatewayAssociationProposalState {
+extension DirectConnectGatewayAssociationProposalStateValue
+    on DirectConnectGatewayAssociationProposalState {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayAssociationProposalState.requested:
@@ -4081,7 +4082,7 @@ extension on DirectConnectGatewayAssociationProposalState {
   }
 }
 
-extension on String {
+extension DirectConnectGatewayAssociationProposalStateFromString on String {
   DirectConnectGatewayAssociationProposalState
       toDirectConnectGatewayAssociationProposalState() {
     switch (this) {
@@ -4105,7 +4106,8 @@ enum DirectConnectGatewayAssociationState {
   updating,
 }
 
-extension on DirectConnectGatewayAssociationState {
+extension DirectConnectGatewayAssociationStateValue
+    on DirectConnectGatewayAssociationState {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayAssociationState.associating:
@@ -4122,7 +4124,7 @@ extension on DirectConnectGatewayAssociationState {
   }
 }
 
-extension on String {
+extension DirectConnectGatewayAssociationStateFromString on String {
   DirectConnectGatewayAssociationState
       toDirectConnectGatewayAssociationState() {
     switch (this) {
@@ -4218,7 +4220,8 @@ enum DirectConnectGatewayAttachmentState {
   detached,
 }
 
-extension on DirectConnectGatewayAttachmentState {
+extension DirectConnectGatewayAttachmentStateValue
+    on DirectConnectGatewayAttachmentState {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayAttachmentState.attaching:
@@ -4233,7 +4236,7 @@ extension on DirectConnectGatewayAttachmentState {
   }
 }
 
-extension on String {
+extension DirectConnectGatewayAttachmentStateFromString on String {
   DirectConnectGatewayAttachmentState toDirectConnectGatewayAttachmentState() {
     switch (this) {
       case 'attaching':
@@ -4255,7 +4258,8 @@ enum DirectConnectGatewayAttachmentType {
   privateVirtualInterface,
 }
 
-extension on DirectConnectGatewayAttachmentType {
+extension DirectConnectGatewayAttachmentTypeValue
+    on DirectConnectGatewayAttachmentType {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayAttachmentType.transitVirtualInterface:
@@ -4266,7 +4270,7 @@ extension on DirectConnectGatewayAttachmentType {
   }
 }
 
-extension on String {
+extension DirectConnectGatewayAttachmentTypeFromString on String {
   DirectConnectGatewayAttachmentType toDirectConnectGatewayAttachmentType() {
     switch (this) {
       case 'TransitVirtualInterface':
@@ -4286,7 +4290,7 @@ enum DirectConnectGatewayState {
   deleted,
 }
 
-extension on DirectConnectGatewayState {
+extension DirectConnectGatewayStateValue on DirectConnectGatewayState {
   String toValue() {
     switch (this) {
       case DirectConnectGatewayState.pending:
@@ -4301,7 +4305,7 @@ extension on DirectConnectGatewayState {
   }
 }
 
-extension on String {
+extension DirectConnectGatewayStateFromString on String {
   DirectConnectGatewayState toDirectConnectGatewayState() {
     switch (this) {
       case 'pending':
@@ -4322,7 +4326,7 @@ enum GatewayType {
   transitGateway,
 }
 
-extension on GatewayType {
+extension GatewayTypeValue on GatewayType {
   String toValue() {
     switch (this) {
       case GatewayType.virtualPrivateGateway:
@@ -4333,7 +4337,7 @@ extension on GatewayType {
   }
 }
 
-extension on String {
+extension GatewayTypeFromString on String {
   GatewayType toGatewayType() {
     switch (this) {
       case 'virtualPrivateGateway':
@@ -4351,7 +4355,7 @@ enum HasLogicalRedundancy {
   no,
 }
 
-extension on HasLogicalRedundancy {
+extension HasLogicalRedundancyValue on HasLogicalRedundancy {
   String toValue() {
     switch (this) {
       case HasLogicalRedundancy.unknown:
@@ -4364,7 +4368,7 @@ extension on HasLogicalRedundancy {
   }
 }
 
-extension on String {
+extension HasLogicalRedundancyFromString on String {
   HasLogicalRedundancy toHasLogicalRedundancy() {
     switch (this) {
       case 'unknown':
@@ -4502,7 +4506,7 @@ enum InterconnectState {
   unknown,
 }
 
-extension on InterconnectState {
+extension InterconnectStateValue on InterconnectState {
   String toValue() {
     switch (this) {
       case InterconnectState.requested:
@@ -4523,7 +4527,7 @@ extension on InterconnectState {
   }
 }
 
-extension on String {
+extension InterconnectStateFromString on String {
   InterconnectState toInterconnectState() {
     switch (this) {
       case 'requested':
@@ -4704,7 +4708,7 @@ enum LagState {
   unknown,
 }
 
-extension on LagState {
+extension LagStateValue on LagState {
   String toValue() {
     switch (this) {
       case LagState.requested:
@@ -4725,7 +4729,7 @@ extension on LagState {
   }
 }
 
-extension on String {
+extension LagStateFromString on String {
   LagState toLagState() {
     switch (this) {
       case 'requested':
@@ -4816,7 +4820,7 @@ enum LoaContentType {
   applicationPdf,
 }
 
-extension on LoaContentType {
+extension LoaContentTypeValue on LoaContentType {
   String toValue() {
     switch (this) {
       case LoaContentType.applicationPdf:
@@ -4825,7 +4829,7 @@ extension on LoaContentType {
   }
 }
 
-extension on String {
+extension LoaContentTypeFromString on String {
   LoaContentType toLoaContentType() {
     switch (this) {
       case 'application/pdf':
@@ -5792,7 +5796,7 @@ enum VirtualInterfaceState {
   unknown,
 }
 
-extension on VirtualInterfaceState {
+extension VirtualInterfaceStateValue on VirtualInterfaceState {
   String toValue() {
     switch (this) {
       case VirtualInterfaceState.confirming:
@@ -5817,7 +5821,7 @@ extension on VirtualInterfaceState {
   }
 }
 
-extension on String {
+extension VirtualInterfaceStateFromString on String {
   VirtualInterfaceState toVirtualInterfaceState() {
     switch (this) {
       case 'confirming':

--- a/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
+++ b/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
@@ -1400,7 +1400,7 @@ enum AgentStatus {
   shutdown,
 }
 
-extension AgentStatusValue on AgentStatus {
+extension AgentStatusValueExtension on AgentStatus {
   String toValue() {
     switch (this) {
       case AgentStatus.healthy:
@@ -1480,7 +1480,7 @@ enum BatchDeleteImportDataErrorCode {
   overLimit,
 }
 
-extension BatchDeleteImportDataErrorCodeValue
+extension BatchDeleteImportDataErrorCodeValueExtension
     on BatchDeleteImportDataErrorCode {
   String toValue() {
     switch (this) {
@@ -1535,7 +1535,7 @@ enum ConfigurationItemType {
   application,
 }
 
-extension ConfigurationItemTypeValue on ConfigurationItemType {
+extension ConfigurationItemTypeValueExtension on ConfigurationItemType {
   String toValue() {
     switch (this) {
       case ConfigurationItemType.server:
@@ -1756,7 +1756,7 @@ enum ContinuousExportStatus {
   inactive,
 }
 
-extension ContinuousExportStatusValue on ContinuousExportStatus {
+extension ContinuousExportStatusValueExtension on ContinuousExportStatus {
   String toValue() {
     switch (this) {
       case ContinuousExportStatus.startInProgress:
@@ -1914,7 +1914,7 @@ enum DataSource {
   agent,
 }
 
-extension DataSourceValue on DataSource {
+extension DataSourceValueExtension on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.agent:
@@ -2143,7 +2143,7 @@ enum ExportDataFormat {
   graphml,
 }
 
-extension ExportDataFormatValue on ExportDataFormat {
+extension ExportDataFormatValueExtension on ExportDataFormat {
   String toValue() {
     switch (this) {
       case ExportDataFormat.csv:
@@ -2268,7 +2268,7 @@ enum ExportStatus {
   inProgress,
 }
 
-extension ExportStatusValue on ExportStatus {
+extension ExportStatusValueExtension on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.failed:
@@ -2395,7 +2395,7 @@ enum ImportStatus {
   internalError,
 }
 
-extension ImportStatusValue on ImportStatus {
+extension ImportStatusValueExtension on ImportStatus {
   String toValue() {
     switch (this) {
       case ImportStatus.importInProgress:
@@ -2595,7 +2595,7 @@ enum ImportTaskFilterName {
   name,
 }
 
-extension ImportTaskFilterNameValue on ImportTaskFilterName {
+extension ImportTaskFilterNameValueExtension on ImportTaskFilterName {
   String toValue() {
     switch (this) {
       case ImportTaskFilterName.importTaskId:
@@ -2936,7 +2936,7 @@ enum OrderString {
   desc,
 }
 
-extension OrderStringValue on OrderString {
+extension OrderStringValueExtension on OrderString {
   String toValue() {
     switch (this) {
       case OrderString.asc:

--- a/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
+++ b/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
@@ -1400,7 +1400,7 @@ enum AgentStatus {
   shutdown,
 }
 
-extension on AgentStatus {
+extension AgentStatusValue on AgentStatus {
   String toValue() {
     switch (this) {
       case AgentStatus.healthy:
@@ -1419,7 +1419,7 @@ extension on AgentStatus {
   }
 }
 
-extension on String {
+extension AgentStatusFromString on String {
   AgentStatus toAgentStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -1480,7 +1480,8 @@ enum BatchDeleteImportDataErrorCode {
   overLimit,
 }
 
-extension on BatchDeleteImportDataErrorCode {
+extension BatchDeleteImportDataErrorCodeValue
+    on BatchDeleteImportDataErrorCode {
   String toValue() {
     switch (this) {
       case BatchDeleteImportDataErrorCode.notFound:
@@ -1493,7 +1494,7 @@ extension on BatchDeleteImportDataErrorCode {
   }
 }
 
-extension on String {
+extension BatchDeleteImportDataErrorCodeFromString on String {
   BatchDeleteImportDataErrorCode toBatchDeleteImportDataErrorCode() {
     switch (this) {
       case 'NOT_FOUND':
@@ -1534,7 +1535,7 @@ enum ConfigurationItemType {
   application,
 }
 
-extension on ConfigurationItemType {
+extension ConfigurationItemTypeValue on ConfigurationItemType {
   String toValue() {
     switch (this) {
       case ConfigurationItemType.server:
@@ -1549,7 +1550,7 @@ extension on ConfigurationItemType {
   }
 }
 
-extension on String {
+extension ConfigurationItemTypeFromString on String {
   ConfigurationItemType toConfigurationItemType() {
     switch (this) {
       case 'SERVER':
@@ -1755,7 +1756,7 @@ enum ContinuousExportStatus {
   inactive,
 }
 
-extension on ContinuousExportStatus {
+extension ContinuousExportStatusValue on ContinuousExportStatus {
   String toValue() {
     switch (this) {
       case ContinuousExportStatus.startInProgress:
@@ -1776,7 +1777,7 @@ extension on ContinuousExportStatus {
   }
 }
 
-extension on String {
+extension ContinuousExportStatusFromString on String {
   ContinuousExportStatus toContinuousExportStatus() {
     switch (this) {
       case 'START_IN_PROGRESS':
@@ -1913,7 +1914,7 @@ enum DataSource {
   agent,
 }
 
-extension on DataSource {
+extension DataSourceValue on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.agent:
@@ -1922,7 +1923,7 @@ extension on DataSource {
   }
 }
 
-extension on String {
+extension DataSourceFromString on String {
   DataSource toDataSource() {
     switch (this) {
       case 'AGENT':
@@ -2142,7 +2143,7 @@ enum ExportDataFormat {
   graphml,
 }
 
-extension on ExportDataFormat {
+extension ExportDataFormatValue on ExportDataFormat {
   String toValue() {
     switch (this) {
       case ExportDataFormat.csv:
@@ -2153,7 +2154,7 @@ extension on ExportDataFormat {
   }
 }
 
-extension on String {
+extension ExportDataFormatFromString on String {
   ExportDataFormat toExportDataFormat() {
     switch (this) {
       case 'CSV':
@@ -2267,7 +2268,7 @@ enum ExportStatus {
   inProgress,
 }
 
-extension on ExportStatus {
+extension ExportStatusValue on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.failed:
@@ -2280,7 +2281,7 @@ extension on ExportStatus {
   }
 }
 
-extension on String {
+extension ExportStatusFromString on String {
   ExportStatus toExportStatus() {
     switch (this) {
       case 'FAILED':
@@ -2394,7 +2395,7 @@ enum ImportStatus {
   internalError,
 }
 
-extension on ImportStatus {
+extension ImportStatusValue on ImportStatus {
   String toValue() {
     switch (this) {
       case ImportStatus.importInProgress:
@@ -2423,7 +2424,7 @@ extension on ImportStatus {
   }
 }
 
-extension on String {
+extension ImportStatusFromString on String {
   ImportStatus toImportStatus() {
     switch (this) {
       case 'IMPORT_IN_PROGRESS':
@@ -2594,7 +2595,7 @@ enum ImportTaskFilterName {
   name,
 }
 
-extension on ImportTaskFilterName {
+extension ImportTaskFilterNameValue on ImportTaskFilterName {
   String toValue() {
     switch (this) {
       case ImportTaskFilterName.importTaskId:
@@ -2607,7 +2608,7 @@ extension on ImportTaskFilterName {
   }
 }
 
-extension on String {
+extension ImportTaskFilterNameFromString on String {
   ImportTaskFilterName toImportTaskFilterName() {
     switch (this) {
       case 'IMPORT_TASK_ID':
@@ -2935,7 +2936,7 @@ enum OrderString {
   desc,
 }
 
-extension on OrderString {
+extension OrderStringValue on OrderString {
   String toValue() {
     switch (this) {
       case OrderString.asc:
@@ -2946,7 +2947,7 @@ extension on OrderString {
   }
 }
 
-extension on String {
+extension OrderStringFromString on String {
   OrderString toOrderString() {
     switch (this) {
       case 'ASC':

--- a/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
+++ b/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
@@ -747,7 +747,7 @@ enum EventSourceValues {
   managedCwe,
 }
 
-extension on EventSourceValues {
+extension EventSourceValuesValue on EventSourceValues {
   String toValue() {
     switch (this) {
       case EventSourceValues.managedCwe:
@@ -756,7 +756,7 @@ extension on EventSourceValues {
   }
 }
 
-extension on String {
+extension EventSourceValuesFromString on String {
   EventSourceValues toEventSourceValues() {
     switch (this) {
       case 'MANAGED_CWE':
@@ -770,7 +770,7 @@ enum EventTypeValues {
   shareSnapshot,
 }
 
-extension on EventTypeValues {
+extension EventTypeValuesValue on EventTypeValues {
   String toValue() {
     switch (this) {
       case EventTypeValues.shareSnapshot:
@@ -779,7 +779,7 @@ extension on EventTypeValues {
   }
 }
 
-extension on String {
+extension EventTypeValuesFromString on String {
   EventTypeValues toEventTypeValues() {
     switch (this) {
       case 'shareSnapshot':
@@ -878,7 +878,7 @@ enum GettablePolicyStateValues {
   error,
 }
 
-extension on GettablePolicyStateValues {
+extension GettablePolicyStateValuesValue on GettablePolicyStateValues {
   String toValue() {
     switch (this) {
       case GettablePolicyStateValues.enabled:
@@ -891,7 +891,7 @@ extension on GettablePolicyStateValues {
   }
 }
 
-extension on String {
+extension GettablePolicyStateValuesFromString on String {
   GettablePolicyStateValues toGettablePolicyStateValues() {
     switch (this) {
       case 'ENABLED':
@@ -909,7 +909,7 @@ enum IntervalUnitValues {
   hours,
 }
 
-extension on IntervalUnitValues {
+extension IntervalUnitValuesValue on IntervalUnitValues {
   String toValue() {
     switch (this) {
       case IntervalUnitValues.hours:
@@ -918,7 +918,7 @@ extension on IntervalUnitValues {
   }
 }
 
-extension on String {
+extension IntervalUnitValuesFromString on String {
   IntervalUnitValues toIntervalUnitValues() {
     switch (this) {
       case 'HOURS':
@@ -1203,7 +1203,7 @@ enum PolicyTypeValues {
   eventBasedPolicy,
 }
 
-extension on PolicyTypeValues {
+extension PolicyTypeValuesValue on PolicyTypeValues {
   String toValue() {
     switch (this) {
       case PolicyTypeValues.ebsSnapshotManagement:
@@ -1216,7 +1216,7 @@ extension on PolicyTypeValues {
   }
 }
 
-extension on String {
+extension PolicyTypeValuesFromString on String {
   PolicyTypeValues toPolicyTypeValues() {
     switch (this) {
       case 'EBS_SNAPSHOT_MANAGEMENT':
@@ -1235,7 +1235,7 @@ enum ResourceTypeValues {
   instance,
 }
 
-extension on ResourceTypeValues {
+extension ResourceTypeValuesValue on ResourceTypeValues {
   String toValue() {
     switch (this) {
       case ResourceTypeValues.volume:
@@ -1246,7 +1246,7 @@ extension on ResourceTypeValues {
   }
 }
 
-extension on String {
+extension ResourceTypeValuesFromString on String {
   ResourceTypeValues toResourceTypeValues() {
     switch (this) {
       case 'VOLUME':
@@ -1304,7 +1304,7 @@ enum RetentionIntervalUnitValues {
   years,
 }
 
-extension on RetentionIntervalUnitValues {
+extension RetentionIntervalUnitValuesValue on RetentionIntervalUnitValues {
   String toValue() {
     switch (this) {
       case RetentionIntervalUnitValues.days:
@@ -1319,7 +1319,7 @@ extension on RetentionIntervalUnitValues {
   }
 }
 
-extension on String {
+extension RetentionIntervalUnitValuesFromString on String {
   RetentionIntervalUnitValues toRetentionIntervalUnitValues() {
     switch (this) {
       case 'DAYS':
@@ -1444,7 +1444,7 @@ enum SettablePolicyStateValues {
   disabled,
 }
 
-extension on SettablePolicyStateValues {
+extension SettablePolicyStateValuesValue on SettablePolicyStateValues {
   String toValue() {
     switch (this) {
       case SettablePolicyStateValues.enabled:
@@ -1455,7 +1455,7 @@ extension on SettablePolicyStateValues {
   }
 }
 
-extension on String {
+extension SettablePolicyStateValuesFromString on String {
   SettablePolicyStateValues toSettablePolicyStateValues() {
     switch (this) {
       case 'ENABLED':

--- a/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
+++ b/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
@@ -747,7 +747,7 @@ enum EventSourceValues {
   managedCwe,
 }
 
-extension EventSourceValuesValue on EventSourceValues {
+extension EventSourceValuesValueExtension on EventSourceValues {
   String toValue() {
     switch (this) {
       case EventSourceValues.managedCwe:
@@ -770,7 +770,7 @@ enum EventTypeValues {
   shareSnapshot,
 }
 
-extension EventTypeValuesValue on EventTypeValues {
+extension EventTypeValuesValueExtension on EventTypeValues {
   String toValue() {
     switch (this) {
       case EventTypeValues.shareSnapshot:
@@ -878,7 +878,7 @@ enum GettablePolicyStateValues {
   error,
 }
 
-extension GettablePolicyStateValuesValue on GettablePolicyStateValues {
+extension GettablePolicyStateValuesValueExtension on GettablePolicyStateValues {
   String toValue() {
     switch (this) {
       case GettablePolicyStateValues.enabled:
@@ -909,7 +909,7 @@ enum IntervalUnitValues {
   hours,
 }
 
-extension IntervalUnitValuesValue on IntervalUnitValues {
+extension IntervalUnitValuesValueExtension on IntervalUnitValues {
   String toValue() {
     switch (this) {
       case IntervalUnitValues.hours:
@@ -1203,7 +1203,7 @@ enum PolicyTypeValues {
   eventBasedPolicy,
 }
 
-extension PolicyTypeValuesValue on PolicyTypeValues {
+extension PolicyTypeValuesValueExtension on PolicyTypeValues {
   String toValue() {
     switch (this) {
       case PolicyTypeValues.ebsSnapshotManagement:
@@ -1235,7 +1235,7 @@ enum ResourceTypeValues {
   instance,
 }
 
-extension ResourceTypeValuesValue on ResourceTypeValues {
+extension ResourceTypeValuesValueExtension on ResourceTypeValues {
   String toValue() {
     switch (this) {
       case ResourceTypeValues.volume:
@@ -1304,7 +1304,8 @@ enum RetentionIntervalUnitValues {
   years,
 }
 
-extension RetentionIntervalUnitValuesValue on RetentionIntervalUnitValues {
+extension RetentionIntervalUnitValuesValueExtension
+    on RetentionIntervalUnitValues {
   String toValue() {
     switch (this) {
       case RetentionIntervalUnitValues.days:
@@ -1444,7 +1445,7 @@ enum SettablePolicyStateValues {
   disabled,
 }
 
-extension SettablePolicyStateValuesValue on SettablePolicyStateValues {
+extension SettablePolicyStateValuesValueExtension on SettablePolicyStateValues {
   String toValue() {
     switch (this) {
       case SettablePolicyStateValues.enabled:

--- a/generated/aws_dms_api/lib/dms-2016-01-01.dart
+++ b/generated/aws_dms_api/lib/dms-2016-01-01.dart
@@ -3771,7 +3771,7 @@ enum AuthMechanismValue {
   scramSha_1,
 }
 
-extension AuthMechanismValueValue on AuthMechanismValue {
+extension AuthMechanismValueValueExtension on AuthMechanismValue {
   String toValue() {
     switch (this) {
       case AuthMechanismValue.$default:
@@ -3803,7 +3803,7 @@ enum AuthTypeValue {
   password,
 }
 
-extension AuthTypeValueValue on AuthTypeValue {
+extension AuthTypeValueValueExtension on AuthTypeValue {
   String toValue() {
     switch (this) {
       case AuthTypeValue.no:
@@ -3939,7 +3939,7 @@ enum CharLengthSemantics {
   byte,
 }
 
-extension CharLengthSemanticsValue on CharLengthSemantics {
+extension CharLengthSemanticsValueExtension on CharLengthSemantics {
   String toValue() {
     switch (this) {
       case CharLengthSemantics.$default:
@@ -3971,7 +3971,7 @@ enum CompressionTypeValue {
   gzip,
 }
 
-extension CompressionTypeValueValue on CompressionTypeValue {
+extension CompressionTypeValueValueExtension on CompressionTypeValue {
   String toValue() {
     switch (this) {
       case CompressionTypeValue.none:
@@ -4151,7 +4151,7 @@ enum DataFormatValue {
   parquet,
 }
 
-extension DataFormatValueValue on DataFormatValue {
+extension DataFormatValueValueExtension on DataFormatValue {
   String toValue() {
     switch (this) {
       case DataFormatValue.csv:
@@ -4181,7 +4181,8 @@ enum DatePartitionDelimiterValue {
   none,
 }
 
-extension DatePartitionDelimiterValueValue on DatePartitionDelimiterValue {
+extension DatePartitionDelimiterValueValueExtension
+    on DatePartitionDelimiterValue {
   String toValue() {
     switch (this) {
       case DatePartitionDelimiterValue.slash:
@@ -4220,7 +4221,8 @@ enum DatePartitionSequenceValue {
   ddmmyyyy,
 }
 
-extension DatePartitionSequenceValueValue on DatePartitionSequenceValue {
+extension DatePartitionSequenceValueValueExtension
+    on DatePartitionSequenceValue {
   String toValue() {
     switch (this) {
       case DatePartitionSequenceValue.yyyymmdd:
@@ -4965,7 +4967,7 @@ enum DmsSslModeValue {
   verifyFull,
 }
 
-extension DmsSslModeValueValue on DmsSslModeValue {
+extension DmsSslModeValueValueExtension on DmsSslModeValue {
   String toValue() {
     switch (this) {
       case DmsSslModeValue.none:
@@ -5237,7 +5239,7 @@ enum EncodingTypeValue {
   rleDictionary,
 }
 
-extension EncodingTypeValueValue on EncodingTypeValue {
+extension EncodingTypeValueValueExtension on EncodingTypeValue {
   String toValue() {
     switch (this) {
       case EncodingTypeValue.plain:
@@ -5269,7 +5271,7 @@ enum EncryptionModeValue {
   sseKms,
 }
 
-extension EncryptionModeValueValue on EncryptionModeValue {
+extension EncryptionModeValueValueExtension on EncryptionModeValue {
   String toValue() {
     switch (this) {
       case EncryptionModeValue.sseS3:
@@ -6133,7 +6135,7 @@ enum MessageFormatValue {
   jsonUnformatted,
 }
 
-extension MessageFormatValueValue on MessageFormatValue {
+extension MessageFormatValueValueExtension on MessageFormatValue {
   String toValue() {
     switch (this) {
       case MessageFormatValue.json:
@@ -6311,7 +6313,7 @@ enum MigrationTypeValue {
   fullLoadAndCdc,
 }
 
-extension MigrationTypeValueValue on MigrationTypeValue {
+extension MigrationTypeValueValueExtension on MigrationTypeValue {
   String toValue() {
     switch (this) {
       case MigrationTypeValue.fullLoad:
@@ -6849,7 +6851,7 @@ enum NestingLevelValue {
   one,
 }
 
-extension NestingLevelValueValue on NestingLevelValue {
+extension NestingLevelValueValueExtension on NestingLevelValue {
   String toValue() {
     switch (this) {
       case NestingLevelValue.none:
@@ -7371,7 +7373,7 @@ enum ParquetVersionValue {
   parquet_2_0,
 }
 
-extension ParquetVersionValueValue on ParquetVersionValue {
+extension ParquetVersionValueValueExtension on ParquetVersionValue {
   String toValue() {
     switch (this) {
       case ParquetVersionValue.parquet_1_0:
@@ -8035,7 +8037,8 @@ enum RefreshSchemasStatusTypeValue {
   refreshing,
 }
 
-extension RefreshSchemasStatusTypeValueValue on RefreshSchemasStatusTypeValue {
+extension RefreshSchemasStatusTypeValueValueExtension
+    on RefreshSchemasStatusTypeValue {
   String toValue() {
     switch (this) {
       case RefreshSchemasStatusTypeValue.successful:
@@ -8066,7 +8069,7 @@ enum ReleaseStatusValues {
   beta,
 }
 
-extension ReleaseStatusValuesValue on ReleaseStatusValues {
+extension ReleaseStatusValuesValueExtension on ReleaseStatusValues {
   String toValue() {
     switch (this) {
       case ReleaseStatusValues.beta:
@@ -8090,7 +8093,7 @@ enum ReloadOptionValue {
   validateOnly,
 }
 
-extension ReloadOptionValueValue on ReloadOptionValue {
+extension ReloadOptionValueValueExtension on ReloadOptionValue {
   String toValue() {
     switch (this) {
       case ReloadOptionValue.dataReload:
@@ -8140,7 +8143,8 @@ enum ReplicationEndpointTypeValue {
   target,
 }
 
-extension ReplicationEndpointTypeValueValue on ReplicationEndpointTypeValue {
+extension ReplicationEndpointTypeValueValueExtension
+    on ReplicationEndpointTypeValue {
   String toValue() {
     switch (this) {
       case ReplicationEndpointTypeValue.source:
@@ -9679,7 +9683,7 @@ enum SafeguardPolicy {
   sharedAutomaticTruncation,
 }
 
-extension SafeguardPolicyValue on SafeguardPolicy {
+extension SafeguardPolicyValueExtension on SafeguardPolicy {
   String toValue() {
     switch (this) {
       case SafeguardPolicy.relyOnSqlServerReplicationAgent:
@@ -9710,7 +9714,7 @@ enum SourceType {
   replicationInstance,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.replicationInstance:
@@ -9791,7 +9795,8 @@ enum StartReplicationTaskTypeValue {
   reloadTarget,
 }
 
-extension StartReplicationTaskTypeValueValue on StartReplicationTaskTypeValue {
+extension StartReplicationTaskTypeValueValueExtension
+    on StartReplicationTaskTypeValue {
   String toValue() {
     switch (this) {
       case StartReplicationTaskTypeValue.startReplication:
@@ -10241,7 +10246,7 @@ enum TargetDbType {
   multipleDatabases,
 }
 
-extension TargetDbTypeValue on TargetDbType {
+extension TargetDbTypeValueExtension on TargetDbType {
   String toValue() {
     switch (this) {
       case TargetDbType.specificDatabase:

--- a/generated/aws_dms_api/lib/dms-2016-01-01.dart
+++ b/generated/aws_dms_api/lib/dms-2016-01-01.dart
@@ -3771,7 +3771,7 @@ enum AuthMechanismValue {
   scramSha_1,
 }
 
-extension on AuthMechanismValue {
+extension AuthMechanismValueValue on AuthMechanismValue {
   String toValue() {
     switch (this) {
       case AuthMechanismValue.$default:
@@ -3784,7 +3784,7 @@ extension on AuthMechanismValue {
   }
 }
 
-extension on String {
+extension AuthMechanismValueFromString on String {
   AuthMechanismValue toAuthMechanismValue() {
     switch (this) {
       case 'default':
@@ -3803,7 +3803,7 @@ enum AuthTypeValue {
   password,
 }
 
-extension on AuthTypeValue {
+extension AuthTypeValueValue on AuthTypeValue {
   String toValue() {
     switch (this) {
       case AuthTypeValue.no:
@@ -3814,7 +3814,7 @@ extension on AuthTypeValue {
   }
 }
 
-extension on String {
+extension AuthTypeValueFromString on String {
   AuthTypeValue toAuthTypeValue() {
     switch (this) {
       case 'no':
@@ -3939,7 +3939,7 @@ enum CharLengthSemantics {
   byte,
 }
 
-extension on CharLengthSemantics {
+extension CharLengthSemanticsValue on CharLengthSemantics {
   String toValue() {
     switch (this) {
       case CharLengthSemantics.$default:
@@ -3952,7 +3952,7 @@ extension on CharLengthSemantics {
   }
 }
 
-extension on String {
+extension CharLengthSemanticsFromString on String {
   CharLengthSemantics toCharLengthSemantics() {
     switch (this) {
       case 'default':
@@ -3971,7 +3971,7 @@ enum CompressionTypeValue {
   gzip,
 }
 
-extension on CompressionTypeValue {
+extension CompressionTypeValueValue on CompressionTypeValue {
   String toValue() {
     switch (this) {
       case CompressionTypeValue.none:
@@ -3982,7 +3982,7 @@ extension on CompressionTypeValue {
   }
 }
 
-extension on String {
+extension CompressionTypeValueFromString on String {
   CompressionTypeValue toCompressionTypeValue() {
     switch (this) {
       case 'none':
@@ -4151,7 +4151,7 @@ enum DataFormatValue {
   parquet,
 }
 
-extension on DataFormatValue {
+extension DataFormatValueValue on DataFormatValue {
   String toValue() {
     switch (this) {
       case DataFormatValue.csv:
@@ -4162,7 +4162,7 @@ extension on DataFormatValue {
   }
 }
 
-extension on String {
+extension DataFormatValueFromString on String {
   DataFormatValue toDataFormatValue() {
     switch (this) {
       case 'csv':
@@ -4181,7 +4181,7 @@ enum DatePartitionDelimiterValue {
   none,
 }
 
-extension on DatePartitionDelimiterValue {
+extension DatePartitionDelimiterValueValue on DatePartitionDelimiterValue {
   String toValue() {
     switch (this) {
       case DatePartitionDelimiterValue.slash:
@@ -4196,7 +4196,7 @@ extension on DatePartitionDelimiterValue {
   }
 }
 
-extension on String {
+extension DatePartitionDelimiterValueFromString on String {
   DatePartitionDelimiterValue toDatePartitionDelimiterValue() {
     switch (this) {
       case 'SLASH':
@@ -4220,7 +4220,7 @@ enum DatePartitionSequenceValue {
   ddmmyyyy,
 }
 
-extension on DatePartitionSequenceValue {
+extension DatePartitionSequenceValueValue on DatePartitionSequenceValue {
   String toValue() {
     switch (this) {
       case DatePartitionSequenceValue.yyyymmdd:
@@ -4237,7 +4237,7 @@ extension on DatePartitionSequenceValue {
   }
 }
 
-extension on String {
+extension DatePartitionSequenceValueFromString on String {
   DatePartitionSequenceValue toDatePartitionSequenceValue() {
     switch (this) {
       case 'YYYYMMDD':
@@ -4965,7 +4965,7 @@ enum DmsSslModeValue {
   verifyFull,
 }
 
-extension on DmsSslModeValue {
+extension DmsSslModeValueValue on DmsSslModeValue {
   String toValue() {
     switch (this) {
       case DmsSslModeValue.none:
@@ -4980,7 +4980,7 @@ extension on DmsSslModeValue {
   }
 }
 
-extension on String {
+extension DmsSslModeValueFromString on String {
   DmsSslModeValue toDmsSslModeValue() {
     switch (this) {
       case 'none':
@@ -5237,7 +5237,7 @@ enum EncodingTypeValue {
   rleDictionary,
 }
 
-extension on EncodingTypeValue {
+extension EncodingTypeValueValue on EncodingTypeValue {
   String toValue() {
     switch (this) {
       case EncodingTypeValue.plain:
@@ -5250,7 +5250,7 @@ extension on EncodingTypeValue {
   }
 }
 
-extension on String {
+extension EncodingTypeValueFromString on String {
   EncodingTypeValue toEncodingTypeValue() {
     switch (this) {
       case 'plain':
@@ -5269,7 +5269,7 @@ enum EncryptionModeValue {
   sseKms,
 }
 
-extension on EncryptionModeValue {
+extension EncryptionModeValueValue on EncryptionModeValue {
   String toValue() {
     switch (this) {
       case EncryptionModeValue.sseS3:
@@ -5280,7 +5280,7 @@ extension on EncryptionModeValue {
   }
 }
 
-extension on String {
+extension EncryptionModeValueFromString on String {
   EncryptionModeValue toEncryptionModeValue() {
     switch (this) {
       case 'sse-s3':
@@ -6133,7 +6133,7 @@ enum MessageFormatValue {
   jsonUnformatted,
 }
 
-extension on MessageFormatValue {
+extension MessageFormatValueValue on MessageFormatValue {
   String toValue() {
     switch (this) {
       case MessageFormatValue.json:
@@ -6144,7 +6144,7 @@ extension on MessageFormatValue {
   }
 }
 
-extension on String {
+extension MessageFormatValueFromString on String {
   MessageFormatValue toMessageFormatValue() {
     switch (this) {
       case 'json':
@@ -6311,7 +6311,7 @@ enum MigrationTypeValue {
   fullLoadAndCdc,
 }
 
-extension on MigrationTypeValue {
+extension MigrationTypeValueValue on MigrationTypeValue {
   String toValue() {
     switch (this) {
       case MigrationTypeValue.fullLoad:
@@ -6324,7 +6324,7 @@ extension on MigrationTypeValue {
   }
 }
 
-extension on String {
+extension MigrationTypeValueFromString on String {
   MigrationTypeValue toMigrationTypeValue() {
     switch (this) {
       case 'full-load':
@@ -6849,7 +6849,7 @@ enum NestingLevelValue {
   one,
 }
 
-extension on NestingLevelValue {
+extension NestingLevelValueValue on NestingLevelValue {
   String toValue() {
     switch (this) {
       case NestingLevelValue.none:
@@ -6860,7 +6860,7 @@ extension on NestingLevelValue {
   }
 }
 
-extension on String {
+extension NestingLevelValueFromString on String {
   NestingLevelValue toNestingLevelValue() {
     switch (this) {
       case 'none':
@@ -7371,7 +7371,7 @@ enum ParquetVersionValue {
   parquet_2_0,
 }
 
-extension on ParquetVersionValue {
+extension ParquetVersionValueValue on ParquetVersionValue {
   String toValue() {
     switch (this) {
       case ParquetVersionValue.parquet_1_0:
@@ -7382,7 +7382,7 @@ extension on ParquetVersionValue {
   }
 }
 
-extension on String {
+extension ParquetVersionValueFromString on String {
   ParquetVersionValue toParquetVersionValue() {
     switch (this) {
       case 'parquet-1-0':
@@ -8035,7 +8035,7 @@ enum RefreshSchemasStatusTypeValue {
   refreshing,
 }
 
-extension on RefreshSchemasStatusTypeValue {
+extension RefreshSchemasStatusTypeValueValue on RefreshSchemasStatusTypeValue {
   String toValue() {
     switch (this) {
       case RefreshSchemasStatusTypeValue.successful:
@@ -8048,7 +8048,7 @@ extension on RefreshSchemasStatusTypeValue {
   }
 }
 
-extension on String {
+extension RefreshSchemasStatusTypeValueFromString on String {
   RefreshSchemasStatusTypeValue toRefreshSchemasStatusTypeValue() {
     switch (this) {
       case 'successful':
@@ -8066,7 +8066,7 @@ enum ReleaseStatusValues {
   beta,
 }
 
-extension on ReleaseStatusValues {
+extension ReleaseStatusValuesValue on ReleaseStatusValues {
   String toValue() {
     switch (this) {
       case ReleaseStatusValues.beta:
@@ -8075,7 +8075,7 @@ extension on ReleaseStatusValues {
   }
 }
 
-extension on String {
+extension ReleaseStatusValuesFromString on String {
   ReleaseStatusValues toReleaseStatusValues() {
     switch (this) {
       case 'beta':
@@ -8090,7 +8090,7 @@ enum ReloadOptionValue {
   validateOnly,
 }
 
-extension on ReloadOptionValue {
+extension ReloadOptionValueValue on ReloadOptionValue {
   String toValue() {
     switch (this) {
       case ReloadOptionValue.dataReload:
@@ -8101,7 +8101,7 @@ extension on ReloadOptionValue {
   }
 }
 
-extension on String {
+extension ReloadOptionValueFromString on String {
   ReloadOptionValue toReloadOptionValue() {
     switch (this) {
       case 'data-reload':
@@ -8140,7 +8140,7 @@ enum ReplicationEndpointTypeValue {
   target,
 }
 
-extension on ReplicationEndpointTypeValue {
+extension ReplicationEndpointTypeValueValue on ReplicationEndpointTypeValue {
   String toValue() {
     switch (this) {
       case ReplicationEndpointTypeValue.source:
@@ -8151,7 +8151,7 @@ extension on ReplicationEndpointTypeValue {
   }
 }
 
-extension on String {
+extension ReplicationEndpointTypeValueFromString on String {
   ReplicationEndpointTypeValue toReplicationEndpointTypeValue() {
     switch (this) {
       case 'source':
@@ -9679,7 +9679,7 @@ enum SafeguardPolicy {
   sharedAutomaticTruncation,
 }
 
-extension on SafeguardPolicy {
+extension SafeguardPolicyValue on SafeguardPolicy {
   String toValue() {
     switch (this) {
       case SafeguardPolicy.relyOnSqlServerReplicationAgent:
@@ -9692,7 +9692,7 @@ extension on SafeguardPolicy {
   }
 }
 
-extension on String {
+extension SafeguardPolicyFromString on String {
   SafeguardPolicy toSafeguardPolicy() {
     switch (this) {
       case 'rely-on-sql-server-replication-agent':
@@ -9710,7 +9710,7 @@ enum SourceType {
   replicationInstance,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.replicationInstance:
@@ -9719,7 +9719,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'replication-instance':
@@ -9791,7 +9791,7 @@ enum StartReplicationTaskTypeValue {
   reloadTarget,
 }
 
-extension on StartReplicationTaskTypeValue {
+extension StartReplicationTaskTypeValueValue on StartReplicationTaskTypeValue {
   String toValue() {
     switch (this) {
       case StartReplicationTaskTypeValue.startReplication:
@@ -9804,7 +9804,7 @@ extension on StartReplicationTaskTypeValue {
   }
 }
 
-extension on String {
+extension StartReplicationTaskTypeValueFromString on String {
   StartReplicationTaskTypeValue toStartReplicationTaskTypeValue() {
     switch (this) {
       case 'start-replication':
@@ -10241,7 +10241,7 @@ enum TargetDbType {
   multipleDatabases,
 }
 
-extension on TargetDbType {
+extension TargetDbTypeValue on TargetDbType {
   String toValue() {
     switch (this) {
       case TargetDbType.specificDatabase:
@@ -10252,7 +10252,7 @@ extension on TargetDbType {
   }
 }
 
-extension on String {
+extension TargetDbTypeFromString on String {
   TargetDbType toTargetDbType() {
     switch (this) {
       case 'specific-database':

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -3420,7 +3420,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -5488,7 +5488,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -3420,7 +3420,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -3431,7 +3431,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -5488,7 +5488,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -5507,7 +5507,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_ds_api/lib/ds-2015-04-16.dart
+++ b/generated/aws_ds_api/lib/ds-2015-04-16.dart
@@ -3447,7 +3447,7 @@ enum CertificateState {
   deregisterFailed,
 }
 
-extension on CertificateState {
+extension CertificateStateValue on CertificateState {
   String toValue() {
     switch (this) {
       case CertificateState.registering:
@@ -3466,7 +3466,7 @@ extension on CertificateState {
   }
 }
 
-extension on String {
+extension CertificateStateFromString on String {
   CertificateState toCertificateState() {
     switch (this) {
       case 'Registering':
@@ -3491,7 +3491,7 @@ enum CertificateType {
   clientLDAPS,
 }
 
-extension on CertificateType {
+extension CertificateTypeValue on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.clientCertAuth:
@@ -3502,7 +3502,7 @@ extension on CertificateType {
   }
 }
 
-extension on String {
+extension CertificateTypeFromString on String {
   CertificateType toCertificateType() {
     switch (this) {
       case 'ClientCertAuth':
@@ -3518,7 +3518,7 @@ enum ClientAuthenticationType {
   smartCard,
 }
 
-extension on ClientAuthenticationType {
+extension ClientAuthenticationTypeValue on ClientAuthenticationType {
   String toValue() {
     switch (this) {
       case ClientAuthenticationType.smartCard:
@@ -3527,7 +3527,7 @@ extension on ClientAuthenticationType {
   }
 }
 
-extension on String {
+extension ClientAuthenticationTypeFromString on String {
   ClientAuthenticationType toClientAuthenticationType() {
     switch (this) {
       case 'SmartCard':
@@ -4354,7 +4354,7 @@ enum DirectoryEdition {
   standard,
 }
 
-extension on DirectoryEdition {
+extension DirectoryEditionValue on DirectoryEdition {
   String toValue() {
     switch (this) {
       case DirectoryEdition.enterprise:
@@ -4365,7 +4365,7 @@ extension on DirectoryEdition {
   }
 }
 
-extension on String {
+extension DirectoryEditionFromString on String {
   DirectoryEdition toDirectoryEdition() {
     switch (this) {
       case 'Enterprise':
@@ -4444,7 +4444,7 @@ enum DirectorySize {
   large,
 }
 
-extension on DirectorySize {
+extension DirectorySizeValue on DirectorySize {
   String toValue() {
     switch (this) {
       case DirectorySize.small:
@@ -4455,7 +4455,7 @@ extension on DirectorySize {
   }
 }
 
-extension on String {
+extension DirectorySizeFromString on String {
   DirectorySize toDirectorySize() {
     switch (this) {
       case 'Small':
@@ -4481,7 +4481,7 @@ enum DirectoryStage {
   failed,
 }
 
-extension on DirectoryStage {
+extension DirectoryStageValue on DirectoryStage {
   String toValue() {
     switch (this) {
       case DirectoryStage.requested:
@@ -4510,7 +4510,7 @@ extension on DirectoryStage {
   }
 }
 
-extension on String {
+extension DirectoryStageFromString on String {
   DirectoryStage toDirectoryStage() {
     switch (this) {
       case 'Requested':
@@ -4547,7 +4547,7 @@ enum DirectoryType {
   sharedMicrosoftAD,
 }
 
-extension on DirectoryType {
+extension DirectoryTypeValue on DirectoryType {
   String toValue() {
     switch (this) {
       case DirectoryType.simpleAD:
@@ -4562,7 +4562,7 @@ extension on DirectoryType {
   }
 }
 
-extension on String {
+extension DirectoryTypeFromString on String {
   DirectoryType toDirectoryType() {
     switch (this) {
       case 'SimpleAD':
@@ -4750,7 +4750,7 @@ enum DomainControllerStatus {
   failed,
 }
 
-extension on DomainControllerStatus {
+extension DomainControllerStatusValue on DomainControllerStatus {
   String toValue() {
     switch (this) {
       case DomainControllerStatus.creating:
@@ -4771,7 +4771,7 @@ extension on DomainControllerStatus {
   }
 }
 
-extension on String {
+extension DomainControllerStatusFromString on String {
   DomainControllerStatus toDomainControllerStatus() {
     switch (this) {
       case 'Creating':
@@ -4975,7 +4975,7 @@ enum IpRouteStatusMsg {
   removeFailed,
 }
 
-extension on IpRouteStatusMsg {
+extension IpRouteStatusMsgValue on IpRouteStatusMsg {
   String toValue() {
     switch (this) {
       case IpRouteStatusMsg.adding:
@@ -4994,7 +4994,7 @@ extension on IpRouteStatusMsg {
   }
 }
 
-extension on String {
+extension IpRouteStatusMsgFromString on String {
   IpRouteStatusMsg toIpRouteStatusMsg() {
     switch (this) {
       case 'Adding':
@@ -5046,7 +5046,7 @@ enum LDAPSStatus {
   disabled,
 }
 
-extension on LDAPSStatus {
+extension LDAPSStatusValue on LDAPSStatus {
   String toValue() {
     switch (this) {
       case LDAPSStatus.enabling:
@@ -5061,7 +5061,7 @@ extension on LDAPSStatus {
   }
 }
 
-extension on String {
+extension LDAPSStatusFromString on String {
   LDAPSStatus toLDAPSStatus() {
     switch (this) {
       case 'Enabling':
@@ -5081,7 +5081,7 @@ enum LDAPSType {
   client,
 }
 
-extension on LDAPSType {
+extension LDAPSTypeValue on LDAPSType {
   String toValue() {
     switch (this) {
       case LDAPSType.client:
@@ -5090,7 +5090,7 @@ extension on LDAPSType {
   }
 }
 
-extension on String {
+extension LDAPSTypeFromString on String {
   LDAPSType toLDAPSType() {
     switch (this) {
       case 'Client':
@@ -5303,7 +5303,7 @@ enum RadiusAuthenticationProtocol {
   msCHAPv2,
 }
 
-extension on RadiusAuthenticationProtocol {
+extension RadiusAuthenticationProtocolValue on RadiusAuthenticationProtocol {
   String toValue() {
     switch (this) {
       case RadiusAuthenticationProtocol.pap:
@@ -5318,7 +5318,7 @@ extension on RadiusAuthenticationProtocol {
   }
 }
 
-extension on String {
+extension RadiusAuthenticationProtocolFromString on String {
   RadiusAuthenticationProtocol toRadiusAuthenticationProtocol() {
     switch (this) {
       case 'PAP':
@@ -5422,7 +5422,7 @@ enum RadiusStatus {
   failed,
 }
 
-extension on RadiusStatus {
+extension RadiusStatusValue on RadiusStatus {
   String toValue() {
     switch (this) {
       case RadiusStatus.creating:
@@ -5435,7 +5435,7 @@ extension on RadiusStatus {
   }
 }
 
-extension on String {
+extension RadiusStatusFromString on String {
   RadiusStatus toRadiusStatus() {
     switch (this) {
       case 'Creating':
@@ -5513,7 +5513,7 @@ enum RegionType {
   additional,
 }
 
-extension on RegionType {
+extension RegionTypeValue on RegionType {
   String toValue() {
     switch (this) {
       case RegionType.primary:
@@ -5524,7 +5524,7 @@ extension on RegionType {
   }
 }
 
-extension on String {
+extension RegionTypeFromString on String {
   RegionType toRegionType() {
     switch (this) {
       case 'Primary':
@@ -5623,7 +5623,7 @@ enum ReplicationScope {
   domain,
 }
 
-extension on ReplicationScope {
+extension ReplicationScopeValue on ReplicationScope {
   String toValue() {
     switch (this) {
       case ReplicationScope.domain:
@@ -5632,7 +5632,7 @@ extension on ReplicationScope {
   }
 }
 
-extension on String {
+extension ReplicationScopeFromString on String {
   ReplicationScope toReplicationScope() {
     switch (this) {
       case 'Domain':
@@ -5717,7 +5717,7 @@ enum SchemaExtensionStatus {
   completed,
 }
 
-extension on SchemaExtensionStatus {
+extension SchemaExtensionStatusValue on SchemaExtensionStatus {
   String toValue() {
     switch (this) {
       case SchemaExtensionStatus.initializing:
@@ -5742,7 +5742,7 @@ extension on SchemaExtensionStatus {
   }
 }
 
-extension on String {
+extension SchemaExtensionStatusFromString on String {
   SchemaExtensionStatus toSchemaExtensionStatus() {
     switch (this) {
       case 'Initializing':
@@ -5773,7 +5773,7 @@ enum SelectiveAuth {
   disabled,
 }
 
-extension on SelectiveAuth {
+extension SelectiveAuthValue on SelectiveAuth {
   String toValue() {
     switch (this) {
       case SelectiveAuth.enabled:
@@ -5784,7 +5784,7 @@ extension on SelectiveAuth {
   }
 }
 
-extension on String {
+extension SelectiveAuthFromString on String {
   SelectiveAuth toSelectiveAuth() {
     switch (this) {
       case 'Enabled':
@@ -5816,7 +5816,7 @@ enum ShareMethod {
   handshake,
 }
 
-extension on ShareMethod {
+extension ShareMethodValue on ShareMethod {
   String toValue() {
     switch (this) {
       case ShareMethod.organizations:
@@ -5827,7 +5827,7 @@ extension on ShareMethod {
   }
 }
 
-extension on String {
+extension ShareMethodFromString on String {
   ShareMethod toShareMethod() {
     switch (this) {
       case 'ORGANIZATIONS':
@@ -5851,7 +5851,7 @@ enum ShareStatus {
   deleting,
 }
 
-extension on ShareStatus {
+extension ShareStatusValue on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.shared:
@@ -5876,7 +5876,7 @@ extension on ShareStatus {
   }
 }
 
-extension on String {
+extension ShareStatusFromString on String {
   ShareStatus toShareStatus() {
     switch (this) {
       case 'Shared':
@@ -6060,7 +6060,7 @@ enum SnapshotStatus {
   failed,
 }
 
-extension on SnapshotStatus {
+extension SnapshotStatusValue on SnapshotStatus {
   String toValue() {
     switch (this) {
       case SnapshotStatus.creating:
@@ -6073,7 +6073,7 @@ extension on SnapshotStatus {
   }
 }
 
-extension on String {
+extension SnapshotStatusFromString on String {
   SnapshotStatus toSnapshotStatus() {
     switch (this) {
       case 'Creating':
@@ -6092,7 +6092,7 @@ enum SnapshotType {
   manual,
 }
 
-extension on SnapshotType {
+extension SnapshotTypeValue on SnapshotType {
   String toValue() {
     switch (this) {
       case SnapshotType.auto:
@@ -6103,7 +6103,7 @@ extension on SnapshotType {
   }
 }
 
-extension on String {
+extension SnapshotTypeFromString on String {
   SnapshotType toSnapshotType() {
     switch (this) {
       case 'Auto':
@@ -6168,7 +6168,7 @@ enum TargetType {
   account,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:
@@ -6177,7 +6177,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'ACCOUNT':
@@ -6194,7 +6194,7 @@ enum TopicStatus {
   deleted,
 }
 
-extension on TopicStatus {
+extension TopicStatusValue on TopicStatus {
   String toValue() {
     switch (this) {
       case TopicStatus.registered:
@@ -6209,7 +6209,7 @@ extension on TopicStatus {
   }
 }
 
-extension on String {
+extension TopicStatusFromString on String {
   TopicStatus toTopicStatus() {
     switch (this) {
       case 'Registered':
@@ -6299,7 +6299,7 @@ enum TrustDirection {
   twoWay,
 }
 
-extension on TrustDirection {
+extension TrustDirectionValue on TrustDirection {
   String toValue() {
     switch (this) {
       case TrustDirection.oneWayOutgoing:
@@ -6312,7 +6312,7 @@ extension on TrustDirection {
   }
 }
 
-extension on String {
+extension TrustDirectionFromString on String {
   TrustDirection toTrustDirection() {
     switch (this) {
       case 'One-Way: Outgoing':
@@ -6340,7 +6340,7 @@ enum TrustState {
   failed,
 }
 
-extension on TrustState {
+extension TrustStateValue on TrustState {
   String toValue() {
     switch (this) {
       case TrustState.creating:
@@ -6369,7 +6369,7 @@ extension on TrustState {
   }
 }
 
-extension on String {
+extension TrustStateFromString on String {
   TrustState toTrustState() {
     switch (this) {
       case 'Creating':
@@ -6404,7 +6404,7 @@ enum TrustType {
   external,
 }
 
-extension on TrustType {
+extension TrustTypeValue on TrustType {
   String toValue() {
     switch (this) {
       case TrustType.forest:
@@ -6415,7 +6415,7 @@ extension on TrustType {
   }
 }
 
-extension on String {
+extension TrustTypeFromString on String {
   TrustType toTrustType() {
     switch (this) {
       case 'Forest':

--- a/generated/aws_ds_api/lib/ds-2015-04-16.dart
+++ b/generated/aws_ds_api/lib/ds-2015-04-16.dart
@@ -3447,7 +3447,7 @@ enum CertificateState {
   deregisterFailed,
 }
 
-extension CertificateStateValue on CertificateState {
+extension CertificateStateValueExtension on CertificateState {
   String toValue() {
     switch (this) {
       case CertificateState.registering:
@@ -3491,7 +3491,7 @@ enum CertificateType {
   clientLDAPS,
 }
 
-extension CertificateTypeValue on CertificateType {
+extension CertificateTypeValueExtension on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.clientCertAuth:
@@ -3518,7 +3518,7 @@ enum ClientAuthenticationType {
   smartCard,
 }
 
-extension ClientAuthenticationTypeValue on ClientAuthenticationType {
+extension ClientAuthenticationTypeValueExtension on ClientAuthenticationType {
   String toValue() {
     switch (this) {
       case ClientAuthenticationType.smartCard:
@@ -4354,7 +4354,7 @@ enum DirectoryEdition {
   standard,
 }
 
-extension DirectoryEditionValue on DirectoryEdition {
+extension DirectoryEditionValueExtension on DirectoryEdition {
   String toValue() {
     switch (this) {
       case DirectoryEdition.enterprise:
@@ -4444,7 +4444,7 @@ enum DirectorySize {
   large,
 }
 
-extension DirectorySizeValue on DirectorySize {
+extension DirectorySizeValueExtension on DirectorySize {
   String toValue() {
     switch (this) {
       case DirectorySize.small:
@@ -4481,7 +4481,7 @@ enum DirectoryStage {
   failed,
 }
 
-extension DirectoryStageValue on DirectoryStage {
+extension DirectoryStageValueExtension on DirectoryStage {
   String toValue() {
     switch (this) {
       case DirectoryStage.requested:
@@ -4547,7 +4547,7 @@ enum DirectoryType {
   sharedMicrosoftAD,
 }
 
-extension DirectoryTypeValue on DirectoryType {
+extension DirectoryTypeValueExtension on DirectoryType {
   String toValue() {
     switch (this) {
       case DirectoryType.simpleAD:
@@ -4750,7 +4750,7 @@ enum DomainControllerStatus {
   failed,
 }
 
-extension DomainControllerStatusValue on DomainControllerStatus {
+extension DomainControllerStatusValueExtension on DomainControllerStatus {
   String toValue() {
     switch (this) {
       case DomainControllerStatus.creating:
@@ -4975,7 +4975,7 @@ enum IpRouteStatusMsg {
   removeFailed,
 }
 
-extension IpRouteStatusMsgValue on IpRouteStatusMsg {
+extension IpRouteStatusMsgValueExtension on IpRouteStatusMsg {
   String toValue() {
     switch (this) {
       case IpRouteStatusMsg.adding:
@@ -5046,7 +5046,7 @@ enum LDAPSStatus {
   disabled,
 }
 
-extension LDAPSStatusValue on LDAPSStatus {
+extension LDAPSStatusValueExtension on LDAPSStatus {
   String toValue() {
     switch (this) {
       case LDAPSStatus.enabling:
@@ -5081,7 +5081,7 @@ enum LDAPSType {
   client,
 }
 
-extension LDAPSTypeValue on LDAPSType {
+extension LDAPSTypeValueExtension on LDAPSType {
   String toValue() {
     switch (this) {
       case LDAPSType.client:
@@ -5303,7 +5303,8 @@ enum RadiusAuthenticationProtocol {
   msCHAPv2,
 }
 
-extension RadiusAuthenticationProtocolValue on RadiusAuthenticationProtocol {
+extension RadiusAuthenticationProtocolValueExtension
+    on RadiusAuthenticationProtocol {
   String toValue() {
     switch (this) {
       case RadiusAuthenticationProtocol.pap:
@@ -5422,7 +5423,7 @@ enum RadiusStatus {
   failed,
 }
 
-extension RadiusStatusValue on RadiusStatus {
+extension RadiusStatusValueExtension on RadiusStatus {
   String toValue() {
     switch (this) {
       case RadiusStatus.creating:
@@ -5513,7 +5514,7 @@ enum RegionType {
   additional,
 }
 
-extension RegionTypeValue on RegionType {
+extension RegionTypeValueExtension on RegionType {
   String toValue() {
     switch (this) {
       case RegionType.primary:
@@ -5623,7 +5624,7 @@ enum ReplicationScope {
   domain,
 }
 
-extension ReplicationScopeValue on ReplicationScope {
+extension ReplicationScopeValueExtension on ReplicationScope {
   String toValue() {
     switch (this) {
       case ReplicationScope.domain:
@@ -5717,7 +5718,7 @@ enum SchemaExtensionStatus {
   completed,
 }
 
-extension SchemaExtensionStatusValue on SchemaExtensionStatus {
+extension SchemaExtensionStatusValueExtension on SchemaExtensionStatus {
   String toValue() {
     switch (this) {
       case SchemaExtensionStatus.initializing:
@@ -5773,7 +5774,7 @@ enum SelectiveAuth {
   disabled,
 }
 
-extension SelectiveAuthValue on SelectiveAuth {
+extension SelectiveAuthValueExtension on SelectiveAuth {
   String toValue() {
     switch (this) {
       case SelectiveAuth.enabled:
@@ -5816,7 +5817,7 @@ enum ShareMethod {
   handshake,
 }
 
-extension ShareMethodValue on ShareMethod {
+extension ShareMethodValueExtension on ShareMethod {
   String toValue() {
     switch (this) {
       case ShareMethod.organizations:
@@ -5851,7 +5852,7 @@ enum ShareStatus {
   deleting,
 }
 
-extension ShareStatusValue on ShareStatus {
+extension ShareStatusValueExtension on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.shared:
@@ -6060,7 +6061,7 @@ enum SnapshotStatus {
   failed,
 }
 
-extension SnapshotStatusValue on SnapshotStatus {
+extension SnapshotStatusValueExtension on SnapshotStatus {
   String toValue() {
     switch (this) {
       case SnapshotStatus.creating:
@@ -6092,7 +6093,7 @@ enum SnapshotType {
   manual,
 }
 
-extension SnapshotTypeValue on SnapshotType {
+extension SnapshotTypeValueExtension on SnapshotType {
   String toValue() {
     switch (this) {
       case SnapshotType.auto:
@@ -6168,7 +6169,7 @@ enum TargetType {
   account,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:
@@ -6194,7 +6195,7 @@ enum TopicStatus {
   deleted,
 }
 
-extension TopicStatusValue on TopicStatus {
+extension TopicStatusValueExtension on TopicStatus {
   String toValue() {
     switch (this) {
       case TopicStatus.registered:
@@ -6299,7 +6300,7 @@ enum TrustDirection {
   twoWay,
 }
 
-extension TrustDirectionValue on TrustDirection {
+extension TrustDirectionValueExtension on TrustDirection {
   String toValue() {
     switch (this) {
       case TrustDirection.oneWayOutgoing:
@@ -6340,7 +6341,7 @@ enum TrustState {
   failed,
 }
 
-extension TrustStateValue on TrustState {
+extension TrustStateValueExtension on TrustState {
   String toValue() {
     switch (this) {
       case TrustState.creating:
@@ -6404,7 +6405,7 @@ enum TrustType {
   external,
 }
 
-extension TrustTypeValue on TrustType {
+extension TrustTypeValueExtension on TrustType {
   String toValue() {
     switch (this) {
       case TrustType.forest:

--- a/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
@@ -792,7 +792,7 @@ enum AttributeAction {
   delete,
 }
 
-extension on AttributeAction {
+extension AttributeActionValue on AttributeAction {
   String toValue() {
     switch (this) {
       case AttributeAction.add:
@@ -805,7 +805,7 @@ extension on AttributeAction {
   }
 }
 
-extension on String {
+extension AttributeActionFromString on String {
   AttributeAction toAttributeAction() {
     switch (this) {
       case 'ADD':
@@ -1039,7 +1039,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -1072,7 +1072,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -1597,7 +1597,7 @@ enum ReturnValue {
   updatedNew,
 }
 
-extension on ReturnValue {
+extension ReturnValueValue on ReturnValue {
   String toValue() {
     switch (this) {
       case ReturnValue.none:
@@ -1614,7 +1614,7 @@ extension on ReturnValue {
   }
 }
 
-extension on String {
+extension ReturnValueFromString on String {
   ReturnValue toReturnValue() {
     switch (this) {
       case 'NONE':
@@ -1638,7 +1638,7 @@ enum ScalarAttributeType {
   b,
 }
 
-extension on ScalarAttributeType {
+extension ScalarAttributeTypeValue on ScalarAttributeType {
   String toValue() {
     switch (this) {
       case ScalarAttributeType.s:
@@ -1651,7 +1651,7 @@ extension on ScalarAttributeType {
   }
 }
 
-extension on String {
+extension ScalarAttributeTypeFromString on String {
   ScalarAttributeType toScalarAttributeType() {
     switch (this) {
       case 'S':
@@ -1752,7 +1752,7 @@ enum TableStatus {
   active,
 }
 
-extension on TableStatus {
+extension TableStatusValue on TableStatus {
   String toValue() {
     switch (this) {
       case TableStatus.creating:
@@ -1767,7 +1767,7 @@ extension on TableStatus {
   }
 }
 
-extension on String {
+extension TableStatusFromString on String {
   TableStatus toTableStatus() {
     switch (this) {
       case 'CREATING':

--- a/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
@@ -792,7 +792,7 @@ enum AttributeAction {
   delete,
 }
 
-extension AttributeActionValue on AttributeAction {
+extension AttributeActionValueExtension on AttributeAction {
   String toValue() {
     switch (this) {
       case AttributeAction.add:
@@ -1039,7 +1039,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -1597,7 +1597,7 @@ enum ReturnValue {
   updatedNew,
 }
 
-extension ReturnValueValue on ReturnValue {
+extension ReturnValueValueExtension on ReturnValue {
   String toValue() {
     switch (this) {
       case ReturnValue.none:
@@ -1638,7 +1638,7 @@ enum ScalarAttributeType {
   b,
 }
 
-extension ScalarAttributeTypeValue on ScalarAttributeType {
+extension ScalarAttributeTypeValueExtension on ScalarAttributeType {
   String toValue() {
     switch (this) {
       case ScalarAttributeType.s:
@@ -1752,7 +1752,7 @@ enum TableStatus {
   active,
 }
 
-extension TableStatusValue on TableStatus {
+extension TableStatusValueExtension on TableStatus {
   String toValue() {
     switch (this) {
       case TableStatus.creating:

--- a/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
@@ -5431,7 +5431,7 @@ enum AttributeAction {
   delete,
 }
 
-extension on AttributeAction {
+extension AttributeActionValue on AttributeAction {
   String toValue() {
     switch (this) {
       case AttributeAction.add:
@@ -5444,7 +5444,7 @@ extension on AttributeAction {
   }
 }
 
-extension on String {
+extension AttributeActionFromString on String {
   AttributeAction toAttributeAction() {
     switch (this) {
       case 'ADD':
@@ -6101,7 +6101,7 @@ enum BackupStatus {
   available,
 }
 
-extension on BackupStatus {
+extension BackupStatusValue on BackupStatus {
   String toValue() {
     switch (this) {
       case BackupStatus.creating:
@@ -6114,7 +6114,7 @@ extension on BackupStatus {
   }
 }
 
-extension on String {
+extension BackupStatusFromString on String {
   BackupStatus toBackupStatus() {
     switch (this) {
       case 'CREATING':
@@ -6214,7 +6214,7 @@ enum BackupType {
   awsBackup,
 }
 
-extension on BackupType {
+extension BackupTypeValue on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.user:
@@ -6227,7 +6227,7 @@ extension on BackupType {
   }
 }
 
-extension on String {
+extension BackupTypeFromString on String {
   BackupType toBackupType() {
     switch (this) {
       case 'USER':
@@ -6248,7 +6248,7 @@ enum BackupTypeFilter {
   all,
 }
 
-extension on BackupTypeFilter {
+extension BackupTypeFilterValue on BackupTypeFilter {
   String toValue() {
     switch (this) {
       case BackupTypeFilter.user:
@@ -6263,7 +6263,7 @@ extension on BackupTypeFilter {
   }
 }
 
-extension on String {
+extension BackupTypeFilterFromString on String {
   BackupTypeFilter toBackupTypeFilter() {
     switch (this) {
       case 'USER':
@@ -6408,7 +6408,7 @@ enum BatchStatementErrorCodeEnum {
   duplicateItem,
 }
 
-extension on BatchStatementErrorCodeEnum {
+extension BatchStatementErrorCodeEnumValue on BatchStatementErrorCodeEnum {
   String toValue() {
     switch (this) {
       case BatchStatementErrorCodeEnum.conditionalCheckFailed:
@@ -6437,7 +6437,7 @@ extension on BatchStatementErrorCodeEnum {
   }
 }
 
-extension on String {
+extension BatchStatementErrorCodeEnumFromString on String {
   BatchStatementErrorCodeEnum toBatchStatementErrorCodeEnum() {
     switch (this) {
       case 'ConditionalCheckFailed':
@@ -6648,7 +6648,7 @@ enum BillingMode {
   payPerRequest,
 }
 
-extension on BillingMode {
+extension BillingModeValue on BillingMode {
   String toValue() {
     switch (this) {
       case BillingMode.provisioned:
@@ -6659,7 +6659,7 @@ extension on BillingMode {
   }
 }
 
-extension on String {
+extension BillingModeFromString on String {
   BillingMode toBillingMode() {
     switch (this) {
       case 'PROVISIONED':
@@ -6749,7 +6749,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -6782,7 +6782,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -7103,7 +7103,7 @@ enum ConditionalOperator {
   or,
 }
 
-extension on ConditionalOperator {
+extension ConditionalOperatorValue on ConditionalOperator {
   String toValue() {
     switch (this) {
       case ConditionalOperator.and:
@@ -7114,7 +7114,7 @@ extension on ConditionalOperator {
   }
 }
 
-extension on String {
+extension ConditionalOperatorFromString on String {
   ConditionalOperator toConditionalOperator() {
     switch (this) {
       case 'AND':
@@ -7218,7 +7218,7 @@ enum ContinuousBackupsStatus {
   disabled,
 }
 
-extension on ContinuousBackupsStatus {
+extension ContinuousBackupsStatusValue on ContinuousBackupsStatus {
   String toValue() {
     switch (this) {
       case ContinuousBackupsStatus.enabled:
@@ -7229,7 +7229,7 @@ extension on ContinuousBackupsStatus {
   }
 }
 
-extension on String {
+extension ContinuousBackupsStatusFromString on String {
   ContinuousBackupsStatus toContinuousBackupsStatus() {
     switch (this) {
       case 'ENABLED':
@@ -7246,7 +7246,7 @@ enum ContributorInsightsAction {
   disable,
 }
 
-extension on ContributorInsightsAction {
+extension ContributorInsightsActionValue on ContributorInsightsAction {
   String toValue() {
     switch (this) {
       case ContributorInsightsAction.enable:
@@ -7257,7 +7257,7 @@ extension on ContributorInsightsAction {
   }
 }
 
-extension on String {
+extension ContributorInsightsActionFromString on String {
   ContributorInsightsAction toContributorInsightsAction() {
     switch (this) {
       case 'ENABLE':
@@ -7277,7 +7277,7 @@ enum ContributorInsightsStatus {
   failed,
 }
 
-extension on ContributorInsightsStatus {
+extension ContributorInsightsStatusValue on ContributorInsightsStatus {
   String toValue() {
     switch (this) {
       case ContributorInsightsStatus.enabling:
@@ -7294,7 +7294,7 @@ extension on ContributorInsightsStatus {
   }
 }
 
-extension on String {
+extension ContributorInsightsStatusFromString on String {
   ContributorInsightsStatus toContributorInsightsStatus() {
     switch (this) {
       case 'ENABLING':
@@ -8026,7 +8026,7 @@ enum DestinationStatus {
   enableFailed,
 }
 
-extension on DestinationStatus {
+extension DestinationStatusValue on DestinationStatus {
   String toValue() {
     switch (this) {
       case DestinationStatus.enabling:
@@ -8043,7 +8043,7 @@ extension on DestinationStatus {
   }
 }
 
-extension on String {
+extension DestinationStatusFromString on String {
   DestinationStatus toDestinationStatus() {
     switch (this) {
       case 'ENABLING':
@@ -8537,7 +8537,7 @@ enum ExportFormat {
   ion,
 }
 
-extension on ExportFormat {
+extension ExportFormatValue on ExportFormat {
   String toValue() {
     switch (this) {
       case ExportFormat.dynamodbJson:
@@ -8548,7 +8548,7 @@ extension on ExportFormat {
   }
 }
 
-extension on String {
+extension ExportFormatFromString on String {
   ExportFormat toExportFormat() {
     switch (this) {
       case 'DYNAMODB_JSON':
@@ -8566,7 +8566,7 @@ enum ExportStatus {
   failed,
 }
 
-extension on ExportStatus {
+extension ExportStatusValue on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -8579,7 +8579,7 @@ extension on ExportStatus {
   }
 }
 
-extension on String {
+extension ExportStatusFromString on String {
   ExportStatus toExportStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -9182,7 +9182,7 @@ enum GlobalTableStatus {
   updating,
 }
 
-extension on GlobalTableStatus {
+extension GlobalTableStatusValue on GlobalTableStatus {
   String toValue() {
     switch (this) {
       case GlobalTableStatus.creating:
@@ -9197,7 +9197,7 @@ extension on GlobalTableStatus {
   }
 }
 
-extension on String {
+extension GlobalTableStatusFromString on String {
   GlobalTableStatus toGlobalTableStatus() {
     switch (this) {
       case 'CREATING':
@@ -9220,7 +9220,7 @@ enum IndexStatus {
   active,
 }
 
-extension on IndexStatus {
+extension IndexStatusValue on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.creating:
@@ -9235,7 +9235,7 @@ extension on IndexStatus {
   }
 }
 
-extension on String {
+extension IndexStatusFromString on String {
   IndexStatus toIndexStatus() {
     switch (this) {
       case 'CREATING':
@@ -9369,7 +9369,7 @@ enum KeyType {
   range,
 }
 
-extension on KeyType {
+extension KeyTypeValue on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.hash:
@@ -9380,7 +9380,7 @@ extension on KeyType {
   }
 }
 
-extension on String {
+extension KeyTypeFromString on String {
   KeyType toKeyType() {
     switch (this) {
       case 'HASH':
@@ -10003,7 +10003,7 @@ enum PointInTimeRecoveryStatus {
   disabled,
 }
 
-extension on PointInTimeRecoveryStatus {
+extension PointInTimeRecoveryStatusValue on PointInTimeRecoveryStatus {
   String toValue() {
     switch (this) {
       case PointInTimeRecoveryStatus.enabled:
@@ -10014,7 +10014,7 @@ extension on PointInTimeRecoveryStatus {
   }
 }
 
-extension on String {
+extension PointInTimeRecoveryStatusFromString on String {
   PointInTimeRecoveryStatus toPointInTimeRecoveryStatus() {
     switch (this) {
       case 'ENABLED':
@@ -10088,7 +10088,7 @@ enum ProjectionType {
   include,
 }
 
-extension on ProjectionType {
+extension ProjectionTypeValue on ProjectionType {
   String toValue() {
     switch (this) {
       case ProjectionType.all:
@@ -10101,7 +10101,7 @@ extension on ProjectionType {
   }
 }
 
-extension on String {
+extension ProjectionTypeFromString on String {
   ProjectionType toProjectionType() {
     switch (this) {
       case 'ALL':
@@ -11089,7 +11089,7 @@ enum ReplicaStatus {
   inaccessibleEncryptionCredentials,
 }
 
-extension on ReplicaStatus {
+extension ReplicaStatusValue on ReplicaStatus {
   String toValue() {
     switch (this) {
       case ReplicaStatus.creating:
@@ -11110,7 +11110,7 @@ extension on ReplicaStatus {
   }
 }
 
-extension on String {
+extension ReplicaStatusFromString on String {
   ReplicaStatus toReplicaStatus() {
     switch (this) {
       case 'CREATING':
@@ -11307,7 +11307,7 @@ enum ReturnConsumedCapacity {
   none,
 }
 
-extension on ReturnConsumedCapacity {
+extension ReturnConsumedCapacityValue on ReturnConsumedCapacity {
   String toValue() {
     switch (this) {
       case ReturnConsumedCapacity.indexes:
@@ -11320,7 +11320,7 @@ extension on ReturnConsumedCapacity {
   }
 }
 
-extension on String {
+extension ReturnConsumedCapacityFromString on String {
   ReturnConsumedCapacity toReturnConsumedCapacity() {
     switch (this) {
       case 'INDEXES':
@@ -11339,7 +11339,7 @@ enum ReturnItemCollectionMetrics {
   none,
 }
 
-extension on ReturnItemCollectionMetrics {
+extension ReturnItemCollectionMetricsValue on ReturnItemCollectionMetrics {
   String toValue() {
     switch (this) {
       case ReturnItemCollectionMetrics.size:
@@ -11350,7 +11350,7 @@ extension on ReturnItemCollectionMetrics {
   }
 }
 
-extension on String {
+extension ReturnItemCollectionMetricsFromString on String {
   ReturnItemCollectionMetrics toReturnItemCollectionMetrics() {
     switch (this) {
       case 'SIZE':
@@ -11370,7 +11370,7 @@ enum ReturnValue {
   updatedNew,
 }
 
-extension on ReturnValue {
+extension ReturnValueValue on ReturnValue {
   String toValue() {
     switch (this) {
       case ReturnValue.none:
@@ -11387,7 +11387,7 @@ extension on ReturnValue {
   }
 }
 
-extension on String {
+extension ReturnValueFromString on String {
   ReturnValue toReturnValue() {
     switch (this) {
       case 'NONE':
@@ -11410,7 +11410,8 @@ enum ReturnValuesOnConditionCheckFailure {
   none,
 }
 
-extension on ReturnValuesOnConditionCheckFailure {
+extension ReturnValuesOnConditionCheckFailureValue
+    on ReturnValuesOnConditionCheckFailure {
   String toValue() {
     switch (this) {
       case ReturnValuesOnConditionCheckFailure.allOld:
@@ -11421,7 +11422,7 @@ extension on ReturnValuesOnConditionCheckFailure {
   }
 }
 
-extension on String {
+extension ReturnValuesOnConditionCheckFailureFromString on String {
   ReturnValuesOnConditionCheckFailure toReturnValuesOnConditionCheckFailure() {
     switch (this) {
       case 'ALL_OLD':
@@ -11439,7 +11440,7 @@ enum S3SseAlgorithm {
   kms,
 }
 
-extension on S3SseAlgorithm {
+extension S3SseAlgorithmValue on S3SseAlgorithm {
   String toValue() {
     switch (this) {
       case S3SseAlgorithm.aes256:
@@ -11450,7 +11451,7 @@ extension on S3SseAlgorithm {
   }
 }
 
-extension on String {
+extension S3SseAlgorithmFromString on String {
   S3SseAlgorithm toS3SseAlgorithm() {
     switch (this) {
       case 'AES256':
@@ -11567,7 +11568,7 @@ enum SSEStatus {
   updating,
 }
 
-extension on SSEStatus {
+extension SSEStatusValue on SSEStatus {
   String toValue() {
     switch (this) {
       case SSEStatus.enabling:
@@ -11584,7 +11585,7 @@ extension on SSEStatus {
   }
 }
 
-extension on String {
+extension SSEStatusFromString on String {
   SSEStatus toSSEStatus() {
     switch (this) {
       case 'ENABLING':
@@ -11607,7 +11608,7 @@ enum SSEType {
   kms,
 }
 
-extension on SSEType {
+extension SSETypeValue on SSEType {
   String toValue() {
     switch (this) {
       case SSEType.aes256:
@@ -11618,7 +11619,7 @@ extension on SSEType {
   }
 }
 
-extension on String {
+extension SSETypeFromString on String {
   SSEType toSSEType() {
     switch (this) {
       case 'AES256':
@@ -11636,7 +11637,7 @@ enum ScalarAttributeType {
   b,
 }
 
-extension on ScalarAttributeType {
+extension ScalarAttributeTypeValue on ScalarAttributeType {
   String toValue() {
     switch (this) {
       case ScalarAttributeType.s:
@@ -11649,7 +11650,7 @@ extension on ScalarAttributeType {
   }
 }
 
-extension on String {
+extension ScalarAttributeTypeFromString on String {
   ScalarAttributeType toScalarAttributeType() {
     switch (this) {
       case 'S':
@@ -11748,7 +11749,7 @@ enum Select {
   count,
 }
 
-extension on Select {
+extension SelectValue on Select {
   String toValue() {
     switch (this) {
       case Select.allAttributes:
@@ -11763,7 +11764,7 @@ extension on Select {
   }
 }
 
-extension on String {
+extension SelectFromString on String {
   Select toSelect() {
     switch (this) {
       case 'ALL_ATTRIBUTES':
@@ -11969,7 +11970,7 @@ enum StreamViewType {
   keysOnly,
 }
 
-extension on StreamViewType {
+extension StreamViewTypeValue on StreamViewType {
   String toValue() {
     switch (this) {
       case StreamViewType.newImage:
@@ -11984,7 +11985,7 @@ extension on StreamViewType {
   }
 }
 
-extension on String {
+extension StreamViewTypeFromString on String {
   StreamViewType toStreamViewType() {
     switch (this) {
       case 'NEW_IMAGE':
@@ -12457,7 +12458,7 @@ enum TableStatus {
   archived,
 }
 
-extension on TableStatus {
+extension TableStatusValue on TableStatus {
   String toValue() {
     switch (this) {
       case TableStatus.creating:
@@ -12478,7 +12479,7 @@ extension on TableStatus {
   }
 }
 
-extension on String {
+extension TableStatusFromString on String {
   TableStatus toTableStatus() {
     switch (this) {
       case 'CREATING':
@@ -12602,7 +12603,7 @@ enum TimeToLiveStatus {
   disabled,
 }
 
-extension on TimeToLiveStatus {
+extension TimeToLiveStatusValue on TimeToLiveStatus {
   String toValue() {
     switch (this) {
       case TimeToLiveStatus.enabling:
@@ -12617,7 +12618,7 @@ extension on TimeToLiveStatus {
   }
 }
 
-extension on String {
+extension TimeToLiveStatusFromString on String {
   TimeToLiveStatus toTimeToLiveStatus() {
     switch (this) {
       case 'ENABLING':

--- a/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
@@ -5431,7 +5431,7 @@ enum AttributeAction {
   delete,
 }
 
-extension AttributeActionValue on AttributeAction {
+extension AttributeActionValueExtension on AttributeAction {
   String toValue() {
     switch (this) {
       case AttributeAction.add:
@@ -6101,7 +6101,7 @@ enum BackupStatus {
   available,
 }
 
-extension BackupStatusValue on BackupStatus {
+extension BackupStatusValueExtension on BackupStatus {
   String toValue() {
     switch (this) {
       case BackupStatus.creating:
@@ -6214,7 +6214,7 @@ enum BackupType {
   awsBackup,
 }
 
-extension BackupTypeValue on BackupType {
+extension BackupTypeValueExtension on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.user:
@@ -6248,7 +6248,7 @@ enum BackupTypeFilter {
   all,
 }
 
-extension BackupTypeFilterValue on BackupTypeFilter {
+extension BackupTypeFilterValueExtension on BackupTypeFilter {
   String toValue() {
     switch (this) {
       case BackupTypeFilter.user:
@@ -6408,7 +6408,8 @@ enum BatchStatementErrorCodeEnum {
   duplicateItem,
 }
 
-extension BatchStatementErrorCodeEnumValue on BatchStatementErrorCodeEnum {
+extension BatchStatementErrorCodeEnumValueExtension
+    on BatchStatementErrorCodeEnum {
   String toValue() {
     switch (this) {
       case BatchStatementErrorCodeEnum.conditionalCheckFailed:
@@ -6648,7 +6649,7 @@ enum BillingMode {
   payPerRequest,
 }
 
-extension BillingModeValue on BillingMode {
+extension BillingModeValueExtension on BillingMode {
   String toValue() {
     switch (this) {
       case BillingMode.provisioned:
@@ -6749,7 +6750,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -7103,7 +7104,7 @@ enum ConditionalOperator {
   or,
 }
 
-extension ConditionalOperatorValue on ConditionalOperator {
+extension ConditionalOperatorValueExtension on ConditionalOperator {
   String toValue() {
     switch (this) {
       case ConditionalOperator.and:
@@ -7218,7 +7219,7 @@ enum ContinuousBackupsStatus {
   disabled,
 }
 
-extension ContinuousBackupsStatusValue on ContinuousBackupsStatus {
+extension ContinuousBackupsStatusValueExtension on ContinuousBackupsStatus {
   String toValue() {
     switch (this) {
       case ContinuousBackupsStatus.enabled:
@@ -7246,7 +7247,7 @@ enum ContributorInsightsAction {
   disable,
 }
 
-extension ContributorInsightsActionValue on ContributorInsightsAction {
+extension ContributorInsightsActionValueExtension on ContributorInsightsAction {
   String toValue() {
     switch (this) {
       case ContributorInsightsAction.enable:
@@ -7277,7 +7278,7 @@ enum ContributorInsightsStatus {
   failed,
 }
 
-extension ContributorInsightsStatusValue on ContributorInsightsStatus {
+extension ContributorInsightsStatusValueExtension on ContributorInsightsStatus {
   String toValue() {
     switch (this) {
       case ContributorInsightsStatus.enabling:
@@ -8026,7 +8027,7 @@ enum DestinationStatus {
   enableFailed,
 }
 
-extension DestinationStatusValue on DestinationStatus {
+extension DestinationStatusValueExtension on DestinationStatus {
   String toValue() {
     switch (this) {
       case DestinationStatus.enabling:
@@ -8537,7 +8538,7 @@ enum ExportFormat {
   ion,
 }
 
-extension ExportFormatValue on ExportFormat {
+extension ExportFormatValueExtension on ExportFormat {
   String toValue() {
     switch (this) {
       case ExportFormat.dynamodbJson:
@@ -8566,7 +8567,7 @@ enum ExportStatus {
   failed,
 }
 
-extension ExportStatusValue on ExportStatus {
+extension ExportStatusValueExtension on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -9182,7 +9183,7 @@ enum GlobalTableStatus {
   updating,
 }
 
-extension GlobalTableStatusValue on GlobalTableStatus {
+extension GlobalTableStatusValueExtension on GlobalTableStatus {
   String toValue() {
     switch (this) {
       case GlobalTableStatus.creating:
@@ -9220,7 +9221,7 @@ enum IndexStatus {
   active,
 }
 
-extension IndexStatusValue on IndexStatus {
+extension IndexStatusValueExtension on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.creating:
@@ -9369,7 +9370,7 @@ enum KeyType {
   range,
 }
 
-extension KeyTypeValue on KeyType {
+extension KeyTypeValueExtension on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.hash:
@@ -10003,7 +10004,7 @@ enum PointInTimeRecoveryStatus {
   disabled,
 }
 
-extension PointInTimeRecoveryStatusValue on PointInTimeRecoveryStatus {
+extension PointInTimeRecoveryStatusValueExtension on PointInTimeRecoveryStatus {
   String toValue() {
     switch (this) {
       case PointInTimeRecoveryStatus.enabled:
@@ -10088,7 +10089,7 @@ enum ProjectionType {
   include,
 }
 
-extension ProjectionTypeValue on ProjectionType {
+extension ProjectionTypeValueExtension on ProjectionType {
   String toValue() {
     switch (this) {
       case ProjectionType.all:
@@ -11089,7 +11090,7 @@ enum ReplicaStatus {
   inaccessibleEncryptionCredentials,
 }
 
-extension ReplicaStatusValue on ReplicaStatus {
+extension ReplicaStatusValueExtension on ReplicaStatus {
   String toValue() {
     switch (this) {
       case ReplicaStatus.creating:
@@ -11307,7 +11308,7 @@ enum ReturnConsumedCapacity {
   none,
 }
 
-extension ReturnConsumedCapacityValue on ReturnConsumedCapacity {
+extension ReturnConsumedCapacityValueExtension on ReturnConsumedCapacity {
   String toValue() {
     switch (this) {
       case ReturnConsumedCapacity.indexes:
@@ -11339,7 +11340,8 @@ enum ReturnItemCollectionMetrics {
   none,
 }
 
-extension ReturnItemCollectionMetricsValue on ReturnItemCollectionMetrics {
+extension ReturnItemCollectionMetricsValueExtension
+    on ReturnItemCollectionMetrics {
   String toValue() {
     switch (this) {
       case ReturnItemCollectionMetrics.size:
@@ -11370,7 +11372,7 @@ enum ReturnValue {
   updatedNew,
 }
 
-extension ReturnValueValue on ReturnValue {
+extension ReturnValueValueExtension on ReturnValue {
   String toValue() {
     switch (this) {
       case ReturnValue.none:
@@ -11410,7 +11412,7 @@ enum ReturnValuesOnConditionCheckFailure {
   none,
 }
 
-extension ReturnValuesOnConditionCheckFailureValue
+extension ReturnValuesOnConditionCheckFailureValueExtension
     on ReturnValuesOnConditionCheckFailure {
   String toValue() {
     switch (this) {
@@ -11440,7 +11442,7 @@ enum S3SseAlgorithm {
   kms,
 }
 
-extension S3SseAlgorithmValue on S3SseAlgorithm {
+extension S3SseAlgorithmValueExtension on S3SseAlgorithm {
   String toValue() {
     switch (this) {
       case S3SseAlgorithm.aes256:
@@ -11568,7 +11570,7 @@ enum SSEStatus {
   updating,
 }
 
-extension SSEStatusValue on SSEStatus {
+extension SSEStatusValueExtension on SSEStatus {
   String toValue() {
     switch (this) {
       case SSEStatus.enabling:
@@ -11608,7 +11610,7 @@ enum SSEType {
   kms,
 }
 
-extension SSETypeValue on SSEType {
+extension SSETypeValueExtension on SSEType {
   String toValue() {
     switch (this) {
       case SSEType.aes256:
@@ -11637,7 +11639,7 @@ enum ScalarAttributeType {
   b,
 }
 
-extension ScalarAttributeTypeValue on ScalarAttributeType {
+extension ScalarAttributeTypeValueExtension on ScalarAttributeType {
   String toValue() {
     switch (this) {
       case ScalarAttributeType.s:
@@ -11749,7 +11751,7 @@ enum Select {
   count,
 }
 
-extension SelectValue on Select {
+extension SelectValueExtension on Select {
   String toValue() {
     switch (this) {
       case Select.allAttributes:
@@ -11970,7 +11972,7 @@ enum StreamViewType {
   keysOnly,
 }
 
-extension StreamViewTypeValue on StreamViewType {
+extension StreamViewTypeValueExtension on StreamViewType {
   String toValue() {
     switch (this) {
       case StreamViewType.newImage:
@@ -12458,7 +12460,7 @@ enum TableStatus {
   archived,
 }
 
-extension TableStatusValue on TableStatus {
+extension TableStatusValueExtension on TableStatus {
   String toValue() {
     switch (this) {
       case TableStatus.creating:
@@ -12603,7 +12605,7 @@ enum TimeToLiveStatus {
   disabled,
 }
 
-extension TimeToLiveStatusValue on TimeToLiveStatus {
+extension TimeToLiveStatusValueExtension on TimeToLiveStatus {
   String toValue() {
     switch (this) {
       case TimeToLiveStatus.enabling:

--- a/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
@@ -606,7 +606,7 @@ enum KeyType {
   range,
 }
 
-extension on KeyType {
+extension KeyTypeValue on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.hash:
@@ -617,7 +617,7 @@ extension on KeyType {
   }
 }
 
-extension on String {
+extension KeyTypeFromString on String {
   KeyType toKeyType() {
     switch (this) {
       case 'HASH':
@@ -669,7 +669,7 @@ enum OperationType {
   remove,
 }
 
-extension on OperationType {
+extension OperationTypeValue on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.insert:
@@ -682,7 +682,7 @@ extension on OperationType {
   }
 }
 
-extension on String {
+extension OperationTypeFromString on String {
   OperationType toOperationType() {
     switch (this) {
       case 'INSERT':
@@ -839,7 +839,7 @@ enum ShardIteratorType {
   afterSequenceNumber,
 }
 
-extension on ShardIteratorType {
+extension ShardIteratorTypeValue on ShardIteratorType {
   String toValue() {
     switch (this) {
       case ShardIteratorType.trimHorizon:
@@ -854,7 +854,7 @@ extension on ShardIteratorType {
   }
 }
 
-extension on String {
+extension ShardIteratorTypeFromString on String {
   ShardIteratorType toShardIteratorType() {
     switch (this) {
       case 'TRIM_HORIZON':
@@ -1115,7 +1115,7 @@ enum StreamStatus {
   disabled,
 }
 
-extension on StreamStatus {
+extension StreamStatusValue on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.enabling:
@@ -1130,7 +1130,7 @@ extension on StreamStatus {
   }
 }
 
-extension on String {
+extension StreamStatusFromString on String {
   StreamStatus toStreamStatus() {
     switch (this) {
       case 'ENABLING':
@@ -1153,7 +1153,7 @@ enum StreamViewType {
   keysOnly,
 }
 
-extension on StreamViewType {
+extension StreamViewTypeValue on StreamViewType {
   String toValue() {
     switch (this) {
       case StreamViewType.newImage:
@@ -1168,7 +1168,7 @@ extension on StreamViewType {
   }
 }
 
-extension on String {
+extension StreamViewTypeFromString on String {
   StreamViewType toStreamViewType() {
     switch (this) {
       case 'NEW_IMAGE':

--- a/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
@@ -606,7 +606,7 @@ enum KeyType {
   range,
 }
 
-extension KeyTypeValue on KeyType {
+extension KeyTypeValueExtension on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.hash:
@@ -669,7 +669,7 @@ enum OperationType {
   remove,
 }
 
-extension OperationTypeValue on OperationType {
+extension OperationTypeValueExtension on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.insert:
@@ -839,7 +839,7 @@ enum ShardIteratorType {
   afterSequenceNumber,
 }
 
-extension ShardIteratorTypeValue on ShardIteratorType {
+extension ShardIteratorTypeValueExtension on ShardIteratorType {
   String toValue() {
     switch (this) {
       case ShardIteratorType.trimHorizon:
@@ -1115,7 +1115,7 @@ enum StreamStatus {
   disabled,
 }
 
-extension StreamStatusValue on StreamStatus {
+extension StreamStatusValueExtension on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.enabling:
@@ -1153,7 +1153,7 @@ enum StreamViewType {
   keysOnly,
 }
 
-extension StreamViewTypeValue on StreamViewType {
+extension StreamViewTypeValueExtension on StreamViewType {
   String toValue() {
     switch (this) {
       case StreamViewType.newImage:

--- a/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
+++ b/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
@@ -740,7 +740,7 @@ enum ChecksumAggregationMethod {
   linear,
 }
 
-extension ChecksumAggregationMethodValue on ChecksumAggregationMethod {
+extension ChecksumAggregationMethodValueExtension on ChecksumAggregationMethod {
   String toValue() {
     switch (this) {
       case ChecksumAggregationMethod.linear:
@@ -763,7 +763,7 @@ enum ChecksumAlgorithm {
   sha256,
 }
 
-extension ChecksumAlgorithmValue on ChecksumAlgorithm {
+extension ChecksumAlgorithmValueExtension on ChecksumAlgorithm {
   String toValue() {
     switch (this) {
       case ChecksumAlgorithm.sha256:
@@ -979,7 +979,7 @@ enum Status {
   error,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.completed:

--- a/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
+++ b/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
@@ -740,7 +740,7 @@ enum ChecksumAggregationMethod {
   linear,
 }
 
-extension on ChecksumAggregationMethod {
+extension ChecksumAggregationMethodValue on ChecksumAggregationMethod {
   String toValue() {
     switch (this) {
       case ChecksumAggregationMethod.linear:
@@ -749,7 +749,7 @@ extension on ChecksumAggregationMethod {
   }
 }
 
-extension on String {
+extension ChecksumAggregationMethodFromString on String {
   ChecksumAggregationMethod toChecksumAggregationMethod() {
     switch (this) {
       case 'LINEAR':
@@ -763,7 +763,7 @@ enum ChecksumAlgorithm {
   sha256,
 }
 
-extension on ChecksumAlgorithm {
+extension ChecksumAlgorithmValue on ChecksumAlgorithm {
   String toValue() {
     switch (this) {
       case ChecksumAlgorithm.sha256:
@@ -772,7 +772,7 @@ extension on ChecksumAlgorithm {
   }
 }
 
-extension on String {
+extension ChecksumAlgorithmFromString on String {
   ChecksumAlgorithm toChecksumAlgorithm() {
     switch (this) {
       case 'SHA256':
@@ -979,7 +979,7 @@ enum Status {
   error,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.completed:
@@ -992,7 +992,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'completed':

--- a/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
+++ b/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
@@ -23383,7 +23383,7 @@ enum AccountAttributeName {
   defaultVpc,
 }
 
-extension on AccountAttributeName {
+extension AccountAttributeNameValue on AccountAttributeName {
   String toValue() {
     switch (this) {
       case AccountAttributeName.supportedPlatforms:
@@ -23394,7 +23394,7 @@ extension on AccountAttributeName {
   }
 }
 
-extension on String {
+extension AccountAttributeNameFromString on String {
   AccountAttributeName toAccountAttributeName() {
     switch (this) {
       case 'supported-platforms':
@@ -23448,7 +23448,7 @@ enum ActivityStatus {
   fulfilled,
 }
 
-extension on ActivityStatus {
+extension ActivityStatusValue on ActivityStatus {
   String toValue() {
     switch (this) {
       case ActivityStatus.error:
@@ -23463,7 +23463,7 @@ extension on ActivityStatus {
   }
 }
 
-extension on String {
+extension ActivityStatusFromString on String {
   ActivityStatus toActivityStatus() {
     switch (this) {
       case 'error':
@@ -23577,7 +23577,7 @@ enum Affinity {
   host,
 }
 
-extension on Affinity {
+extension AffinityValue on Affinity {
   String toValue() {
     switch (this) {
       case Affinity.$default:
@@ -23588,7 +23588,7 @@ extension on Affinity {
   }
 }
 
-extension on String {
+extension AffinityFromString on String {
   Affinity toAffinity() {
     switch (this) {
       case 'default':
@@ -23661,7 +23661,7 @@ enum AllocationState {
   pending,
 }
 
-extension on AllocationState {
+extension AllocationStateValue on AllocationState {
   String toValue() {
     switch (this) {
       case AllocationState.available:
@@ -23680,7 +23680,7 @@ extension on AllocationState {
   }
 }
 
-extension on String {
+extension AllocationStateFromString on String {
   AllocationState toAllocationState() {
     switch (this) {
       case 'available':
@@ -23706,7 +23706,7 @@ enum AllocationStrategy {
   capacityOptimized,
 }
 
-extension on AllocationStrategy {
+extension AllocationStrategyValue on AllocationStrategy {
   String toValue() {
     switch (this) {
       case AllocationStrategy.lowestPrice:
@@ -23719,7 +23719,7 @@ extension on AllocationStrategy {
   }
 }
 
-extension on String {
+extension AllocationStrategyFromString on String {
   AllocationStrategy toAllocationStrategy() {
     switch (this) {
       case 'lowestPrice':
@@ -23752,7 +23752,7 @@ enum AllowsMultipleInstanceTypes {
   off,
 }
 
-extension on AllowsMultipleInstanceTypes {
+extension AllowsMultipleInstanceTypesValue on AllowsMultipleInstanceTypes {
   String toValue() {
     switch (this) {
       case AllowsMultipleInstanceTypes.on:
@@ -23763,7 +23763,7 @@ extension on AllowsMultipleInstanceTypes {
   }
 }
 
-extension on String {
+extension AllowsMultipleInstanceTypesFromString on String {
   AllowsMultipleInstanceTypes toAllowsMultipleInstanceTypes() {
     switch (this) {
       case 'on':
@@ -24003,7 +24003,7 @@ enum AnalysisStatus {
   failed,
 }
 
-extension on AnalysisStatus {
+extension AnalysisStatusValue on AnalysisStatus {
   String toValue() {
     switch (this) {
       case AnalysisStatus.running:
@@ -24016,7 +24016,7 @@ extension on AnalysisStatus {
   }
 }
 
-extension on String {
+extension AnalysisStatusFromString on String {
   AnalysisStatus toAnalysisStatus() {
     switch (this) {
       case 'running':
@@ -24035,7 +24035,7 @@ enum ApplianceModeSupportValue {
   disable,
 }
 
-extension on ApplianceModeSupportValue {
+extension ApplianceModeSupportValueValue on ApplianceModeSupportValue {
   String toValue() {
     switch (this) {
       case ApplianceModeSupportValue.enable:
@@ -24046,7 +24046,7 @@ extension on ApplianceModeSupportValue {
   }
 }
 
-extension on String {
+extension ApplianceModeSupportValueFromString on String {
   ApplianceModeSupportValue toApplianceModeSupportValue() {
     switch (this) {
       case 'enable':
@@ -24073,7 +24073,7 @@ enum ArchitectureType {
   arm64,
 }
 
-extension on ArchitectureType {
+extension ArchitectureTypeValue on ArchitectureType {
   String toValue() {
     switch (this) {
       case ArchitectureType.i386:
@@ -24086,7 +24086,7 @@ extension on ArchitectureType {
   }
 }
 
-extension on String {
+extension ArchitectureTypeFromString on String {
   ArchitectureType toArchitectureType() {
     switch (this) {
       case 'i386':
@@ -24106,7 +24106,7 @@ enum ArchitectureValues {
   arm64,
 }
 
-extension on ArchitectureValues {
+extension ArchitectureValuesValue on ArchitectureValues {
   String toValue() {
     switch (this) {
       case ArchitectureValues.i386:
@@ -24119,7 +24119,7 @@ extension on ArchitectureValues {
   }
 }
 
-extension on String {
+extension ArchitectureValuesFromString on String {
   ArchitectureValues toArchitectureValues() {
     switch (this) {
       case 'i386':
@@ -24287,7 +24287,7 @@ enum AssociatedNetworkType {
   vpc,
 }
 
-extension on AssociatedNetworkType {
+extension AssociatedNetworkTypeValue on AssociatedNetworkType {
   String toValue() {
     switch (this) {
       case AssociatedNetworkType.vpc:
@@ -24296,7 +24296,7 @@ extension on AssociatedNetworkType {
   }
 }
 
-extension on String {
+extension AssociatedNetworkTypeFromString on String {
   AssociatedNetworkType toAssociatedNetworkType() {
     switch (this) {
       case 'vpc':
@@ -24367,7 +24367,7 @@ enum AssociationStatusCode {
   disassociated,
 }
 
-extension on AssociationStatusCode {
+extension AssociationStatusCodeValue on AssociationStatusCode {
   String toValue() {
     switch (this) {
       case AssociationStatusCode.associating:
@@ -24384,7 +24384,7 @@ extension on AssociationStatusCode {
   }
 }
 
-extension on String {
+extension AssociationStatusCodeFromString on String {
   AssociationStatusCode toAssociationStatusCode() {
     switch (this) {
       case 'associating':
@@ -24443,7 +24443,7 @@ enum AttachmentStatus {
   detached,
 }
 
-extension on AttachmentStatus {
+extension AttachmentStatusValue on AttachmentStatus {
   String toValue() {
     switch (this) {
       case AttachmentStatus.attaching:
@@ -24458,7 +24458,7 @@ extension on AttachmentStatus {
   }
 }
 
-extension on String {
+extension AttachmentStatusFromString on String {
   AttachmentStatus toAttachmentStatus() {
     switch (this) {
       case 'attaching':
@@ -24542,7 +24542,8 @@ enum AutoAcceptSharedAssociationsValue {
   disable,
 }
 
-extension on AutoAcceptSharedAssociationsValue {
+extension AutoAcceptSharedAssociationsValueValue
+    on AutoAcceptSharedAssociationsValue {
   String toValue() {
     switch (this) {
       case AutoAcceptSharedAssociationsValue.enable:
@@ -24553,7 +24554,7 @@ extension on AutoAcceptSharedAssociationsValue {
   }
 }
 
-extension on String {
+extension AutoAcceptSharedAssociationsValueFromString on String {
   AutoAcceptSharedAssociationsValue toAutoAcceptSharedAssociationsValue() {
     switch (this) {
       case 'enable':
@@ -24571,7 +24572,8 @@ enum AutoAcceptSharedAttachmentsValue {
   disable,
 }
 
-extension on AutoAcceptSharedAttachmentsValue {
+extension AutoAcceptSharedAttachmentsValueValue
+    on AutoAcceptSharedAttachmentsValue {
   String toValue() {
     switch (this) {
       case AutoAcceptSharedAttachmentsValue.enable:
@@ -24582,7 +24584,7 @@ extension on AutoAcceptSharedAttachmentsValue {
   }
 }
 
-extension on String {
+extension AutoAcceptSharedAttachmentsValueFromString on String {
   AutoAcceptSharedAttachmentsValue toAutoAcceptSharedAttachmentsValue() {
     switch (this) {
       case 'enable':
@@ -24600,7 +24602,7 @@ enum AutoPlacement {
   off,
 }
 
-extension on AutoPlacement {
+extension AutoPlacementValue on AutoPlacement {
   String toValue() {
     switch (this) {
       case AutoPlacement.on:
@@ -24611,7 +24613,7 @@ extension on AutoPlacement {
   }
 }
 
-extension on String {
+extension AutoPlacementFromString on String {
   AutoPlacement toAutoPlacement() {
     switch (this) {
       case 'on':
@@ -24705,7 +24707,7 @@ enum AvailabilityZoneOptInStatus {
   notOptedIn,
 }
 
-extension on AvailabilityZoneOptInStatus {
+extension AvailabilityZoneOptInStatusValue on AvailabilityZoneOptInStatus {
   String toValue() {
     switch (this) {
       case AvailabilityZoneOptInStatus.optInNotRequired:
@@ -24718,7 +24720,7 @@ extension on AvailabilityZoneOptInStatus {
   }
 }
 
-extension on String {
+extension AvailabilityZoneOptInStatusFromString on String {
   AvailabilityZoneOptInStatus toAvailabilityZoneOptInStatus() {
     switch (this) {
       case 'opt-in-not-required':
@@ -24739,7 +24741,7 @@ enum AvailabilityZoneState {
   unavailable,
 }
 
-extension on AvailabilityZoneState {
+extension AvailabilityZoneStateValue on AvailabilityZoneState {
   String toValue() {
     switch (this) {
       case AvailabilityZoneState.available:
@@ -24754,7 +24756,7 @@ extension on AvailabilityZoneState {
   }
 }
 
-extension on String {
+extension AvailabilityZoneStateFromString on String {
   AvailabilityZoneState toAvailabilityZoneState() {
     switch (this) {
       case 'available':
@@ -24799,7 +24801,7 @@ enum BatchState {
   modifying,
 }
 
-extension on BatchState {
+extension BatchStateValue on BatchState {
   String toValue() {
     switch (this) {
       case BatchState.submitted:
@@ -24820,7 +24822,7 @@ extension on BatchState {
   }
 }
 
-extension on String {
+extension BatchStateFromString on String {
   BatchState toBatchState() {
     switch (this) {
       case 'submitted':
@@ -24847,7 +24849,7 @@ enum BgpStatus {
   down,
 }
 
-extension on BgpStatus {
+extension BgpStatusValue on BgpStatus {
   String toValue() {
     switch (this) {
       case BgpStatus.up:
@@ -24858,7 +24860,7 @@ extension on BgpStatus {
   }
 }
 
-extension on String {
+extension BgpStatusFromString on String {
   BgpStatus toBgpStatus() {
     switch (this) {
       case 'up':
@@ -24987,7 +24989,7 @@ enum BundleTaskState {
   failed,
 }
 
-extension on BundleTaskState {
+extension BundleTaskStateValue on BundleTaskState {
   String toValue() {
     switch (this) {
       case BundleTaskState.pending:
@@ -25008,7 +25010,7 @@ extension on BundleTaskState {
   }
 }
 
-extension on String {
+extension BundleTaskStateFromString on String {
   BundleTaskState toBundleTaskState() {
     switch (this) {
       case 'pending':
@@ -25065,7 +25067,7 @@ enum ByoipCidrState {
   provisionedNotPubliclyAdvertisable,
 }
 
-extension on ByoipCidrState {
+extension ByoipCidrStateValue on ByoipCidrState {
   String toValue() {
     switch (this) {
       case ByoipCidrState.advertised:
@@ -25088,7 +25090,7 @@ extension on ByoipCidrState {
   }
 }
 
-extension on String {
+extension ByoipCidrStateFromString on String {
   ByoipCidrState toByoipCidrState() {
     switch (this) {
       case 'advertised':
@@ -25119,7 +25121,7 @@ enum CancelBatchErrorCode {
   unexpectedError,
 }
 
-extension on CancelBatchErrorCode {
+extension CancelBatchErrorCodeValue on CancelBatchErrorCode {
   String toValue() {
     switch (this) {
       case CancelBatchErrorCode.fleetRequestIdDoesNotExist:
@@ -25134,7 +25136,7 @@ extension on CancelBatchErrorCode {
   }
 }
 
-extension on String {
+extension CancelBatchErrorCodeFromString on String {
   CancelBatchErrorCode toCancelBatchErrorCode() {
     switch (this) {
       case 'fleetRequestIdDoesNotExist':
@@ -25266,7 +25268,8 @@ enum CancelSpotInstanceRequestState {
   completed,
 }
 
-extension on CancelSpotInstanceRequestState {
+extension CancelSpotInstanceRequestStateValue
+    on CancelSpotInstanceRequestState {
   String toValue() {
     switch (this) {
       case CancelSpotInstanceRequestState.active:
@@ -25283,7 +25286,7 @@ extension on CancelSpotInstanceRequestState {
   }
 }
 
-extension on String {
+extension CancelSpotInstanceRequestStateFromString on String {
   CancelSpotInstanceRequestState toCancelSpotInstanceRequestState() {
     switch (this) {
       case 'active':
@@ -25509,7 +25512,8 @@ enum CapacityReservationInstancePlatform {
   linuxWithSqlServerEnterprise,
 }
 
-extension on CapacityReservationInstancePlatform {
+extension CapacityReservationInstancePlatformValue
+    on CapacityReservationInstancePlatform {
   String toValue() {
     switch (this) {
       case CapacityReservationInstancePlatform.linuxUnix:
@@ -25538,7 +25542,7 @@ extension on CapacityReservationInstancePlatform {
   }
 }
 
-extension on String {
+extension CapacityReservationInstancePlatformFromString on String {
   CapacityReservationInstancePlatform toCapacityReservationInstancePlatform() {
     switch (this) {
       case 'Linux/UNIX':
@@ -25647,7 +25651,7 @@ enum CapacityReservationPreference {
   none,
 }
 
-extension on CapacityReservationPreference {
+extension CapacityReservationPreferenceValue on CapacityReservationPreference {
   String toValue() {
     switch (this) {
       case CapacityReservationPreference.open:
@@ -25658,7 +25662,7 @@ extension on CapacityReservationPreference {
   }
 }
 
-extension on String {
+extension CapacityReservationPreferenceFromString on String {
   CapacityReservationPreference toCapacityReservationPreference() {
     switch (this) {
       case 'open':
@@ -25751,7 +25755,7 @@ enum CapacityReservationState {
   failed,
 }
 
-extension on CapacityReservationState {
+extension CapacityReservationStateValue on CapacityReservationState {
   String toValue() {
     switch (this) {
       case CapacityReservationState.active:
@@ -25768,7 +25772,7 @@ extension on CapacityReservationState {
   }
 }
 
-extension on String {
+extension CapacityReservationStateFromString on String {
   CapacityReservationState toCapacityReservationState() {
     switch (this) {
       case 'active':
@@ -25820,7 +25824,7 @@ enum CapacityReservationTenancy {
   dedicated,
 }
 
-extension on CapacityReservationTenancy {
+extension CapacityReservationTenancyValue on CapacityReservationTenancy {
   String toValue() {
     switch (this) {
       case CapacityReservationTenancy.$default:
@@ -25831,7 +25835,7 @@ extension on CapacityReservationTenancy {
   }
 }
 
-extension on String {
+extension CapacityReservationTenancyFromString on String {
   CapacityReservationTenancy toCapacityReservationTenancy() {
     switch (this) {
       case 'default':
@@ -25876,7 +25880,7 @@ enum CarrierGatewayState {
   deleted,
 }
 
-extension on CarrierGatewayState {
+extension CarrierGatewayStateValue on CarrierGatewayState {
   String toValue() {
     switch (this) {
       case CarrierGatewayState.pending:
@@ -25891,7 +25895,7 @@ extension on CarrierGatewayState {
   }
 }
 
-extension on String {
+extension CarrierGatewayStateFromString on String {
   CarrierGatewayState toCarrierGatewayState() {
     switch (this) {
       case 'pending':
@@ -26035,7 +26039,8 @@ enum ClientCertificateRevocationListStatusCode {
   active,
 }
 
-extension on ClientCertificateRevocationListStatusCode {
+extension ClientCertificateRevocationListStatusCodeValue
+    on ClientCertificateRevocationListStatusCode {
   String toValue() {
     switch (this) {
       case ClientCertificateRevocationListStatusCode.pending:
@@ -26046,7 +26051,7 @@ extension on ClientCertificateRevocationListStatusCode {
   }
 }
 
-extension on String {
+extension ClientCertificateRevocationListStatusCodeFromString on String {
   ClientCertificateRevocationListStatusCode
       toClientCertificateRevocationListStatusCode() {
     switch (this) {
@@ -26181,7 +26186,7 @@ enum ClientVpnAuthenticationType {
   federatedAuthentication,
 }
 
-extension on ClientVpnAuthenticationType {
+extension ClientVpnAuthenticationTypeValue on ClientVpnAuthenticationType {
   String toValue() {
     switch (this) {
       case ClientVpnAuthenticationType.certificateAuthentication:
@@ -26194,7 +26199,7 @@ extension on ClientVpnAuthenticationType {
   }
 }
 
-extension on String {
+extension ClientVpnAuthenticationTypeFromString on String {
   ClientVpnAuthenticationType toClientVpnAuthenticationType() {
     switch (this) {
       case 'certificate-authentication':
@@ -26229,7 +26234,8 @@ enum ClientVpnAuthorizationRuleStatusCode {
   revoking,
 }
 
-extension on ClientVpnAuthorizationRuleStatusCode {
+extension ClientVpnAuthorizationRuleStatusCodeValue
+    on ClientVpnAuthorizationRuleStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnAuthorizationRuleStatusCode.authorizing:
@@ -26244,7 +26250,7 @@ extension on ClientVpnAuthorizationRuleStatusCode {
   }
 }
 
-extension on String {
+extension ClientVpnAuthorizationRuleStatusCodeFromString on String {
   ClientVpnAuthorizationRuleStatusCode
       toClientVpnAuthorizationRuleStatusCode() {
     switch (this) {
@@ -26349,7 +26355,7 @@ enum ClientVpnConnectionStatusCode {
   terminated,
 }
 
-extension on ClientVpnConnectionStatusCode {
+extension ClientVpnConnectionStatusCodeValue on ClientVpnConnectionStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnConnectionStatusCode.active:
@@ -26364,7 +26370,7 @@ extension on ClientVpnConnectionStatusCode {
   }
 }
 
-extension on String {
+extension ClientVpnConnectionStatusCodeFromString on String {
   ClientVpnConnectionStatusCode toClientVpnConnectionStatusCode() {
     switch (this) {
       case 'active':
@@ -26499,7 +26505,8 @@ enum ClientVpnEndpointAttributeStatusCode {
   applied,
 }
 
-extension on ClientVpnEndpointAttributeStatusCode {
+extension ClientVpnEndpointAttributeStatusCodeValue
+    on ClientVpnEndpointAttributeStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnEndpointAttributeStatusCode.applying:
@@ -26510,7 +26517,7 @@ extension on ClientVpnEndpointAttributeStatusCode {
   }
 }
 
-extension on String {
+extension ClientVpnEndpointAttributeStatusCodeFromString on String {
   ClientVpnEndpointAttributeStatusCode
       toClientVpnEndpointAttributeStatusCode() {
     switch (this) {
@@ -26566,7 +26573,7 @@ enum ClientVpnEndpointStatusCode {
   deleted,
 }
 
-extension on ClientVpnEndpointStatusCode {
+extension ClientVpnEndpointStatusCodeValue on ClientVpnEndpointStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnEndpointStatusCode.pendingAssociate:
@@ -26581,7 +26588,7 @@ extension on ClientVpnEndpointStatusCode {
   }
 }
 
-extension on String {
+extension ClientVpnEndpointStatusCodeFromString on String {
   ClientVpnEndpointStatusCode toClientVpnEndpointStatusCode() {
     switch (this) {
       case 'pending-associate':
@@ -26656,7 +26663,7 @@ enum ClientVpnRouteStatusCode {
   deleting,
 }
 
-extension on ClientVpnRouteStatusCode {
+extension ClientVpnRouteStatusCodeValue on ClientVpnRouteStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnRouteStatusCode.creating:
@@ -26671,7 +26678,7 @@ extension on ClientVpnRouteStatusCode {
   }
 }
 
-extension on String {
+extension ClientVpnRouteStatusCodeFromString on String {
   ClientVpnRouteStatusCode toClientVpnRouteStatusCode() {
     switch (this) {
       case 'creating':
@@ -26834,7 +26841,7 @@ enum ConnectionNotificationState {
   disabled,
 }
 
-extension on ConnectionNotificationState {
+extension ConnectionNotificationStateValue on ConnectionNotificationState {
   String toValue() {
     switch (this) {
       case ConnectionNotificationState.enabled:
@@ -26845,7 +26852,7 @@ extension on ConnectionNotificationState {
   }
 }
 
-extension on String {
+extension ConnectionNotificationStateFromString on String {
   ConnectionNotificationState toConnectionNotificationState() {
     switch (this) {
       case 'Enabled':
@@ -26861,7 +26868,7 @@ enum ConnectionNotificationType {
   topic,
 }
 
-extension on ConnectionNotificationType {
+extension ConnectionNotificationTypeValue on ConnectionNotificationType {
   String toValue() {
     switch (this) {
       case ConnectionNotificationType.topic:
@@ -26870,7 +26877,7 @@ extension on ConnectionNotificationType {
   }
 }
 
-extension on String {
+extension ConnectionNotificationTypeFromString on String {
   ConnectionNotificationType toConnectionNotificationType() {
     switch (this) {
       case 'Topic':
@@ -26884,7 +26891,7 @@ enum ContainerFormat {
   ova,
 }
 
-extension on ContainerFormat {
+extension ContainerFormatValue on ContainerFormat {
   String toValue() {
     switch (this) {
       case ContainerFormat.ova:
@@ -26893,7 +26900,7 @@ extension on ContainerFormat {
   }
 }
 
-extension on String {
+extension ContainerFormatFromString on String {
   ContainerFormat toContainerFormat() {
     switch (this) {
       case 'ova':
@@ -26947,7 +26954,7 @@ enum ConversionTaskState {
   completed,
 }
 
-extension on ConversionTaskState {
+extension ConversionTaskStateValue on ConversionTaskState {
   String toValue() {
     switch (this) {
       case ConversionTaskState.active:
@@ -26962,7 +26969,7 @@ extension on ConversionTaskState {
   }
 }
 
-extension on String {
+extension ConversionTaskStateFromString on String {
   ConversionTaskState toConversionTaskState() {
     switch (this) {
       case 'active':
@@ -27014,7 +27021,7 @@ enum CopyTagsFromSource {
   volume,
 }
 
-extension on CopyTagsFromSource {
+extension CopyTagsFromSourceValue on CopyTagsFromSource {
   String toValue() {
     switch (this) {
       case CopyTagsFromSource.volume:
@@ -27023,7 +27030,7 @@ extension on CopyTagsFromSource {
   }
 }
 
-extension on String {
+extension CopyTagsFromSourceFromString on String {
   CopyTagsFromSource toCopyTagsFromSource() {
     switch (this) {
       case 'volume':
@@ -27819,7 +27826,7 @@ enum CurrencyCodeValues {
   usd,
 }
 
-extension on CurrencyCodeValues {
+extension CurrencyCodeValuesValue on CurrencyCodeValues {
   String toValue() {
     switch (this) {
       case CurrencyCodeValues.usd:
@@ -27828,7 +27835,7 @@ extension on CurrencyCodeValues {
   }
 }
 
-extension on String {
+extension CurrencyCodeValuesFromString on String {
   CurrencyCodeValues toCurrencyCodeValues() {
     switch (this) {
       case 'USD':
@@ -27885,7 +27892,7 @@ enum DatafeedSubscriptionState {
   inactive,
 }
 
-extension on DatafeedSubscriptionState {
+extension DatafeedSubscriptionStateValue on DatafeedSubscriptionState {
   String toValue() {
     switch (this) {
       case DatafeedSubscriptionState.active:
@@ -27896,7 +27903,7 @@ extension on DatafeedSubscriptionState {
   }
 }
 
-extension on String {
+extension DatafeedSubscriptionStateFromString on String {
   DatafeedSubscriptionState toDatafeedSubscriptionState() {
     switch (this) {
       case 'Active':
@@ -27913,7 +27920,8 @@ enum DefaultRouteTableAssociationValue {
   disable,
 }
 
-extension on DefaultRouteTableAssociationValue {
+extension DefaultRouteTableAssociationValueValue
+    on DefaultRouteTableAssociationValue {
   String toValue() {
     switch (this) {
       case DefaultRouteTableAssociationValue.enable:
@@ -27924,7 +27932,7 @@ extension on DefaultRouteTableAssociationValue {
   }
 }
 
-extension on String {
+extension DefaultRouteTableAssociationValueFromString on String {
   DefaultRouteTableAssociationValue toDefaultRouteTableAssociationValue() {
     switch (this) {
       case 'enable':
@@ -27942,7 +27950,8 @@ enum DefaultRouteTablePropagationValue {
   disable,
 }
 
-extension on DefaultRouteTablePropagationValue {
+extension DefaultRouteTablePropagationValueValue
+    on DefaultRouteTablePropagationValue {
   String toValue() {
     switch (this) {
       case DefaultRouteTablePropagationValue.enable:
@@ -27953,7 +27962,7 @@ extension on DefaultRouteTablePropagationValue {
   }
 }
 
-extension on String {
+extension DefaultRouteTablePropagationValueFromString on String {
   DefaultRouteTablePropagationValue toDefaultRouteTablePropagationValue() {
     switch (this) {
       case 'enable':
@@ -27971,7 +27980,7 @@ enum DefaultTargetCapacityType {
   onDemand,
 }
 
-extension on DefaultTargetCapacityType {
+extension DefaultTargetCapacityTypeValue on DefaultTargetCapacityType {
   String toValue() {
     switch (this) {
       case DefaultTargetCapacityType.spot:
@@ -27982,7 +27991,7 @@ extension on DefaultTargetCapacityType {
   }
 }
 
-extension on String {
+extension DefaultTargetCapacityTypeFromString on String {
   DefaultTargetCapacityType toDefaultTargetCapacityType() {
     switch (this) {
       case 'spot':
@@ -28052,7 +28061,7 @@ enum DeleteFleetErrorCode {
   unexpectedError,
 }
 
-extension on DeleteFleetErrorCode {
+extension DeleteFleetErrorCodeValue on DeleteFleetErrorCode {
   String toValue() {
     switch (this) {
       case DeleteFleetErrorCode.fleetIdDoesNotExist:
@@ -28067,7 +28076,7 @@ extension on DeleteFleetErrorCode {
   }
 }
 
-extension on String {
+extension DeleteFleetErrorCodeFromString on String {
   DeleteFleetErrorCode toDeleteFleetErrorCode() {
     switch (this) {
       case 'fleetIdDoesNotExist':
@@ -28298,7 +28307,8 @@ enum DeleteQueuedReservedInstancesErrorCode {
   unexpectedError,
 }
 
-extension on DeleteQueuedReservedInstancesErrorCode {
+extension DeleteQueuedReservedInstancesErrorCodeValue
+    on DeleteQueuedReservedInstancesErrorCode {
   String toValue() {
     switch (this) {
       case DeleteQueuedReservedInstancesErrorCode.reservedInstancesIdInvalid:
@@ -28312,7 +28322,7 @@ extension on DeleteQueuedReservedInstancesErrorCode {
   }
 }
 
-extension on String {
+extension DeleteQueuedReservedInstancesErrorCodeFromString on String {
   DeleteQueuedReservedInstancesErrorCode
       toDeleteQueuedReservedInstancesErrorCode() {
     switch (this) {
@@ -30341,7 +30351,7 @@ enum DeviceType {
   instanceStore,
 }
 
-extension on DeviceType {
+extension DeviceTypeValue on DeviceType {
   String toValue() {
     switch (this) {
       case DeviceType.ebs:
@@ -30352,7 +30362,7 @@ extension on DeviceType {
   }
 }
 
-extension on String {
+extension DeviceTypeFromString on String {
   DeviceType toDeviceType() {
     switch (this) {
       case 'ebs':
@@ -30752,7 +30762,7 @@ enum DiskImageFormat {
   vhd,
 }
 
-extension on DiskImageFormat {
+extension DiskImageFormatValue on DiskImageFormat {
   String toValue() {
     switch (this) {
       case DiskImageFormat.vmdk:
@@ -30765,7 +30775,7 @@ extension on DiskImageFormat {
   }
 }
 
-extension on String {
+extension DiskImageFormatFromString on String {
   DiskImageFormat toDiskImageFormat() {
     switch (this) {
       case 'VMDK':
@@ -30816,7 +30826,7 @@ enum DiskType {
   ssd,
 }
 
-extension on DiskType {
+extension DiskTypeValue on DiskType {
   String toValue() {
     switch (this) {
       case DiskType.hdd:
@@ -30827,7 +30837,7 @@ extension on DiskType {
   }
 }
 
-extension on String {
+extension DiskTypeFromString on String {
   DiskType toDiskType() {
     switch (this) {
       case 'hdd':
@@ -30859,7 +30869,7 @@ enum DnsNameState {
   failed,
 }
 
-extension on DnsNameState {
+extension DnsNameStateValue on DnsNameState {
   String toValue() {
     switch (this) {
       case DnsNameState.pendingVerification:
@@ -30872,7 +30882,7 @@ extension on DnsNameState {
   }
 }
 
-extension on String {
+extension DnsNameStateFromString on String {
   DnsNameState toDnsNameState() {
     switch (this) {
       case 'pendingVerification':
@@ -30908,7 +30918,7 @@ enum DnsSupportValue {
   disable,
 }
 
-extension on DnsSupportValue {
+extension DnsSupportValueValue on DnsSupportValue {
   String toValue() {
     switch (this) {
       case DnsSupportValue.enable:
@@ -30919,7 +30929,7 @@ extension on DnsSupportValue {
   }
 }
 
-extension on String {
+extension DnsSupportValueFromString on String {
   DnsSupportValue toDnsSupportValue() {
     switch (this) {
       case 'enable':
@@ -30936,7 +30946,7 @@ enum DomainType {
   standard,
 }
 
-extension on DomainType {
+extension DomainTypeValue on DomainType {
   String toValue() {
     switch (this) {
       case DomainType.vpc:
@@ -30947,7 +30957,7 @@ extension on DomainType {
   }
 }
 
-extension on String {
+extension DomainTypeFromString on String {
   DomainType toDomainType() {
     switch (this) {
       case 'vpc':
@@ -31089,7 +31099,7 @@ enum EbsEncryptionSupport {
   supported,
 }
 
-extension on EbsEncryptionSupport {
+extension EbsEncryptionSupportValue on EbsEncryptionSupport {
   String toValue() {
     switch (this) {
       case EbsEncryptionSupport.unsupported:
@@ -31100,7 +31110,7 @@ extension on EbsEncryptionSupport {
   }
 }
 
-extension on String {
+extension EbsEncryptionSupportFromString on String {
   EbsEncryptionSupport toEbsEncryptionSupport() {
     switch (this) {
       case 'unsupported':
@@ -31182,7 +31192,7 @@ enum EbsNvmeSupport {
   required,
 }
 
-extension on EbsNvmeSupport {
+extension EbsNvmeSupportValue on EbsNvmeSupport {
   String toValue() {
     switch (this) {
       case EbsNvmeSupport.unsupported:
@@ -31195,7 +31205,7 @@ extension on EbsNvmeSupport {
   }
 }
 
-extension on String {
+extension EbsNvmeSupportFromString on String {
   EbsNvmeSupport toEbsNvmeSupport() {
     switch (this) {
       case 'unsupported':
@@ -31251,7 +31261,7 @@ enum EbsOptimizedSupport {
   $default,
 }
 
-extension on EbsOptimizedSupport {
+extension EbsOptimizedSupportValue on EbsOptimizedSupport {
   String toValue() {
     switch (this) {
       case EbsOptimizedSupport.unsupported:
@@ -31264,7 +31274,7 @@ extension on EbsOptimizedSupport {
   }
 }
 
-extension on String {
+extension EbsOptimizedSupportFromString on String {
   EbsOptimizedSupport toEbsOptimizedSupport() {
     switch (this) {
       case 'unsupported':
@@ -31358,7 +31368,7 @@ enum ElasticGpuState {
   attached,
 }
 
-extension on ElasticGpuState {
+extension ElasticGpuStateValue on ElasticGpuState {
   String toValue() {
     switch (this) {
       case ElasticGpuState.attached:
@@ -31367,7 +31377,7 @@ extension on ElasticGpuState {
   }
 }
 
-extension on String {
+extension ElasticGpuStateFromString on String {
   ElasticGpuState toElasticGpuState() {
     switch (this) {
       case 'ATTACHED':
@@ -31382,7 +31392,7 @@ enum ElasticGpuStatus {
   impaired,
 }
 
-extension on ElasticGpuStatus {
+extension ElasticGpuStatusValue on ElasticGpuStatus {
   String toValue() {
     switch (this) {
       case ElasticGpuStatus.ok:
@@ -31393,7 +31403,7 @@ extension on ElasticGpuStatus {
   }
 }
 
-extension on String {
+extension ElasticGpuStatusFromString on String {
   ElasticGpuStatus toElasticGpuStatus() {
     switch (this) {
       case 'OK':
@@ -31489,7 +31499,7 @@ enum EnaSupport {
   required,
 }
 
-extension on EnaSupport {
+extension EnaSupportValue on EnaSupport {
   String toValue() {
     switch (this) {
       case EnaSupport.unsupported:
@@ -31502,7 +31512,7 @@ extension on EnaSupport {
   }
 }
 
-extension on String {
+extension EnaSupportFromString on String {
   EnaSupport toEnaSupport() {
     switch (this) {
       case 'unsupported':
@@ -31713,7 +31723,7 @@ enum EndDateType {
   limited,
 }
 
-extension on EndDateType {
+extension EndDateTypeValue on EndDateType {
   String toValue() {
     switch (this) {
       case EndDateType.unlimited:
@@ -31724,7 +31734,7 @@ extension on EndDateType {
   }
 }
 
-extension on String {
+extension EndDateTypeFromString on String {
   EndDateType toEndDateType() {
     switch (this) {
       case 'unlimited':
@@ -31742,7 +31752,7 @@ enum EphemeralNvmeSupport {
   required,
 }
 
-extension on EphemeralNvmeSupport {
+extension EphemeralNvmeSupportValue on EphemeralNvmeSupport {
   String toValue() {
     switch (this) {
       case EphemeralNvmeSupport.unsupported:
@@ -31755,7 +31765,7 @@ extension on EphemeralNvmeSupport {
   }
 }
 
-extension on String {
+extension EphemeralNvmeSupportFromString on String {
   EphemeralNvmeSupport toEphemeralNvmeSupport() {
     switch (this) {
       case 'unsupported':
@@ -31777,7 +31787,7 @@ enum EventCode {
   instanceStop,
 }
 
-extension on EventCode {
+extension EventCodeValue on EventCode {
   String toValue() {
     switch (this) {
       case EventCode.instanceReboot:
@@ -31794,7 +31804,7 @@ extension on EventCode {
   }
 }
 
-extension on String {
+extension EventCodeFromString on String {
   EventCode toEventCode() {
     switch (this) {
       case 'instance-reboot':
@@ -31930,7 +31940,7 @@ enum EventType {
   information,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.instanceChange:
@@ -31945,7 +31955,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'instanceChange':
@@ -31966,7 +31976,8 @@ enum ExcessCapacityTerminationPolicy {
   $default,
 }
 
-extension on ExcessCapacityTerminationPolicy {
+extension ExcessCapacityTerminationPolicyValue
+    on ExcessCapacityTerminationPolicy {
   String toValue() {
     switch (this) {
       case ExcessCapacityTerminationPolicy.noTermination:
@@ -31977,7 +31988,7 @@ extension on ExcessCapacityTerminationPolicy {
   }
 }
 
-extension on String {
+extension ExcessCapacityTerminationPolicyFromString on String {
   ExcessCapacityTerminationPolicy toExcessCapacityTerminationPolicy() {
     switch (this) {
       case 'noTermination':
@@ -32216,7 +32227,7 @@ enum ExportEnvironment {
   microsoft,
 }
 
-extension on ExportEnvironment {
+extension ExportEnvironmentValue on ExportEnvironment {
   String toValue() {
     switch (this) {
       case ExportEnvironment.citrix:
@@ -32229,7 +32240,7 @@ extension on ExportEnvironment {
   }
 }
 
-extension on String {
+extension ExportEnvironmentFromString on String {
   ExportEnvironment toExportEnvironment() {
     switch (this) {
       case 'citrix':
@@ -32400,7 +32411,7 @@ enum ExportTaskState {
   completed,
 }
 
-extension on ExportTaskState {
+extension ExportTaskStateValue on ExportTaskState {
   String toValue() {
     switch (this) {
       case ExportTaskState.active:
@@ -32415,7 +32426,7 @@ extension on ExportTaskState {
   }
 }
 
-extension on String {
+extension ExportTaskStateFromString on String {
   ExportTaskState toExportTaskState() {
     switch (this) {
       case 'active':
@@ -32514,7 +32525,7 @@ enum FastSnapshotRestoreStateCode {
   disabled,
 }
 
-extension on FastSnapshotRestoreStateCode {
+extension FastSnapshotRestoreStateCodeValue on FastSnapshotRestoreStateCode {
   String toValue() {
     switch (this) {
       case FastSnapshotRestoreStateCode.enabling:
@@ -32531,7 +32542,7 @@ extension on FastSnapshotRestoreStateCode {
   }
 }
 
-extension on String {
+extension FastSnapshotRestoreStateCodeFromString on String {
   FastSnapshotRestoreStateCode toFastSnapshotRestoreStateCode() {
     switch (this) {
       case 'enabling':
@@ -32637,7 +32648,7 @@ enum FleetActivityStatus {
   fulfilled,
 }
 
-extension on FleetActivityStatus {
+extension FleetActivityStatusValue on FleetActivityStatus {
   String toValue() {
     switch (this) {
       case FleetActivityStatus.error:
@@ -32652,7 +32663,7 @@ extension on FleetActivityStatus {
   }
 }
 
-extension on String {
+extension FleetActivityStatusFromString on String {
   FleetActivityStatus toFleetActivityStatus() {
     switch (this) {
       case 'error':
@@ -32672,7 +32683,8 @@ enum FleetCapacityReservationUsageStrategy {
   useCapacityReservationsFirst,
 }
 
-extension on FleetCapacityReservationUsageStrategy {
+extension FleetCapacityReservationUsageStrategyValue
+    on FleetCapacityReservationUsageStrategy {
   String toValue() {
     switch (this) {
       case FleetCapacityReservationUsageStrategy.useCapacityReservationsFirst:
@@ -32681,7 +32693,7 @@ extension on FleetCapacityReservationUsageStrategy {
   }
 }
 
-extension on String {
+extension FleetCapacityReservationUsageStrategyFromString on String {
   FleetCapacityReservationUsageStrategy
       toFleetCapacityReservationUsageStrategy() {
     switch (this) {
@@ -32820,7 +32832,7 @@ enum FleetEventType {
   serviceError,
 }
 
-extension on FleetEventType {
+extension FleetEventTypeValue on FleetEventType {
   String toValue() {
     switch (this) {
       case FleetEventType.instanceChange:
@@ -32833,7 +32845,7 @@ extension on FleetEventType {
   }
 }
 
-extension on String {
+extension FleetEventTypeFromString on String {
   FleetEventType toFleetEventType() {
     switch (this) {
       case 'instance-change':
@@ -32852,7 +32864,8 @@ enum FleetExcessCapacityTerminationPolicy {
   termination,
 }
 
-extension on FleetExcessCapacityTerminationPolicy {
+extension FleetExcessCapacityTerminationPolicyValue
+    on FleetExcessCapacityTerminationPolicy {
   String toValue() {
     switch (this) {
       case FleetExcessCapacityTerminationPolicy.noTermination:
@@ -32863,7 +32876,7 @@ extension on FleetExcessCapacityTerminationPolicy {
   }
 }
 
-extension on String {
+extension FleetExcessCapacityTerminationPolicyFromString on String {
   FleetExcessCapacityTerminationPolicy
       toFleetExcessCapacityTerminationPolicy() {
     switch (this) {
@@ -33063,7 +33076,8 @@ enum FleetOnDemandAllocationStrategy {
   prioritized,
 }
 
-extension on FleetOnDemandAllocationStrategy {
+extension FleetOnDemandAllocationStrategyValue
+    on FleetOnDemandAllocationStrategy {
   String toValue() {
     switch (this) {
       case FleetOnDemandAllocationStrategy.lowestPrice:
@@ -33074,7 +33088,7 @@ extension on FleetOnDemandAllocationStrategy {
   }
 }
 
-extension on String {
+extension FleetOnDemandAllocationStrategyFromString on String {
   FleetOnDemandAllocationStrategy toFleetOnDemandAllocationStrategy() {
     switch (this) {
       case 'lowest-price':
@@ -33091,7 +33105,7 @@ enum FleetReplacementStrategy {
   launch,
 }
 
-extension on FleetReplacementStrategy {
+extension FleetReplacementStrategyValue on FleetReplacementStrategy {
   String toValue() {
     switch (this) {
       case FleetReplacementStrategy.launch:
@@ -33100,7 +33114,7 @@ extension on FleetReplacementStrategy {
   }
 }
 
-extension on String {
+extension FleetReplacementStrategyFromString on String {
   FleetReplacementStrategy toFleetReplacementStrategy() {
     switch (this) {
       case 'launch':
@@ -33188,7 +33202,7 @@ enum FleetStateCode {
   modifying,
 }
 
-extension on FleetStateCode {
+extension FleetStateCodeValue on FleetStateCode {
   String toValue() {
     switch (this) {
       case FleetStateCode.submitted:
@@ -33209,7 +33223,7 @@ extension on FleetStateCode {
   }
 }
 
-extension on String {
+extension FleetStateCodeFromString on String {
   FleetStateCode toFleetStateCode() {
     switch (this) {
       case 'submitted':
@@ -33237,7 +33251,7 @@ enum FleetType {
   instant,
 }
 
-extension on FleetType {
+extension FleetTypeValue on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.request:
@@ -33250,7 +33264,7 @@ extension on FleetType {
   }
 }
 
-extension on String {
+extension FleetTypeFromString on String {
   FleetType toFleetType() {
     switch (this) {
       case 'request':
@@ -33353,7 +33367,7 @@ enum FlowLogsResourceType {
   networkInterface,
 }
 
-extension on FlowLogsResourceType {
+extension FlowLogsResourceTypeValue on FlowLogsResourceType {
   String toValue() {
     switch (this) {
       case FlowLogsResourceType.vpc:
@@ -33366,7 +33380,7 @@ extension on FlowLogsResourceType {
   }
 }
 
-extension on String {
+extension FlowLogsResourceTypeFromString on String {
   FlowLogsResourceType toFlowLogsResourceType() {
     switch (this) {
       case 'VPC':
@@ -33512,7 +33526,7 @@ enum FpgaImageAttributeName {
   productCodes,
 }
 
-extension on FpgaImageAttributeName {
+extension FpgaImageAttributeNameValue on FpgaImageAttributeName {
   String toValue() {
     switch (this) {
       case FpgaImageAttributeName.description:
@@ -33527,7 +33541,7 @@ extension on FpgaImageAttributeName {
   }
 }
 
-extension on String {
+extension FpgaImageAttributeNameFromString on String {
   FpgaImageAttributeName toFpgaImageAttributeName() {
     switch (this) {
       case 'description':
@@ -33580,7 +33594,7 @@ enum FpgaImageStateCode {
   unavailable,
 }
 
-extension on FpgaImageStateCode {
+extension FpgaImageStateCodeValue on FpgaImageStateCode {
   String toValue() {
     switch (this) {
       case FpgaImageStateCode.pending:
@@ -33595,7 +33609,7 @@ extension on FpgaImageStateCode {
   }
 }
 
-extension on String {
+extension FpgaImageStateCodeFromString on String {
   FpgaImageStateCode toFpgaImageStateCode() {
     switch (this) {
       case 'pending':
@@ -33629,7 +33643,7 @@ enum GatewayType {
   ipsec_1,
 }
 
-extension on GatewayType {
+extension GatewayTypeValue on GatewayType {
   String toValue() {
     switch (this) {
       case GatewayType.ipsec_1:
@@ -33638,7 +33652,7 @@ extension on GatewayType {
   }
 }
 
-extension on String {
+extension GatewayTypeFromString on String {
   GatewayType toGatewayType() {
     switch (this) {
       case 'ipsec.1':
@@ -34340,7 +34354,7 @@ enum HostRecovery {
   off,
 }
 
-extension on HostRecovery {
+extension HostRecoveryValue on HostRecovery {
   String toValue() {
     switch (this) {
       case HostRecovery.on:
@@ -34351,7 +34365,7 @@ extension on HostRecovery {
   }
 }
 
-extension on String {
+extension HostRecoveryFromString on String {
   HostRecovery toHostRecovery() {
     switch (this) {
       case 'on':
@@ -34436,7 +34450,7 @@ enum HostTenancy {
   host,
 }
 
-extension on HostTenancy {
+extension HostTenancyValue on HostTenancy {
   String toValue() {
     switch (this) {
       case HostTenancy.dedicated:
@@ -34447,7 +34461,7 @@ extension on HostTenancy {
   }
 }
 
-extension on String {
+extension HostTenancyFromString on String {
   HostTenancy toHostTenancy() {
     switch (this) {
       case 'dedicated':
@@ -34464,7 +34478,7 @@ enum HttpTokensState {
   required,
 }
 
-extension on HttpTokensState {
+extension HttpTokensStateValue on HttpTokensState {
   String toValue() {
     switch (this) {
       case HttpTokensState.optional:
@@ -34475,7 +34489,7 @@ extension on HttpTokensState {
   }
 }
 
-extension on String {
+extension HttpTokensStateFromString on String {
   HttpTokensState toHttpTokensState() {
     switch (this) {
       case 'optional':
@@ -34492,7 +34506,7 @@ enum HypervisorType {
   xen,
 }
 
-extension on HypervisorType {
+extension HypervisorTypeValue on HypervisorType {
   String toValue() {
     switch (this) {
       case HypervisorType.ovm:
@@ -34503,7 +34517,7 @@ extension on HypervisorType {
   }
 }
 
-extension on String {
+extension HypervisorTypeFromString on String {
   HypervisorType toHypervisorType() {
     switch (this) {
       case 'ovm':
@@ -34582,7 +34596,8 @@ enum IamInstanceProfileAssociationState {
   disassociated,
 }
 
-extension on IamInstanceProfileAssociationState {
+extension IamInstanceProfileAssociationStateValue
+    on IamInstanceProfileAssociationState {
   String toValue() {
     switch (this) {
       case IamInstanceProfileAssociationState.associating:
@@ -34597,7 +34612,7 @@ extension on IamInstanceProfileAssociationState {
   }
 }
 
-extension on String {
+extension IamInstanceProfileAssociationStateFromString on String {
   IamInstanceProfileAssociationState toIamInstanceProfileAssociationState() {
     switch (this) {
       case 'associating':
@@ -34668,7 +34683,7 @@ enum Igmpv2SupportValue {
   disable,
 }
 
-extension on Igmpv2SupportValue {
+extension Igmpv2SupportValueValue on Igmpv2SupportValue {
   String toValue() {
     switch (this) {
       case Igmpv2SupportValue.enable:
@@ -34679,7 +34694,7 @@ extension on Igmpv2SupportValue {
   }
 }
 
-extension on String {
+extension Igmpv2SupportValueFromString on String {
   Igmpv2SupportValue toIgmpv2SupportValue() {
     switch (this) {
       case 'enable':
@@ -34873,7 +34888,7 @@ enum ImageAttributeName {
   sriovNetSupport,
 }
 
-extension on ImageAttributeName {
+extension ImageAttributeNameValue on ImageAttributeName {
   String toValue() {
     switch (this) {
       case ImageAttributeName.description:
@@ -34894,7 +34909,7 @@ extension on ImageAttributeName {
   }
 }
 
-extension on String {
+extension ImageAttributeNameFromString on String {
   ImageAttributeName toImageAttributeName() {
     switch (this) {
       case 'description':
@@ -34960,7 +34975,7 @@ enum ImageState {
   error,
 }
 
-extension on ImageState {
+extension ImageStateValue on ImageState {
   String toValue() {
     switch (this) {
       case ImageState.pending:
@@ -34981,7 +34996,7 @@ extension on ImageState {
   }
 }
 
-extension on String {
+extension ImageStateFromString on String {
   ImageState toImageState() {
     switch (this) {
       case 'pending':
@@ -35009,7 +35024,7 @@ enum ImageTypeValues {
   ramdisk,
 }
 
-extension on ImageTypeValues {
+extension ImageTypeValuesValue on ImageTypeValues {
   String toValue() {
     switch (this) {
       case ImageTypeValues.machine:
@@ -35022,7 +35037,7 @@ extension on ImageTypeValues {
   }
 }
 
-extension on String {
+extension ImageTypeValuesFromString on String {
   ImageTypeValues toImageTypeValues() {
     switch (this) {
       case 'machine':
@@ -35779,7 +35794,7 @@ enum InstanceAttributeName {
   enclaveOptions,
 }
 
-extension on InstanceAttributeName {
+extension InstanceAttributeNameValue on InstanceAttributeName {
   String toValue() {
     switch (this) {
       case InstanceAttributeName.instanceType:
@@ -35816,7 +35831,7 @@ extension on InstanceAttributeName {
   }
 }
 
-extension on String {
+extension InstanceAttributeNameFromString on String {
   InstanceAttributeName toInstanceAttributeName() {
     switch (this) {
       case 'instanceType':
@@ -35995,7 +36010,7 @@ enum InstanceHealthStatus {
   unhealthy,
 }
 
-extension on InstanceHealthStatus {
+extension InstanceHealthStatusValue on InstanceHealthStatus {
   String toValue() {
     switch (this) {
       case InstanceHealthStatus.healthy:
@@ -36006,7 +36021,7 @@ extension on InstanceHealthStatus {
   }
 }
 
-extension on String {
+extension InstanceHealthStatusFromString on String {
   InstanceHealthStatus toInstanceHealthStatus() {
     switch (this) {
       case 'healthy':
@@ -36024,7 +36039,7 @@ enum InstanceInterruptionBehavior {
   terminate,
 }
 
-extension on InstanceInterruptionBehavior {
+extension InstanceInterruptionBehaviorValue on InstanceInterruptionBehavior {
   String toValue() {
     switch (this) {
       case InstanceInterruptionBehavior.hibernate:
@@ -36037,7 +36052,7 @@ extension on InstanceInterruptionBehavior {
   }
 }
 
-extension on String {
+extension InstanceInterruptionBehaviorFromString on String {
   InstanceInterruptionBehavior toInstanceInterruptionBehavior() {
     switch (this) {
       case 'hibernate':
@@ -36076,7 +36091,7 @@ enum InstanceLifecycle {
   onDemand,
 }
 
-extension on InstanceLifecycle {
+extension InstanceLifecycleValue on InstanceLifecycle {
   String toValue() {
     switch (this) {
       case InstanceLifecycle.spot:
@@ -36087,7 +36102,7 @@ extension on InstanceLifecycle {
   }
 }
 
-extension on String {
+extension InstanceLifecycleFromString on String {
   InstanceLifecycle toInstanceLifecycle() {
     switch (this) {
       case 'spot':
@@ -36104,7 +36119,7 @@ enum InstanceLifecycleType {
   scheduled,
 }
 
-extension on InstanceLifecycleType {
+extension InstanceLifecycleTypeValue on InstanceLifecycleType {
   String toValue() {
     switch (this) {
       case InstanceLifecycleType.spot:
@@ -36115,7 +36130,7 @@ extension on InstanceLifecycleType {
   }
 }
 
-extension on String {
+extension InstanceLifecycleTypeFromString on String {
   InstanceLifecycleType toInstanceLifecycleType() {
     switch (this) {
       case 'spot':
@@ -36146,7 +36161,7 @@ enum InstanceMatchCriteria {
   targeted,
 }
 
-extension on InstanceMatchCriteria {
+extension InstanceMatchCriteriaValue on InstanceMatchCriteria {
   String toValue() {
     switch (this) {
       case InstanceMatchCriteria.open:
@@ -36157,7 +36172,7 @@ extension on InstanceMatchCriteria {
   }
 }
 
-extension on String {
+extension InstanceMatchCriteriaFromString on String {
   InstanceMatchCriteria toInstanceMatchCriteria() {
     switch (this) {
       case 'open':
@@ -36174,7 +36189,7 @@ enum InstanceMetadataEndpointState {
   enabled,
 }
 
-extension on InstanceMetadataEndpointState {
+extension InstanceMetadataEndpointStateValue on InstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
       case InstanceMetadataEndpointState.disabled:
@@ -36185,7 +36200,7 @@ extension on InstanceMetadataEndpointState {
   }
 }
 
-extension on String {
+extension InstanceMetadataEndpointStateFromString on String {
   InstanceMetadataEndpointState toInstanceMetadataEndpointState() {
     switch (this) {
       case 'disabled':
@@ -36296,7 +36311,7 @@ enum InstanceMetadataOptionsState {
   applied,
 }
 
-extension on InstanceMetadataOptionsState {
+extension InstanceMetadataOptionsStateValue on InstanceMetadataOptionsState {
   String toValue() {
     switch (this) {
       case InstanceMetadataOptionsState.pending:
@@ -36307,7 +36322,7 @@ extension on InstanceMetadataOptionsState {
   }
 }
 
-extension on String {
+extension InstanceMetadataOptionsStateFromString on String {
   InstanceMetadataOptionsState toInstanceMetadataOptionsState() {
     switch (this) {
       case 'pending':
@@ -36692,7 +36707,7 @@ enum InstanceStateName {
   stopped,
 }
 
-extension on InstanceStateName {
+extension InstanceStateNameValue on InstanceStateName {
   String toValue() {
     switch (this) {
       case InstanceStateName.pending:
@@ -36711,7 +36726,7 @@ extension on InstanceStateName {
   }
 }
 
-extension on String {
+extension InstanceStateNameFromString on String {
   InstanceStateName toInstanceStateName() {
     switch (this) {
       case 'pending':
@@ -37263,7 +37278,7 @@ enum InstanceType {
   mac1Metal,
 }
 
-extension on InstanceType {
+extension InstanceTypeValue on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.t1Micro:
@@ -38048,7 +38063,7 @@ extension on InstanceType {
   }
 }
 
-extension on String {
+extension InstanceTypeFromString on String {
   InstanceType toInstanceType() {
     switch (this) {
       case 't1.micro':
@@ -38839,7 +38854,7 @@ enum InstanceTypeHypervisor {
   xen,
 }
 
-extension on InstanceTypeHypervisor {
+extension InstanceTypeHypervisorValue on InstanceTypeHypervisor {
   String toValue() {
     switch (this) {
       case InstanceTypeHypervisor.nitro:
@@ -38850,7 +38865,7 @@ extension on InstanceTypeHypervisor {
   }
 }
 
-extension on String {
+extension InstanceTypeHypervisorFromString on String {
   InstanceTypeHypervisor toInstanceTypeHypervisor() {
     switch (this) {
       case 'nitro':
@@ -39005,7 +39020,7 @@ enum InterfacePermissionType {
   eipAssociate,
 }
 
-extension on InterfacePermissionType {
+extension InterfacePermissionTypeValue on InterfacePermissionType {
   String toValue() {
     switch (this) {
       case InterfacePermissionType.instanceAttach:
@@ -39016,7 +39031,7 @@ extension on InterfacePermissionType {
   }
 }
 
-extension on String {
+extension InterfacePermissionTypeFromString on String {
   InterfacePermissionType toInterfacePermissionType() {
     switch (this) {
       case 'INSTANCE-ATTACH':
@@ -39208,7 +39223,7 @@ enum Ipv6SupportValue {
   disable,
 }
 
-extension on Ipv6SupportValue {
+extension Ipv6SupportValueValue on Ipv6SupportValue {
   String toValue() {
     switch (this) {
       case Ipv6SupportValue.enable:
@@ -39219,7 +39234,7 @@ extension on Ipv6SupportValue {
   }
 }
 
-extension on String {
+extension Ipv6SupportValueFromString on String {
   Ipv6SupportValue toIpv6SupportValue() {
     switch (this) {
       case 'enable':
@@ -39807,7 +39822,7 @@ enum LaunchTemplateErrorCode {
   unexpectedError,
 }
 
-extension on LaunchTemplateErrorCode {
+extension LaunchTemplateErrorCodeValue on LaunchTemplateErrorCode {
   String toValue() {
     switch (this) {
       case LaunchTemplateErrorCode.launchTemplateIdDoesNotExist:
@@ -39826,7 +39841,7 @@ extension on LaunchTemplateErrorCode {
   }
 }
 
-extension on String {
+extension LaunchTemplateErrorCodeFromString on String {
   LaunchTemplateErrorCode toLaunchTemplateErrorCode() {
     switch (this) {
       case 'launchTemplateIdDoesNotExist':
@@ -39878,7 +39893,7 @@ enum LaunchTemplateHttpTokensState {
   required,
 }
 
-extension on LaunchTemplateHttpTokensState {
+extension LaunchTemplateHttpTokensStateValue on LaunchTemplateHttpTokensState {
   String toValue() {
     switch (this) {
       case LaunchTemplateHttpTokensState.optional:
@@ -39889,7 +39904,7 @@ extension on LaunchTemplateHttpTokensState {
   }
 }
 
-extension on String {
+extension LaunchTemplateHttpTokensStateFromString on String {
   LaunchTemplateHttpTokensState toLaunchTemplateHttpTokensState() {
     switch (this) {
       case 'optional':
@@ -39962,7 +39977,8 @@ enum LaunchTemplateInstanceMetadataEndpointState {
   enabled,
 }
 
-extension on LaunchTemplateInstanceMetadataEndpointState {
+extension LaunchTemplateInstanceMetadataEndpointStateValue
+    on LaunchTemplateInstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
       case LaunchTemplateInstanceMetadataEndpointState.disabled:
@@ -39973,7 +39989,7 @@ extension on LaunchTemplateInstanceMetadataEndpointState {
   }
 }
 
-extension on String {
+extension LaunchTemplateInstanceMetadataEndpointStateFromString on String {
   LaunchTemplateInstanceMetadataEndpointState
       toLaunchTemplateInstanceMetadataEndpointState() {
     switch (this) {
@@ -40092,7 +40108,8 @@ enum LaunchTemplateInstanceMetadataOptionsState {
   applied,
 }
 
-extension on LaunchTemplateInstanceMetadataOptionsState {
+extension LaunchTemplateInstanceMetadataOptionsStateValue
+    on LaunchTemplateInstanceMetadataOptionsState {
   String toValue() {
     switch (this) {
       case LaunchTemplateInstanceMetadataOptionsState.pending:
@@ -40103,7 +40120,7 @@ extension on LaunchTemplateInstanceMetadataOptionsState {
   }
 }
 
-extension on String {
+extension LaunchTemplateInstanceMetadataOptionsStateFromString on String {
   LaunchTemplateInstanceMetadataOptionsState
       toLaunchTemplateInstanceMetadataOptionsState() {
     switch (this) {
@@ -40623,7 +40640,7 @@ enum ListingState {
   pending,
 }
 
-extension on ListingState {
+extension ListingStateValue on ListingState {
   String toValue() {
     switch (this) {
       case ListingState.available:
@@ -40638,7 +40655,7 @@ extension on ListingState {
   }
 }
 
-extension on String {
+extension ListingStateFromString on String {
   ListingState toListingState() {
     switch (this) {
       case 'available':
@@ -40661,7 +40678,7 @@ enum ListingStatus {
   closed,
 }
 
-extension on ListingStatus {
+extension ListingStatusValue on ListingStatus {
   String toValue() {
     switch (this) {
       case ListingStatus.active:
@@ -40676,7 +40693,7 @@ extension on ListingStatus {
   }
 }
 
-extension on String {
+extension ListingStatusFromString on String {
   ListingStatus toListingStatus() {
     switch (this) {
       case 'active':
@@ -40818,7 +40835,7 @@ enum LocalGatewayRouteState {
   deleted,
 }
 
-extension on LocalGatewayRouteState {
+extension LocalGatewayRouteStateValue on LocalGatewayRouteState {
   String toValue() {
     switch (this) {
       case LocalGatewayRouteState.pending:
@@ -40835,7 +40852,7 @@ extension on LocalGatewayRouteState {
   }
 }
 
-extension on String {
+extension LocalGatewayRouteStateFromString on String {
   LocalGatewayRouteState toLocalGatewayRouteState() {
     switch (this) {
       case 'pending':
@@ -40973,7 +40990,7 @@ enum LocalGatewayRouteType {
   propagated,
 }
 
-extension on LocalGatewayRouteType {
+extension LocalGatewayRouteTypeValue on LocalGatewayRouteType {
   String toValue() {
     switch (this) {
       case LocalGatewayRouteType.static:
@@ -40984,7 +41001,7 @@ extension on LocalGatewayRouteType {
   }
 }
 
-extension on String {
+extension LocalGatewayRouteTypeFromString on String {
   LocalGatewayRouteType toLocalGatewayRouteType() {
     switch (this) {
       case 'static':
@@ -41071,7 +41088,7 @@ enum LocationType {
   availabilityZoneId,
 }
 
-extension on LocationType {
+extension LocationTypeValue on LocationType {
   String toValue() {
     switch (this) {
       case LocationType.region:
@@ -41084,7 +41101,7 @@ extension on LocationType {
   }
 }
 
-extension on String {
+extension LocationTypeFromString on String {
   LocationType toLocationType() {
     switch (this) {
       case 'region':
@@ -41103,7 +41120,7 @@ enum LogDestinationType {
   s3,
 }
 
-extension on LogDestinationType {
+extension LogDestinationTypeValue on LogDestinationType {
   String toValue() {
     switch (this) {
       case LogDestinationType.cloudWatchLogs:
@@ -41114,7 +41131,7 @@ extension on LogDestinationType {
   }
 }
 
-extension on String {
+extension LogDestinationTypeFromString on String {
   LogDestinationType toLogDestinationType() {
     switch (this) {
       case 'cloud-watch-logs':
@@ -41176,7 +41193,7 @@ enum MarketType {
   spot,
 }
 
-extension on MarketType {
+extension MarketTypeValue on MarketType {
   String toValue() {
     switch (this) {
       case MarketType.spot:
@@ -41185,7 +41202,7 @@ extension on MarketType {
   }
 }
 
-extension on String {
+extension MarketTypeFromString on String {
   MarketType toMarketType() {
     switch (this) {
       case 'spot':
@@ -41200,7 +41217,7 @@ enum MembershipType {
   igmp,
 }
 
-extension on MembershipType {
+extension MembershipTypeValue on MembershipType {
   String toValue() {
     switch (this) {
       case MembershipType.static:
@@ -41211,7 +41228,7 @@ extension on MembershipType {
   }
 }
 
-extension on String {
+extension MembershipTypeFromString on String {
   MembershipType toMembershipType() {
     switch (this) {
       case 'static':
@@ -41247,7 +41264,8 @@ enum ModifyAvailabilityZoneOptInStatus {
   notOptedIn,
 }
 
-extension on ModifyAvailabilityZoneOptInStatus {
+extension ModifyAvailabilityZoneOptInStatusValue
+    on ModifyAvailabilityZoneOptInStatus {
   String toValue() {
     switch (this) {
       case ModifyAvailabilityZoneOptInStatus.optedIn:
@@ -41258,7 +41276,7 @@ extension on ModifyAvailabilityZoneOptInStatus {
   }
 }
 
-extension on String {
+extension ModifyAvailabilityZoneOptInStatusFromString on String {
   ModifyAvailabilityZoneOptInStatus toModifyAvailabilityZoneOptInStatus() {
     switch (this) {
       case 'opted-in':
@@ -41880,7 +41898,7 @@ enum MonitoringState {
   pending,
 }
 
-extension on MonitoringState {
+extension MonitoringStateValue on MonitoringState {
   String toValue() {
     switch (this) {
       case MonitoringState.disabled:
@@ -41895,7 +41913,7 @@ extension on MonitoringState {
   }
 }
 
-extension on String {
+extension MonitoringStateFromString on String {
   MonitoringState toMonitoringState() {
     switch (this) {
       case 'disabled':
@@ -41929,7 +41947,7 @@ enum MoveStatus {
   restoringToClassic,
 }
 
-extension on MoveStatus {
+extension MoveStatusValue on MoveStatus {
   String toValue() {
     switch (this) {
       case MoveStatus.movingToVpc:
@@ -41940,7 +41958,7 @@ extension on MoveStatus {
   }
 }
 
-extension on String {
+extension MoveStatusFromString on String {
   MoveStatus toMoveStatus() {
     switch (this) {
       case 'movingToVpc':
@@ -41972,7 +41990,7 @@ enum MulticastSupportValue {
   disable,
 }
 
-extension on MulticastSupportValue {
+extension MulticastSupportValueValue on MulticastSupportValue {
   String toValue() {
     switch (this) {
       case MulticastSupportValue.enable:
@@ -41983,7 +42001,7 @@ extension on MulticastSupportValue {
   }
 }
 
-extension on String {
+extension MulticastSupportValueFromString on String {
   MulticastSupportValue toMulticastSupportValue() {
     switch (this) {
       case 'enable':
@@ -42138,7 +42156,7 @@ enum NatGatewayState {
   deleted,
 }
 
-extension on NatGatewayState {
+extension NatGatewayStateValue on NatGatewayState {
   String toValue() {
     switch (this) {
       case NatGatewayState.pending:
@@ -42155,7 +42173,7 @@ extension on NatGatewayState {
   }
 }
 
-extension on String {
+extension NatGatewayStateFromString on String {
   NatGatewayState toNatGatewayState() {
     switch (this) {
       case 'pending':
@@ -42629,7 +42647,7 @@ enum NetworkInterfaceAttribute {
   attachment,
 }
 
-extension on NetworkInterfaceAttribute {
+extension NetworkInterfaceAttributeValue on NetworkInterfaceAttribute {
   String toValue() {
     switch (this) {
       case NetworkInterfaceAttribute.description:
@@ -42644,7 +42662,7 @@ extension on NetworkInterfaceAttribute {
   }
 }
 
-extension on String {
+extension NetworkInterfaceAttributeFromString on String {
   NetworkInterfaceAttribute toNetworkInterfaceAttribute() {
     switch (this) {
       case 'description':
@@ -42664,7 +42682,7 @@ enum NetworkInterfaceCreationType {
   efa,
 }
 
-extension on NetworkInterfaceCreationType {
+extension NetworkInterfaceCreationTypeValue on NetworkInterfaceCreationType {
   String toValue() {
     switch (this) {
       case NetworkInterfaceCreationType.efa:
@@ -42673,7 +42691,7 @@ extension on NetworkInterfaceCreationType {
   }
 }
 
-extension on String {
+extension NetworkInterfaceCreationTypeFromString on String {
   NetworkInterfaceCreationType toNetworkInterfaceCreationType() {
     switch (this) {
       case 'efa':
@@ -42744,7 +42762,8 @@ enum NetworkInterfacePermissionStateCode {
   revoked,
 }
 
-extension on NetworkInterfacePermissionStateCode {
+extension NetworkInterfacePermissionStateCodeValue
+    on NetworkInterfacePermissionStateCode {
   String toValue() {
     switch (this) {
       case NetworkInterfacePermissionStateCode.pending:
@@ -42759,7 +42778,7 @@ extension on NetworkInterfacePermissionStateCode {
   }
 }
 
-extension on String {
+extension NetworkInterfacePermissionStateCodeFromString on String {
   NetworkInterfacePermissionStateCode toNetworkInterfacePermissionStateCode() {
     switch (this) {
       case 'pending':
@@ -42808,7 +42827,7 @@ enum NetworkInterfaceStatus {
   detaching,
 }
 
-extension on NetworkInterfaceStatus {
+extension NetworkInterfaceStatusValue on NetworkInterfaceStatus {
   String toValue() {
     switch (this) {
       case NetworkInterfaceStatus.available:
@@ -42825,7 +42844,7 @@ extension on NetworkInterfaceStatus {
   }
 }
 
-extension on String {
+extension NetworkInterfaceStatusFromString on String {
   NetworkInterfaceStatus toNetworkInterfaceStatus() {
     switch (this) {
       case 'available':
@@ -42849,7 +42868,7 @@ enum NetworkInterfaceType {
   efa,
 }
 
-extension on NetworkInterfaceType {
+extension NetworkInterfaceTypeValue on NetworkInterfaceType {
   String toValue() {
     switch (this) {
       case NetworkInterfaceType.interface:
@@ -42862,7 +42881,7 @@ extension on NetworkInterfaceType {
   }
 }
 
-extension on String {
+extension NetworkInterfaceTypeFromString on String {
   NetworkInterfaceType toNetworkInterfaceType() {
     switch (this) {
       case 'interface':
@@ -42891,7 +42910,7 @@ enum OfferingClassType {
   convertible,
 }
 
-extension on OfferingClassType {
+extension OfferingClassTypeValue on OfferingClassType {
   String toValue() {
     switch (this) {
       case OfferingClassType.standard:
@@ -42902,7 +42921,7 @@ extension on OfferingClassType {
   }
 }
 
-extension on String {
+extension OfferingClassTypeFromString on String {
   OfferingClassType toOfferingClassType() {
     switch (this) {
       case 'standard':
@@ -42923,7 +42942,7 @@ enum OfferingTypeValues {
   allUpfront,
 }
 
-extension on OfferingTypeValues {
+extension OfferingTypeValuesValue on OfferingTypeValues {
   String toValue() {
     switch (this) {
       case OfferingTypeValues.heavyUtilization:
@@ -42942,7 +42961,7 @@ extension on OfferingTypeValues {
   }
 }
 
-extension on String {
+extension OfferingTypeValuesFromString on String {
   OfferingTypeValues toOfferingTypeValues() {
     switch (this) {
       case 'Heavy Utilization':
@@ -42967,7 +42986,7 @@ enum OnDemandAllocationStrategy {
   prioritized,
 }
 
-extension on OnDemandAllocationStrategy {
+extension OnDemandAllocationStrategyValue on OnDemandAllocationStrategy {
   String toValue() {
     switch (this) {
       case OnDemandAllocationStrategy.lowestPrice:
@@ -42978,7 +42997,7 @@ extension on OnDemandAllocationStrategy {
   }
 }
 
-extension on String {
+extension OnDemandAllocationStrategyFromString on String {
   OnDemandAllocationStrategy toOnDemandAllocationStrategy() {
     switch (this) {
       case 'lowestPrice':
@@ -43077,7 +43096,7 @@ enum OperationType {
   remove,
 }
 
-extension on OperationType {
+extension OperationTypeValue on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.add:
@@ -43088,7 +43107,7 @@ extension on OperationType {
   }
 }
 
-extension on String {
+extension OperationTypeFromString on String {
   OperationType toOperationType() {
     switch (this) {
       case 'add':
@@ -43156,7 +43175,7 @@ enum PaymentOption {
   noUpfront,
 }
 
-extension on PaymentOption {
+extension PaymentOptionValue on PaymentOption {
   String toValue() {
     switch (this) {
       case PaymentOption.allUpfront:
@@ -43169,7 +43188,7 @@ extension on PaymentOption {
   }
 }
 
-extension on String {
+extension PaymentOptionFromString on String {
   PaymentOption toPaymentOption() {
     switch (this) {
       case 'AllUpfront':
@@ -43284,7 +43303,7 @@ enum PermissionGroup {
   all,
 }
 
-extension on PermissionGroup {
+extension PermissionGroupValue on PermissionGroup {
   String toValue() {
     switch (this) {
       case PermissionGroup.all:
@@ -43293,7 +43312,7 @@ extension on PermissionGroup {
   }
 }
 
-extension on String {
+extension PermissionGroupFromString on String {
   PermissionGroup toPermissionGroup() {
     switch (this) {
       case 'all':
@@ -43552,7 +43571,7 @@ enum PlacementGroupState {
   deleted,
 }
 
-extension on PlacementGroupState {
+extension PlacementGroupStateValue on PlacementGroupState {
   String toValue() {
     switch (this) {
       case PlacementGroupState.pending:
@@ -43567,7 +43586,7 @@ extension on PlacementGroupState {
   }
 }
 
-extension on String {
+extension PlacementGroupStateFromString on String {
   PlacementGroupState toPlacementGroupState() {
     switch (this) {
       case 'pending':
@@ -43589,7 +43608,7 @@ enum PlacementGroupStrategy {
   spread,
 }
 
-extension on PlacementGroupStrategy {
+extension PlacementGroupStrategyValue on PlacementGroupStrategy {
   String toValue() {
     switch (this) {
       case PlacementGroupStrategy.cluster:
@@ -43602,7 +43621,7 @@ extension on PlacementGroupStrategy {
   }
 }
 
-extension on String {
+extension PlacementGroupStrategyFromString on String {
   PlacementGroupStrategy toPlacementGroupStrategy() {
     switch (this) {
       case 'cluster':
@@ -43632,7 +43651,7 @@ enum PlacementStrategy {
   partition,
 }
 
-extension on PlacementStrategy {
+extension PlacementStrategyValue on PlacementStrategy {
   String toValue() {
     switch (this) {
       case PlacementStrategy.cluster:
@@ -43645,7 +43664,7 @@ extension on PlacementStrategy {
   }
 }
 
-extension on String {
+extension PlacementStrategyFromString on String {
   PlacementStrategy toPlacementStrategy() {
     switch (this) {
       case 'cluster':
@@ -43663,7 +43682,7 @@ enum PlatformValues {
   windows,
 }
 
-extension on PlatformValues {
+extension PlatformValuesValue on PlatformValues {
   String toValue() {
     switch (this) {
       case PlatformValues.windows:
@@ -43672,7 +43691,7 @@ extension on PlatformValues {
   }
 }
 
-extension on String {
+extension PlatformValuesFromString on String {
   PlatformValues toPlatformValues() {
     switch (this) {
       case 'Windows':
@@ -43785,7 +43804,7 @@ enum PrefixListState {
   deleteFailed,
 }
 
-extension on PrefixListState {
+extension PrefixListStateValue on PrefixListState {
   String toValue() {
     switch (this) {
       case PrefixListState.createInProgress:
@@ -43816,7 +43835,7 @@ extension on PrefixListState {
   }
 }
 
-extension on String {
+extension PrefixListStateFromString on String {
   PrefixListState toPrefixListState() {
     switch (this) {
       case 'create-in-progress':
@@ -43938,7 +43957,7 @@ enum PrincipalType {
   role,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.all:
@@ -43957,7 +43976,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'All':
@@ -44066,7 +44085,7 @@ enum ProductCodeValues {
   marketplace,
 }
 
-extension on ProductCodeValues {
+extension ProductCodeValuesValue on ProductCodeValues {
   String toValue() {
     switch (this) {
       case ProductCodeValues.devpay:
@@ -44077,7 +44096,7 @@ extension on ProductCodeValues {
   }
 }
 
-extension on String {
+extension ProductCodeValuesFromString on String {
   ProductCodeValues toProductCodeValues() {
     switch (this) {
       case 'devpay':
@@ -44104,7 +44123,7 @@ enum Protocol {
   udp,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.tcp:
@@ -44115,7 +44134,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'tcp':
@@ -44131,7 +44150,7 @@ enum ProtocolValue {
   gre,
 }
 
-extension on ProtocolValue {
+extension ProtocolValueValue on ProtocolValue {
   String toValue() {
     switch (this) {
       case ProtocolValue.gre:
@@ -44140,7 +44159,7 @@ extension on ProtocolValue {
   }
 }
 
-extension on String {
+extension ProtocolValueFromString on String {
   ProtocolValue toProtocolValue() {
     switch (this) {
       case 'gre':
@@ -44373,7 +44392,7 @@ enum RIProductDescription {
   windowsAmazonVpc,
 }
 
-extension on RIProductDescription {
+extension RIProductDescriptionValue on RIProductDescription {
   String toValue() {
     switch (this) {
       case RIProductDescription.linuxUnix:
@@ -44388,7 +44407,7 @@ extension on RIProductDescription {
   }
 }
 
-extension on String {
+extension RIProductDescriptionFromString on String {
   RIProductDescription toRIProductDescription() {
     switch (this) {
       case 'Linux/UNIX':
@@ -44422,7 +44441,7 @@ enum RecurringChargeFrequency {
   hourly,
 }
 
-extension on RecurringChargeFrequency {
+extension RecurringChargeFrequencyValue on RecurringChargeFrequency {
   String toValue() {
     switch (this) {
       case RecurringChargeFrequency.hourly:
@@ -44431,7 +44450,7 @@ extension on RecurringChargeFrequency {
   }
 }
 
-extension on String {
+extension RecurringChargeFrequencyFromString on String {
   RecurringChargeFrequency toRecurringChargeFrequency() {
     switch (this) {
       case 'Hourly':
@@ -44631,7 +44650,7 @@ enum ReplacementStrategy {
   launch,
 }
 
-extension on ReplacementStrategy {
+extension ReplacementStrategyValue on ReplacementStrategy {
   String toValue() {
     switch (this) {
       case ReplacementStrategy.launch:
@@ -44640,7 +44659,7 @@ extension on ReplacementStrategy {
   }
 }
 
-extension on String {
+extension ReplacementStrategyFromString on String {
   ReplacementStrategy toReplacementStrategy() {
     switch (this) {
       case 'launch':
@@ -44662,7 +44681,7 @@ enum ReportInstanceReasonCodes {
   other,
 }
 
-extension on ReportInstanceReasonCodes {
+extension ReportInstanceReasonCodesValue on ReportInstanceReasonCodes {
   String toValue() {
     switch (this) {
       case ReportInstanceReasonCodes.instanceStuckInState:
@@ -44687,7 +44706,7 @@ extension on ReportInstanceReasonCodes {
   }
 }
 
-extension on String {
+extension ReportInstanceReasonCodesFromString on String {
   ReportInstanceReasonCodes toReportInstanceReasonCodes() {
     switch (this) {
       case 'instance-stuck-in-state':
@@ -44718,7 +44737,7 @@ enum ReportStatusType {
   impaired,
 }
 
-extension on ReportStatusType {
+extension ReportStatusTypeValue on ReportStatusType {
   String toValue() {
     switch (this) {
       case ReportStatusType.ok:
@@ -44729,7 +44748,7 @@ extension on ReportStatusType {
   }
 }
 
-extension on String {
+extension ReportStatusTypeFromString on String {
   ReportStatusType toReportStatusType() {
     switch (this) {
       case 'ok':
@@ -45070,7 +45089,7 @@ enum ReservationState {
   retired,
 }
 
-extension on ReservationState {
+extension ReservationStateValue on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.paymentPending:
@@ -45085,7 +45104,7 @@ extension on ReservationState {
   }
 }
 
-extension on String {
+extension ReservationStateFromString on String {
   ReservationState toReservationState() {
     switch (this) {
       case 'payment-pending':
@@ -45160,7 +45179,7 @@ enum ReservedInstanceState {
   queuedDeleted,
 }
 
-extension on ReservedInstanceState {
+extension ReservedInstanceStateValue on ReservedInstanceState {
   String toValue() {
     switch (this) {
       case ReservedInstanceState.paymentPending:
@@ -45179,7 +45198,7 @@ extension on ReservedInstanceState {
   }
 }
 
-extension on String {
+extension ReservedInstanceStateFromString on String {
   ReservedInstanceState toReservedInstanceState() {
     switch (this) {
       case 'payment-pending':
@@ -45522,7 +45541,7 @@ enum ResetFpgaImageAttributeName {
   loadPermission,
 }
 
-extension on ResetFpgaImageAttributeName {
+extension ResetFpgaImageAttributeNameValue on ResetFpgaImageAttributeName {
   String toValue() {
     switch (this) {
       case ResetFpgaImageAttributeName.loadPermission:
@@ -45531,7 +45550,7 @@ extension on ResetFpgaImageAttributeName {
   }
 }
 
-extension on String {
+extension ResetFpgaImageAttributeNameFromString on String {
   ResetFpgaImageAttributeName toResetFpgaImageAttributeName() {
     switch (this) {
       case 'loadPermission':
@@ -45554,7 +45573,7 @@ enum ResetImageAttributeName {
   launchPermission,
 }
 
-extension on ResetImageAttributeName {
+extension ResetImageAttributeNameValue on ResetImageAttributeName {
   String toValue() {
     switch (this) {
       case ResetImageAttributeName.launchPermission:
@@ -45563,7 +45582,7 @@ extension on ResetImageAttributeName {
   }
 }
 
-extension on String {
+extension ResetImageAttributeNameFromString on String {
   ResetImageAttributeName toResetImageAttributeName() {
     switch (this) {
       case 'launchPermission':
@@ -45623,7 +45642,7 @@ enum ResourceType {
   vpcFlowLog,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.clientVpnEndpoint:
@@ -45724,7 +45743,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'client-vpn-endpoint':
@@ -46036,7 +46055,7 @@ enum RootDeviceType {
   instanceStore,
 }
 
-extension on RootDeviceType {
+extension RootDeviceTypeValue on RootDeviceType {
   String toValue() {
     switch (this) {
       case RootDeviceType.ebs:
@@ -46047,7 +46066,7 @@ extension on RootDeviceType {
   }
 }
 
-extension on String {
+extension RootDeviceTypeFromString on String {
   RootDeviceType toRootDeviceType() {
     switch (this) {
       case 'ebs':
@@ -46147,7 +46166,7 @@ enum RouteOrigin {
   enableVgwRoutePropagation,
 }
 
-extension on RouteOrigin {
+extension RouteOriginValue on RouteOrigin {
   String toValue() {
     switch (this) {
       case RouteOrigin.createRouteTable:
@@ -46160,7 +46179,7 @@ extension on RouteOrigin {
   }
 }
 
-extension on String {
+extension RouteOriginFromString on String {
   RouteOrigin toRouteOrigin() {
     switch (this) {
       case 'CreateRouteTable':
@@ -46179,7 +46198,7 @@ enum RouteState {
   blackhole,
 }
 
-extension on RouteState {
+extension RouteStateValue on RouteState {
   String toValue() {
     switch (this) {
       case RouteState.active:
@@ -46190,7 +46209,7 @@ extension on RouteState {
   }
 }
 
-extension on String {
+extension RouteStateFromString on String {
   RouteState toRouteState() {
     switch (this) {
       case 'active':
@@ -46291,7 +46310,8 @@ enum RouteTableAssociationStateCode {
   failed,
 }
 
-extension on RouteTableAssociationStateCode {
+extension RouteTableAssociationStateCodeValue
+    on RouteTableAssociationStateCode {
   String toValue() {
     switch (this) {
       case RouteTableAssociationStateCode.associating:
@@ -46308,7 +46328,7 @@ extension on RouteTableAssociationStateCode {
   }
 }
 
-extension on String {
+extension RouteTableAssociationStateCodeFromString on String {
   RouteTableAssociationStateCode toRouteTableAssociationStateCode() {
     switch (this) {
       case 'associating':
@@ -46332,7 +46352,7 @@ enum RuleAction {
   deny,
 }
 
-extension on RuleAction {
+extension RuleActionValue on RuleAction {
   String toValue() {
     switch (this) {
       case RuleAction.allow:
@@ -46343,7 +46363,7 @@ extension on RuleAction {
   }
 }
 
-extension on String {
+extension RuleActionFromString on String {
   RuleAction toRuleAction() {
     switch (this) {
       case 'allow':
@@ -46997,7 +47017,7 @@ enum SelfServicePortal {
   disabled,
 }
 
-extension on SelfServicePortal {
+extension SelfServicePortalValue on SelfServicePortal {
   String toValue() {
     switch (this) {
       case SelfServicePortal.enabled:
@@ -47008,7 +47028,7 @@ extension on SelfServicePortal {
   }
 }
 
-extension on String {
+extension SelfServicePortalFromString on String {
   SelfServicePortal toSelfServicePortal() {
     switch (this) {
       case 'enabled':
@@ -47153,7 +47173,7 @@ enum ServiceState {
   failed,
 }
 
-extension on ServiceState {
+extension ServiceStateValue on ServiceState {
   String toValue() {
     switch (this) {
       case ServiceState.pending:
@@ -47170,7 +47190,7 @@ extension on ServiceState {
   }
 }
 
-extension on String {
+extension ServiceStateFromString on String {
   ServiceState toServiceState() {
     switch (this) {
       case 'Pending':
@@ -47194,7 +47214,7 @@ enum ServiceType {
   gatewayLoadBalancer,
 }
 
-extension on ServiceType {
+extension ServiceTypeValue on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.interface:
@@ -47207,7 +47227,7 @@ extension on ServiceType {
   }
 }
 
-extension on String {
+extension ServiceTypeFromString on String {
   ServiceType toServiceType() {
     switch (this) {
       case 'Interface':
@@ -47236,7 +47256,7 @@ enum ShutdownBehavior {
   terminate,
 }
 
-extension on ShutdownBehavior {
+extension ShutdownBehaviorValue on ShutdownBehavior {
   String toValue() {
     switch (this) {
       case ShutdownBehavior.stop:
@@ -47247,7 +47267,7 @@ extension on ShutdownBehavior {
   }
 }
 
-extension on String {
+extension ShutdownBehaviorFromString on String {
   ShutdownBehavior toShutdownBehavior() {
     switch (this) {
       case 'stop':
@@ -47374,7 +47394,7 @@ enum SnapshotAttributeName {
   createVolumePermission,
 }
 
-extension on SnapshotAttributeName {
+extension SnapshotAttributeNameValue on SnapshotAttributeName {
   String toValue() {
     switch (this) {
       case SnapshotAttributeName.productCodes:
@@ -47385,7 +47405,7 @@ extension on SnapshotAttributeName {
   }
 }
 
-extension on String {
+extension SnapshotAttributeNameFromString on String {
   SnapshotAttributeName toSnapshotAttributeName() {
     switch (this) {
       case 'productCodes':
@@ -47522,7 +47542,7 @@ enum SnapshotState {
   error,
 }
 
-extension on SnapshotState {
+extension SnapshotStateValue on SnapshotState {
   String toValue() {
     switch (this) {
       case SnapshotState.pending:
@@ -47535,7 +47555,7 @@ extension on SnapshotState {
   }
 }
 
-extension on String {
+extension SnapshotStateFromString on String {
   SnapshotState toSnapshotState() {
     switch (this) {
       case 'pending':
@@ -47606,7 +47626,7 @@ enum SpotAllocationStrategy {
   capacityOptimized,
 }
 
-extension on SpotAllocationStrategy {
+extension SpotAllocationStrategyValue on SpotAllocationStrategy {
   String toValue() {
     switch (this) {
       case SpotAllocationStrategy.lowestPrice:
@@ -47619,7 +47639,7 @@ extension on SpotAllocationStrategy {
   }
 }
 
-extension on String {
+extension SpotAllocationStrategyFromString on String {
   SpotAllocationStrategy toSpotAllocationStrategy() {
     switch (this) {
       case 'lowest-price':
@@ -48077,7 +48097,8 @@ enum SpotInstanceInterruptionBehavior {
   terminate,
 }
 
-extension on SpotInstanceInterruptionBehavior {
+extension SpotInstanceInterruptionBehaviorValue
+    on SpotInstanceInterruptionBehavior {
   String toValue() {
     switch (this) {
       case SpotInstanceInterruptionBehavior.hibernate:
@@ -48090,7 +48111,7 @@ extension on SpotInstanceInterruptionBehavior {
   }
 }
 
-extension on String {
+extension SpotInstanceInterruptionBehaviorFromString on String {
   SpotInstanceInterruptionBehavior toSpotInstanceInterruptionBehavior() {
     switch (this) {
       case 'hibernate':
@@ -48223,7 +48244,7 @@ enum SpotInstanceState {
   failed,
 }
 
-extension on SpotInstanceState {
+extension SpotInstanceStateValue on SpotInstanceState {
   String toValue() {
     switch (this) {
       case SpotInstanceState.open:
@@ -48240,7 +48261,7 @@ extension on SpotInstanceState {
   }
 }
 
-extension on String {
+extension SpotInstanceStateFromString on String {
   SpotInstanceState toSpotInstanceState() {
     switch (this) {
       case 'open':
@@ -48298,7 +48319,7 @@ enum SpotInstanceType {
   persistent,
 }
 
-extension on SpotInstanceType {
+extension SpotInstanceTypeValue on SpotInstanceType {
   String toValue() {
     switch (this) {
       case SpotInstanceType.oneTime:
@@ -48309,7 +48330,7 @@ extension on SpotInstanceType {
   }
 }
 
-extension on String {
+extension SpotInstanceTypeFromString on String {
   SpotInstanceType toSpotInstanceType() {
     switch (this) {
       case 'one-time':
@@ -48670,7 +48691,7 @@ enum State {
   expired,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.pendingAcceptance:
@@ -48693,7 +48714,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'PendingAcceptance':
@@ -48792,7 +48813,7 @@ enum StaticSourcesSupportValue {
   disable,
 }
 
-extension on StaticSourcesSupportValue {
+extension StaticSourcesSupportValueValue on StaticSourcesSupportValue {
   String toValue() {
     switch (this) {
       case StaticSourcesSupportValue.enable:
@@ -48803,7 +48824,7 @@ extension on StaticSourcesSupportValue {
   }
 }
 
-extension on String {
+extension StaticSourcesSupportValueFromString on String {
   StaticSourcesSupportValue toStaticSourcesSupportValue() {
     switch (this) {
       case 'enable':
@@ -48821,7 +48842,7 @@ enum Status {
   inClassic,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.moveInProgress:
@@ -48834,7 +48855,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'MoveInProgress':
@@ -48852,7 +48873,7 @@ enum StatusName {
   reachability,
 }
 
-extension on StatusName {
+extension StatusNameValue on StatusName {
   String toValue() {
     switch (this) {
       case StatusName.reachability:
@@ -48861,7 +48882,7 @@ extension on StatusName {
   }
 }
 
-extension on String {
+extension StatusNameFromString on String {
   StatusName toStatusName() {
     switch (this) {
       case 'reachability':
@@ -48878,7 +48899,7 @@ enum StatusType {
   initializing,
 }
 
-extension on StatusType {
+extension StatusTypeValue on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.passed:
@@ -48893,7 +48914,7 @@ extension on StatusType {
   }
 }
 
-extension on String {
+extension StatusTypeFromString on String {
   StatusType toStatusType() {
     switch (this) {
       case 'passed':
@@ -49058,7 +49079,7 @@ enum SubnetCidrBlockStateCode {
   failed,
 }
 
-extension on SubnetCidrBlockStateCode {
+extension SubnetCidrBlockStateCodeValue on SubnetCidrBlockStateCode {
   String toValue() {
     switch (this) {
       case SubnetCidrBlockStateCode.associating:
@@ -49077,7 +49098,7 @@ extension on SubnetCidrBlockStateCode {
   }
 }
 
-extension on String {
+extension SubnetCidrBlockStateCodeFromString on String {
   SubnetCidrBlockStateCode toSubnetCidrBlockStateCode() {
     switch (this) {
       case 'associating':
@@ -49120,7 +49141,7 @@ enum SubnetState {
   available,
 }
 
-extension on SubnetState {
+extension SubnetStateValue on SubnetState {
   String toValue() {
     switch (this) {
       case SubnetState.pending:
@@ -49131,7 +49152,7 @@ extension on SubnetState {
   }
 }
 
-extension on String {
+extension SubnetStateFromString on String {
   SubnetState toSubnetState() {
     switch (this) {
       case 'pending':
@@ -49173,7 +49194,7 @@ enum SummaryStatus {
   initializing,
 }
 
-extension on SummaryStatus {
+extension SummaryStatusValue on SummaryStatus {
   String toValue() {
     switch (this) {
       case SummaryStatus.ok:
@@ -49190,7 +49211,7 @@ extension on SummaryStatus {
   }
 }
 
-extension on String {
+extension SummaryStatusFromString on String {
   SummaryStatus toSummaryStatus() {
     switch (this) {
       case 'ok':
@@ -49483,7 +49504,7 @@ enum TelemetryStatus {
   down,
 }
 
-extension on TelemetryStatus {
+extension TelemetryStatusValue on TelemetryStatus {
   String toValue() {
     switch (this) {
       case TelemetryStatus.up:
@@ -49494,7 +49515,7 @@ extension on TelemetryStatus {
   }
 }
 
-extension on String {
+extension TelemetryStatusFromString on String {
   TelemetryStatus toTelemetryStatus() {
     switch (this) {
       case 'UP':
@@ -49512,7 +49533,7 @@ enum Tenancy {
   host,
 }
 
-extension on Tenancy {
+extension TenancyValue on Tenancy {
   String toValue() {
     switch (this) {
       case Tenancy.$default:
@@ -49525,7 +49546,7 @@ extension on Tenancy {
   }
 }
 
-extension on String {
+extension TenancyFromString on String {
   Tenancy toTenancy() {
     switch (this) {
       case 'default':
@@ -49588,7 +49609,7 @@ enum TrafficDirection {
   egress,
 }
 
-extension on TrafficDirection {
+extension TrafficDirectionValue on TrafficDirection {
   String toValue() {
     switch (this) {
       case TrafficDirection.ingress:
@@ -49599,7 +49620,7 @@ extension on TrafficDirection {
   }
 }
 
-extension on String {
+extension TrafficDirectionFromString on String {
   TrafficDirection toTrafficDirection() {
     switch (this) {
       case 'ingress':
@@ -49701,7 +49722,7 @@ enum TrafficMirrorFilterRuleField {
   description,
 }
 
-extension on TrafficMirrorFilterRuleField {
+extension TrafficMirrorFilterRuleFieldValue on TrafficMirrorFilterRuleField {
   String toValue() {
     switch (this) {
       case TrafficMirrorFilterRuleField.destinationPortRange:
@@ -49716,7 +49737,7 @@ extension on TrafficMirrorFilterRuleField {
   }
 }
 
-extension on String {
+extension TrafficMirrorFilterRuleFieldFromString on String {
   TrafficMirrorFilterRuleField toTrafficMirrorFilterRuleField() {
     switch (this) {
       case 'destination-port-range':
@@ -49736,7 +49757,7 @@ enum TrafficMirrorNetworkService {
   amazonDns,
 }
 
-extension on TrafficMirrorNetworkService {
+extension TrafficMirrorNetworkServiceValue on TrafficMirrorNetworkService {
   String toValue() {
     switch (this) {
       case TrafficMirrorNetworkService.amazonDns:
@@ -49745,7 +49766,7 @@ extension on TrafficMirrorNetworkService {
   }
 }
 
-extension on String {
+extension TrafficMirrorNetworkServiceFromString on String {
   TrafficMirrorNetworkService toTrafficMirrorNetworkService() {
     switch (this) {
       case 'amazon-dns':
@@ -49792,7 +49813,7 @@ enum TrafficMirrorRuleAction {
   reject,
 }
 
-extension on TrafficMirrorRuleAction {
+extension TrafficMirrorRuleActionValue on TrafficMirrorRuleAction {
   String toValue() {
     switch (this) {
       case TrafficMirrorRuleAction.accept:
@@ -49803,7 +49824,7 @@ extension on TrafficMirrorRuleAction {
   }
 }
 
-extension on String {
+extension TrafficMirrorRuleActionFromString on String {
   TrafficMirrorRuleAction toTrafficMirrorRuleAction() {
     switch (this) {
       case 'accept':
@@ -49875,7 +49896,7 @@ enum TrafficMirrorSessionField {
   virtualNetworkId,
 }
 
-extension on TrafficMirrorSessionField {
+extension TrafficMirrorSessionFieldValue on TrafficMirrorSessionField {
   String toValue() {
     switch (this) {
       case TrafficMirrorSessionField.packetLength:
@@ -49888,7 +49909,7 @@ extension on TrafficMirrorSessionField {
   }
 }
 
-extension on String {
+extension TrafficMirrorSessionFieldFromString on String {
   TrafficMirrorSessionField toTrafficMirrorSessionField() {
     switch (this) {
       case 'packet-length':
@@ -49941,7 +49962,7 @@ enum TrafficMirrorTargetType {
   networkLoadBalancer,
 }
 
-extension on TrafficMirrorTargetType {
+extension TrafficMirrorTargetTypeValue on TrafficMirrorTargetType {
   String toValue() {
     switch (this) {
       case TrafficMirrorTargetType.networkInterface:
@@ -49952,7 +49973,7 @@ extension on TrafficMirrorTargetType {
   }
 }
 
-extension on String {
+extension TrafficMirrorTargetTypeFromString on String {
   TrafficMirrorTargetType toTrafficMirrorTargetType() {
     switch (this) {
       case 'network-interface':
@@ -49970,7 +49991,7 @@ enum TrafficType {
   all,
 }
 
-extension on TrafficType {
+extension TrafficTypeValue on TrafficType {
   String toValue() {
     switch (this) {
       case TrafficType.accept:
@@ -49983,7 +50004,7 @@ extension on TrafficType {
   }
 }
 
-extension on String {
+extension TrafficTypeFromString on String {
   TrafficType toTrafficType() {
     switch (this) {
       case 'ACCEPT':
@@ -50070,7 +50091,8 @@ enum TransitGatewayAssociationState {
   disassociated,
 }
 
-extension on TransitGatewayAssociationState {
+extension TransitGatewayAssociationStateValue
+    on TransitGatewayAssociationState {
   String toValue() {
     switch (this) {
       case TransitGatewayAssociationState.associating:
@@ -50085,7 +50107,7 @@ extension on TransitGatewayAssociationState {
   }
 }
 
-extension on String {
+extension TransitGatewayAssociationStateFromString on String {
   TransitGatewayAssociationState toTransitGatewayAssociationState() {
     switch (this) {
       case 'associating':
@@ -50213,7 +50235,8 @@ enum TransitGatewayAttachmentResourceType {
   tgwPeering,
 }
 
-extension on TransitGatewayAttachmentResourceType {
+extension TransitGatewayAttachmentResourceTypeValue
+    on TransitGatewayAttachmentResourceType {
   String toValue() {
     switch (this) {
       case TransitGatewayAttachmentResourceType.vpc:
@@ -50232,7 +50255,7 @@ extension on TransitGatewayAttachmentResourceType {
   }
 }
 
-extension on String {
+extension TransitGatewayAttachmentResourceTypeFromString on String {
   TransitGatewayAttachmentResourceType
       toTransitGatewayAttachmentResourceType() {
     switch (this) {
@@ -50270,7 +50293,7 @@ enum TransitGatewayAttachmentState {
   failing,
 }
 
-extension on TransitGatewayAttachmentState {
+extension TransitGatewayAttachmentStateValue on TransitGatewayAttachmentState {
   String toValue() {
     switch (this) {
       case TransitGatewayAttachmentState.initiating:
@@ -50303,7 +50326,7 @@ extension on TransitGatewayAttachmentState {
   }
 }
 
-extension on String {
+extension TransitGatewayAttachmentStateFromString on String {
   TransitGatewayAttachmentState toTransitGatewayAttachmentState() {
     switch (this) {
       case 'initiating':
@@ -50444,7 +50467,8 @@ enum TransitGatewayConnectPeerState {
   deleted,
 }
 
-extension on TransitGatewayConnectPeerState {
+extension TransitGatewayConnectPeerStateValue
+    on TransitGatewayConnectPeerState {
   String toValue() {
     switch (this) {
       case TransitGatewayConnectPeerState.pending:
@@ -50459,7 +50483,7 @@ extension on TransitGatewayConnectPeerState {
   }
 }
 
-extension on String {
+extension TransitGatewayConnectPeerStateFromString on String {
   TransitGatewayConnectPeerState toTransitGatewayConnectPeerState() {
     switch (this) {
       case 'pending':
@@ -50496,7 +50520,8 @@ enum TransitGatewayMulitcastDomainAssociationState {
   failed,
 }
 
-extension on TransitGatewayMulitcastDomainAssociationState {
+extension TransitGatewayMulitcastDomainAssociationStateValue
+    on TransitGatewayMulitcastDomainAssociationState {
   String toValue() {
     switch (this) {
       case TransitGatewayMulitcastDomainAssociationState.pendingAcceptance:
@@ -50517,7 +50542,7 @@ extension on TransitGatewayMulitcastDomainAssociationState {
   }
 }
 
-extension on String {
+extension TransitGatewayMulitcastDomainAssociationStateFromString on String {
   TransitGatewayMulitcastDomainAssociationState
       toTransitGatewayMulitcastDomainAssociationState() {
     switch (this) {
@@ -50701,7 +50726,8 @@ enum TransitGatewayMulticastDomainState {
   deleted,
 }
 
-extension on TransitGatewayMulticastDomainState {
+extension TransitGatewayMulticastDomainStateValue
+    on TransitGatewayMulticastDomainState {
   String toValue() {
     switch (this) {
       case TransitGatewayMulticastDomainState.pending:
@@ -50716,7 +50742,7 @@ extension on TransitGatewayMulticastDomainState {
   }
 }
 
-extension on String {
+extension TransitGatewayMulticastDomainStateFromString on String {
   TransitGatewayMulticastDomainState toTransitGatewayMulticastDomainState() {
     switch (this) {
       case 'pending':
@@ -50962,7 +50988,8 @@ enum TransitGatewayPrefixListReferenceState {
   deleting,
 }
 
-extension on TransitGatewayPrefixListReferenceState {
+extension TransitGatewayPrefixListReferenceStateValue
+    on TransitGatewayPrefixListReferenceState {
   String toValue() {
     switch (this) {
       case TransitGatewayPrefixListReferenceState.pending:
@@ -50977,7 +51004,7 @@ extension on TransitGatewayPrefixListReferenceState {
   }
 }
 
-extension on String {
+extension TransitGatewayPrefixListReferenceStateFromString on String {
   TransitGatewayPrefixListReferenceState
       toTransitGatewayPrefixListReferenceState() {
     switch (this) {
@@ -51029,7 +51056,8 @@ enum TransitGatewayPropagationState {
   disabled,
 }
 
-extension on TransitGatewayPropagationState {
+extension TransitGatewayPropagationStateValue
+    on TransitGatewayPropagationState {
   String toValue() {
     switch (this) {
       case TransitGatewayPropagationState.enabling:
@@ -51044,7 +51072,7 @@ extension on TransitGatewayPropagationState {
   }
 }
 
-extension on String {
+extension TransitGatewayPropagationStateFromString on String {
   TransitGatewayPropagationState toTransitGatewayPropagationState() {
     switch (this) {
       case 'enabling':
@@ -51159,7 +51187,7 @@ enum TransitGatewayRouteState {
   deleted,
 }
 
-extension on TransitGatewayRouteState {
+extension TransitGatewayRouteStateValue on TransitGatewayRouteState {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteState.pending:
@@ -51176,7 +51204,7 @@ extension on TransitGatewayRouteState {
   }
 }
 
-extension on String {
+extension TransitGatewayRouteStateFromString on String {
   TransitGatewayRouteState toTransitGatewayRouteState() {
     switch (this) {
       case 'pending':
@@ -51283,7 +51311,7 @@ enum TransitGatewayRouteTableState {
   deleted,
 }
 
-extension on TransitGatewayRouteTableState {
+extension TransitGatewayRouteTableStateValue on TransitGatewayRouteTableState {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteTableState.pending:
@@ -51298,7 +51326,7 @@ extension on TransitGatewayRouteTableState {
   }
 }
 
-extension on String {
+extension TransitGatewayRouteTableStateFromString on String {
   TransitGatewayRouteTableState toTransitGatewayRouteTableState() {
     switch (this) {
       case 'pending':
@@ -51319,7 +51347,7 @@ enum TransitGatewayRouteType {
   propagated,
 }
 
-extension on TransitGatewayRouteType {
+extension TransitGatewayRouteTypeValue on TransitGatewayRouteType {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteType.static:
@@ -51330,7 +51358,7 @@ extension on TransitGatewayRouteType {
   }
 }
 
-extension on String {
+extension TransitGatewayRouteTypeFromString on String {
   TransitGatewayRouteType toTransitGatewayRouteType() {
     switch (this) {
       case 'static':
@@ -51350,7 +51378,7 @@ enum TransitGatewayState {
   deleted,
 }
 
-extension on TransitGatewayState {
+extension TransitGatewayStateValue on TransitGatewayState {
   String toValue() {
     switch (this) {
       case TransitGatewayState.pending:
@@ -51367,7 +51395,7 @@ extension on TransitGatewayState {
   }
 }
 
-extension on String {
+extension TransitGatewayStateFromString on String {
   TransitGatewayState toTransitGatewayState() {
     switch (this) {
       case 'pending':
@@ -51451,7 +51479,7 @@ enum TransportProtocol {
   udp,
 }
 
-extension on TransportProtocol {
+extension TransportProtocolValue on TransportProtocol {
   String toValue() {
     switch (this) {
       case TransportProtocol.tcp:
@@ -51462,7 +51490,7 @@ extension on TransportProtocol {
   }
 }
 
-extension on String {
+extension TransportProtocolFromString on String {
   TransportProtocol toTransportProtocol() {
     switch (this) {
       case 'tcp':
@@ -51479,7 +51507,7 @@ enum TunnelInsideIpVersion {
   ipv6,
 }
 
-extension on TunnelInsideIpVersion {
+extension TunnelInsideIpVersionValue on TunnelInsideIpVersion {
   String toValue() {
     switch (this) {
       case TunnelInsideIpVersion.ipv4:
@@ -51490,7 +51518,7 @@ extension on TunnelInsideIpVersion {
   }
 }
 
-extension on String {
+extension TunnelInsideIpVersionFromString on String {
   TunnelInsideIpVersion toTunnelInsideIpVersion() {
     switch (this) {
       case 'ipv4':
@@ -51615,7 +51643,8 @@ enum UnlimitedSupportedInstanceFamily {
   t4g,
 }
 
-extension on UnlimitedSupportedInstanceFamily {
+extension UnlimitedSupportedInstanceFamilyValue
+    on UnlimitedSupportedInstanceFamily {
   String toValue() {
     switch (this) {
       case UnlimitedSupportedInstanceFamily.t2:
@@ -51630,7 +51659,7 @@ extension on UnlimitedSupportedInstanceFamily {
   }
 }
 
-extension on String {
+extension UnlimitedSupportedInstanceFamilyFromString on String {
   UnlimitedSupportedInstanceFamily toUnlimitedSupportedInstanceFamily() {
     switch (this) {
       case 't2':
@@ -51663,7 +51692,8 @@ enum UnsuccessfulInstanceCreditSpecificationErrorCode {
   instanceCreditSpecificationNotSupported,
 }
 
-extension on UnsuccessfulInstanceCreditSpecificationErrorCode {
+extension UnsuccessfulInstanceCreditSpecificationErrorCodeValue
+    on UnsuccessfulInstanceCreditSpecificationErrorCode {
   String toValue() {
     switch (this) {
       case UnsuccessfulInstanceCreditSpecificationErrorCode
@@ -51682,7 +51712,7 @@ extension on UnsuccessfulInstanceCreditSpecificationErrorCode {
   }
 }
 
-extension on String {
+extension UnsuccessfulInstanceCreditSpecificationErrorCodeFromString on String {
   UnsuccessfulInstanceCreditSpecificationErrorCode
       toUnsuccessfulInstanceCreditSpecificationErrorCode() {
     switch (this) {
@@ -51792,7 +51822,7 @@ enum UsageClassType {
   onDemand,
 }
 
-extension on UsageClassType {
+extension UsageClassTypeValue on UsageClassType {
   String toValue() {
     switch (this) {
       case UsageClassType.spot:
@@ -51803,7 +51833,7 @@ extension on UsageClassType {
   }
 }
 
-extension on String {
+extension UsageClassTypeFromString on String {
   UsageClassType toUsageClassType() {
     switch (this) {
       case 'spot':
@@ -52002,7 +52032,7 @@ enum VirtualizationType {
   paravirtual,
 }
 
-extension on VirtualizationType {
+extension VirtualizationTypeValue on VirtualizationType {
   String toValue() {
     switch (this) {
       case VirtualizationType.hvm:
@@ -52013,7 +52043,7 @@ extension on VirtualizationType {
   }
 }
 
-extension on String {
+extension VirtualizationTypeFromString on String {
   VirtualizationType toVirtualizationType() {
     switch (this) {
       case 'hvm':
@@ -52139,7 +52169,7 @@ enum VolumeAttachmentState {
   busy,
 }
 
-extension on VolumeAttachmentState {
+extension VolumeAttachmentStateValue on VolumeAttachmentState {
   String toValue() {
     switch (this) {
       case VolumeAttachmentState.attaching:
@@ -52156,7 +52186,7 @@ extension on VolumeAttachmentState {
   }
 }
 
-extension on String {
+extension VolumeAttachmentStateFromString on String {
   VolumeAttachmentState toVolumeAttachmentState() {
     switch (this) {
       case 'attaching':
@@ -52179,7 +52209,7 @@ enum VolumeAttributeName {
   productCodes,
 }
 
-extension on VolumeAttributeName {
+extension VolumeAttributeNameValue on VolumeAttributeName {
   String toValue() {
     switch (this) {
       case VolumeAttributeName.autoEnableIO:
@@ -52190,7 +52220,7 @@ extension on VolumeAttributeName {
   }
 }
 
-extension on String {
+extension VolumeAttributeNameFromString on String {
   VolumeAttributeName toVolumeAttributeName() {
     switch (this) {
       case 'autoEnableIO':
@@ -52292,7 +52322,7 @@ enum VolumeModificationState {
   failed,
 }
 
-extension on VolumeModificationState {
+extension VolumeModificationStateValue on VolumeModificationState {
   String toValue() {
     switch (this) {
       case VolumeModificationState.modifying:
@@ -52307,7 +52337,7 @@ extension on VolumeModificationState {
   }
 }
 
-extension on String {
+extension VolumeModificationStateFromString on String {
   VolumeModificationState toVolumeModificationState() {
     switch (this) {
       case 'modifying':
@@ -52332,7 +52362,7 @@ enum VolumeState {
   error,
 }
 
-extension on VolumeState {
+extension VolumeStateValue on VolumeState {
   String toValue() {
     switch (this) {
       case VolumeState.creating:
@@ -52351,7 +52381,7 @@ extension on VolumeState {
   }
 }
 
-extension on String {
+extension VolumeStateFromString on String {
   VolumeState toVolumeState() {
     switch (this) {
       case 'creating':
@@ -52472,7 +52502,7 @@ enum VolumeStatusInfoStatus {
   insufficientData,
 }
 
-extension on VolumeStatusInfoStatus {
+extension VolumeStatusInfoStatusValue on VolumeStatusInfoStatus {
   String toValue() {
     switch (this) {
       case VolumeStatusInfoStatus.ok:
@@ -52485,7 +52515,7 @@ extension on VolumeStatusInfoStatus {
   }
 }
 
-extension on String {
+extension VolumeStatusInfoStatusFromString on String {
   VolumeStatusInfoStatus toVolumeStatusInfoStatus() {
     switch (this) {
       case 'ok':
@@ -52538,7 +52568,7 @@ enum VolumeStatusName {
   ioPerformance,
 }
 
-extension on VolumeStatusName {
+extension VolumeStatusNameValue on VolumeStatusName {
   String toValue() {
     switch (this) {
       case VolumeStatusName.ioEnabled:
@@ -52549,7 +52579,7 @@ extension on VolumeStatusName {
   }
 }
 
-extension on String {
+extension VolumeStatusNameFromString on String {
   VolumeStatusName toVolumeStatusName() {
     switch (this) {
       case 'io-enabled':
@@ -52571,7 +52601,7 @@ enum VolumeType {
   gp3,
 }
 
-extension on VolumeType {
+extension VolumeTypeValue on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.standard:
@@ -52592,7 +52622,7 @@ extension on VolumeType {
   }
 }
 
-extension on String {
+extension VolumeTypeFromString on String {
   VolumeType toVolumeType() {
     switch (this) {
       case 'standard':
@@ -52679,7 +52709,7 @@ enum VpcAttributeName {
   enableDnsHostnames,
 }
 
-extension on VpcAttributeName {
+extension VpcAttributeNameValue on VpcAttributeName {
   String toValue() {
     switch (this) {
       case VpcAttributeName.enableDnsSupport:
@@ -52690,7 +52720,7 @@ extension on VpcAttributeName {
   }
 }
 
-extension on String {
+extension VpcAttributeNameFromString on String {
   VpcAttributeName toVpcAttributeName() {
     switch (this) {
       case 'enableDnsSupport':
@@ -52743,7 +52773,7 @@ enum VpcCidrBlockStateCode {
   failed,
 }
 
-extension on VpcCidrBlockStateCode {
+extension VpcCidrBlockStateCodeValue on VpcCidrBlockStateCode {
   String toValue() {
     switch (this) {
       case VpcCidrBlockStateCode.associating:
@@ -52762,7 +52792,7 @@ extension on VpcCidrBlockStateCode {
   }
 }
 
-extension on String {
+extension VpcCidrBlockStateCodeFromString on String {
   VpcCidrBlockStateCode toVpcCidrBlockStateCode() {
     switch (this) {
       case 'associating':
@@ -52922,7 +52952,7 @@ enum VpcEndpointType {
   gatewayLoadBalancer,
 }
 
-extension on VpcEndpointType {
+extension VpcEndpointTypeValue on VpcEndpointType {
   String toValue() {
     switch (this) {
       case VpcEndpointType.interface:
@@ -52935,7 +52965,7 @@ extension on VpcEndpointType {
   }
 }
 
-extension on String {
+extension VpcEndpointTypeFromString on String {
   VpcEndpointType toVpcEndpointType() {
     switch (this) {
       case 'Interface':
@@ -53056,7 +53086,8 @@ enum VpcPeeringConnectionStateReasonCode {
   deleting,
 }
 
-extension on VpcPeeringConnectionStateReasonCode {
+extension VpcPeeringConnectionStateReasonCodeValue
+    on VpcPeeringConnectionStateReasonCode {
   String toValue() {
     switch (this) {
       case VpcPeeringConnectionStateReasonCode.initiatingRequest:
@@ -53081,7 +53112,7 @@ extension on VpcPeeringConnectionStateReasonCode {
   }
 }
 
-extension on String {
+extension VpcPeeringConnectionStateReasonCodeFromString on String {
   VpcPeeringConnectionStateReasonCode toVpcPeeringConnectionStateReasonCode() {
     switch (this) {
       case 'initiating-request':
@@ -53148,7 +53179,7 @@ enum VpcState {
   available,
 }
 
-extension on VpcState {
+extension VpcStateValue on VpcState {
   String toValue() {
     switch (this) {
       case VpcState.pending:
@@ -53159,7 +53190,7 @@ extension on VpcState {
   }
 }
 
-extension on String {
+extension VpcStateFromString on String {
   VpcState toVpcState() {
     switch (this) {
       case 'pending':
@@ -53175,7 +53206,7 @@ enum VpcTenancy {
   $default,
 }
 
-extension on VpcTenancy {
+extension VpcTenancyValue on VpcTenancy {
   String toValue() {
     switch (this) {
       case VpcTenancy.$default:
@@ -53184,7 +53215,7 @@ extension on VpcTenancy {
   }
 }
 
-extension on String {
+extension VpcTenancyFromString on String {
   VpcTenancy toVpcTenancy() {
     switch (this) {
       case 'default':
@@ -53357,7 +53388,7 @@ enum VpnEcmpSupportValue {
   disable,
 }
 
-extension on VpnEcmpSupportValue {
+extension VpnEcmpSupportValueValue on VpnEcmpSupportValue {
   String toValue() {
     switch (this) {
       case VpnEcmpSupportValue.enable:
@@ -53368,7 +53399,7 @@ extension on VpnEcmpSupportValue {
   }
 }
 
-extension on String {
+extension VpnEcmpSupportValueFromString on String {
   VpnEcmpSupportValue toVpnEcmpSupportValue() {
     switch (this) {
       case 'enable':
@@ -53420,7 +53451,7 @@ enum VpnProtocol {
   openvpn,
 }
 
-extension on VpnProtocol {
+extension VpnProtocolValue on VpnProtocol {
   String toValue() {
     switch (this) {
       case VpnProtocol.openvpn:
@@ -53429,7 +53460,7 @@ extension on VpnProtocol {
   }
 }
 
-extension on String {
+extension VpnProtocolFromString on String {
   VpnProtocol toVpnProtocol() {
     switch (this) {
       case 'openvpn':
@@ -53446,7 +53477,7 @@ enum VpnState {
   deleted,
 }
 
-extension on VpnState {
+extension VpnStateValue on VpnState {
   String toValue() {
     switch (this) {
       case VpnState.pending:
@@ -53461,7 +53492,7 @@ extension on VpnState {
   }
 }
 
-extension on String {
+extension VpnStateFromString on String {
   VpnState toVpnState() {
     switch (this) {
       case 'pending':
@@ -53499,7 +53530,7 @@ enum VpnStaticRouteSource {
   static,
 }
 
-extension on VpnStaticRouteSource {
+extension VpnStaticRouteSourceValue on VpnStaticRouteSource {
   String toValue() {
     switch (this) {
       case VpnStaticRouteSource.static:
@@ -53508,7 +53539,7 @@ extension on VpnStaticRouteSource {
   }
 }
 
-extension on String {
+extension VpnStaticRouteSourceFromString on String {
   VpnStaticRouteSource toVpnStaticRouteSource() {
     switch (this) {
       case 'Static':
@@ -53726,7 +53757,7 @@ enum Scope {
   region,
 }
 
-extension on Scope {
+extension ScopeValue on Scope {
   String toValue() {
     switch (this) {
       case Scope.availabilityZone:
@@ -53737,7 +53768,7 @@ extension on Scope {
   }
 }
 
-extension on String {
+extension ScopeFromString on String {
   Scope toScope() {
     switch (this) {
       case 'Availability Zone':

--- a/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
+++ b/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
@@ -23383,7 +23383,7 @@ enum AccountAttributeName {
   defaultVpc,
 }
 
-extension AccountAttributeNameValue on AccountAttributeName {
+extension AccountAttributeNameValueExtension on AccountAttributeName {
   String toValue() {
     switch (this) {
       case AccountAttributeName.supportedPlatforms:
@@ -23448,7 +23448,7 @@ enum ActivityStatus {
   fulfilled,
 }
 
-extension ActivityStatusValue on ActivityStatus {
+extension ActivityStatusValueExtension on ActivityStatus {
   String toValue() {
     switch (this) {
       case ActivityStatus.error:
@@ -23577,7 +23577,7 @@ enum Affinity {
   host,
 }
 
-extension AffinityValue on Affinity {
+extension AffinityValueExtension on Affinity {
   String toValue() {
     switch (this) {
       case Affinity.$default:
@@ -23661,7 +23661,7 @@ enum AllocationState {
   pending,
 }
 
-extension AllocationStateValue on AllocationState {
+extension AllocationStateValueExtension on AllocationState {
   String toValue() {
     switch (this) {
       case AllocationState.available:
@@ -23706,7 +23706,7 @@ enum AllocationStrategy {
   capacityOptimized,
 }
 
-extension AllocationStrategyValue on AllocationStrategy {
+extension AllocationStrategyValueExtension on AllocationStrategy {
   String toValue() {
     switch (this) {
       case AllocationStrategy.lowestPrice:
@@ -23752,7 +23752,8 @@ enum AllowsMultipleInstanceTypes {
   off,
 }
 
-extension AllowsMultipleInstanceTypesValue on AllowsMultipleInstanceTypes {
+extension AllowsMultipleInstanceTypesValueExtension
+    on AllowsMultipleInstanceTypes {
   String toValue() {
     switch (this) {
       case AllowsMultipleInstanceTypes.on:
@@ -24003,7 +24004,7 @@ enum AnalysisStatus {
   failed,
 }
 
-extension AnalysisStatusValue on AnalysisStatus {
+extension AnalysisStatusValueExtension on AnalysisStatus {
   String toValue() {
     switch (this) {
       case AnalysisStatus.running:
@@ -24035,7 +24036,7 @@ enum ApplianceModeSupportValue {
   disable,
 }
 
-extension ApplianceModeSupportValueValue on ApplianceModeSupportValue {
+extension ApplianceModeSupportValueValueExtension on ApplianceModeSupportValue {
   String toValue() {
     switch (this) {
       case ApplianceModeSupportValue.enable:
@@ -24073,7 +24074,7 @@ enum ArchitectureType {
   arm64,
 }
 
-extension ArchitectureTypeValue on ArchitectureType {
+extension ArchitectureTypeValueExtension on ArchitectureType {
   String toValue() {
     switch (this) {
       case ArchitectureType.i386:
@@ -24106,7 +24107,7 @@ enum ArchitectureValues {
   arm64,
 }
 
-extension ArchitectureValuesValue on ArchitectureValues {
+extension ArchitectureValuesValueExtension on ArchitectureValues {
   String toValue() {
     switch (this) {
       case ArchitectureValues.i386:
@@ -24287,7 +24288,7 @@ enum AssociatedNetworkType {
   vpc,
 }
 
-extension AssociatedNetworkTypeValue on AssociatedNetworkType {
+extension AssociatedNetworkTypeValueExtension on AssociatedNetworkType {
   String toValue() {
     switch (this) {
       case AssociatedNetworkType.vpc:
@@ -24367,7 +24368,7 @@ enum AssociationStatusCode {
   disassociated,
 }
 
-extension AssociationStatusCodeValue on AssociationStatusCode {
+extension AssociationStatusCodeValueExtension on AssociationStatusCode {
   String toValue() {
     switch (this) {
       case AssociationStatusCode.associating:
@@ -24443,7 +24444,7 @@ enum AttachmentStatus {
   detached,
 }
 
-extension AttachmentStatusValue on AttachmentStatus {
+extension AttachmentStatusValueExtension on AttachmentStatus {
   String toValue() {
     switch (this) {
       case AttachmentStatus.attaching:
@@ -24542,7 +24543,7 @@ enum AutoAcceptSharedAssociationsValue {
   disable,
 }
 
-extension AutoAcceptSharedAssociationsValueValue
+extension AutoAcceptSharedAssociationsValueValueExtension
     on AutoAcceptSharedAssociationsValue {
   String toValue() {
     switch (this) {
@@ -24572,7 +24573,7 @@ enum AutoAcceptSharedAttachmentsValue {
   disable,
 }
 
-extension AutoAcceptSharedAttachmentsValueValue
+extension AutoAcceptSharedAttachmentsValueValueExtension
     on AutoAcceptSharedAttachmentsValue {
   String toValue() {
     switch (this) {
@@ -24602,7 +24603,7 @@ enum AutoPlacement {
   off,
 }
 
-extension AutoPlacementValue on AutoPlacement {
+extension AutoPlacementValueExtension on AutoPlacement {
   String toValue() {
     switch (this) {
       case AutoPlacement.on:
@@ -24707,7 +24708,8 @@ enum AvailabilityZoneOptInStatus {
   notOptedIn,
 }
 
-extension AvailabilityZoneOptInStatusValue on AvailabilityZoneOptInStatus {
+extension AvailabilityZoneOptInStatusValueExtension
+    on AvailabilityZoneOptInStatus {
   String toValue() {
     switch (this) {
       case AvailabilityZoneOptInStatus.optInNotRequired:
@@ -24741,7 +24743,7 @@ enum AvailabilityZoneState {
   unavailable,
 }
 
-extension AvailabilityZoneStateValue on AvailabilityZoneState {
+extension AvailabilityZoneStateValueExtension on AvailabilityZoneState {
   String toValue() {
     switch (this) {
       case AvailabilityZoneState.available:
@@ -24801,7 +24803,7 @@ enum BatchState {
   modifying,
 }
 
-extension BatchStateValue on BatchState {
+extension BatchStateValueExtension on BatchState {
   String toValue() {
     switch (this) {
       case BatchState.submitted:
@@ -24849,7 +24851,7 @@ enum BgpStatus {
   down,
 }
 
-extension BgpStatusValue on BgpStatus {
+extension BgpStatusValueExtension on BgpStatus {
   String toValue() {
     switch (this) {
       case BgpStatus.up:
@@ -24989,7 +24991,7 @@ enum BundleTaskState {
   failed,
 }
 
-extension BundleTaskStateValue on BundleTaskState {
+extension BundleTaskStateValueExtension on BundleTaskState {
   String toValue() {
     switch (this) {
       case BundleTaskState.pending:
@@ -25067,7 +25069,7 @@ enum ByoipCidrState {
   provisionedNotPubliclyAdvertisable,
 }
 
-extension ByoipCidrStateValue on ByoipCidrState {
+extension ByoipCidrStateValueExtension on ByoipCidrState {
   String toValue() {
     switch (this) {
       case ByoipCidrState.advertised:
@@ -25121,7 +25123,7 @@ enum CancelBatchErrorCode {
   unexpectedError,
 }
 
-extension CancelBatchErrorCodeValue on CancelBatchErrorCode {
+extension CancelBatchErrorCodeValueExtension on CancelBatchErrorCode {
   String toValue() {
     switch (this) {
       case CancelBatchErrorCode.fleetRequestIdDoesNotExist:
@@ -25268,7 +25270,7 @@ enum CancelSpotInstanceRequestState {
   completed,
 }
 
-extension CancelSpotInstanceRequestStateValue
+extension CancelSpotInstanceRequestStateValueExtension
     on CancelSpotInstanceRequestState {
   String toValue() {
     switch (this) {
@@ -25512,7 +25514,7 @@ enum CapacityReservationInstancePlatform {
   linuxWithSqlServerEnterprise,
 }
 
-extension CapacityReservationInstancePlatformValue
+extension CapacityReservationInstancePlatformValueExtension
     on CapacityReservationInstancePlatform {
   String toValue() {
     switch (this) {
@@ -25651,7 +25653,8 @@ enum CapacityReservationPreference {
   none,
 }
 
-extension CapacityReservationPreferenceValue on CapacityReservationPreference {
+extension CapacityReservationPreferenceValueExtension
+    on CapacityReservationPreference {
   String toValue() {
     switch (this) {
       case CapacityReservationPreference.open:
@@ -25755,7 +25758,7 @@ enum CapacityReservationState {
   failed,
 }
 
-extension CapacityReservationStateValue on CapacityReservationState {
+extension CapacityReservationStateValueExtension on CapacityReservationState {
   String toValue() {
     switch (this) {
       case CapacityReservationState.active:
@@ -25824,7 +25827,8 @@ enum CapacityReservationTenancy {
   dedicated,
 }
 
-extension CapacityReservationTenancyValue on CapacityReservationTenancy {
+extension CapacityReservationTenancyValueExtension
+    on CapacityReservationTenancy {
   String toValue() {
     switch (this) {
       case CapacityReservationTenancy.$default:
@@ -25880,7 +25884,7 @@ enum CarrierGatewayState {
   deleted,
 }
 
-extension CarrierGatewayStateValue on CarrierGatewayState {
+extension CarrierGatewayStateValueExtension on CarrierGatewayState {
   String toValue() {
     switch (this) {
       case CarrierGatewayState.pending:
@@ -26039,7 +26043,7 @@ enum ClientCertificateRevocationListStatusCode {
   active,
 }
 
-extension ClientCertificateRevocationListStatusCodeValue
+extension ClientCertificateRevocationListStatusCodeValueExtension
     on ClientCertificateRevocationListStatusCode {
   String toValue() {
     switch (this) {
@@ -26186,7 +26190,8 @@ enum ClientVpnAuthenticationType {
   federatedAuthentication,
 }
 
-extension ClientVpnAuthenticationTypeValue on ClientVpnAuthenticationType {
+extension ClientVpnAuthenticationTypeValueExtension
+    on ClientVpnAuthenticationType {
   String toValue() {
     switch (this) {
       case ClientVpnAuthenticationType.certificateAuthentication:
@@ -26234,7 +26239,7 @@ enum ClientVpnAuthorizationRuleStatusCode {
   revoking,
 }
 
-extension ClientVpnAuthorizationRuleStatusCodeValue
+extension ClientVpnAuthorizationRuleStatusCodeValueExtension
     on ClientVpnAuthorizationRuleStatusCode {
   String toValue() {
     switch (this) {
@@ -26355,7 +26360,8 @@ enum ClientVpnConnectionStatusCode {
   terminated,
 }
 
-extension ClientVpnConnectionStatusCodeValue on ClientVpnConnectionStatusCode {
+extension ClientVpnConnectionStatusCodeValueExtension
+    on ClientVpnConnectionStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnConnectionStatusCode.active:
@@ -26505,7 +26511,7 @@ enum ClientVpnEndpointAttributeStatusCode {
   applied,
 }
 
-extension ClientVpnEndpointAttributeStatusCodeValue
+extension ClientVpnEndpointAttributeStatusCodeValueExtension
     on ClientVpnEndpointAttributeStatusCode {
   String toValue() {
     switch (this) {
@@ -26573,7 +26579,8 @@ enum ClientVpnEndpointStatusCode {
   deleted,
 }
 
-extension ClientVpnEndpointStatusCodeValue on ClientVpnEndpointStatusCode {
+extension ClientVpnEndpointStatusCodeValueExtension
+    on ClientVpnEndpointStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnEndpointStatusCode.pendingAssociate:
@@ -26663,7 +26670,7 @@ enum ClientVpnRouteStatusCode {
   deleting,
 }
 
-extension ClientVpnRouteStatusCodeValue on ClientVpnRouteStatusCode {
+extension ClientVpnRouteStatusCodeValueExtension on ClientVpnRouteStatusCode {
   String toValue() {
     switch (this) {
       case ClientVpnRouteStatusCode.creating:
@@ -26841,7 +26848,8 @@ enum ConnectionNotificationState {
   disabled,
 }
 
-extension ConnectionNotificationStateValue on ConnectionNotificationState {
+extension ConnectionNotificationStateValueExtension
+    on ConnectionNotificationState {
   String toValue() {
     switch (this) {
       case ConnectionNotificationState.enabled:
@@ -26868,7 +26876,8 @@ enum ConnectionNotificationType {
   topic,
 }
 
-extension ConnectionNotificationTypeValue on ConnectionNotificationType {
+extension ConnectionNotificationTypeValueExtension
+    on ConnectionNotificationType {
   String toValue() {
     switch (this) {
       case ConnectionNotificationType.topic:
@@ -26891,7 +26900,7 @@ enum ContainerFormat {
   ova,
 }
 
-extension ContainerFormatValue on ContainerFormat {
+extension ContainerFormatValueExtension on ContainerFormat {
   String toValue() {
     switch (this) {
       case ContainerFormat.ova:
@@ -26954,7 +26963,7 @@ enum ConversionTaskState {
   completed,
 }
 
-extension ConversionTaskStateValue on ConversionTaskState {
+extension ConversionTaskStateValueExtension on ConversionTaskState {
   String toValue() {
     switch (this) {
       case ConversionTaskState.active:
@@ -27021,7 +27030,7 @@ enum CopyTagsFromSource {
   volume,
 }
 
-extension CopyTagsFromSourceValue on CopyTagsFromSource {
+extension CopyTagsFromSourceValueExtension on CopyTagsFromSource {
   String toValue() {
     switch (this) {
       case CopyTagsFromSource.volume:
@@ -27826,7 +27835,7 @@ enum CurrencyCodeValues {
   usd,
 }
 
-extension CurrencyCodeValuesValue on CurrencyCodeValues {
+extension CurrencyCodeValuesValueExtension on CurrencyCodeValues {
   String toValue() {
     switch (this) {
       case CurrencyCodeValues.usd:
@@ -27892,7 +27901,7 @@ enum DatafeedSubscriptionState {
   inactive,
 }
 
-extension DatafeedSubscriptionStateValue on DatafeedSubscriptionState {
+extension DatafeedSubscriptionStateValueExtension on DatafeedSubscriptionState {
   String toValue() {
     switch (this) {
       case DatafeedSubscriptionState.active:
@@ -27920,7 +27929,7 @@ enum DefaultRouteTableAssociationValue {
   disable,
 }
 
-extension DefaultRouteTableAssociationValueValue
+extension DefaultRouteTableAssociationValueValueExtension
     on DefaultRouteTableAssociationValue {
   String toValue() {
     switch (this) {
@@ -27950,7 +27959,7 @@ enum DefaultRouteTablePropagationValue {
   disable,
 }
 
-extension DefaultRouteTablePropagationValueValue
+extension DefaultRouteTablePropagationValueValueExtension
     on DefaultRouteTablePropagationValue {
   String toValue() {
     switch (this) {
@@ -27980,7 +27989,7 @@ enum DefaultTargetCapacityType {
   onDemand,
 }
 
-extension DefaultTargetCapacityTypeValue on DefaultTargetCapacityType {
+extension DefaultTargetCapacityTypeValueExtension on DefaultTargetCapacityType {
   String toValue() {
     switch (this) {
       case DefaultTargetCapacityType.spot:
@@ -28061,7 +28070,7 @@ enum DeleteFleetErrorCode {
   unexpectedError,
 }
 
-extension DeleteFleetErrorCodeValue on DeleteFleetErrorCode {
+extension DeleteFleetErrorCodeValueExtension on DeleteFleetErrorCode {
   String toValue() {
     switch (this) {
       case DeleteFleetErrorCode.fleetIdDoesNotExist:
@@ -28307,7 +28316,7 @@ enum DeleteQueuedReservedInstancesErrorCode {
   unexpectedError,
 }
 
-extension DeleteQueuedReservedInstancesErrorCodeValue
+extension DeleteQueuedReservedInstancesErrorCodeValueExtension
     on DeleteQueuedReservedInstancesErrorCode {
   String toValue() {
     switch (this) {
@@ -30351,7 +30360,7 @@ enum DeviceType {
   instanceStore,
 }
 
-extension DeviceTypeValue on DeviceType {
+extension DeviceTypeValueExtension on DeviceType {
   String toValue() {
     switch (this) {
       case DeviceType.ebs:
@@ -30762,7 +30771,7 @@ enum DiskImageFormat {
   vhd,
 }
 
-extension DiskImageFormatValue on DiskImageFormat {
+extension DiskImageFormatValueExtension on DiskImageFormat {
   String toValue() {
     switch (this) {
       case DiskImageFormat.vmdk:
@@ -30826,7 +30835,7 @@ enum DiskType {
   ssd,
 }
 
-extension DiskTypeValue on DiskType {
+extension DiskTypeValueExtension on DiskType {
   String toValue() {
     switch (this) {
       case DiskType.hdd:
@@ -30869,7 +30878,7 @@ enum DnsNameState {
   failed,
 }
 
-extension DnsNameStateValue on DnsNameState {
+extension DnsNameStateValueExtension on DnsNameState {
   String toValue() {
     switch (this) {
       case DnsNameState.pendingVerification:
@@ -30918,7 +30927,7 @@ enum DnsSupportValue {
   disable,
 }
 
-extension DnsSupportValueValue on DnsSupportValue {
+extension DnsSupportValueValueExtension on DnsSupportValue {
   String toValue() {
     switch (this) {
       case DnsSupportValue.enable:
@@ -30946,7 +30955,7 @@ enum DomainType {
   standard,
 }
 
-extension DomainTypeValue on DomainType {
+extension DomainTypeValueExtension on DomainType {
   String toValue() {
     switch (this) {
       case DomainType.vpc:
@@ -31099,7 +31108,7 @@ enum EbsEncryptionSupport {
   supported,
 }
 
-extension EbsEncryptionSupportValue on EbsEncryptionSupport {
+extension EbsEncryptionSupportValueExtension on EbsEncryptionSupport {
   String toValue() {
     switch (this) {
       case EbsEncryptionSupport.unsupported:
@@ -31192,7 +31201,7 @@ enum EbsNvmeSupport {
   required,
 }
 
-extension EbsNvmeSupportValue on EbsNvmeSupport {
+extension EbsNvmeSupportValueExtension on EbsNvmeSupport {
   String toValue() {
     switch (this) {
       case EbsNvmeSupport.unsupported:
@@ -31261,7 +31270,7 @@ enum EbsOptimizedSupport {
   $default,
 }
 
-extension EbsOptimizedSupportValue on EbsOptimizedSupport {
+extension EbsOptimizedSupportValueExtension on EbsOptimizedSupport {
   String toValue() {
     switch (this) {
       case EbsOptimizedSupport.unsupported:
@@ -31368,7 +31377,7 @@ enum ElasticGpuState {
   attached,
 }
 
-extension ElasticGpuStateValue on ElasticGpuState {
+extension ElasticGpuStateValueExtension on ElasticGpuState {
   String toValue() {
     switch (this) {
       case ElasticGpuState.attached:
@@ -31392,7 +31401,7 @@ enum ElasticGpuStatus {
   impaired,
 }
 
-extension ElasticGpuStatusValue on ElasticGpuStatus {
+extension ElasticGpuStatusValueExtension on ElasticGpuStatus {
   String toValue() {
     switch (this) {
       case ElasticGpuStatus.ok:
@@ -31499,7 +31508,7 @@ enum EnaSupport {
   required,
 }
 
-extension EnaSupportValue on EnaSupport {
+extension EnaSupportValueExtension on EnaSupport {
   String toValue() {
     switch (this) {
       case EnaSupport.unsupported:
@@ -31723,7 +31732,7 @@ enum EndDateType {
   limited,
 }
 
-extension EndDateTypeValue on EndDateType {
+extension EndDateTypeValueExtension on EndDateType {
   String toValue() {
     switch (this) {
       case EndDateType.unlimited:
@@ -31752,7 +31761,7 @@ enum EphemeralNvmeSupport {
   required,
 }
 
-extension EphemeralNvmeSupportValue on EphemeralNvmeSupport {
+extension EphemeralNvmeSupportValueExtension on EphemeralNvmeSupport {
   String toValue() {
     switch (this) {
       case EphemeralNvmeSupport.unsupported:
@@ -31787,7 +31796,7 @@ enum EventCode {
   instanceStop,
 }
 
-extension EventCodeValue on EventCode {
+extension EventCodeValueExtension on EventCode {
   String toValue() {
     switch (this) {
       case EventCode.instanceReboot:
@@ -31940,7 +31949,7 @@ enum EventType {
   information,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.instanceChange:
@@ -31976,7 +31985,7 @@ enum ExcessCapacityTerminationPolicy {
   $default,
 }
 
-extension ExcessCapacityTerminationPolicyValue
+extension ExcessCapacityTerminationPolicyValueExtension
     on ExcessCapacityTerminationPolicy {
   String toValue() {
     switch (this) {
@@ -32227,7 +32236,7 @@ enum ExportEnvironment {
   microsoft,
 }
 
-extension ExportEnvironmentValue on ExportEnvironment {
+extension ExportEnvironmentValueExtension on ExportEnvironment {
   String toValue() {
     switch (this) {
       case ExportEnvironment.citrix:
@@ -32411,7 +32420,7 @@ enum ExportTaskState {
   completed,
 }
 
-extension ExportTaskStateValue on ExportTaskState {
+extension ExportTaskStateValueExtension on ExportTaskState {
   String toValue() {
     switch (this) {
       case ExportTaskState.active:
@@ -32525,7 +32534,8 @@ enum FastSnapshotRestoreStateCode {
   disabled,
 }
 
-extension FastSnapshotRestoreStateCodeValue on FastSnapshotRestoreStateCode {
+extension FastSnapshotRestoreStateCodeValueExtension
+    on FastSnapshotRestoreStateCode {
   String toValue() {
     switch (this) {
       case FastSnapshotRestoreStateCode.enabling:
@@ -32648,7 +32658,7 @@ enum FleetActivityStatus {
   fulfilled,
 }
 
-extension FleetActivityStatusValue on FleetActivityStatus {
+extension FleetActivityStatusValueExtension on FleetActivityStatus {
   String toValue() {
     switch (this) {
       case FleetActivityStatus.error:
@@ -32683,7 +32693,7 @@ enum FleetCapacityReservationUsageStrategy {
   useCapacityReservationsFirst,
 }
 
-extension FleetCapacityReservationUsageStrategyValue
+extension FleetCapacityReservationUsageStrategyValueExtension
     on FleetCapacityReservationUsageStrategy {
   String toValue() {
     switch (this) {
@@ -32832,7 +32842,7 @@ enum FleetEventType {
   serviceError,
 }
 
-extension FleetEventTypeValue on FleetEventType {
+extension FleetEventTypeValueExtension on FleetEventType {
   String toValue() {
     switch (this) {
       case FleetEventType.instanceChange:
@@ -32864,7 +32874,7 @@ enum FleetExcessCapacityTerminationPolicy {
   termination,
 }
 
-extension FleetExcessCapacityTerminationPolicyValue
+extension FleetExcessCapacityTerminationPolicyValueExtension
     on FleetExcessCapacityTerminationPolicy {
   String toValue() {
     switch (this) {
@@ -33076,7 +33086,7 @@ enum FleetOnDemandAllocationStrategy {
   prioritized,
 }
 
-extension FleetOnDemandAllocationStrategyValue
+extension FleetOnDemandAllocationStrategyValueExtension
     on FleetOnDemandAllocationStrategy {
   String toValue() {
     switch (this) {
@@ -33105,7 +33115,7 @@ enum FleetReplacementStrategy {
   launch,
 }
 
-extension FleetReplacementStrategyValue on FleetReplacementStrategy {
+extension FleetReplacementStrategyValueExtension on FleetReplacementStrategy {
   String toValue() {
     switch (this) {
       case FleetReplacementStrategy.launch:
@@ -33202,7 +33212,7 @@ enum FleetStateCode {
   modifying,
 }
 
-extension FleetStateCodeValue on FleetStateCode {
+extension FleetStateCodeValueExtension on FleetStateCode {
   String toValue() {
     switch (this) {
       case FleetStateCode.submitted:
@@ -33251,7 +33261,7 @@ enum FleetType {
   instant,
 }
 
-extension FleetTypeValue on FleetType {
+extension FleetTypeValueExtension on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.request:
@@ -33367,7 +33377,7 @@ enum FlowLogsResourceType {
   networkInterface,
 }
 
-extension FlowLogsResourceTypeValue on FlowLogsResourceType {
+extension FlowLogsResourceTypeValueExtension on FlowLogsResourceType {
   String toValue() {
     switch (this) {
       case FlowLogsResourceType.vpc:
@@ -33526,7 +33536,7 @@ enum FpgaImageAttributeName {
   productCodes,
 }
 
-extension FpgaImageAttributeNameValue on FpgaImageAttributeName {
+extension FpgaImageAttributeNameValueExtension on FpgaImageAttributeName {
   String toValue() {
     switch (this) {
       case FpgaImageAttributeName.description:
@@ -33594,7 +33604,7 @@ enum FpgaImageStateCode {
   unavailable,
 }
 
-extension FpgaImageStateCodeValue on FpgaImageStateCode {
+extension FpgaImageStateCodeValueExtension on FpgaImageStateCode {
   String toValue() {
     switch (this) {
       case FpgaImageStateCode.pending:
@@ -33643,7 +33653,7 @@ enum GatewayType {
   ipsec_1,
 }
 
-extension GatewayTypeValue on GatewayType {
+extension GatewayTypeValueExtension on GatewayType {
   String toValue() {
     switch (this) {
       case GatewayType.ipsec_1:
@@ -34354,7 +34364,7 @@ enum HostRecovery {
   off,
 }
 
-extension HostRecoveryValue on HostRecovery {
+extension HostRecoveryValueExtension on HostRecovery {
   String toValue() {
     switch (this) {
       case HostRecovery.on:
@@ -34450,7 +34460,7 @@ enum HostTenancy {
   host,
 }
 
-extension HostTenancyValue on HostTenancy {
+extension HostTenancyValueExtension on HostTenancy {
   String toValue() {
     switch (this) {
       case HostTenancy.dedicated:
@@ -34478,7 +34488,7 @@ enum HttpTokensState {
   required,
 }
 
-extension HttpTokensStateValue on HttpTokensState {
+extension HttpTokensStateValueExtension on HttpTokensState {
   String toValue() {
     switch (this) {
       case HttpTokensState.optional:
@@ -34506,7 +34516,7 @@ enum HypervisorType {
   xen,
 }
 
-extension HypervisorTypeValue on HypervisorType {
+extension HypervisorTypeValueExtension on HypervisorType {
   String toValue() {
     switch (this) {
       case HypervisorType.ovm:
@@ -34596,7 +34606,7 @@ enum IamInstanceProfileAssociationState {
   disassociated,
 }
 
-extension IamInstanceProfileAssociationStateValue
+extension IamInstanceProfileAssociationStateValueExtension
     on IamInstanceProfileAssociationState {
   String toValue() {
     switch (this) {
@@ -34683,7 +34693,7 @@ enum Igmpv2SupportValue {
   disable,
 }
 
-extension Igmpv2SupportValueValue on Igmpv2SupportValue {
+extension Igmpv2SupportValueValueExtension on Igmpv2SupportValue {
   String toValue() {
     switch (this) {
       case Igmpv2SupportValue.enable:
@@ -34888,7 +34898,7 @@ enum ImageAttributeName {
   sriovNetSupport,
 }
 
-extension ImageAttributeNameValue on ImageAttributeName {
+extension ImageAttributeNameValueExtension on ImageAttributeName {
   String toValue() {
     switch (this) {
       case ImageAttributeName.description:
@@ -34975,7 +34985,7 @@ enum ImageState {
   error,
 }
 
-extension ImageStateValue on ImageState {
+extension ImageStateValueExtension on ImageState {
   String toValue() {
     switch (this) {
       case ImageState.pending:
@@ -35024,7 +35034,7 @@ enum ImageTypeValues {
   ramdisk,
 }
 
-extension ImageTypeValuesValue on ImageTypeValues {
+extension ImageTypeValuesValueExtension on ImageTypeValues {
   String toValue() {
     switch (this) {
       case ImageTypeValues.machine:
@@ -35794,7 +35804,7 @@ enum InstanceAttributeName {
   enclaveOptions,
 }
 
-extension InstanceAttributeNameValue on InstanceAttributeName {
+extension InstanceAttributeNameValueExtension on InstanceAttributeName {
   String toValue() {
     switch (this) {
       case InstanceAttributeName.instanceType:
@@ -36010,7 +36020,7 @@ enum InstanceHealthStatus {
   unhealthy,
 }
 
-extension InstanceHealthStatusValue on InstanceHealthStatus {
+extension InstanceHealthStatusValueExtension on InstanceHealthStatus {
   String toValue() {
     switch (this) {
       case InstanceHealthStatus.healthy:
@@ -36039,7 +36049,8 @@ enum InstanceInterruptionBehavior {
   terminate,
 }
 
-extension InstanceInterruptionBehaviorValue on InstanceInterruptionBehavior {
+extension InstanceInterruptionBehaviorValueExtension
+    on InstanceInterruptionBehavior {
   String toValue() {
     switch (this) {
       case InstanceInterruptionBehavior.hibernate:
@@ -36091,7 +36102,7 @@ enum InstanceLifecycle {
   onDemand,
 }
 
-extension InstanceLifecycleValue on InstanceLifecycle {
+extension InstanceLifecycleValueExtension on InstanceLifecycle {
   String toValue() {
     switch (this) {
       case InstanceLifecycle.spot:
@@ -36119,7 +36130,7 @@ enum InstanceLifecycleType {
   scheduled,
 }
 
-extension InstanceLifecycleTypeValue on InstanceLifecycleType {
+extension InstanceLifecycleTypeValueExtension on InstanceLifecycleType {
   String toValue() {
     switch (this) {
       case InstanceLifecycleType.spot:
@@ -36161,7 +36172,7 @@ enum InstanceMatchCriteria {
   targeted,
 }
 
-extension InstanceMatchCriteriaValue on InstanceMatchCriteria {
+extension InstanceMatchCriteriaValueExtension on InstanceMatchCriteria {
   String toValue() {
     switch (this) {
       case InstanceMatchCriteria.open:
@@ -36189,7 +36200,8 @@ enum InstanceMetadataEndpointState {
   enabled,
 }
 
-extension InstanceMetadataEndpointStateValue on InstanceMetadataEndpointState {
+extension InstanceMetadataEndpointStateValueExtension
+    on InstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
       case InstanceMetadataEndpointState.disabled:
@@ -36311,7 +36323,8 @@ enum InstanceMetadataOptionsState {
   applied,
 }
 
-extension InstanceMetadataOptionsStateValue on InstanceMetadataOptionsState {
+extension InstanceMetadataOptionsStateValueExtension
+    on InstanceMetadataOptionsState {
   String toValue() {
     switch (this) {
       case InstanceMetadataOptionsState.pending:
@@ -36707,7 +36720,7 @@ enum InstanceStateName {
   stopped,
 }
 
-extension InstanceStateNameValue on InstanceStateName {
+extension InstanceStateNameValueExtension on InstanceStateName {
   String toValue() {
     switch (this) {
       case InstanceStateName.pending:
@@ -37278,7 +37291,7 @@ enum InstanceType {
   mac1Metal,
 }
 
-extension InstanceTypeValue on InstanceType {
+extension InstanceTypeValueExtension on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.t1Micro:
@@ -38854,7 +38867,7 @@ enum InstanceTypeHypervisor {
   xen,
 }
 
-extension InstanceTypeHypervisorValue on InstanceTypeHypervisor {
+extension InstanceTypeHypervisorValueExtension on InstanceTypeHypervisor {
   String toValue() {
     switch (this) {
       case InstanceTypeHypervisor.nitro:
@@ -39020,7 +39033,7 @@ enum InterfacePermissionType {
   eipAssociate,
 }
 
-extension InterfacePermissionTypeValue on InterfacePermissionType {
+extension InterfacePermissionTypeValueExtension on InterfacePermissionType {
   String toValue() {
     switch (this) {
       case InterfacePermissionType.instanceAttach:
@@ -39223,7 +39236,7 @@ enum Ipv6SupportValue {
   disable,
 }
 
-extension Ipv6SupportValueValue on Ipv6SupportValue {
+extension Ipv6SupportValueValueExtension on Ipv6SupportValue {
   String toValue() {
     switch (this) {
       case Ipv6SupportValue.enable:
@@ -39822,7 +39835,7 @@ enum LaunchTemplateErrorCode {
   unexpectedError,
 }
 
-extension LaunchTemplateErrorCodeValue on LaunchTemplateErrorCode {
+extension LaunchTemplateErrorCodeValueExtension on LaunchTemplateErrorCode {
   String toValue() {
     switch (this) {
       case LaunchTemplateErrorCode.launchTemplateIdDoesNotExist:
@@ -39893,7 +39906,8 @@ enum LaunchTemplateHttpTokensState {
   required,
 }
 
-extension LaunchTemplateHttpTokensStateValue on LaunchTemplateHttpTokensState {
+extension LaunchTemplateHttpTokensStateValueExtension
+    on LaunchTemplateHttpTokensState {
   String toValue() {
     switch (this) {
       case LaunchTemplateHttpTokensState.optional:
@@ -39977,7 +39991,7 @@ enum LaunchTemplateInstanceMetadataEndpointState {
   enabled,
 }
 
-extension LaunchTemplateInstanceMetadataEndpointStateValue
+extension LaunchTemplateInstanceMetadataEndpointStateValueExtension
     on LaunchTemplateInstanceMetadataEndpointState {
   String toValue() {
     switch (this) {
@@ -40108,7 +40122,7 @@ enum LaunchTemplateInstanceMetadataOptionsState {
   applied,
 }
 
-extension LaunchTemplateInstanceMetadataOptionsStateValue
+extension LaunchTemplateInstanceMetadataOptionsStateValueExtension
     on LaunchTemplateInstanceMetadataOptionsState {
   String toValue() {
     switch (this) {
@@ -40640,7 +40654,7 @@ enum ListingState {
   pending,
 }
 
-extension ListingStateValue on ListingState {
+extension ListingStateValueExtension on ListingState {
   String toValue() {
     switch (this) {
       case ListingState.available:
@@ -40678,7 +40692,7 @@ enum ListingStatus {
   closed,
 }
 
-extension ListingStatusValue on ListingStatus {
+extension ListingStatusValueExtension on ListingStatus {
   String toValue() {
     switch (this) {
       case ListingStatus.active:
@@ -40835,7 +40849,7 @@ enum LocalGatewayRouteState {
   deleted,
 }
 
-extension LocalGatewayRouteStateValue on LocalGatewayRouteState {
+extension LocalGatewayRouteStateValueExtension on LocalGatewayRouteState {
   String toValue() {
     switch (this) {
       case LocalGatewayRouteState.pending:
@@ -40990,7 +41004,7 @@ enum LocalGatewayRouteType {
   propagated,
 }
 
-extension LocalGatewayRouteTypeValue on LocalGatewayRouteType {
+extension LocalGatewayRouteTypeValueExtension on LocalGatewayRouteType {
   String toValue() {
     switch (this) {
       case LocalGatewayRouteType.static:
@@ -41088,7 +41102,7 @@ enum LocationType {
   availabilityZoneId,
 }
 
-extension LocationTypeValue on LocationType {
+extension LocationTypeValueExtension on LocationType {
   String toValue() {
     switch (this) {
       case LocationType.region:
@@ -41120,7 +41134,7 @@ enum LogDestinationType {
   s3,
 }
 
-extension LogDestinationTypeValue on LogDestinationType {
+extension LogDestinationTypeValueExtension on LogDestinationType {
   String toValue() {
     switch (this) {
       case LogDestinationType.cloudWatchLogs:
@@ -41193,7 +41207,7 @@ enum MarketType {
   spot,
 }
 
-extension MarketTypeValue on MarketType {
+extension MarketTypeValueExtension on MarketType {
   String toValue() {
     switch (this) {
       case MarketType.spot:
@@ -41217,7 +41231,7 @@ enum MembershipType {
   igmp,
 }
 
-extension MembershipTypeValue on MembershipType {
+extension MembershipTypeValueExtension on MembershipType {
   String toValue() {
     switch (this) {
       case MembershipType.static:
@@ -41264,7 +41278,7 @@ enum ModifyAvailabilityZoneOptInStatus {
   notOptedIn,
 }
 
-extension ModifyAvailabilityZoneOptInStatusValue
+extension ModifyAvailabilityZoneOptInStatusValueExtension
     on ModifyAvailabilityZoneOptInStatus {
   String toValue() {
     switch (this) {
@@ -41898,7 +41912,7 @@ enum MonitoringState {
   pending,
 }
 
-extension MonitoringStateValue on MonitoringState {
+extension MonitoringStateValueExtension on MonitoringState {
   String toValue() {
     switch (this) {
       case MonitoringState.disabled:
@@ -41947,7 +41961,7 @@ enum MoveStatus {
   restoringToClassic,
 }
 
-extension MoveStatusValue on MoveStatus {
+extension MoveStatusValueExtension on MoveStatus {
   String toValue() {
     switch (this) {
       case MoveStatus.movingToVpc:
@@ -41990,7 +42004,7 @@ enum MulticastSupportValue {
   disable,
 }
 
-extension MulticastSupportValueValue on MulticastSupportValue {
+extension MulticastSupportValueValueExtension on MulticastSupportValue {
   String toValue() {
     switch (this) {
       case MulticastSupportValue.enable:
@@ -42156,7 +42170,7 @@ enum NatGatewayState {
   deleted,
 }
 
-extension NatGatewayStateValue on NatGatewayState {
+extension NatGatewayStateValueExtension on NatGatewayState {
   String toValue() {
     switch (this) {
       case NatGatewayState.pending:
@@ -42647,7 +42661,7 @@ enum NetworkInterfaceAttribute {
   attachment,
 }
 
-extension NetworkInterfaceAttributeValue on NetworkInterfaceAttribute {
+extension NetworkInterfaceAttributeValueExtension on NetworkInterfaceAttribute {
   String toValue() {
     switch (this) {
       case NetworkInterfaceAttribute.description:
@@ -42682,7 +42696,8 @@ enum NetworkInterfaceCreationType {
   efa,
 }
 
-extension NetworkInterfaceCreationTypeValue on NetworkInterfaceCreationType {
+extension NetworkInterfaceCreationTypeValueExtension
+    on NetworkInterfaceCreationType {
   String toValue() {
     switch (this) {
       case NetworkInterfaceCreationType.efa:
@@ -42762,7 +42777,7 @@ enum NetworkInterfacePermissionStateCode {
   revoked,
 }
 
-extension NetworkInterfacePermissionStateCodeValue
+extension NetworkInterfacePermissionStateCodeValueExtension
     on NetworkInterfacePermissionStateCode {
   String toValue() {
     switch (this) {
@@ -42827,7 +42842,7 @@ enum NetworkInterfaceStatus {
   detaching,
 }
 
-extension NetworkInterfaceStatusValue on NetworkInterfaceStatus {
+extension NetworkInterfaceStatusValueExtension on NetworkInterfaceStatus {
   String toValue() {
     switch (this) {
       case NetworkInterfaceStatus.available:
@@ -42868,7 +42883,7 @@ enum NetworkInterfaceType {
   efa,
 }
 
-extension NetworkInterfaceTypeValue on NetworkInterfaceType {
+extension NetworkInterfaceTypeValueExtension on NetworkInterfaceType {
   String toValue() {
     switch (this) {
       case NetworkInterfaceType.interface:
@@ -42910,7 +42925,7 @@ enum OfferingClassType {
   convertible,
 }
 
-extension OfferingClassTypeValue on OfferingClassType {
+extension OfferingClassTypeValueExtension on OfferingClassType {
   String toValue() {
     switch (this) {
       case OfferingClassType.standard:
@@ -42942,7 +42957,7 @@ enum OfferingTypeValues {
   allUpfront,
 }
 
-extension OfferingTypeValuesValue on OfferingTypeValues {
+extension OfferingTypeValuesValueExtension on OfferingTypeValues {
   String toValue() {
     switch (this) {
       case OfferingTypeValues.heavyUtilization:
@@ -42986,7 +43001,8 @@ enum OnDemandAllocationStrategy {
   prioritized,
 }
 
-extension OnDemandAllocationStrategyValue on OnDemandAllocationStrategy {
+extension OnDemandAllocationStrategyValueExtension
+    on OnDemandAllocationStrategy {
   String toValue() {
     switch (this) {
       case OnDemandAllocationStrategy.lowestPrice:
@@ -43096,7 +43112,7 @@ enum OperationType {
   remove,
 }
 
-extension OperationTypeValue on OperationType {
+extension OperationTypeValueExtension on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.add:
@@ -43175,7 +43191,7 @@ enum PaymentOption {
   noUpfront,
 }
 
-extension PaymentOptionValue on PaymentOption {
+extension PaymentOptionValueExtension on PaymentOption {
   String toValue() {
     switch (this) {
       case PaymentOption.allUpfront:
@@ -43303,7 +43319,7 @@ enum PermissionGroup {
   all,
 }
 
-extension PermissionGroupValue on PermissionGroup {
+extension PermissionGroupValueExtension on PermissionGroup {
   String toValue() {
     switch (this) {
       case PermissionGroup.all:
@@ -43571,7 +43587,7 @@ enum PlacementGroupState {
   deleted,
 }
 
-extension PlacementGroupStateValue on PlacementGroupState {
+extension PlacementGroupStateValueExtension on PlacementGroupState {
   String toValue() {
     switch (this) {
       case PlacementGroupState.pending:
@@ -43608,7 +43624,7 @@ enum PlacementGroupStrategy {
   spread,
 }
 
-extension PlacementGroupStrategyValue on PlacementGroupStrategy {
+extension PlacementGroupStrategyValueExtension on PlacementGroupStrategy {
   String toValue() {
     switch (this) {
       case PlacementGroupStrategy.cluster:
@@ -43651,7 +43667,7 @@ enum PlacementStrategy {
   partition,
 }
 
-extension PlacementStrategyValue on PlacementStrategy {
+extension PlacementStrategyValueExtension on PlacementStrategy {
   String toValue() {
     switch (this) {
       case PlacementStrategy.cluster:
@@ -43682,7 +43698,7 @@ enum PlatformValues {
   windows,
 }
 
-extension PlatformValuesValue on PlatformValues {
+extension PlatformValuesValueExtension on PlatformValues {
   String toValue() {
     switch (this) {
       case PlatformValues.windows:
@@ -43804,7 +43820,7 @@ enum PrefixListState {
   deleteFailed,
 }
 
-extension PrefixListStateValue on PrefixListState {
+extension PrefixListStateValueExtension on PrefixListState {
   String toValue() {
     switch (this) {
       case PrefixListState.createInProgress:
@@ -43957,7 +43973,7 @@ enum PrincipalType {
   role,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.all:
@@ -44085,7 +44101,7 @@ enum ProductCodeValues {
   marketplace,
 }
 
-extension ProductCodeValuesValue on ProductCodeValues {
+extension ProductCodeValuesValueExtension on ProductCodeValues {
   String toValue() {
     switch (this) {
       case ProductCodeValues.devpay:
@@ -44123,7 +44139,7 @@ enum Protocol {
   udp,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.tcp:
@@ -44150,7 +44166,7 @@ enum ProtocolValue {
   gre,
 }
 
-extension ProtocolValueValue on ProtocolValue {
+extension ProtocolValueValueExtension on ProtocolValue {
   String toValue() {
     switch (this) {
       case ProtocolValue.gre:
@@ -44392,7 +44408,7 @@ enum RIProductDescription {
   windowsAmazonVpc,
 }
 
-extension RIProductDescriptionValue on RIProductDescription {
+extension RIProductDescriptionValueExtension on RIProductDescription {
   String toValue() {
     switch (this) {
       case RIProductDescription.linuxUnix:
@@ -44441,7 +44457,7 @@ enum RecurringChargeFrequency {
   hourly,
 }
 
-extension RecurringChargeFrequencyValue on RecurringChargeFrequency {
+extension RecurringChargeFrequencyValueExtension on RecurringChargeFrequency {
   String toValue() {
     switch (this) {
       case RecurringChargeFrequency.hourly:
@@ -44650,7 +44666,7 @@ enum ReplacementStrategy {
   launch,
 }
 
-extension ReplacementStrategyValue on ReplacementStrategy {
+extension ReplacementStrategyValueExtension on ReplacementStrategy {
   String toValue() {
     switch (this) {
       case ReplacementStrategy.launch:
@@ -44681,7 +44697,7 @@ enum ReportInstanceReasonCodes {
   other,
 }
 
-extension ReportInstanceReasonCodesValue on ReportInstanceReasonCodes {
+extension ReportInstanceReasonCodesValueExtension on ReportInstanceReasonCodes {
   String toValue() {
     switch (this) {
       case ReportInstanceReasonCodes.instanceStuckInState:
@@ -44737,7 +44753,7 @@ enum ReportStatusType {
   impaired,
 }
 
-extension ReportStatusTypeValue on ReportStatusType {
+extension ReportStatusTypeValueExtension on ReportStatusType {
   String toValue() {
     switch (this) {
       case ReportStatusType.ok:
@@ -45089,7 +45105,7 @@ enum ReservationState {
   retired,
 }
 
-extension ReservationStateValue on ReservationState {
+extension ReservationStateValueExtension on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.paymentPending:
@@ -45179,7 +45195,7 @@ enum ReservedInstanceState {
   queuedDeleted,
 }
 
-extension ReservedInstanceStateValue on ReservedInstanceState {
+extension ReservedInstanceStateValueExtension on ReservedInstanceState {
   String toValue() {
     switch (this) {
       case ReservedInstanceState.paymentPending:
@@ -45541,7 +45557,8 @@ enum ResetFpgaImageAttributeName {
   loadPermission,
 }
 
-extension ResetFpgaImageAttributeNameValue on ResetFpgaImageAttributeName {
+extension ResetFpgaImageAttributeNameValueExtension
+    on ResetFpgaImageAttributeName {
   String toValue() {
     switch (this) {
       case ResetFpgaImageAttributeName.loadPermission:
@@ -45573,7 +45590,7 @@ enum ResetImageAttributeName {
   launchPermission,
 }
 
-extension ResetImageAttributeNameValue on ResetImageAttributeName {
+extension ResetImageAttributeNameValueExtension on ResetImageAttributeName {
   String toValue() {
     switch (this) {
       case ResetImageAttributeName.launchPermission:
@@ -45642,7 +45659,7 @@ enum ResourceType {
   vpcFlowLog,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.clientVpnEndpoint:
@@ -46055,7 +46072,7 @@ enum RootDeviceType {
   instanceStore,
 }
 
-extension RootDeviceTypeValue on RootDeviceType {
+extension RootDeviceTypeValueExtension on RootDeviceType {
   String toValue() {
     switch (this) {
       case RootDeviceType.ebs:
@@ -46166,7 +46183,7 @@ enum RouteOrigin {
   enableVgwRoutePropagation,
 }
 
-extension RouteOriginValue on RouteOrigin {
+extension RouteOriginValueExtension on RouteOrigin {
   String toValue() {
     switch (this) {
       case RouteOrigin.createRouteTable:
@@ -46198,7 +46215,7 @@ enum RouteState {
   blackhole,
 }
 
-extension RouteStateValue on RouteState {
+extension RouteStateValueExtension on RouteState {
   String toValue() {
     switch (this) {
       case RouteState.active:
@@ -46310,7 +46327,7 @@ enum RouteTableAssociationStateCode {
   failed,
 }
 
-extension RouteTableAssociationStateCodeValue
+extension RouteTableAssociationStateCodeValueExtension
     on RouteTableAssociationStateCode {
   String toValue() {
     switch (this) {
@@ -46352,7 +46369,7 @@ enum RuleAction {
   deny,
 }
 
-extension RuleActionValue on RuleAction {
+extension RuleActionValueExtension on RuleAction {
   String toValue() {
     switch (this) {
       case RuleAction.allow:
@@ -47017,7 +47034,7 @@ enum SelfServicePortal {
   disabled,
 }
 
-extension SelfServicePortalValue on SelfServicePortal {
+extension SelfServicePortalValueExtension on SelfServicePortal {
   String toValue() {
     switch (this) {
       case SelfServicePortal.enabled:
@@ -47173,7 +47190,7 @@ enum ServiceState {
   failed,
 }
 
-extension ServiceStateValue on ServiceState {
+extension ServiceStateValueExtension on ServiceState {
   String toValue() {
     switch (this) {
       case ServiceState.pending:
@@ -47214,7 +47231,7 @@ enum ServiceType {
   gatewayLoadBalancer,
 }
 
-extension ServiceTypeValue on ServiceType {
+extension ServiceTypeValueExtension on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.interface:
@@ -47256,7 +47273,7 @@ enum ShutdownBehavior {
   terminate,
 }
 
-extension ShutdownBehaviorValue on ShutdownBehavior {
+extension ShutdownBehaviorValueExtension on ShutdownBehavior {
   String toValue() {
     switch (this) {
       case ShutdownBehavior.stop:
@@ -47394,7 +47411,7 @@ enum SnapshotAttributeName {
   createVolumePermission,
 }
 
-extension SnapshotAttributeNameValue on SnapshotAttributeName {
+extension SnapshotAttributeNameValueExtension on SnapshotAttributeName {
   String toValue() {
     switch (this) {
       case SnapshotAttributeName.productCodes:
@@ -47542,7 +47559,7 @@ enum SnapshotState {
   error,
 }
 
-extension SnapshotStateValue on SnapshotState {
+extension SnapshotStateValueExtension on SnapshotState {
   String toValue() {
     switch (this) {
       case SnapshotState.pending:
@@ -47626,7 +47643,7 @@ enum SpotAllocationStrategy {
   capacityOptimized,
 }
 
-extension SpotAllocationStrategyValue on SpotAllocationStrategy {
+extension SpotAllocationStrategyValueExtension on SpotAllocationStrategy {
   String toValue() {
     switch (this) {
       case SpotAllocationStrategy.lowestPrice:
@@ -48097,7 +48114,7 @@ enum SpotInstanceInterruptionBehavior {
   terminate,
 }
 
-extension SpotInstanceInterruptionBehaviorValue
+extension SpotInstanceInterruptionBehaviorValueExtension
     on SpotInstanceInterruptionBehavior {
   String toValue() {
     switch (this) {
@@ -48244,7 +48261,7 @@ enum SpotInstanceState {
   failed,
 }
 
-extension SpotInstanceStateValue on SpotInstanceState {
+extension SpotInstanceStateValueExtension on SpotInstanceState {
   String toValue() {
     switch (this) {
       case SpotInstanceState.open:
@@ -48319,7 +48336,7 @@ enum SpotInstanceType {
   persistent,
 }
 
-extension SpotInstanceTypeValue on SpotInstanceType {
+extension SpotInstanceTypeValueExtension on SpotInstanceType {
   String toValue() {
     switch (this) {
       case SpotInstanceType.oneTime:
@@ -48691,7 +48708,7 @@ enum State {
   expired,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.pendingAcceptance:
@@ -48813,7 +48830,7 @@ enum StaticSourcesSupportValue {
   disable,
 }
 
-extension StaticSourcesSupportValueValue on StaticSourcesSupportValue {
+extension StaticSourcesSupportValueValueExtension on StaticSourcesSupportValue {
   String toValue() {
     switch (this) {
       case StaticSourcesSupportValue.enable:
@@ -48842,7 +48859,7 @@ enum Status {
   inClassic,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.moveInProgress:
@@ -48873,7 +48890,7 @@ enum StatusName {
   reachability,
 }
 
-extension StatusNameValue on StatusName {
+extension StatusNameValueExtension on StatusName {
   String toValue() {
     switch (this) {
       case StatusName.reachability:
@@ -48899,7 +48916,7 @@ enum StatusType {
   initializing,
 }
 
-extension StatusTypeValue on StatusType {
+extension StatusTypeValueExtension on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.passed:
@@ -49079,7 +49096,7 @@ enum SubnetCidrBlockStateCode {
   failed,
 }
 
-extension SubnetCidrBlockStateCodeValue on SubnetCidrBlockStateCode {
+extension SubnetCidrBlockStateCodeValueExtension on SubnetCidrBlockStateCode {
   String toValue() {
     switch (this) {
       case SubnetCidrBlockStateCode.associating:
@@ -49141,7 +49158,7 @@ enum SubnetState {
   available,
 }
 
-extension SubnetStateValue on SubnetState {
+extension SubnetStateValueExtension on SubnetState {
   String toValue() {
     switch (this) {
       case SubnetState.pending:
@@ -49194,7 +49211,7 @@ enum SummaryStatus {
   initializing,
 }
 
-extension SummaryStatusValue on SummaryStatus {
+extension SummaryStatusValueExtension on SummaryStatus {
   String toValue() {
     switch (this) {
       case SummaryStatus.ok:
@@ -49504,7 +49521,7 @@ enum TelemetryStatus {
   down,
 }
 
-extension TelemetryStatusValue on TelemetryStatus {
+extension TelemetryStatusValueExtension on TelemetryStatus {
   String toValue() {
     switch (this) {
       case TelemetryStatus.up:
@@ -49533,7 +49550,7 @@ enum Tenancy {
   host,
 }
 
-extension TenancyValue on Tenancy {
+extension TenancyValueExtension on Tenancy {
   String toValue() {
     switch (this) {
       case Tenancy.$default:
@@ -49609,7 +49626,7 @@ enum TrafficDirection {
   egress,
 }
 
-extension TrafficDirectionValue on TrafficDirection {
+extension TrafficDirectionValueExtension on TrafficDirection {
   String toValue() {
     switch (this) {
       case TrafficDirection.ingress:
@@ -49722,7 +49739,8 @@ enum TrafficMirrorFilterRuleField {
   description,
 }
 
-extension TrafficMirrorFilterRuleFieldValue on TrafficMirrorFilterRuleField {
+extension TrafficMirrorFilterRuleFieldValueExtension
+    on TrafficMirrorFilterRuleField {
   String toValue() {
     switch (this) {
       case TrafficMirrorFilterRuleField.destinationPortRange:
@@ -49757,7 +49775,8 @@ enum TrafficMirrorNetworkService {
   amazonDns,
 }
 
-extension TrafficMirrorNetworkServiceValue on TrafficMirrorNetworkService {
+extension TrafficMirrorNetworkServiceValueExtension
+    on TrafficMirrorNetworkService {
   String toValue() {
     switch (this) {
       case TrafficMirrorNetworkService.amazonDns:
@@ -49813,7 +49832,7 @@ enum TrafficMirrorRuleAction {
   reject,
 }
 
-extension TrafficMirrorRuleActionValue on TrafficMirrorRuleAction {
+extension TrafficMirrorRuleActionValueExtension on TrafficMirrorRuleAction {
   String toValue() {
     switch (this) {
       case TrafficMirrorRuleAction.accept:
@@ -49896,7 +49915,7 @@ enum TrafficMirrorSessionField {
   virtualNetworkId,
 }
 
-extension TrafficMirrorSessionFieldValue on TrafficMirrorSessionField {
+extension TrafficMirrorSessionFieldValueExtension on TrafficMirrorSessionField {
   String toValue() {
     switch (this) {
       case TrafficMirrorSessionField.packetLength:
@@ -49962,7 +49981,7 @@ enum TrafficMirrorTargetType {
   networkLoadBalancer,
 }
 
-extension TrafficMirrorTargetTypeValue on TrafficMirrorTargetType {
+extension TrafficMirrorTargetTypeValueExtension on TrafficMirrorTargetType {
   String toValue() {
     switch (this) {
       case TrafficMirrorTargetType.networkInterface:
@@ -49991,7 +50010,7 @@ enum TrafficType {
   all,
 }
 
-extension TrafficTypeValue on TrafficType {
+extension TrafficTypeValueExtension on TrafficType {
   String toValue() {
     switch (this) {
       case TrafficType.accept:
@@ -50091,7 +50110,7 @@ enum TransitGatewayAssociationState {
   disassociated,
 }
 
-extension TransitGatewayAssociationStateValue
+extension TransitGatewayAssociationStateValueExtension
     on TransitGatewayAssociationState {
   String toValue() {
     switch (this) {
@@ -50235,7 +50254,7 @@ enum TransitGatewayAttachmentResourceType {
   tgwPeering,
 }
 
-extension TransitGatewayAttachmentResourceTypeValue
+extension TransitGatewayAttachmentResourceTypeValueExtension
     on TransitGatewayAttachmentResourceType {
   String toValue() {
     switch (this) {
@@ -50293,7 +50312,8 @@ enum TransitGatewayAttachmentState {
   failing,
 }
 
-extension TransitGatewayAttachmentStateValue on TransitGatewayAttachmentState {
+extension TransitGatewayAttachmentStateValueExtension
+    on TransitGatewayAttachmentState {
   String toValue() {
     switch (this) {
       case TransitGatewayAttachmentState.initiating:
@@ -50467,7 +50487,7 @@ enum TransitGatewayConnectPeerState {
   deleted,
 }
 
-extension TransitGatewayConnectPeerStateValue
+extension TransitGatewayConnectPeerStateValueExtension
     on TransitGatewayConnectPeerState {
   String toValue() {
     switch (this) {
@@ -50520,7 +50540,7 @@ enum TransitGatewayMulitcastDomainAssociationState {
   failed,
 }
 
-extension TransitGatewayMulitcastDomainAssociationStateValue
+extension TransitGatewayMulitcastDomainAssociationStateValueExtension
     on TransitGatewayMulitcastDomainAssociationState {
   String toValue() {
     switch (this) {
@@ -50726,7 +50746,7 @@ enum TransitGatewayMulticastDomainState {
   deleted,
 }
 
-extension TransitGatewayMulticastDomainStateValue
+extension TransitGatewayMulticastDomainStateValueExtension
     on TransitGatewayMulticastDomainState {
   String toValue() {
     switch (this) {
@@ -50988,7 +51008,7 @@ enum TransitGatewayPrefixListReferenceState {
   deleting,
 }
 
-extension TransitGatewayPrefixListReferenceStateValue
+extension TransitGatewayPrefixListReferenceStateValueExtension
     on TransitGatewayPrefixListReferenceState {
   String toValue() {
     switch (this) {
@@ -51056,7 +51076,7 @@ enum TransitGatewayPropagationState {
   disabled,
 }
 
-extension TransitGatewayPropagationStateValue
+extension TransitGatewayPropagationStateValueExtension
     on TransitGatewayPropagationState {
   String toValue() {
     switch (this) {
@@ -51187,7 +51207,7 @@ enum TransitGatewayRouteState {
   deleted,
 }
 
-extension TransitGatewayRouteStateValue on TransitGatewayRouteState {
+extension TransitGatewayRouteStateValueExtension on TransitGatewayRouteState {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteState.pending:
@@ -51311,7 +51331,8 @@ enum TransitGatewayRouteTableState {
   deleted,
 }
 
-extension TransitGatewayRouteTableStateValue on TransitGatewayRouteTableState {
+extension TransitGatewayRouteTableStateValueExtension
+    on TransitGatewayRouteTableState {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteTableState.pending:
@@ -51347,7 +51368,7 @@ enum TransitGatewayRouteType {
   propagated,
 }
 
-extension TransitGatewayRouteTypeValue on TransitGatewayRouteType {
+extension TransitGatewayRouteTypeValueExtension on TransitGatewayRouteType {
   String toValue() {
     switch (this) {
       case TransitGatewayRouteType.static:
@@ -51378,7 +51399,7 @@ enum TransitGatewayState {
   deleted,
 }
 
-extension TransitGatewayStateValue on TransitGatewayState {
+extension TransitGatewayStateValueExtension on TransitGatewayState {
   String toValue() {
     switch (this) {
       case TransitGatewayState.pending:
@@ -51479,7 +51500,7 @@ enum TransportProtocol {
   udp,
 }
 
-extension TransportProtocolValue on TransportProtocol {
+extension TransportProtocolValueExtension on TransportProtocol {
   String toValue() {
     switch (this) {
       case TransportProtocol.tcp:
@@ -51507,7 +51528,7 @@ enum TunnelInsideIpVersion {
   ipv6,
 }
 
-extension TunnelInsideIpVersionValue on TunnelInsideIpVersion {
+extension TunnelInsideIpVersionValueExtension on TunnelInsideIpVersion {
   String toValue() {
     switch (this) {
       case TunnelInsideIpVersion.ipv4:
@@ -51643,7 +51664,7 @@ enum UnlimitedSupportedInstanceFamily {
   t4g,
 }
 
-extension UnlimitedSupportedInstanceFamilyValue
+extension UnlimitedSupportedInstanceFamilyValueExtension
     on UnlimitedSupportedInstanceFamily {
   String toValue() {
     switch (this) {
@@ -51692,7 +51713,7 @@ enum UnsuccessfulInstanceCreditSpecificationErrorCode {
   instanceCreditSpecificationNotSupported,
 }
 
-extension UnsuccessfulInstanceCreditSpecificationErrorCodeValue
+extension UnsuccessfulInstanceCreditSpecificationErrorCodeValueExtension
     on UnsuccessfulInstanceCreditSpecificationErrorCode {
   String toValue() {
     switch (this) {
@@ -51822,7 +51843,7 @@ enum UsageClassType {
   onDemand,
 }
 
-extension UsageClassTypeValue on UsageClassType {
+extension UsageClassTypeValueExtension on UsageClassType {
   String toValue() {
     switch (this) {
       case UsageClassType.spot:
@@ -52032,7 +52053,7 @@ enum VirtualizationType {
   paravirtual,
 }
 
-extension VirtualizationTypeValue on VirtualizationType {
+extension VirtualizationTypeValueExtension on VirtualizationType {
   String toValue() {
     switch (this) {
       case VirtualizationType.hvm:
@@ -52169,7 +52190,7 @@ enum VolumeAttachmentState {
   busy,
 }
 
-extension VolumeAttachmentStateValue on VolumeAttachmentState {
+extension VolumeAttachmentStateValueExtension on VolumeAttachmentState {
   String toValue() {
     switch (this) {
       case VolumeAttachmentState.attaching:
@@ -52209,7 +52230,7 @@ enum VolumeAttributeName {
   productCodes,
 }
 
-extension VolumeAttributeNameValue on VolumeAttributeName {
+extension VolumeAttributeNameValueExtension on VolumeAttributeName {
   String toValue() {
     switch (this) {
       case VolumeAttributeName.autoEnableIO:
@@ -52322,7 +52343,7 @@ enum VolumeModificationState {
   failed,
 }
 
-extension VolumeModificationStateValue on VolumeModificationState {
+extension VolumeModificationStateValueExtension on VolumeModificationState {
   String toValue() {
     switch (this) {
       case VolumeModificationState.modifying:
@@ -52362,7 +52383,7 @@ enum VolumeState {
   error,
 }
 
-extension VolumeStateValue on VolumeState {
+extension VolumeStateValueExtension on VolumeState {
   String toValue() {
     switch (this) {
       case VolumeState.creating:
@@ -52502,7 +52523,7 @@ enum VolumeStatusInfoStatus {
   insufficientData,
 }
 
-extension VolumeStatusInfoStatusValue on VolumeStatusInfoStatus {
+extension VolumeStatusInfoStatusValueExtension on VolumeStatusInfoStatus {
   String toValue() {
     switch (this) {
       case VolumeStatusInfoStatus.ok:
@@ -52568,7 +52589,7 @@ enum VolumeStatusName {
   ioPerformance,
 }
 
-extension VolumeStatusNameValue on VolumeStatusName {
+extension VolumeStatusNameValueExtension on VolumeStatusName {
   String toValue() {
     switch (this) {
       case VolumeStatusName.ioEnabled:
@@ -52601,7 +52622,7 @@ enum VolumeType {
   gp3,
 }
 
-extension VolumeTypeValue on VolumeType {
+extension VolumeTypeValueExtension on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.standard:
@@ -52709,7 +52730,7 @@ enum VpcAttributeName {
   enableDnsHostnames,
 }
 
-extension VpcAttributeNameValue on VpcAttributeName {
+extension VpcAttributeNameValueExtension on VpcAttributeName {
   String toValue() {
     switch (this) {
       case VpcAttributeName.enableDnsSupport:
@@ -52773,7 +52794,7 @@ enum VpcCidrBlockStateCode {
   failed,
 }
 
-extension VpcCidrBlockStateCodeValue on VpcCidrBlockStateCode {
+extension VpcCidrBlockStateCodeValueExtension on VpcCidrBlockStateCode {
   String toValue() {
     switch (this) {
       case VpcCidrBlockStateCode.associating:
@@ -52952,7 +52973,7 @@ enum VpcEndpointType {
   gatewayLoadBalancer,
 }
 
-extension VpcEndpointTypeValue on VpcEndpointType {
+extension VpcEndpointTypeValueExtension on VpcEndpointType {
   String toValue() {
     switch (this) {
       case VpcEndpointType.interface:
@@ -53086,7 +53107,7 @@ enum VpcPeeringConnectionStateReasonCode {
   deleting,
 }
 
-extension VpcPeeringConnectionStateReasonCodeValue
+extension VpcPeeringConnectionStateReasonCodeValueExtension
     on VpcPeeringConnectionStateReasonCode {
   String toValue() {
     switch (this) {
@@ -53179,7 +53200,7 @@ enum VpcState {
   available,
 }
 
-extension VpcStateValue on VpcState {
+extension VpcStateValueExtension on VpcState {
   String toValue() {
     switch (this) {
       case VpcState.pending:
@@ -53206,7 +53227,7 @@ enum VpcTenancy {
   $default,
 }
 
-extension VpcTenancyValue on VpcTenancy {
+extension VpcTenancyValueExtension on VpcTenancy {
   String toValue() {
     switch (this) {
       case VpcTenancy.$default:
@@ -53388,7 +53409,7 @@ enum VpnEcmpSupportValue {
   disable,
 }
 
-extension VpnEcmpSupportValueValue on VpnEcmpSupportValue {
+extension VpnEcmpSupportValueValueExtension on VpnEcmpSupportValue {
   String toValue() {
     switch (this) {
       case VpnEcmpSupportValue.enable:
@@ -53451,7 +53472,7 @@ enum VpnProtocol {
   openvpn,
 }
 
-extension VpnProtocolValue on VpnProtocol {
+extension VpnProtocolValueExtension on VpnProtocol {
   String toValue() {
     switch (this) {
       case VpnProtocol.openvpn:
@@ -53477,7 +53498,7 @@ enum VpnState {
   deleted,
 }
 
-extension VpnStateValue on VpnState {
+extension VpnStateValueExtension on VpnState {
   String toValue() {
     switch (this) {
       case VpnState.pending:
@@ -53530,7 +53551,7 @@ enum VpnStaticRouteSource {
   static,
 }
 
-extension VpnStaticRouteSourceValue on VpnStaticRouteSource {
+extension VpnStaticRouteSourceValueExtension on VpnStaticRouteSource {
   String toValue() {
     switch (this) {
       case VpnStaticRouteSource.static:
@@ -53757,7 +53778,7 @@ enum Scope {
   region,
 }
 
-extension ScopeValue on Scope {
+extension ScopeValueExtension on Scope {
   String toValue() {
     switch (this) {
       case Scope.availabilityZone:

--- a/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
+++ b/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
@@ -2535,7 +2535,7 @@ enum EncryptionType {
   kms,
 }
 
-extension EncryptionTypeValue on EncryptionType {
+extension EncryptionTypeValueExtension on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.aes256:
@@ -2567,7 +2567,7 @@ enum FindingSeverity {
   undefined,
 }
 
-extension FindingSeverityValue on FindingSeverity {
+extension FindingSeverityValueExtension on FindingSeverity {
   String toValue() {
     switch (this) {
       case FindingSeverity.informational:
@@ -2814,7 +2814,7 @@ enum ImageActionType {
   expire,
 }
 
-extension ImageActionTypeValue on ImageActionType {
+extension ImageActionTypeValueExtension on ImageActionType {
   String toValue() {
     switch (this) {
       case ImageActionType.expire:
@@ -2950,7 +2950,7 @@ enum ImageFailureCode {
   kmsError,
 }
 
-extension ImageFailureCodeValue on ImageFailureCode {
+extension ImageFailureCodeValueExtension on ImageFailureCode {
   String toValue() {
     switch (this) {
       case ImageFailureCode.invalidImageDigest:
@@ -3175,7 +3175,7 @@ enum ImageTagMutability {
   immutable,
 }
 
-extension ImageTagMutabilityValue on ImageTagMutability {
+extension ImageTagMutabilityValueExtension on ImageTagMutability {
   String toValue() {
     switch (this) {
       case ImageTagMutability.mutable:
@@ -3256,7 +3256,7 @@ enum LayerAvailability {
   unavailable,
 }
 
-extension LayerAvailabilityValue on LayerAvailability {
+extension LayerAvailabilityValueExtension on LayerAvailability {
   String toValue() {
     switch (this) {
       case LayerAvailability.available:
@@ -3309,7 +3309,7 @@ enum LayerFailureCode {
   missingLayerDigest,
 }
 
-extension LayerFailureCodeValue on LayerFailureCode {
+extension LayerFailureCodeValueExtension on LayerFailureCode {
   String toValue() {
     switch (this) {
       case LayerFailureCode.invalidLayerDigest:
@@ -3397,7 +3397,8 @@ enum LifecyclePolicyPreviewStatus {
   failed,
 }
 
-extension LifecyclePolicyPreviewStatusValue on LifecyclePolicyPreviewStatus {
+extension LifecyclePolicyPreviewStatusValueExtension
+    on LifecyclePolicyPreviewStatus {
   String toValue() {
     switch (this) {
       case LifecyclePolicyPreviewStatus.inProgress:
@@ -3803,7 +3804,7 @@ enum ScanStatus {
   failed,
 }
 
-extension ScanStatusValue on ScanStatus {
+extension ScanStatusValueExtension on ScanStatus {
   String toValue() {
     switch (this) {
       case ScanStatus.inProgress:
@@ -3964,7 +3965,7 @@ enum TagStatus {
   any,
 }
 
-extension TagStatusValue on TagStatus {
+extension TagStatusValueExtension on TagStatus {
   String toValue() {
     switch (this) {
       case TagStatus.tagged:

--- a/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
+++ b/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
@@ -2535,7 +2535,7 @@ enum EncryptionType {
   kms,
 }
 
-extension on EncryptionType {
+extension EncryptionTypeValue on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.aes256:
@@ -2546,7 +2546,7 @@ extension on EncryptionType {
   }
 }
 
-extension on String {
+extension EncryptionTypeFromString on String {
   EncryptionType toEncryptionType() {
     switch (this) {
       case 'AES256':
@@ -2567,7 +2567,7 @@ enum FindingSeverity {
   undefined,
 }
 
-extension on FindingSeverity {
+extension FindingSeverityValue on FindingSeverity {
   String toValue() {
     switch (this) {
       case FindingSeverity.informational:
@@ -2586,7 +2586,7 @@ extension on FindingSeverity {
   }
 }
 
-extension on String {
+extension FindingSeverityFromString on String {
   FindingSeverity toFindingSeverity() {
     switch (this) {
       case 'INFORMATIONAL':
@@ -2814,7 +2814,7 @@ enum ImageActionType {
   expire,
 }
 
-extension on ImageActionType {
+extension ImageActionTypeValue on ImageActionType {
   String toValue() {
     switch (this) {
       case ImageActionType.expire:
@@ -2823,7 +2823,7 @@ extension on ImageActionType {
   }
 }
 
-extension on String {
+extension ImageActionTypeFromString on String {
   ImageActionType toImageActionType() {
     switch (this) {
       case 'EXPIRE':
@@ -2950,7 +2950,7 @@ enum ImageFailureCode {
   kmsError,
 }
 
-extension on ImageFailureCode {
+extension ImageFailureCodeValue on ImageFailureCode {
   String toValue() {
     switch (this) {
       case ImageFailureCode.invalidImageDigest:
@@ -2971,7 +2971,7 @@ extension on ImageFailureCode {
   }
 }
 
-extension on String {
+extension ImageFailureCodeFromString on String {
   ImageFailureCode toImageFailureCode() {
     switch (this) {
       case 'InvalidImageDigest':
@@ -3175,7 +3175,7 @@ enum ImageTagMutability {
   immutable,
 }
 
-extension on ImageTagMutability {
+extension ImageTagMutabilityValue on ImageTagMutability {
   String toValue() {
     switch (this) {
       case ImageTagMutability.mutable:
@@ -3186,7 +3186,7 @@ extension on ImageTagMutability {
   }
 }
 
-extension on String {
+extension ImageTagMutabilityFromString on String {
   ImageTagMutability toImageTagMutability() {
     switch (this) {
       case 'MUTABLE':
@@ -3256,7 +3256,7 @@ enum LayerAvailability {
   unavailable,
 }
 
-extension on LayerAvailability {
+extension LayerAvailabilityValue on LayerAvailability {
   String toValue() {
     switch (this) {
       case LayerAvailability.available:
@@ -3267,7 +3267,7 @@ extension on LayerAvailability {
   }
 }
 
-extension on String {
+extension LayerAvailabilityFromString on String {
   LayerAvailability toLayerAvailability() {
     switch (this) {
       case 'AVAILABLE':
@@ -3309,7 +3309,7 @@ enum LayerFailureCode {
   missingLayerDigest,
 }
 
-extension on LayerFailureCode {
+extension LayerFailureCodeValue on LayerFailureCode {
   String toValue() {
     switch (this) {
       case LayerFailureCode.invalidLayerDigest:
@@ -3320,7 +3320,7 @@ extension on LayerFailureCode {
   }
 }
 
-extension on String {
+extension LayerFailureCodeFromString on String {
   LayerFailureCode toLayerFailureCode() {
     switch (this) {
       case 'InvalidLayerDigest':
@@ -3397,7 +3397,7 @@ enum LifecyclePolicyPreviewStatus {
   failed,
 }
 
-extension on LifecyclePolicyPreviewStatus {
+extension LifecyclePolicyPreviewStatusValue on LifecyclePolicyPreviewStatus {
   String toValue() {
     switch (this) {
       case LifecyclePolicyPreviewStatus.inProgress:
@@ -3412,7 +3412,7 @@ extension on LifecyclePolicyPreviewStatus {
   }
 }
 
-extension on String {
+extension LifecyclePolicyPreviewStatusFromString on String {
   LifecyclePolicyPreviewStatus toLifecyclePolicyPreviewStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3803,7 +3803,7 @@ enum ScanStatus {
   failed,
 }
 
-extension on ScanStatus {
+extension ScanStatusValue on ScanStatus {
   String toValue() {
     switch (this) {
       case ScanStatus.inProgress:
@@ -3816,7 +3816,7 @@ extension on ScanStatus {
   }
 }
 
-extension on String {
+extension ScanStatusFromString on String {
   ScanStatus toScanStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3964,7 +3964,7 @@ enum TagStatus {
   any,
 }
 
-extension on TagStatus {
+extension TagStatusValue on TagStatus {
   String toValue() {
     switch (this) {
       case TagStatus.tagged:
@@ -3977,7 +3977,7 @@ extension on TagStatus {
   }
 }
 
-extension on String {
+extension TagStatusFromString on String {
   TagStatus toTagStatus() {
     switch (this) {
       case 'TAGGED':

--- a/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
+++ b/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
@@ -4803,7 +4803,7 @@ enum AgentUpdateStatus {
   failed,
 }
 
-extension on AgentUpdateStatus {
+extension AgentUpdateStatusValue on AgentUpdateStatus {
   String toValue() {
     switch (this) {
       case AgentUpdateStatus.pending:
@@ -4822,7 +4822,7 @@ extension on AgentUpdateStatus {
   }
 }
 
-extension on String {
+extension AgentUpdateStatusFromString on String {
   AgentUpdateStatus toAgentUpdateStatus() {
     switch (this) {
       case 'PENDING':
@@ -4847,7 +4847,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension on AssignPublicIp {
+extension AssignPublicIpValue on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -4858,7 +4858,7 @@ extension on AssignPublicIp {
   }
 }
 
-extension on String {
+extension AssignPublicIpFromString on String {
   AssignPublicIp toAssignPublicIp() {
     switch (this) {
       case 'ENABLED':
@@ -5238,7 +5238,7 @@ enum CapacityProviderField {
   tags,
 }
 
-extension on CapacityProviderField {
+extension CapacityProviderFieldValue on CapacityProviderField {
   String toValue() {
     switch (this) {
       case CapacityProviderField.tags:
@@ -5247,7 +5247,7 @@ extension on CapacityProviderField {
   }
 }
 
-extension on String {
+extension CapacityProviderFieldFromString on String {
   CapacityProviderField toCapacityProviderField() {
     switch (this) {
       case 'TAGS':
@@ -5262,7 +5262,7 @@ enum CapacityProviderStatus {
   inactive,
 }
 
-extension on CapacityProviderStatus {
+extension CapacityProviderStatusValue on CapacityProviderStatus {
   String toValue() {
     switch (this) {
       case CapacityProviderStatus.active:
@@ -5273,7 +5273,7 @@ extension on CapacityProviderStatus {
   }
 }
 
-extension on String {
+extension CapacityProviderStatusFromString on String {
   CapacityProviderStatus toCapacityProviderStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -5341,7 +5341,7 @@ enum CapacityProviderUpdateStatus {
   updateFailed,
 }
 
-extension on CapacityProviderUpdateStatus {
+extension CapacityProviderUpdateStatusValue on CapacityProviderUpdateStatus {
   String toValue() {
     switch (this) {
       case CapacityProviderUpdateStatus.deleteInProgress:
@@ -5360,7 +5360,7 @@ extension on CapacityProviderUpdateStatus {
   }
 }
 
-extension on String {
+extension CapacityProviderUpdateStatusFromString on String {
   CapacityProviderUpdateStatus toCapacityProviderUpdateStatus() {
     switch (this) {
       case 'DELETE_IN_PROGRESS':
@@ -5597,7 +5597,7 @@ enum ClusterField {
   tags,
 }
 
-extension on ClusterField {
+extension ClusterFieldValue on ClusterField {
   String toValue() {
     switch (this) {
       case ClusterField.attachments:
@@ -5612,7 +5612,7 @@ extension on ClusterField {
   }
 }
 
-extension on String {
+extension ClusterFieldFromString on String {
   ClusterField toClusterField() {
     switch (this) {
       case 'ATTACHMENTS':
@@ -5669,7 +5669,7 @@ enum ClusterSettingName {
   containerInsights,
 }
 
-extension on ClusterSettingName {
+extension ClusterSettingNameValue on ClusterSettingName {
   String toValue() {
     switch (this) {
       case ClusterSettingName.containerInsights:
@@ -5678,7 +5678,7 @@ extension on ClusterSettingName {
   }
 }
 
-extension on String {
+extension ClusterSettingNameFromString on String {
   ClusterSettingName toClusterSettingName() {
     switch (this) {
       case 'containerInsights':
@@ -5693,7 +5693,7 @@ enum Compatibility {
   fargate,
 }
 
-extension on Compatibility {
+extension CompatibilityValue on Compatibility {
   String toValue() {
     switch (this) {
       case Compatibility.ec2:
@@ -5704,7 +5704,7 @@ extension on Compatibility {
   }
 }
 
-extension on String {
+extension CompatibilityFromString on String {
   Compatibility toCompatibility() {
     switch (this) {
       case 'EC2':
@@ -5721,7 +5721,7 @@ enum Connectivity {
   disconnected,
 }
 
-extension on Connectivity {
+extension ConnectivityValue on Connectivity {
   String toValue() {
     switch (this) {
       case Connectivity.connected:
@@ -5732,7 +5732,7 @@ extension on Connectivity {
   }
 }
 
-extension on String {
+extension ConnectivityFromString on String {
   Connectivity toConnectivity() {
     switch (this) {
       case 'CONNECTED':
@@ -5859,7 +5859,7 @@ enum ContainerCondition {
   healthy,
 }
 
-extension on ContainerCondition {
+extension ContainerConditionValue on ContainerCondition {
   String toValue() {
     switch (this) {
       case ContainerCondition.start:
@@ -5874,7 +5874,7 @@ extension on ContainerCondition {
   }
 }
 
-extension on String {
+extension ContainerConditionFromString on String {
   ContainerCondition toContainerCondition() {
     switch (this) {
       case 'START':
@@ -7199,7 +7199,7 @@ enum ContainerInstanceField {
   tags,
 }
 
-extension on ContainerInstanceField {
+extension ContainerInstanceFieldValue on ContainerInstanceField {
   String toValue() {
     switch (this) {
       case ContainerInstanceField.tags:
@@ -7208,7 +7208,7 @@ extension on ContainerInstanceField {
   }
 }
 
-extension on String {
+extension ContainerInstanceFieldFromString on String {
   ContainerInstanceField toContainerInstanceField() {
     switch (this) {
       case 'TAGS':
@@ -7226,7 +7226,7 @@ enum ContainerInstanceStatus {
   registrationFailed,
 }
 
-extension on ContainerInstanceStatus {
+extension ContainerInstanceStatusValue on ContainerInstanceStatus {
   String toValue() {
     switch (this) {
       case ContainerInstanceStatus.active:
@@ -7243,7 +7243,7 @@ extension on ContainerInstanceStatus {
   }
 }
 
-extension on String {
+extension ContainerInstanceStatusFromString on String {
   ContainerInstanceStatus toContainerInstanceStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -7911,7 +7911,7 @@ enum DeploymentControllerType {
   external,
 }
 
-extension on DeploymentControllerType {
+extension DeploymentControllerTypeValue on DeploymentControllerType {
   String toValue() {
     switch (this) {
       case DeploymentControllerType.ecs:
@@ -7924,7 +7924,7 @@ extension on DeploymentControllerType {
   }
 }
 
-extension on String {
+extension DeploymentControllerTypeFromString on String {
   DeploymentControllerType toDeploymentControllerType() {
     switch (this) {
       case 'ECS':
@@ -7944,7 +7944,7 @@ enum DeploymentRolloutState {
   inProgress,
 }
 
-extension on DeploymentRolloutState {
+extension DeploymentRolloutStateValue on DeploymentRolloutState {
   String toValue() {
     switch (this) {
       case DeploymentRolloutState.completed:
@@ -7957,7 +7957,7 @@ extension on DeploymentRolloutState {
   }
 }
 
-extension on String {
+extension DeploymentRolloutStateFromString on String {
   DeploymentRolloutState toDeploymentRolloutState() {
     switch (this) {
       case 'COMPLETED':
@@ -8234,7 +8234,7 @@ enum DesiredStatus {
   stopped,
 }
 
-extension on DesiredStatus {
+extension DesiredStatusValue on DesiredStatus {
   String toValue() {
     switch (this) {
       case DesiredStatus.running:
@@ -8247,7 +8247,7 @@ extension on DesiredStatus {
   }
 }
 
-extension on String {
+extension DesiredStatusFromString on String {
   DesiredStatus toDesiredStatus() {
     switch (this) {
       case 'RUNNING':
@@ -8309,7 +8309,7 @@ enum DeviceCgroupPermission {
   mknod,
 }
 
-extension on DeviceCgroupPermission {
+extension DeviceCgroupPermissionValue on DeviceCgroupPermission {
   String toValue() {
     switch (this) {
       case DeviceCgroupPermission.read:
@@ -8322,7 +8322,7 @@ extension on DeviceCgroupPermission {
   }
 }
 
-extension on String {
+extension DeviceCgroupPermissionFromString on String {
   DeviceCgroupPermission toDeviceCgroupPermission() {
     switch (this) {
       case 'read':
@@ -8493,7 +8493,7 @@ enum EFSAuthorizationConfigIAM {
   disabled,
 }
 
-extension on EFSAuthorizationConfigIAM {
+extension EFSAuthorizationConfigIAMValue on EFSAuthorizationConfigIAM {
   String toValue() {
     switch (this) {
       case EFSAuthorizationConfigIAM.enabled:
@@ -8504,7 +8504,7 @@ extension on EFSAuthorizationConfigIAM {
   }
 }
 
-extension on String {
+extension EFSAuthorizationConfigIAMFromString on String {
   EFSAuthorizationConfigIAM toEFSAuthorizationConfigIAM() {
     switch (this) {
       case 'ENABLED':
@@ -8521,7 +8521,7 @@ enum EFSTransitEncryption {
   disabled,
 }
 
-extension on EFSTransitEncryption {
+extension EFSTransitEncryptionValue on EFSTransitEncryption {
   String toValue() {
     switch (this) {
       case EFSTransitEncryption.enabled:
@@ -8532,7 +8532,7 @@ extension on EFSTransitEncryption {
   }
 }
 
-extension on String {
+extension EFSTransitEncryptionFromString on String {
   EFSTransitEncryption toEFSTransitEncryption() {
     switch (this) {
       case 'ENABLED':
@@ -8678,7 +8678,7 @@ enum EnvironmentFileType {
   s3,
 }
 
-extension on EnvironmentFileType {
+extension EnvironmentFileTypeValue on EnvironmentFileType {
   String toValue() {
     switch (this) {
       case EnvironmentFileType.s3:
@@ -8687,7 +8687,7 @@ extension on EnvironmentFileType {
   }
 }
 
-extension on String {
+extension EnvironmentFileTypeFromString on String {
   EnvironmentFileType toEnvironmentFileType() {
     switch (this) {
       case 's3':
@@ -8864,7 +8864,7 @@ enum FirelensConfigurationType {
   fluentbit,
 }
 
-extension on FirelensConfigurationType {
+extension FirelensConfigurationTypeValue on FirelensConfigurationType {
   String toValue() {
     switch (this) {
       case FirelensConfigurationType.fluentd:
@@ -8875,7 +8875,7 @@ extension on FirelensConfigurationType {
   }
 }
 
-extension on String {
+extension FirelensConfigurationTypeFromString on String {
   FirelensConfigurationType toFirelensConfigurationType() {
     switch (this) {
       case 'fluentd':
@@ -9037,7 +9037,7 @@ enum HealthStatus {
   unknown,
 }
 
-extension on HealthStatus {
+extension HealthStatusValue on HealthStatus {
   String toValue() {
     switch (this) {
       case HealthStatus.healthy:
@@ -9050,7 +9050,7 @@ extension on HealthStatus {
   }
 }
 
-extension on String {
+extension HealthStatusFromString on String {
   HealthStatus toHealthStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -9204,7 +9204,7 @@ enum IpcMode {
   none,
 }
 
-extension on IpcMode {
+extension IpcModeValue on IpcMode {
   String toValue() {
     switch (this) {
       case IpcMode.host:
@@ -9217,7 +9217,7 @@ extension on IpcMode {
   }
 }
 
-extension on String {
+extension IpcModeFromString on String {
   IpcMode toIpcMode() {
     switch (this) {
       case 'host':
@@ -9346,7 +9346,7 @@ enum LaunchType {
   fargate,
 }
 
-extension on LaunchType {
+extension LaunchTypeValue on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -9357,7 +9357,7 @@ extension on LaunchType {
   }
 }
 
-extension on String {
+extension LaunchTypeFromString on String {
   LaunchType toLaunchType() {
     switch (this) {
       case 'EC2':
@@ -9957,7 +9957,7 @@ enum LogDriver {
   awsfirelens,
 }
 
-extension on LogDriver {
+extension LogDriverValue on LogDriver {
   String toValue() {
     switch (this) {
       case LogDriver.jsonFile:
@@ -9980,7 +9980,7 @@ extension on LogDriver {
   }
 }
 
-extension on String {
+extension LogDriverFromString on String {
   LogDriver toLogDriver() {
     switch (this) {
       case 'json-file':
@@ -10083,7 +10083,7 @@ enum ManagedScalingStatus {
   disabled,
 }
 
-extension on ManagedScalingStatus {
+extension ManagedScalingStatusValue on ManagedScalingStatus {
   String toValue() {
     switch (this) {
       case ManagedScalingStatus.enabled:
@@ -10094,7 +10094,7 @@ extension on ManagedScalingStatus {
   }
 }
 
-extension on String {
+extension ManagedScalingStatusFromString on String {
   ManagedScalingStatus toManagedScalingStatus() {
     switch (this) {
       case 'ENABLED':
@@ -10111,7 +10111,7 @@ enum ManagedTerminationProtection {
   disabled,
 }
 
-extension on ManagedTerminationProtection {
+extension ManagedTerminationProtectionValue on ManagedTerminationProtection {
   String toValue() {
     switch (this) {
       case ManagedTerminationProtection.enabled:
@@ -10122,7 +10122,7 @@ extension on ManagedTerminationProtection {
   }
 }
 
-extension on String {
+extension ManagedTerminationProtectionFromString on String {
   ManagedTerminationProtection toManagedTerminationProtection() {
     switch (this) {
       case 'ENABLED':
@@ -10281,7 +10281,7 @@ enum NetworkMode {
   none,
 }
 
-extension on NetworkMode {
+extension NetworkModeValue on NetworkMode {
   String toValue() {
     switch (this) {
       case NetworkMode.bridge:
@@ -10296,7 +10296,7 @@ extension on NetworkMode {
   }
 }
 
-extension on String {
+extension NetworkModeFromString on String {
   NetworkMode toNetworkMode() {
     switch (this) {
       case 'bridge':
@@ -10317,7 +10317,7 @@ enum PidMode {
   task,
 }
 
-extension on PidMode {
+extension PidModeValue on PidMode {
   String toValue() {
     switch (this) {
       case PidMode.host:
@@ -10328,7 +10328,7 @@ extension on PidMode {
   }
 }
 
-extension on String {
+extension PidModeFromString on String {
   PidMode toPidMode() {
     switch (this) {
       case 'host':
@@ -10390,7 +10390,7 @@ enum PlacementConstraintType {
   memberOf,
 }
 
-extension on PlacementConstraintType {
+extension PlacementConstraintTypeValue on PlacementConstraintType {
   String toValue() {
     switch (this) {
       case PlacementConstraintType.distinctInstance:
@@ -10401,7 +10401,7 @@ extension on PlacementConstraintType {
   }
 }
 
-extension on String {
+extension PlacementConstraintTypeFromString on String {
   PlacementConstraintType toPlacementConstraintType() {
     switch (this) {
       case 'distinctInstance':
@@ -10466,7 +10466,7 @@ enum PlacementStrategyType {
   binpack,
 }
 
-extension on PlacementStrategyType {
+extension PlacementStrategyTypeValue on PlacementStrategyType {
   String toValue() {
     switch (this) {
       case PlacementStrategyType.random:
@@ -10479,7 +10479,7 @@ extension on PlacementStrategyType {
   }
 }
 
-extension on String {
+extension PlacementStrategyTypeFromString on String {
   PlacementStrategyType toPlacementStrategyType() {
     switch (this) {
       case 'random':
@@ -10523,7 +10523,7 @@ enum PlatformDeviceType {
   gpu,
 }
 
-extension on PlatformDeviceType {
+extension PlatformDeviceTypeValue on PlatformDeviceType {
   String toValue() {
     switch (this) {
       case PlatformDeviceType.gpu:
@@ -10532,7 +10532,7 @@ extension on PlatformDeviceType {
   }
 }
 
-extension on String {
+extension PlatformDeviceTypeFromString on String {
   PlatformDeviceType toPlatformDeviceType() {
     switch (this) {
       case 'GPU':
@@ -10639,7 +10639,7 @@ enum PropagateTags {
   service,
 }
 
-extension on PropagateTags {
+extension PropagateTagsValue on PropagateTags {
   String toValue() {
     switch (this) {
       case PropagateTags.taskDefinition:
@@ -10650,7 +10650,7 @@ extension on PropagateTags {
   }
 }
 
-extension on String {
+extension PropagateTagsFromString on String {
   PropagateTags toPropagateTags() {
     switch (this) {
       case 'TASK_DEFINITION':
@@ -10753,7 +10753,7 @@ enum ProxyConfigurationType {
   appmesh,
 }
 
-extension on ProxyConfigurationType {
+extension ProxyConfigurationTypeValue on ProxyConfigurationType {
   String toValue() {
     switch (this) {
       case ProxyConfigurationType.appmesh:
@@ -10762,7 +10762,7 @@ extension on ProxyConfigurationType {
   }
 }
 
-extension on String {
+extension ProxyConfigurationTypeFromString on String {
   ProxyConfigurationType toProxyConfigurationType() {
     switch (this) {
       case 'APPMESH':
@@ -11026,7 +11026,7 @@ enum ResourceType {
   inferenceAccelerator,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.gpu:
@@ -11037,7 +11037,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'GPU':
@@ -11111,7 +11111,7 @@ enum ScaleUnit {
   percent,
 }
 
-extension on ScaleUnit {
+extension ScaleUnitValue on ScaleUnit {
   String toValue() {
     switch (this) {
       case ScaleUnit.percent:
@@ -11120,7 +11120,7 @@ extension on ScaleUnit {
   }
 }
 
-extension on String {
+extension ScaleUnitFromString on String {
   ScaleUnit toScaleUnit() {
     switch (this) {
       case 'PERCENT':
@@ -11135,7 +11135,7 @@ enum SchedulingStrategy {
   daemon,
 }
 
-extension on SchedulingStrategy {
+extension SchedulingStrategyValue on SchedulingStrategy {
   String toValue() {
     switch (this) {
       case SchedulingStrategy.replica:
@@ -11146,7 +11146,7 @@ extension on SchedulingStrategy {
   }
 }
 
-extension on String {
+extension SchedulingStrategyFromString on String {
   SchedulingStrategy toSchedulingStrategy() {
     switch (this) {
       case 'REPLICA':
@@ -11163,7 +11163,7 @@ enum Scope {
   shared,
 }
 
-extension on Scope {
+extension ScopeValue on Scope {
   String toValue() {
     switch (this) {
       case Scope.task:
@@ -11174,7 +11174,7 @@ extension on Scope {
   }
 }
 
-extension on String {
+extension ScopeFromString on String {
   Scope toScope() {
     switch (this) {
       case 'task':
@@ -11566,7 +11566,7 @@ enum ServiceField {
   tags,
 }
 
-extension on ServiceField {
+extension ServiceFieldValue on ServiceField {
   String toValue() {
     switch (this) {
       case ServiceField.tags:
@@ -11575,7 +11575,7 @@ extension on ServiceField {
   }
 }
 
-extension on String {
+extension ServiceFieldFromString on String {
   ServiceField toServiceField() {
     switch (this) {
       case 'TAGS':
@@ -11683,7 +11683,7 @@ enum SettingName {
   containerInsights,
 }
 
-extension on SettingName {
+extension SettingNameValue on SettingName {
   String toValue() {
     switch (this) {
       case SettingName.serviceLongArnFormat:
@@ -11700,7 +11700,7 @@ extension on SettingName {
   }
 }
 
-extension on String {
+extension SettingNameFromString on String {
   SettingName toSettingName() {
     switch (this) {
       case 'serviceLongArnFormat':
@@ -11723,7 +11723,7 @@ enum SortOrder {
   desc,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -11734,7 +11734,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASC':
@@ -11751,7 +11751,7 @@ enum StabilityStatus {
   stabilizing,
 }
 
-extension on StabilityStatus {
+extension StabilityStatusValue on StabilityStatus {
   String toValue() {
     switch (this) {
       case StabilityStatus.steadyState:
@@ -11762,7 +11762,7 @@ extension on StabilityStatus {
   }
 }
 
-extension on String {
+extension StabilityStatusFromString on String {
   StabilityStatus toStabilityStatus() {
     switch (this) {
       case 'STEADY_STATE':
@@ -11995,7 +11995,7 @@ enum TargetType {
   containerInstance,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.containerInstance:
@@ -12004,7 +12004,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'container-instance':
@@ -12716,7 +12716,7 @@ enum TaskDefinitionFamilyStatus {
   all,
 }
 
-extension on TaskDefinitionFamilyStatus {
+extension TaskDefinitionFamilyStatusValue on TaskDefinitionFamilyStatus {
   String toValue() {
     switch (this) {
       case TaskDefinitionFamilyStatus.active:
@@ -12729,7 +12729,7 @@ extension on TaskDefinitionFamilyStatus {
   }
 }
 
-extension on String {
+extension TaskDefinitionFamilyStatusFromString on String {
   TaskDefinitionFamilyStatus toTaskDefinitionFamilyStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -12747,7 +12747,7 @@ enum TaskDefinitionField {
   tags,
 }
 
-extension on TaskDefinitionField {
+extension TaskDefinitionFieldValue on TaskDefinitionField {
   String toValue() {
     switch (this) {
       case TaskDefinitionField.tags:
@@ -12756,7 +12756,7 @@ extension on TaskDefinitionField {
   }
 }
 
-extension on String {
+extension TaskDefinitionFieldFromString on String {
   TaskDefinitionField toTaskDefinitionField() {
     switch (this) {
       case 'TAGS':
@@ -12814,7 +12814,8 @@ enum TaskDefinitionPlacementConstraintType {
   memberOf,
 }
 
-extension on TaskDefinitionPlacementConstraintType {
+extension TaskDefinitionPlacementConstraintTypeValue
+    on TaskDefinitionPlacementConstraintType {
   String toValue() {
     switch (this) {
       case TaskDefinitionPlacementConstraintType.memberOf:
@@ -12823,7 +12824,7 @@ extension on TaskDefinitionPlacementConstraintType {
   }
 }
 
-extension on String {
+extension TaskDefinitionPlacementConstraintTypeFromString on String {
   TaskDefinitionPlacementConstraintType
       toTaskDefinitionPlacementConstraintType() {
     switch (this) {
@@ -12840,7 +12841,7 @@ enum TaskDefinitionStatus {
   inactive,
 }
 
-extension on TaskDefinitionStatus {
+extension TaskDefinitionStatusValue on TaskDefinitionStatus {
   String toValue() {
     switch (this) {
       case TaskDefinitionStatus.active:
@@ -12851,7 +12852,7 @@ extension on TaskDefinitionStatus {
   }
 }
 
-extension on String {
+extension TaskDefinitionStatusFromString on String {
   TaskDefinitionStatus toTaskDefinitionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -12867,7 +12868,7 @@ enum TaskField {
   tags,
 }
 
-extension on TaskField {
+extension TaskFieldValue on TaskField {
   String toValue() {
     switch (this) {
       case TaskField.tags:
@@ -12876,7 +12877,7 @@ extension on TaskField {
   }
 }
 
-extension on String {
+extension TaskFieldFromString on String {
   TaskField toTaskField() {
     switch (this) {
       case 'TAGS':
@@ -13205,7 +13206,7 @@ enum TaskSetField {
   tags,
 }
 
-extension on TaskSetField {
+extension TaskSetFieldValue on TaskSetField {
   String toValue() {
     switch (this) {
       case TaskSetField.tags:
@@ -13214,7 +13215,7 @@ extension on TaskSetField {
   }
 }
 
-extension on String {
+extension TaskSetFieldFromString on String {
   TaskSetField toTaskSetField() {
     switch (this) {
       case 'TAGS':
@@ -13230,7 +13231,7 @@ enum TaskStopCode {
   userInitiated,
 }
 
-extension on TaskStopCode {
+extension TaskStopCodeValue on TaskStopCode {
   String toValue() {
     switch (this) {
       case TaskStopCode.taskFailedToStart:
@@ -13243,7 +13244,7 @@ extension on TaskStopCode {
   }
 }
 
-extension on String {
+extension TaskStopCodeFromString on String {
   TaskStopCode toTaskStopCode() {
     switch (this) {
       case 'TaskFailedToStart':
@@ -13309,7 +13310,7 @@ enum TransportProtocol {
   udp,
 }
 
-extension on TransportProtocol {
+extension TransportProtocolValue on TransportProtocol {
   String toValue() {
     switch (this) {
       case TransportProtocol.tcp:
@@ -13320,7 +13321,7 @@ extension on TransportProtocol {
   }
 }
 
-extension on String {
+extension TransportProtocolFromString on String {
   TransportProtocol toTransportProtocol() {
     switch (this) {
       case 'tcp':
@@ -13386,7 +13387,7 @@ enum UlimitName {
   stack,
 }
 
-extension on UlimitName {
+extension UlimitNameValue on UlimitName {
   String toValue() {
     switch (this) {
       case UlimitName.core:
@@ -13423,7 +13424,7 @@ extension on UlimitName {
   }
 }
 
-extension on String {
+extension UlimitNameFromString on String {
   UlimitName toUlimitName() {
     switch (this) {
       case 'core':

--- a/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
+++ b/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
@@ -4803,7 +4803,7 @@ enum AgentUpdateStatus {
   failed,
 }
 
-extension AgentUpdateStatusValue on AgentUpdateStatus {
+extension AgentUpdateStatusValueExtension on AgentUpdateStatus {
   String toValue() {
     switch (this) {
       case AgentUpdateStatus.pending:
@@ -4847,7 +4847,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension AssignPublicIpValue on AssignPublicIp {
+extension AssignPublicIpValueExtension on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -5238,7 +5238,7 @@ enum CapacityProviderField {
   tags,
 }
 
-extension CapacityProviderFieldValue on CapacityProviderField {
+extension CapacityProviderFieldValueExtension on CapacityProviderField {
   String toValue() {
     switch (this) {
       case CapacityProviderField.tags:
@@ -5262,7 +5262,7 @@ enum CapacityProviderStatus {
   inactive,
 }
 
-extension CapacityProviderStatusValue on CapacityProviderStatus {
+extension CapacityProviderStatusValueExtension on CapacityProviderStatus {
   String toValue() {
     switch (this) {
       case CapacityProviderStatus.active:
@@ -5341,7 +5341,8 @@ enum CapacityProviderUpdateStatus {
   updateFailed,
 }
 
-extension CapacityProviderUpdateStatusValue on CapacityProviderUpdateStatus {
+extension CapacityProviderUpdateStatusValueExtension
+    on CapacityProviderUpdateStatus {
   String toValue() {
     switch (this) {
       case CapacityProviderUpdateStatus.deleteInProgress:
@@ -5597,7 +5598,7 @@ enum ClusterField {
   tags,
 }
 
-extension ClusterFieldValue on ClusterField {
+extension ClusterFieldValueExtension on ClusterField {
   String toValue() {
     switch (this) {
       case ClusterField.attachments:
@@ -5669,7 +5670,7 @@ enum ClusterSettingName {
   containerInsights,
 }
 
-extension ClusterSettingNameValue on ClusterSettingName {
+extension ClusterSettingNameValueExtension on ClusterSettingName {
   String toValue() {
     switch (this) {
       case ClusterSettingName.containerInsights:
@@ -5693,7 +5694,7 @@ enum Compatibility {
   fargate,
 }
 
-extension CompatibilityValue on Compatibility {
+extension CompatibilityValueExtension on Compatibility {
   String toValue() {
     switch (this) {
       case Compatibility.ec2:
@@ -5721,7 +5722,7 @@ enum Connectivity {
   disconnected,
 }
 
-extension ConnectivityValue on Connectivity {
+extension ConnectivityValueExtension on Connectivity {
   String toValue() {
     switch (this) {
       case Connectivity.connected:
@@ -5859,7 +5860,7 @@ enum ContainerCondition {
   healthy,
 }
 
-extension ContainerConditionValue on ContainerCondition {
+extension ContainerConditionValueExtension on ContainerCondition {
   String toValue() {
     switch (this) {
       case ContainerCondition.start:
@@ -7199,7 +7200,7 @@ enum ContainerInstanceField {
   tags,
 }
 
-extension ContainerInstanceFieldValue on ContainerInstanceField {
+extension ContainerInstanceFieldValueExtension on ContainerInstanceField {
   String toValue() {
     switch (this) {
       case ContainerInstanceField.tags:
@@ -7226,7 +7227,7 @@ enum ContainerInstanceStatus {
   registrationFailed,
 }
 
-extension ContainerInstanceStatusValue on ContainerInstanceStatus {
+extension ContainerInstanceStatusValueExtension on ContainerInstanceStatus {
   String toValue() {
     switch (this) {
       case ContainerInstanceStatus.active:
@@ -7911,7 +7912,7 @@ enum DeploymentControllerType {
   external,
 }
 
-extension DeploymentControllerTypeValue on DeploymentControllerType {
+extension DeploymentControllerTypeValueExtension on DeploymentControllerType {
   String toValue() {
     switch (this) {
       case DeploymentControllerType.ecs:
@@ -7944,7 +7945,7 @@ enum DeploymentRolloutState {
   inProgress,
 }
 
-extension DeploymentRolloutStateValue on DeploymentRolloutState {
+extension DeploymentRolloutStateValueExtension on DeploymentRolloutState {
   String toValue() {
     switch (this) {
       case DeploymentRolloutState.completed:
@@ -8234,7 +8235,7 @@ enum DesiredStatus {
   stopped,
 }
 
-extension DesiredStatusValue on DesiredStatus {
+extension DesiredStatusValueExtension on DesiredStatus {
   String toValue() {
     switch (this) {
       case DesiredStatus.running:
@@ -8309,7 +8310,7 @@ enum DeviceCgroupPermission {
   mknod,
 }
 
-extension DeviceCgroupPermissionValue on DeviceCgroupPermission {
+extension DeviceCgroupPermissionValueExtension on DeviceCgroupPermission {
   String toValue() {
     switch (this) {
       case DeviceCgroupPermission.read:
@@ -8493,7 +8494,7 @@ enum EFSAuthorizationConfigIAM {
   disabled,
 }
 
-extension EFSAuthorizationConfigIAMValue on EFSAuthorizationConfigIAM {
+extension EFSAuthorizationConfigIAMValueExtension on EFSAuthorizationConfigIAM {
   String toValue() {
     switch (this) {
       case EFSAuthorizationConfigIAM.enabled:
@@ -8521,7 +8522,7 @@ enum EFSTransitEncryption {
   disabled,
 }
 
-extension EFSTransitEncryptionValue on EFSTransitEncryption {
+extension EFSTransitEncryptionValueExtension on EFSTransitEncryption {
   String toValue() {
     switch (this) {
       case EFSTransitEncryption.enabled:
@@ -8678,7 +8679,7 @@ enum EnvironmentFileType {
   s3,
 }
 
-extension EnvironmentFileTypeValue on EnvironmentFileType {
+extension EnvironmentFileTypeValueExtension on EnvironmentFileType {
   String toValue() {
     switch (this) {
       case EnvironmentFileType.s3:
@@ -8864,7 +8865,7 @@ enum FirelensConfigurationType {
   fluentbit,
 }
 
-extension FirelensConfigurationTypeValue on FirelensConfigurationType {
+extension FirelensConfigurationTypeValueExtension on FirelensConfigurationType {
   String toValue() {
     switch (this) {
       case FirelensConfigurationType.fluentd:
@@ -9037,7 +9038,7 @@ enum HealthStatus {
   unknown,
 }
 
-extension HealthStatusValue on HealthStatus {
+extension HealthStatusValueExtension on HealthStatus {
   String toValue() {
     switch (this) {
       case HealthStatus.healthy:
@@ -9204,7 +9205,7 @@ enum IpcMode {
   none,
 }
 
-extension IpcModeValue on IpcMode {
+extension IpcModeValueExtension on IpcMode {
   String toValue() {
     switch (this) {
       case IpcMode.host:
@@ -9346,7 +9347,7 @@ enum LaunchType {
   fargate,
 }
 
-extension LaunchTypeValue on LaunchType {
+extension LaunchTypeValueExtension on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -9957,7 +9958,7 @@ enum LogDriver {
   awsfirelens,
 }
 
-extension LogDriverValue on LogDriver {
+extension LogDriverValueExtension on LogDriver {
   String toValue() {
     switch (this) {
       case LogDriver.jsonFile:
@@ -10083,7 +10084,7 @@ enum ManagedScalingStatus {
   disabled,
 }
 
-extension ManagedScalingStatusValue on ManagedScalingStatus {
+extension ManagedScalingStatusValueExtension on ManagedScalingStatus {
   String toValue() {
     switch (this) {
       case ManagedScalingStatus.enabled:
@@ -10111,7 +10112,8 @@ enum ManagedTerminationProtection {
   disabled,
 }
 
-extension ManagedTerminationProtectionValue on ManagedTerminationProtection {
+extension ManagedTerminationProtectionValueExtension
+    on ManagedTerminationProtection {
   String toValue() {
     switch (this) {
       case ManagedTerminationProtection.enabled:
@@ -10281,7 +10283,7 @@ enum NetworkMode {
   none,
 }
 
-extension NetworkModeValue on NetworkMode {
+extension NetworkModeValueExtension on NetworkMode {
   String toValue() {
     switch (this) {
       case NetworkMode.bridge:
@@ -10317,7 +10319,7 @@ enum PidMode {
   task,
 }
 
-extension PidModeValue on PidMode {
+extension PidModeValueExtension on PidMode {
   String toValue() {
     switch (this) {
       case PidMode.host:
@@ -10390,7 +10392,7 @@ enum PlacementConstraintType {
   memberOf,
 }
 
-extension PlacementConstraintTypeValue on PlacementConstraintType {
+extension PlacementConstraintTypeValueExtension on PlacementConstraintType {
   String toValue() {
     switch (this) {
       case PlacementConstraintType.distinctInstance:
@@ -10466,7 +10468,7 @@ enum PlacementStrategyType {
   binpack,
 }
 
-extension PlacementStrategyTypeValue on PlacementStrategyType {
+extension PlacementStrategyTypeValueExtension on PlacementStrategyType {
   String toValue() {
     switch (this) {
       case PlacementStrategyType.random:
@@ -10523,7 +10525,7 @@ enum PlatformDeviceType {
   gpu,
 }
 
-extension PlatformDeviceTypeValue on PlatformDeviceType {
+extension PlatformDeviceTypeValueExtension on PlatformDeviceType {
   String toValue() {
     switch (this) {
       case PlatformDeviceType.gpu:
@@ -10639,7 +10641,7 @@ enum PropagateTags {
   service,
 }
 
-extension PropagateTagsValue on PropagateTags {
+extension PropagateTagsValueExtension on PropagateTags {
   String toValue() {
     switch (this) {
       case PropagateTags.taskDefinition:
@@ -10753,7 +10755,7 @@ enum ProxyConfigurationType {
   appmesh,
 }
 
-extension ProxyConfigurationTypeValue on ProxyConfigurationType {
+extension ProxyConfigurationTypeValueExtension on ProxyConfigurationType {
   String toValue() {
     switch (this) {
       case ProxyConfigurationType.appmesh:
@@ -11026,7 +11028,7 @@ enum ResourceType {
   inferenceAccelerator,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.gpu:
@@ -11111,7 +11113,7 @@ enum ScaleUnit {
   percent,
 }
 
-extension ScaleUnitValue on ScaleUnit {
+extension ScaleUnitValueExtension on ScaleUnit {
   String toValue() {
     switch (this) {
       case ScaleUnit.percent:
@@ -11135,7 +11137,7 @@ enum SchedulingStrategy {
   daemon,
 }
 
-extension SchedulingStrategyValue on SchedulingStrategy {
+extension SchedulingStrategyValueExtension on SchedulingStrategy {
   String toValue() {
     switch (this) {
       case SchedulingStrategy.replica:
@@ -11163,7 +11165,7 @@ enum Scope {
   shared,
 }
 
-extension ScopeValue on Scope {
+extension ScopeValueExtension on Scope {
   String toValue() {
     switch (this) {
       case Scope.task:
@@ -11566,7 +11568,7 @@ enum ServiceField {
   tags,
 }
 
-extension ServiceFieldValue on ServiceField {
+extension ServiceFieldValueExtension on ServiceField {
   String toValue() {
     switch (this) {
       case ServiceField.tags:
@@ -11683,7 +11685,7 @@ enum SettingName {
   containerInsights,
 }
 
-extension SettingNameValue on SettingName {
+extension SettingNameValueExtension on SettingName {
   String toValue() {
     switch (this) {
       case SettingName.serviceLongArnFormat:
@@ -11723,7 +11725,7 @@ enum SortOrder {
   desc,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -11751,7 +11753,7 @@ enum StabilityStatus {
   stabilizing,
 }
 
-extension StabilityStatusValue on StabilityStatus {
+extension StabilityStatusValueExtension on StabilityStatus {
   String toValue() {
     switch (this) {
       case StabilityStatus.steadyState:
@@ -11995,7 +11997,7 @@ enum TargetType {
   containerInstance,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.containerInstance:
@@ -12716,7 +12718,8 @@ enum TaskDefinitionFamilyStatus {
   all,
 }
 
-extension TaskDefinitionFamilyStatusValue on TaskDefinitionFamilyStatus {
+extension TaskDefinitionFamilyStatusValueExtension
+    on TaskDefinitionFamilyStatus {
   String toValue() {
     switch (this) {
       case TaskDefinitionFamilyStatus.active:
@@ -12747,7 +12750,7 @@ enum TaskDefinitionField {
   tags,
 }
 
-extension TaskDefinitionFieldValue on TaskDefinitionField {
+extension TaskDefinitionFieldValueExtension on TaskDefinitionField {
   String toValue() {
     switch (this) {
       case TaskDefinitionField.tags:
@@ -12814,7 +12817,7 @@ enum TaskDefinitionPlacementConstraintType {
   memberOf,
 }
 
-extension TaskDefinitionPlacementConstraintTypeValue
+extension TaskDefinitionPlacementConstraintTypeValueExtension
     on TaskDefinitionPlacementConstraintType {
   String toValue() {
     switch (this) {
@@ -12841,7 +12844,7 @@ enum TaskDefinitionStatus {
   inactive,
 }
 
-extension TaskDefinitionStatusValue on TaskDefinitionStatus {
+extension TaskDefinitionStatusValueExtension on TaskDefinitionStatus {
   String toValue() {
     switch (this) {
       case TaskDefinitionStatus.active:
@@ -12868,7 +12871,7 @@ enum TaskField {
   tags,
 }
 
-extension TaskFieldValue on TaskField {
+extension TaskFieldValueExtension on TaskField {
   String toValue() {
     switch (this) {
       case TaskField.tags:
@@ -13206,7 +13209,7 @@ enum TaskSetField {
   tags,
 }
 
-extension TaskSetFieldValue on TaskSetField {
+extension TaskSetFieldValueExtension on TaskSetField {
   String toValue() {
     switch (this) {
       case TaskSetField.tags:
@@ -13231,7 +13234,7 @@ enum TaskStopCode {
   userInitiated,
 }
 
-extension TaskStopCodeValue on TaskStopCode {
+extension TaskStopCodeValueExtension on TaskStopCode {
   String toValue() {
     switch (this) {
       case TaskStopCode.taskFailedToStart:
@@ -13310,7 +13313,7 @@ enum TransportProtocol {
   udp,
 }
 
-extension TransportProtocolValue on TransportProtocol {
+extension TransportProtocolValueExtension on TransportProtocol {
   String toValue() {
     switch (this) {
       case TransportProtocol.tcp:
@@ -13387,7 +13390,7 @@ enum UlimitName {
   stack,
 }
 
-extension UlimitNameValue on UlimitName {
+extension UlimitNameValueExtension on UlimitName {
   String toValue() {
     switch (this) {
       case UlimitName.core:

--- a/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
+++ b/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
@@ -2199,7 +2199,7 @@ enum LifeCycleState {
   deleted,
 }
 
-extension LifeCycleStateValue on LifeCycleState {
+extension LifeCycleStateValueExtension on LifeCycleState {
   String toValue() {
     switch (this) {
       case LifeCycleState.creating:
@@ -2374,7 +2374,7 @@ enum PerformanceMode {
   maxIO,
 }
 
-extension PerformanceModeValue on PerformanceMode {
+extension PerformanceModeValueExtension on PerformanceMode {
   String toValue() {
     switch (this) {
       case PerformanceMode.generalPurpose:
@@ -2496,7 +2496,7 @@ enum Status {
   disabling,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.enabled:
@@ -2563,7 +2563,7 @@ enum ThroughputMode {
   provisioned,
 }
 
-extension ThroughputModeValue on ThroughputMode {
+extension ThroughputModeValueExtension on ThroughputMode {
   String toValue() {
     switch (this) {
       case ThroughputMode.bursting:
@@ -2594,7 +2594,7 @@ enum TransitionToIARules {
   after_90Days,
 }
 
-extension TransitionToIARulesValue on TransitionToIARules {
+extension TransitionToIARulesValueExtension on TransitionToIARules {
   String toValue() {
     switch (this) {
       case TransitionToIARules.after_7Days:

--- a/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
+++ b/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
@@ -2199,7 +2199,7 @@ enum LifeCycleState {
   deleted,
 }
 
-extension on LifeCycleState {
+extension LifeCycleStateValue on LifeCycleState {
   String toValue() {
     switch (this) {
       case LifeCycleState.creating:
@@ -2216,7 +2216,7 @@ extension on LifeCycleState {
   }
 }
 
-extension on String {
+extension LifeCycleStateFromString on String {
   LifeCycleState toLifeCycleState() {
     switch (this) {
       case 'creating':
@@ -2374,7 +2374,7 @@ enum PerformanceMode {
   maxIO,
 }
 
-extension on PerformanceMode {
+extension PerformanceModeValue on PerformanceMode {
   String toValue() {
     switch (this) {
       case PerformanceMode.generalPurpose:
@@ -2385,7 +2385,7 @@ extension on PerformanceMode {
   }
 }
 
-extension on String {
+extension PerformanceModeFromString on String {
   PerformanceMode toPerformanceMode() {
     switch (this) {
       case 'generalPurpose':
@@ -2496,7 +2496,7 @@ enum Status {
   disabling,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.enabled:
@@ -2511,7 +2511,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'ENABLED':
@@ -2563,7 +2563,7 @@ enum ThroughputMode {
   provisioned,
 }
 
-extension on ThroughputMode {
+extension ThroughputModeValue on ThroughputMode {
   String toValue() {
     switch (this) {
       case ThroughputMode.bursting:
@@ -2574,7 +2574,7 @@ extension on ThroughputMode {
   }
 }
 
-extension on String {
+extension ThroughputModeFromString on String {
   ThroughputMode toThroughputMode() {
     switch (this) {
       case 'bursting':
@@ -2594,7 +2594,7 @@ enum TransitionToIARules {
   after_90Days,
 }
 
-extension on TransitionToIARules {
+extension TransitionToIARulesValue on TransitionToIARules {
   String toValue() {
     switch (this) {
       case TransitionToIARules.after_7Days:
@@ -2611,7 +2611,7 @@ extension on TransitionToIARules {
   }
 }
 
-extension on String {
+extension TransitionToIARulesFromString on String {
   TransitionToIARules toTransitionToIARules() {
     switch (this) {
       case 'AFTER_7_DAYS':

--- a/generated/aws_eks_api/lib/eks-2017-11-01.dart
+++ b/generated/aws_eks_api/lib/eks-2017-11-01.dart
@@ -1798,7 +1798,7 @@ enum AMITypes {
   al2Arm_64,
 }
 
-extension AMITypesValue on AMITypes {
+extension AMITypesValueExtension on AMITypes {
   String toValue() {
     switch (this) {
       case AMITypes.al2X86_64:
@@ -1975,7 +1975,7 @@ enum AddonIssueCode {
   configurationConflict,
 }
 
-extension AddonIssueCodeValue on AddonIssueCode {
+extension AddonIssueCodeValueExtension on AddonIssueCode {
   String toValue() {
     switch (this) {
       case AddonIssueCode.accessDenied:
@@ -2020,7 +2020,7 @@ enum AddonStatus {
   degraded,
 }
 
-extension AddonStatusValue on AddonStatus {
+extension AddonStatusValueExtension on AddonStatus {
   String toValue() {
     switch (this) {
       case AddonStatus.creating:
@@ -2116,7 +2116,7 @@ enum CapacityTypes {
   spot,
 }
 
-extension CapacityTypesValue on CapacityTypes {
+extension CapacityTypesValueExtension on CapacityTypes {
   String toValue() {
     switch (this) {
       case CapacityTypes.onDemand:
@@ -2287,7 +2287,7 @@ enum ClusterStatus {
   updating,
 }
 
-extension ClusterStatusValue on ClusterStatus {
+extension ClusterStatusValueExtension on ClusterStatus {
   String toValue() {
     switch (this) {
       case ClusterStatus.creating:
@@ -2641,7 +2641,7 @@ enum ErrorCode {
   configurationConflict,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.subnetNotFound:
@@ -2882,7 +2882,7 @@ enum FargateProfileStatus {
   deleteFailed,
 }
 
-extension FargateProfileStatusValue on FargateProfileStatus {
+extension FargateProfileStatusValueExtension on FargateProfileStatus {
   String toValue() {
     switch (this) {
       case FargateProfileStatus.creating:
@@ -3353,7 +3353,7 @@ enum LogType {
   scheduler,
 }
 
-extension LogTypeValue on LogType {
+extension LogTypeValueExtension on LogType {
   String toValue() {
     switch (this) {
       case LogType.api:
@@ -3620,7 +3620,7 @@ enum NodegroupIssueCode {
   clusterUnreachable,
 }
 
-extension NodegroupIssueCodeValue on NodegroupIssueCode {
+extension NodegroupIssueCodeValueExtension on NodegroupIssueCode {
   String toValue() {
     switch (this) {
       case NodegroupIssueCode.autoScalingGroupNotFound:
@@ -3784,7 +3784,7 @@ enum NodegroupStatus {
   degraded,
 }
 
-extension NodegroupStatusValue on NodegroupStatus {
+extension NodegroupStatusValueExtension on NodegroupStatus {
   String toValue() {
     switch (this) {
       case NodegroupStatus.creating:
@@ -3922,7 +3922,7 @@ enum ResolveConflicts {
   none,
 }
 
-extension ResolveConflictsValue on ResolveConflicts {
+extension ResolveConflictsValueExtension on ResolveConflicts {
   String toValue() {
     switch (this) {
       case ResolveConflicts.overwrite:
@@ -4141,7 +4141,7 @@ enum UpdateParamType {
   resolveConflicts,
 }
 
-extension UpdateParamTypeValue on UpdateParamType {
+extension UpdateParamTypeValueExtension on UpdateParamType {
   String toValue() {
     switch (this) {
       case UpdateParamType.version:
@@ -4223,7 +4223,7 @@ enum UpdateStatus {
   successful,
 }
 
-extension UpdateStatusValue on UpdateStatus {
+extension UpdateStatusValueExtension on UpdateStatus {
   String toValue() {
     switch (this) {
       case UpdateStatus.inProgress:
@@ -4262,7 +4262,7 @@ enum UpdateType {
   addonUpdate,
 }
 
-extension UpdateTypeValue on UpdateType {
+extension UpdateTypeValueExtension on UpdateType {
   String toValue() {
     switch (this) {
       case UpdateType.versionUpdate:

--- a/generated/aws_eks_api/lib/eks-2017-11-01.dart
+++ b/generated/aws_eks_api/lib/eks-2017-11-01.dart
@@ -1798,7 +1798,7 @@ enum AMITypes {
   al2Arm_64,
 }
 
-extension on AMITypes {
+extension AMITypesValue on AMITypes {
   String toValue() {
     switch (this) {
       case AMITypes.al2X86_64:
@@ -1811,7 +1811,7 @@ extension on AMITypes {
   }
 }
 
-extension on String {
+extension AMITypesFromString on String {
   AMITypes toAMITypes() {
     switch (this) {
       case 'AL2_x86_64':
@@ -1975,7 +1975,7 @@ enum AddonIssueCode {
   configurationConflict,
 }
 
-extension on AddonIssueCode {
+extension AddonIssueCodeValue on AddonIssueCode {
   String toValue() {
     switch (this) {
       case AddonIssueCode.accessDenied:
@@ -1992,7 +1992,7 @@ extension on AddonIssueCode {
   }
 }
 
-extension on String {
+extension AddonIssueCodeFromString on String {
   AddonIssueCode toAddonIssueCode() {
     switch (this) {
       case 'AccessDenied':
@@ -2020,7 +2020,7 @@ enum AddonStatus {
   degraded,
 }
 
-extension on AddonStatus {
+extension AddonStatusValue on AddonStatus {
   String toValue() {
     switch (this) {
       case AddonStatus.creating:
@@ -2041,7 +2041,7 @@ extension on AddonStatus {
   }
 }
 
-extension on String {
+extension AddonStatusFromString on String {
   AddonStatus toAddonStatus() {
     switch (this) {
       case 'CREATING':
@@ -2116,7 +2116,7 @@ enum CapacityTypes {
   spot,
 }
 
-extension on CapacityTypes {
+extension CapacityTypesValue on CapacityTypes {
   String toValue() {
     switch (this) {
       case CapacityTypes.onDemand:
@@ -2127,7 +2127,7 @@ extension on CapacityTypes {
   }
 }
 
-extension on String {
+extension CapacityTypesFromString on String {
   CapacityTypes toCapacityTypes() {
     switch (this) {
       case 'ON_DEMAND':
@@ -2287,7 +2287,7 @@ enum ClusterStatus {
   updating,
 }
 
-extension on ClusterStatus {
+extension ClusterStatusValue on ClusterStatus {
   String toValue() {
     switch (this) {
       case ClusterStatus.creating:
@@ -2304,7 +2304,7 @@ extension on ClusterStatus {
   }
 }
 
-extension on String {
+extension ClusterStatusFromString on String {
   ClusterStatus toClusterStatus() {
     switch (this) {
       case 'CREATING':
@@ -2641,7 +2641,7 @@ enum ErrorCode {
   configurationConflict,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.subnetNotFound:
@@ -2676,7 +2676,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'SubnetNotFound':
@@ -2882,7 +2882,7 @@ enum FargateProfileStatus {
   deleteFailed,
 }
 
-extension on FargateProfileStatus {
+extension FargateProfileStatusValue on FargateProfileStatus {
   String toValue() {
     switch (this) {
       case FargateProfileStatus.creating:
@@ -2899,7 +2899,7 @@ extension on FargateProfileStatus {
   }
 }
 
-extension on String {
+extension FargateProfileStatusFromString on String {
   FargateProfileStatus toFargateProfileStatus() {
     switch (this) {
       case 'CREATING':
@@ -3353,7 +3353,7 @@ enum LogType {
   scheduler,
 }
 
-extension on LogType {
+extension LogTypeValue on LogType {
   String toValue() {
     switch (this) {
       case LogType.api:
@@ -3370,7 +3370,7 @@ extension on LogType {
   }
 }
 
-extension on String {
+extension LogTypeFromString on String {
   LogType toLogType() {
     switch (this) {
       case 'api':
@@ -3620,7 +3620,7 @@ enum NodegroupIssueCode {
   clusterUnreachable,
 }
 
-extension on NodegroupIssueCode {
+extension NodegroupIssueCodeValue on NodegroupIssueCode {
   String toValue() {
     switch (this) {
       case NodegroupIssueCode.autoScalingGroupNotFound:
@@ -3663,7 +3663,7 @@ extension on NodegroupIssueCode {
   }
 }
 
-extension on String {
+extension NodegroupIssueCodeFromString on String {
   NodegroupIssueCode toNodegroupIssueCode() {
     switch (this) {
       case 'AutoScalingGroupNotFound':
@@ -3784,7 +3784,7 @@ enum NodegroupStatus {
   degraded,
 }
 
-extension on NodegroupStatus {
+extension NodegroupStatusValue on NodegroupStatus {
   String toValue() {
     switch (this) {
       case NodegroupStatus.creating:
@@ -3805,7 +3805,7 @@ extension on NodegroupStatus {
   }
 }
 
-extension on String {
+extension NodegroupStatusFromString on String {
   NodegroupStatus toNodegroupStatus() {
     switch (this) {
       case 'CREATING':
@@ -3922,7 +3922,7 @@ enum ResolveConflicts {
   none,
 }
 
-extension on ResolveConflicts {
+extension ResolveConflictsValue on ResolveConflicts {
   String toValue() {
     switch (this) {
       case ResolveConflicts.overwrite:
@@ -3933,7 +3933,7 @@ extension on ResolveConflicts {
   }
 }
 
-extension on String {
+extension ResolveConflictsFromString on String {
   ResolveConflicts toResolveConflicts() {
     switch (this) {
       case 'OVERWRITE':
@@ -4141,7 +4141,7 @@ enum UpdateParamType {
   resolveConflicts,
 }
 
-extension on UpdateParamType {
+extension UpdateParamTypeValue on UpdateParamType {
   String toValue() {
     switch (this) {
       case UpdateParamType.version:
@@ -4178,7 +4178,7 @@ extension on UpdateParamType {
   }
 }
 
-extension on String {
+extension UpdateParamTypeFromString on String {
   UpdateParamType toUpdateParamType() {
     switch (this) {
       case 'Version':
@@ -4223,7 +4223,7 @@ enum UpdateStatus {
   successful,
 }
 
-extension on UpdateStatus {
+extension UpdateStatusValue on UpdateStatus {
   String toValue() {
     switch (this) {
       case UpdateStatus.inProgress:
@@ -4238,7 +4238,7 @@ extension on UpdateStatus {
   }
 }
 
-extension on String {
+extension UpdateStatusFromString on String {
   UpdateStatus toUpdateStatus() {
     switch (this) {
       case 'InProgress':
@@ -4262,7 +4262,7 @@ enum UpdateType {
   addonUpdate,
 }
 
-extension on UpdateType {
+extension UpdateTypeValue on UpdateType {
   String toValue() {
     switch (this) {
       case UpdateType.versionUpdate:
@@ -4279,7 +4279,7 @@ extension on UpdateType {
   }
 }
 
-extension on String {
+extension UpdateTypeFromString on String {
   UpdateType toUpdateType() {
     switch (this) {
       case 'VersionUpdate':

--- a/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
+++ b/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
@@ -499,7 +499,7 @@ enum LocationType {
   availabilityZoneId,
 }
 
-extension on LocationType {
+extension LocationTypeValue on LocationType {
   String toValue() {
     switch (this) {
       case LocationType.region:
@@ -512,7 +512,7 @@ extension on LocationType {
   }
 }
 
-extension on String {
+extension LocationTypeFromString on String {
   LocationType toLocationType() {
     switch (this) {
       case 'region':

--- a/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
+++ b/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
@@ -499,7 +499,7 @@ enum LocationType {
   availabilityZoneId,
 }
 
-extension LocationTypeValue on LocationType {
+extension LocationTypeValueExtension on LocationType {
   String toValue() {
     switch (this) {
       case LocationType.region:

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -5629,7 +5629,7 @@ enum AZMode {
   crossAz,
 }
 
-extension on AZMode {
+extension AZModeValue on AZMode {
   String toValue() {
     switch (this) {
       case AZMode.singleAz:
@@ -5640,7 +5640,7 @@ extension on AZMode {
   }
 }
 
-extension on String {
+extension AZModeFromString on String {
   AZMode toAZMode() {
     switch (this) {
       case 'single-az':
@@ -5691,7 +5691,7 @@ enum AuthTokenUpdateStatus {
   rotating,
 }
 
-extension on AuthTokenUpdateStatus {
+extension AuthTokenUpdateStatusValue on AuthTokenUpdateStatus {
   String toValue() {
     switch (this) {
       case AuthTokenUpdateStatus.setting:
@@ -5702,7 +5702,7 @@ extension on AuthTokenUpdateStatus {
   }
 }
 
-extension on String {
+extension AuthTokenUpdateStatusFromString on String {
   AuthTokenUpdateStatus toAuthTokenUpdateStatus() {
     switch (this) {
       case 'SETTING':
@@ -5720,7 +5720,7 @@ enum AuthTokenUpdateStrategyType {
   delete,
 }
 
-extension on AuthTokenUpdateStrategyType {
+extension AuthTokenUpdateStrategyTypeValue on AuthTokenUpdateStrategyType {
   String toValue() {
     switch (this) {
       case AuthTokenUpdateStrategyType.set:
@@ -5733,7 +5733,7 @@ extension on AuthTokenUpdateStrategyType {
   }
 }
 
-extension on String {
+extension AuthTokenUpdateStrategyTypeFromString on String {
   AuthTokenUpdateStrategyType toAuthTokenUpdateStrategyType() {
     switch (this) {
       case 'SET':
@@ -5772,7 +5772,7 @@ enum AuthenticationType {
   noPassword,
 }
 
-extension on AuthenticationType {
+extension AuthenticationTypeValue on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.password:
@@ -5783,7 +5783,7 @@ extension on AuthenticationType {
   }
 }
 
-extension on String {
+extension AuthenticationTypeFromString on String {
   AuthenticationType toAuthenticationType() {
     switch (this) {
       case 'password':
@@ -5817,7 +5817,7 @@ enum AutomaticFailoverStatus {
   disabling,
 }
 
-extension on AutomaticFailoverStatus {
+extension AutomaticFailoverStatusValue on AutomaticFailoverStatus {
   String toValue() {
     switch (this) {
       case AutomaticFailoverStatus.enabled:
@@ -5832,7 +5832,7 @@ extension on AutomaticFailoverStatus {
   }
 }
 
-extension on String {
+extension AutomaticFailoverStatusFromString on String {
   AutomaticFailoverStatus toAutomaticFailoverStatus() {
     switch (this) {
       case 'enabled':
@@ -7013,7 +7013,7 @@ enum ChangeType {
   requiresReboot,
 }
 
-extension on ChangeType {
+extension ChangeTypeValue on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.immediate:
@@ -7024,7 +7024,7 @@ extension on ChangeType {
   }
 }
 
-extension on String {
+extension ChangeTypeFromString on String {
   ChangeType toChangeType() {
     switch (this) {
       case 'immediate':
@@ -7978,7 +7978,7 @@ enum MultiAZStatus {
   disabled,
 }
 
-extension on MultiAZStatus {
+extension MultiAZStatusValue on MultiAZStatus {
   String toValue() {
     switch (this) {
       case MultiAZStatus.enabled:
@@ -7989,7 +7989,7 @@ extension on MultiAZStatus {
   }
 }
 
-extension on String {
+extension MultiAZStatusFromString on String {
   MultiAZStatus toMultiAZStatus() {
     switch (this) {
       case 'enabled':
@@ -8333,7 +8333,7 @@ enum NodeUpdateInitiatedBy {
   customer,
 }
 
-extension on NodeUpdateInitiatedBy {
+extension NodeUpdateInitiatedByValue on NodeUpdateInitiatedBy {
   String toValue() {
     switch (this) {
       case NodeUpdateInitiatedBy.system:
@@ -8344,7 +8344,7 @@ extension on NodeUpdateInitiatedBy {
   }
 }
 
-extension on String {
+extension NodeUpdateInitiatedByFromString on String {
   NodeUpdateInitiatedBy toNodeUpdateInitiatedBy() {
     switch (this) {
       case 'system':
@@ -8365,7 +8365,7 @@ enum NodeUpdateStatus {
   complete,
 }
 
-extension on NodeUpdateStatus {
+extension NodeUpdateStatusValue on NodeUpdateStatus {
   String toValue() {
     switch (this) {
       case NodeUpdateStatus.notApplied:
@@ -8384,7 +8384,7 @@ extension on NodeUpdateStatus {
   }
 }
 
-extension on String {
+extension NodeUpdateStatusFromString on String {
   NodeUpdateStatus toNodeUpdateStatus() {
     switch (this) {
       case 'not-applied':
@@ -8431,7 +8431,7 @@ enum OutpostMode {
   crossOutpost,
 }
 
-extension on OutpostMode {
+extension OutpostModeValue on OutpostMode {
   String toValue() {
     switch (this) {
       case OutpostMode.singleOutpost:
@@ -8442,7 +8442,7 @@ extension on OutpostMode {
   }
 }
 
-extension on String {
+extension OutpostModeFromString on String {
   OutpostMode toOutpostMode() {
     switch (this) {
       case 'single-outpost':
@@ -8545,7 +8545,8 @@ enum PendingAutomaticFailoverStatus {
   disabled,
 }
 
-extension on PendingAutomaticFailoverStatus {
+extension PendingAutomaticFailoverStatusValue
+    on PendingAutomaticFailoverStatus {
   String toValue() {
     switch (this) {
       case PendingAutomaticFailoverStatus.enabled:
@@ -8556,7 +8557,7 @@ extension on PendingAutomaticFailoverStatus {
   }
 }
 
-extension on String {
+extension PendingAutomaticFailoverStatusFromString on String {
   PendingAutomaticFailoverStatus toPendingAutomaticFailoverStatus() {
     switch (this) {
       case 'enabled':
@@ -9633,7 +9634,7 @@ enum ServiceUpdateSeverity {
   low,
 }
 
-extension on ServiceUpdateSeverity {
+extension ServiceUpdateSeverityValue on ServiceUpdateSeverity {
   String toValue() {
     switch (this) {
       case ServiceUpdateSeverity.critical:
@@ -9648,7 +9649,7 @@ extension on ServiceUpdateSeverity {
   }
 }
 
-extension on String {
+extension ServiceUpdateSeverityFromString on String {
   ServiceUpdateSeverity toServiceUpdateSeverity() {
     switch (this) {
       case 'critical':
@@ -9670,7 +9671,7 @@ enum ServiceUpdateStatus {
   expired,
 }
 
-extension on ServiceUpdateStatus {
+extension ServiceUpdateStatusValue on ServiceUpdateStatus {
   String toValue() {
     switch (this) {
       case ServiceUpdateStatus.available:
@@ -9683,7 +9684,7 @@ extension on ServiceUpdateStatus {
   }
 }
 
-extension on String {
+extension ServiceUpdateStatusFromString on String {
   ServiceUpdateStatus toServiceUpdateStatus() {
     switch (this) {
       case 'available':
@@ -9701,7 +9702,7 @@ enum ServiceUpdateType {
   securityUpdate,
 }
 
-extension on ServiceUpdateType {
+extension ServiceUpdateTypeValue on ServiceUpdateType {
   String toValue() {
     switch (this) {
       case ServiceUpdateType.securityUpdate:
@@ -9710,7 +9711,7 @@ extension on ServiceUpdateType {
   }
 }
 
-extension on String {
+extension ServiceUpdateTypeFromString on String {
   ServiceUpdateType toServiceUpdateType() {
     switch (this) {
       case 'security-update':
@@ -9752,7 +9753,7 @@ enum SlaMet {
   na,
 }
 
-extension on SlaMet {
+extension SlaMetValue on SlaMet {
   String toValue() {
     switch (this) {
       case SlaMet.yes:
@@ -9765,7 +9766,7 @@ extension on SlaMet {
   }
 }
 
-extension on String {
+extension SlaMetFromString on String {
   SlaMet toSlaMet() {
     switch (this) {
       case 'yes':
@@ -10141,7 +10142,7 @@ enum SourceType {
   userGroup,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cacheCluster:
@@ -10162,7 +10163,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'cache-cluster':
@@ -10534,7 +10535,7 @@ enum UpdateActionStatus {
   notApplicable,
 }
 
-extension on UpdateActionStatus {
+extension UpdateActionStatusValue on UpdateActionStatus {
   String toValue() {
     switch (this) {
       case UpdateActionStatus.notApplied:
@@ -10559,7 +10560,7 @@ extension on UpdateActionStatus {
   }
 }
 
-extension on String {
+extension UpdateActionStatusFromString on String {
   UpdateActionStatus toUpdateActionStatus() {
     switch (this) {
       case 'not-applied':

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -5629,7 +5629,7 @@ enum AZMode {
   crossAz,
 }
 
-extension AZModeValue on AZMode {
+extension AZModeValueExtension on AZMode {
   String toValue() {
     switch (this) {
       case AZMode.singleAz:
@@ -5691,7 +5691,7 @@ enum AuthTokenUpdateStatus {
   rotating,
 }
 
-extension AuthTokenUpdateStatusValue on AuthTokenUpdateStatus {
+extension AuthTokenUpdateStatusValueExtension on AuthTokenUpdateStatus {
   String toValue() {
     switch (this) {
       case AuthTokenUpdateStatus.setting:
@@ -5720,7 +5720,8 @@ enum AuthTokenUpdateStrategyType {
   delete,
 }
 
-extension AuthTokenUpdateStrategyTypeValue on AuthTokenUpdateStrategyType {
+extension AuthTokenUpdateStrategyTypeValueExtension
+    on AuthTokenUpdateStrategyType {
   String toValue() {
     switch (this) {
       case AuthTokenUpdateStrategyType.set:
@@ -5772,7 +5773,7 @@ enum AuthenticationType {
   noPassword,
 }
 
-extension AuthenticationTypeValue on AuthenticationType {
+extension AuthenticationTypeValueExtension on AuthenticationType {
   String toValue() {
     switch (this) {
       case AuthenticationType.password:
@@ -5817,7 +5818,7 @@ enum AutomaticFailoverStatus {
   disabling,
 }
 
-extension AutomaticFailoverStatusValue on AutomaticFailoverStatus {
+extension AutomaticFailoverStatusValueExtension on AutomaticFailoverStatus {
   String toValue() {
     switch (this) {
       case AutomaticFailoverStatus.enabled:
@@ -7013,7 +7014,7 @@ enum ChangeType {
   requiresReboot,
 }
 
-extension ChangeTypeValue on ChangeType {
+extension ChangeTypeValueExtension on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.immediate:
@@ -7978,7 +7979,7 @@ enum MultiAZStatus {
   disabled,
 }
 
-extension MultiAZStatusValue on MultiAZStatus {
+extension MultiAZStatusValueExtension on MultiAZStatus {
   String toValue() {
     switch (this) {
       case MultiAZStatus.enabled:
@@ -8333,7 +8334,7 @@ enum NodeUpdateInitiatedBy {
   customer,
 }
 
-extension NodeUpdateInitiatedByValue on NodeUpdateInitiatedBy {
+extension NodeUpdateInitiatedByValueExtension on NodeUpdateInitiatedBy {
   String toValue() {
     switch (this) {
       case NodeUpdateInitiatedBy.system:
@@ -8365,7 +8366,7 @@ enum NodeUpdateStatus {
   complete,
 }
 
-extension NodeUpdateStatusValue on NodeUpdateStatus {
+extension NodeUpdateStatusValueExtension on NodeUpdateStatus {
   String toValue() {
     switch (this) {
       case NodeUpdateStatus.notApplied:
@@ -8431,7 +8432,7 @@ enum OutpostMode {
   crossOutpost,
 }
 
-extension OutpostModeValue on OutpostMode {
+extension OutpostModeValueExtension on OutpostMode {
   String toValue() {
     switch (this) {
       case OutpostMode.singleOutpost:
@@ -8545,7 +8546,7 @@ enum PendingAutomaticFailoverStatus {
   disabled,
 }
 
-extension PendingAutomaticFailoverStatusValue
+extension PendingAutomaticFailoverStatusValueExtension
     on PendingAutomaticFailoverStatus {
   String toValue() {
     switch (this) {
@@ -9634,7 +9635,7 @@ enum ServiceUpdateSeverity {
   low,
 }
 
-extension ServiceUpdateSeverityValue on ServiceUpdateSeverity {
+extension ServiceUpdateSeverityValueExtension on ServiceUpdateSeverity {
   String toValue() {
     switch (this) {
       case ServiceUpdateSeverity.critical:
@@ -9671,7 +9672,7 @@ enum ServiceUpdateStatus {
   expired,
 }
 
-extension ServiceUpdateStatusValue on ServiceUpdateStatus {
+extension ServiceUpdateStatusValueExtension on ServiceUpdateStatus {
   String toValue() {
     switch (this) {
       case ServiceUpdateStatus.available:
@@ -9702,7 +9703,7 @@ enum ServiceUpdateType {
   securityUpdate,
 }
 
-extension ServiceUpdateTypeValue on ServiceUpdateType {
+extension ServiceUpdateTypeValueExtension on ServiceUpdateType {
   String toValue() {
     switch (this) {
       case ServiceUpdateType.securityUpdate:
@@ -9753,7 +9754,7 @@ enum SlaMet {
   na,
 }
 
-extension SlaMetValue on SlaMet {
+extension SlaMetValueExtension on SlaMet {
   String toValue() {
     switch (this) {
       case SlaMet.yes:
@@ -10142,7 +10143,7 @@ enum SourceType {
   userGroup,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cacheCluster:
@@ -10535,7 +10536,7 @@ enum UpdateActionStatus {
   notApplicable,
 }
 
-extension UpdateActionStatusValue on UpdateActionStatus {
+extension UpdateActionStatusValueExtension on UpdateActionStatus {
   String toValue() {
     switch (this) {
       case UpdateActionStatus.notApplied:

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -3099,7 +3099,7 @@ enum ActionHistoryStatus {
   unknown,
 }
 
-extension ActionHistoryStatusValue on ActionHistoryStatus {
+extension ActionHistoryStatusValueExtension on ActionHistoryStatus {
   String toValue() {
     switch (this) {
       case ActionHistoryStatus.completed:
@@ -3133,7 +3133,7 @@ enum ActionStatus {
   unknown,
 }
 
-extension ActionStatusValue on ActionStatus {
+extension ActionStatusValueExtension on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.scheduled:
@@ -3170,7 +3170,7 @@ enum ActionType {
   unknown,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.instanceRefresh:
@@ -3584,7 +3584,7 @@ enum ApplicationVersionStatus {
   building,
 }
 
-extension ApplicationVersionStatusValue on ApplicationVersionStatus {
+extension ApplicationVersionStatusValueExtension on ApplicationVersionStatus {
   String toValue() {
     switch (this) {
       case ApplicationVersionStatus.processed:
@@ -3850,7 +3850,7 @@ enum ComputeType {
   buildGeneral1Large,
 }
 
-extension ComputeTypeValue on ComputeType {
+extension ComputeTypeValueExtension on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.buildGeneral1Small:
@@ -3883,7 +3883,8 @@ enum ConfigurationDeploymentStatus {
   failed,
 }
 
-extension ConfigurationDeploymentStatusValue on ConfigurationDeploymentStatus {
+extension ConfigurationDeploymentStatusValueExtension
+    on ConfigurationDeploymentStatus {
   String toValue() {
     switch (this) {
       case ConfigurationDeploymentStatus.deployed:
@@ -4093,7 +4094,8 @@ enum ConfigurationOptionValueType {
   list,
 }
 
-extension ConfigurationOptionValueTypeValue on ConfigurationOptionValueType {
+extension ConfigurationOptionValueTypeValueExtension
+    on ConfigurationOptionValueType {
   String toValue() {
     switch (this) {
       case ConfigurationOptionValueType.scalar:
@@ -4782,7 +4784,7 @@ enum EnvironmentHealth {
   grey,
 }
 
-extension EnvironmentHealthValue on EnvironmentHealth {
+extension EnvironmentHealthValueExtension on EnvironmentHealth {
   String toValue() {
     switch (this) {
       case EnvironmentHealth.green:
@@ -4824,7 +4826,8 @@ enum EnvironmentHealthAttribute {
   refreshedAt,
 }
 
-extension EnvironmentHealthAttributeValue on EnvironmentHealthAttribute {
+extension EnvironmentHealthAttributeValueExtension
+    on EnvironmentHealthAttribute {
   String toValue() {
     switch (this) {
       case EnvironmentHealthAttribute.status:
@@ -4883,7 +4886,7 @@ enum EnvironmentHealthStatus {
   suspended,
 }
 
-extension EnvironmentHealthStatusValue on EnvironmentHealthStatus {
+extension EnvironmentHealthStatusValueExtension on EnvironmentHealthStatus {
   String toValue() {
     switch (this) {
       case EnvironmentHealthStatus.noData:
@@ -4974,7 +4977,7 @@ enum EnvironmentInfoType {
   bundle,
 }
 
-extension EnvironmentInfoTypeValue on EnvironmentInfoType {
+extension EnvironmentInfoTypeValueExtension on EnvironmentInfoType {
   String toValue() {
     switch (this) {
       case EnvironmentInfoType.tail:
@@ -5137,7 +5140,7 @@ enum EnvironmentStatus {
   terminated,
 }
 
-extension EnvironmentStatusValue on EnvironmentStatus {
+extension EnvironmentStatusValueExtension on EnvironmentStatus {
   String toValue() {
     switch (this) {
       case EnvironmentStatus.aborting:
@@ -5336,7 +5339,7 @@ enum EventSeverity {
   fatal,
 }
 
-extension EventSeverityValue on EventSeverity {
+extension EventSeverityValueExtension on EventSeverity {
   String toValue() {
     switch (this) {
       case EventSeverity.trace:
@@ -5385,7 +5388,7 @@ enum FailureType {
   permissionsError,
 }
 
-extension FailureTypeValue on FailureType {
+extension FailureTypeValueExtension on FailureType {
   String toValue() {
     switch (this) {
       case FailureType.updateCancelled:
@@ -5517,7 +5520,7 @@ enum InstancesHealthAttribute {
   all,
 }
 
-extension InstancesHealthAttributeValue on InstancesHealthAttribute {
+extension InstancesHealthAttributeValueExtension on InstancesHealthAttribute {
   String toValue() {
     switch (this) {
       case InstancesHealthAttribute.healthStatus:
@@ -6325,7 +6328,7 @@ enum PlatformStatus {
   deleted,
 }
 
-extension PlatformStatusValue on PlatformStatus {
+extension PlatformStatusValueExtension on PlatformStatus {
   String toValue() {
     switch (this) {
       case PlatformStatus.creating:
@@ -6839,7 +6842,7 @@ enum SourceRepository {
   s3,
 }
 
-extension SourceRepositoryValue on SourceRepository {
+extension SourceRepositoryValueExtension on SourceRepository {
   String toValue() {
     switch (this) {
       case SourceRepository.codeCommit:
@@ -6867,7 +6870,7 @@ enum SourceType {
   zip,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.git:
@@ -7045,7 +7048,7 @@ enum ValidationSeverity {
   warning,
 }
 
-extension ValidationSeverityValue on ValidationSeverity {
+extension ValidationSeverityValueExtension on ValidationSeverity {
   String toValue() {
     switch (this) {
       case ValidationSeverity.error:

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -3099,7 +3099,7 @@ enum ActionHistoryStatus {
   unknown,
 }
 
-extension on ActionHistoryStatus {
+extension ActionHistoryStatusValue on ActionHistoryStatus {
   String toValue() {
     switch (this) {
       case ActionHistoryStatus.completed:
@@ -3112,7 +3112,7 @@ extension on ActionHistoryStatus {
   }
 }
 
-extension on String {
+extension ActionHistoryStatusFromString on String {
   ActionHistoryStatus toActionHistoryStatus() {
     switch (this) {
       case 'Completed':
@@ -3133,7 +3133,7 @@ enum ActionStatus {
   unknown,
 }
 
-extension on ActionStatus {
+extension ActionStatusValue on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.scheduled:
@@ -3148,7 +3148,7 @@ extension on ActionStatus {
   }
 }
 
-extension on String {
+extension ActionStatusFromString on String {
   ActionStatus toActionStatus() {
     switch (this) {
       case 'Scheduled':
@@ -3170,7 +3170,7 @@ enum ActionType {
   unknown,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.instanceRefresh:
@@ -3183,7 +3183,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'InstanceRefresh':
@@ -3584,7 +3584,7 @@ enum ApplicationVersionStatus {
   building,
 }
 
-extension on ApplicationVersionStatus {
+extension ApplicationVersionStatusValue on ApplicationVersionStatus {
   String toValue() {
     switch (this) {
       case ApplicationVersionStatus.processed:
@@ -3601,7 +3601,7 @@ extension on ApplicationVersionStatus {
   }
 }
 
-extension on String {
+extension ApplicationVersionStatusFromString on String {
   ApplicationVersionStatus toApplicationVersionStatus() {
     switch (this) {
       case 'Processed':
@@ -3850,7 +3850,7 @@ enum ComputeType {
   buildGeneral1Large,
 }
 
-extension on ComputeType {
+extension ComputeTypeValue on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.buildGeneral1Small:
@@ -3863,7 +3863,7 @@ extension on ComputeType {
   }
 }
 
-extension on String {
+extension ComputeTypeFromString on String {
   ComputeType toComputeType() {
     switch (this) {
       case 'BUILD_GENERAL1_SMALL':
@@ -3883,7 +3883,7 @@ enum ConfigurationDeploymentStatus {
   failed,
 }
 
-extension on ConfigurationDeploymentStatus {
+extension ConfigurationDeploymentStatusValue on ConfigurationDeploymentStatus {
   String toValue() {
     switch (this) {
       case ConfigurationDeploymentStatus.deployed:
@@ -3896,7 +3896,7 @@ extension on ConfigurationDeploymentStatus {
   }
 }
 
-extension on String {
+extension ConfigurationDeploymentStatusFromString on String {
   ConfigurationDeploymentStatus toConfigurationDeploymentStatus() {
     switch (this) {
       case 'deployed':
@@ -4093,7 +4093,7 @@ enum ConfigurationOptionValueType {
   list,
 }
 
-extension on ConfigurationOptionValueType {
+extension ConfigurationOptionValueTypeValue on ConfigurationOptionValueType {
   String toValue() {
     switch (this) {
       case ConfigurationOptionValueType.scalar:
@@ -4104,7 +4104,7 @@ extension on ConfigurationOptionValueType {
   }
 }
 
-extension on String {
+extension ConfigurationOptionValueTypeFromString on String {
   ConfigurationOptionValueType toConfigurationOptionValueType() {
     switch (this) {
       case 'Scalar':
@@ -4782,7 +4782,7 @@ enum EnvironmentHealth {
   grey,
 }
 
-extension on EnvironmentHealth {
+extension EnvironmentHealthValue on EnvironmentHealth {
   String toValue() {
     switch (this) {
       case EnvironmentHealth.green:
@@ -4797,7 +4797,7 @@ extension on EnvironmentHealth {
   }
 }
 
-extension on String {
+extension EnvironmentHealthFromString on String {
   EnvironmentHealth toEnvironmentHealth() {
     switch (this) {
       case 'Green':
@@ -4824,7 +4824,7 @@ enum EnvironmentHealthAttribute {
   refreshedAt,
 }
 
-extension on EnvironmentHealthAttribute {
+extension EnvironmentHealthAttributeValue on EnvironmentHealthAttribute {
   String toValue() {
     switch (this) {
       case EnvironmentHealthAttribute.status:
@@ -4847,7 +4847,7 @@ extension on EnvironmentHealthAttribute {
   }
 }
 
-extension on String {
+extension EnvironmentHealthAttributeFromString on String {
   EnvironmentHealthAttribute toEnvironmentHealthAttribute() {
     switch (this) {
       case 'Status':
@@ -4883,7 +4883,7 @@ enum EnvironmentHealthStatus {
   suspended,
 }
 
-extension on EnvironmentHealthStatus {
+extension EnvironmentHealthStatusValue on EnvironmentHealthStatus {
   String toValue() {
     switch (this) {
       case EnvironmentHealthStatus.noData:
@@ -4908,7 +4908,7 @@ extension on EnvironmentHealthStatus {
   }
 }
 
-extension on String {
+extension EnvironmentHealthStatusFromString on String {
   EnvironmentHealthStatus toEnvironmentHealthStatus() {
     switch (this) {
       case 'NoData':
@@ -4974,7 +4974,7 @@ enum EnvironmentInfoType {
   bundle,
 }
 
-extension on EnvironmentInfoType {
+extension EnvironmentInfoTypeValue on EnvironmentInfoType {
   String toValue() {
     switch (this) {
       case EnvironmentInfoType.tail:
@@ -4985,7 +4985,7 @@ extension on EnvironmentInfoType {
   }
 }
 
-extension on String {
+extension EnvironmentInfoTypeFromString on String {
   EnvironmentInfoType toEnvironmentInfoType() {
     switch (this) {
       case 'tail':
@@ -5137,7 +5137,7 @@ enum EnvironmentStatus {
   terminated,
 }
 
-extension on EnvironmentStatus {
+extension EnvironmentStatusValue on EnvironmentStatus {
   String toValue() {
     switch (this) {
       case EnvironmentStatus.aborting:
@@ -5160,7 +5160,7 @@ extension on EnvironmentStatus {
   }
 }
 
-extension on String {
+extension EnvironmentStatusFromString on String {
   EnvironmentStatus toEnvironmentStatus() {
     switch (this) {
       case 'Aborting':
@@ -5336,7 +5336,7 @@ enum EventSeverity {
   fatal,
 }
 
-extension on EventSeverity {
+extension EventSeverityValue on EventSeverity {
   String toValue() {
     switch (this) {
       case EventSeverity.trace:
@@ -5355,7 +5355,7 @@ extension on EventSeverity {
   }
 }
 
-extension on String {
+extension EventSeverityFromString on String {
   EventSeverity toEventSeverity() {
     switch (this) {
       case 'TRACE':
@@ -5385,7 +5385,7 @@ enum FailureType {
   permissionsError,
 }
 
-extension on FailureType {
+extension FailureTypeValue on FailureType {
   String toValue() {
     switch (this) {
       case FailureType.updateCancelled:
@@ -5406,7 +5406,7 @@ extension on FailureType {
   }
 }
 
-extension on String {
+extension FailureTypeFromString on String {
   FailureType toFailureType() {
     switch (this) {
       case 'UpdateCancelled':
@@ -5517,7 +5517,7 @@ enum InstancesHealthAttribute {
   all,
 }
 
-extension on InstancesHealthAttribute {
+extension InstancesHealthAttributeValue on InstancesHealthAttribute {
   String toValue() {
     switch (this) {
       case InstancesHealthAttribute.healthStatus:
@@ -5546,7 +5546,7 @@ extension on InstancesHealthAttribute {
   }
 }
 
-extension on String {
+extension InstancesHealthAttributeFromString on String {
   InstancesHealthAttribute toInstancesHealthAttribute() {
     switch (this) {
       case 'HealthStatus':
@@ -6325,7 +6325,7 @@ enum PlatformStatus {
   deleted,
 }
 
-extension on PlatformStatus {
+extension PlatformStatusValue on PlatformStatus {
   String toValue() {
     switch (this) {
       case PlatformStatus.creating:
@@ -6342,7 +6342,7 @@ extension on PlatformStatus {
   }
 }
 
-extension on String {
+extension PlatformStatusFromString on String {
   PlatformStatus toPlatformStatus() {
     switch (this) {
       case 'Creating':
@@ -6839,7 +6839,7 @@ enum SourceRepository {
   s3,
 }
 
-extension on SourceRepository {
+extension SourceRepositoryValue on SourceRepository {
   String toValue() {
     switch (this) {
       case SourceRepository.codeCommit:
@@ -6850,7 +6850,7 @@ extension on SourceRepository {
   }
 }
 
-extension on String {
+extension SourceRepositoryFromString on String {
   SourceRepository toSourceRepository() {
     switch (this) {
       case 'CodeCommit':
@@ -6867,7 +6867,7 @@ enum SourceType {
   zip,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.git:
@@ -6878,7 +6878,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'Git':
@@ -7045,7 +7045,7 @@ enum ValidationSeverity {
   warning,
 }
 
-extension on ValidationSeverity {
+extension ValidationSeverityValue on ValidationSeverity {
   String toValue() {
     switch (this) {
       case ValidationSeverity.error:
@@ -7056,7 +7056,7 @@ extension on ValidationSeverity {
   }
 }
 
-extension on String {
+extension ValidationSeverityFromString on String {
   ValidationSeverity toValidationSeverity() {
     switch (this) {
       case 'error':

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -2278,7 +2278,7 @@ enum ActionTypeEnum {
   fixedResponse,
 }
 
-extension ActionTypeEnumValue on ActionTypeEnum {
+extension ActionTypeEnumValueExtension on ActionTypeEnum {
   String toValue() {
     switch (this) {
       case ActionTypeEnum.forward:
@@ -2345,7 +2345,7 @@ enum AuthenticateCognitoActionConditionalBehaviorEnum {
   authenticate,
 }
 
-extension AuthenticateCognitoActionConditionalBehaviorEnumValue
+extension AuthenticateCognitoActionConditionalBehaviorEnumValueExtension
     on AuthenticateCognitoActionConditionalBehaviorEnum {
   String toValue() {
     switch (this) {
@@ -2492,7 +2492,7 @@ enum AuthenticateOidcActionConditionalBehaviorEnum {
   authenticate,
 }
 
-extension AuthenticateOidcActionConditionalBehaviorEnumValue
+extension AuthenticateOidcActionConditionalBehaviorEnumValueExtension
     on AuthenticateOidcActionConditionalBehaviorEnum {
   String toValue() {
     switch (this) {
@@ -3292,7 +3292,7 @@ enum IpAddressType {
   dualstack,
 }
 
-extension IpAddressTypeValue on IpAddressType {
+extension IpAddressTypeValueExtension on IpAddressType {
   String toValue() {
     switch (this) {
       case IpAddressType.ipv4:
@@ -3689,7 +3689,7 @@ enum LoadBalancerSchemeEnum {
   internal,
 }
 
-extension LoadBalancerSchemeEnumValue on LoadBalancerSchemeEnum {
+extension LoadBalancerSchemeEnumValueExtension on LoadBalancerSchemeEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerSchemeEnum.internetFacing:
@@ -3742,7 +3742,7 @@ enum LoadBalancerStateEnum {
   failed,
 }
 
-extension LoadBalancerStateEnumValue on LoadBalancerStateEnum {
+extension LoadBalancerStateEnumValueExtension on LoadBalancerStateEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerStateEnum.active:
@@ -3779,7 +3779,7 @@ enum LoadBalancerTypeEnum {
   gateway,
 }
 
-extension LoadBalancerTypeEnumValue on LoadBalancerTypeEnum {
+extension LoadBalancerTypeEnumValueExtension on LoadBalancerTypeEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerTypeEnum.application:
@@ -3967,7 +3967,7 @@ enum ProtocolEnum {
   geneve,
 }
 
-extension ProtocolEnumValue on ProtocolEnum {
+extension ProtocolEnumValueExtension on ProtocolEnum {
   String toValue() {
     switch (this) {
       case ProtocolEnum.http:
@@ -4176,7 +4176,8 @@ enum RedirectActionStatusCodeEnum {
   http_302,
 }
 
-extension RedirectActionStatusCodeEnumValue on RedirectActionStatusCodeEnum {
+extension RedirectActionStatusCodeEnumValueExtension
+    on RedirectActionStatusCodeEnum {
   String toValue() {
     switch (this) {
       case RedirectActionStatusCodeEnum.http_301:
@@ -5179,7 +5180,7 @@ enum TargetHealthReasonEnum {
   elbInternalError,
 }
 
-extension TargetHealthReasonEnumValue on TargetHealthReasonEnum {
+extension TargetHealthReasonEnumValueExtension on TargetHealthReasonEnum {
   String toValue() {
     switch (this) {
       case TargetHealthReasonEnum.elbRegistrationInProgress:
@@ -5251,7 +5252,7 @@ enum TargetHealthStateEnum {
   unavailable,
 }
 
-extension TargetHealthStateEnumValue on TargetHealthStateEnum {
+extension TargetHealthStateEnumValueExtension on TargetHealthStateEnum {
   String toValue() {
     switch (this) {
       case TargetHealthStateEnum.initial:
@@ -5296,7 +5297,7 @@ enum TargetTypeEnum {
   lambda,
 }
 
-extension TargetTypeEnumValue on TargetTypeEnum {
+extension TargetTypeEnumValueExtension on TargetTypeEnum {
   String toValue() {
     switch (this) {
       case TargetTypeEnum.instance:

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -2278,7 +2278,7 @@ enum ActionTypeEnum {
   fixedResponse,
 }
 
-extension on ActionTypeEnum {
+extension ActionTypeEnumValue on ActionTypeEnum {
   String toValue() {
     switch (this) {
       case ActionTypeEnum.forward:
@@ -2295,7 +2295,7 @@ extension on ActionTypeEnum {
   }
 }
 
-extension on String {
+extension ActionTypeEnumFromString on String {
   ActionTypeEnum toActionTypeEnum() {
     switch (this) {
       case 'forward':
@@ -2345,7 +2345,8 @@ enum AuthenticateCognitoActionConditionalBehaviorEnum {
   authenticate,
 }
 
-extension on AuthenticateCognitoActionConditionalBehaviorEnum {
+extension AuthenticateCognitoActionConditionalBehaviorEnumValue
+    on AuthenticateCognitoActionConditionalBehaviorEnum {
   String toValue() {
     switch (this) {
       case AuthenticateCognitoActionConditionalBehaviorEnum.deny:
@@ -2358,7 +2359,7 @@ extension on AuthenticateCognitoActionConditionalBehaviorEnum {
   }
 }
 
-extension on String {
+extension AuthenticateCognitoActionConditionalBehaviorEnumFromString on String {
   AuthenticateCognitoActionConditionalBehaviorEnum
       toAuthenticateCognitoActionConditionalBehaviorEnum() {
     switch (this) {
@@ -2491,7 +2492,8 @@ enum AuthenticateOidcActionConditionalBehaviorEnum {
   authenticate,
 }
 
-extension on AuthenticateOidcActionConditionalBehaviorEnum {
+extension AuthenticateOidcActionConditionalBehaviorEnumValue
+    on AuthenticateOidcActionConditionalBehaviorEnum {
   String toValue() {
     switch (this) {
       case AuthenticateOidcActionConditionalBehaviorEnum.deny:
@@ -2504,7 +2506,7 @@ extension on AuthenticateOidcActionConditionalBehaviorEnum {
   }
 }
 
-extension on String {
+extension AuthenticateOidcActionConditionalBehaviorEnumFromString on String {
   AuthenticateOidcActionConditionalBehaviorEnum
       toAuthenticateOidcActionConditionalBehaviorEnum() {
     switch (this) {
@@ -3290,7 +3292,7 @@ enum IpAddressType {
   dualstack,
 }
 
-extension on IpAddressType {
+extension IpAddressTypeValue on IpAddressType {
   String toValue() {
     switch (this) {
       case IpAddressType.ipv4:
@@ -3301,7 +3303,7 @@ extension on IpAddressType {
   }
 }
 
-extension on String {
+extension IpAddressTypeFromString on String {
   IpAddressType toIpAddressType() {
     switch (this) {
       case 'ipv4':
@@ -3687,7 +3689,7 @@ enum LoadBalancerSchemeEnum {
   internal,
 }
 
-extension on LoadBalancerSchemeEnum {
+extension LoadBalancerSchemeEnumValue on LoadBalancerSchemeEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerSchemeEnum.internetFacing:
@@ -3698,7 +3700,7 @@ extension on LoadBalancerSchemeEnum {
   }
 }
 
-extension on String {
+extension LoadBalancerSchemeEnumFromString on String {
   LoadBalancerSchemeEnum toLoadBalancerSchemeEnum() {
     switch (this) {
       case 'internet-facing':
@@ -3740,7 +3742,7 @@ enum LoadBalancerStateEnum {
   failed,
 }
 
-extension on LoadBalancerStateEnum {
+extension LoadBalancerStateEnumValue on LoadBalancerStateEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerStateEnum.active:
@@ -3755,7 +3757,7 @@ extension on LoadBalancerStateEnum {
   }
 }
 
-extension on String {
+extension LoadBalancerStateEnumFromString on String {
   LoadBalancerStateEnum toLoadBalancerStateEnum() {
     switch (this) {
       case 'active':
@@ -3777,7 +3779,7 @@ enum LoadBalancerTypeEnum {
   gateway,
 }
 
-extension on LoadBalancerTypeEnum {
+extension LoadBalancerTypeEnumValue on LoadBalancerTypeEnum {
   String toValue() {
     switch (this) {
       case LoadBalancerTypeEnum.application:
@@ -3790,7 +3792,7 @@ extension on LoadBalancerTypeEnum {
   }
 }
 
-extension on String {
+extension LoadBalancerTypeEnumFromString on String {
   LoadBalancerTypeEnum toLoadBalancerTypeEnum() {
     switch (this) {
       case 'application':
@@ -3965,7 +3967,7 @@ enum ProtocolEnum {
   geneve,
 }
 
-extension on ProtocolEnum {
+extension ProtocolEnumValue on ProtocolEnum {
   String toValue() {
     switch (this) {
       case ProtocolEnum.http:
@@ -3986,7 +3988,7 @@ extension on ProtocolEnum {
   }
 }
 
-extension on String {
+extension ProtocolEnumFromString on String {
   ProtocolEnum toProtocolEnum() {
     switch (this) {
       case 'HTTP':
@@ -4174,7 +4176,7 @@ enum RedirectActionStatusCodeEnum {
   http_302,
 }
 
-extension on RedirectActionStatusCodeEnum {
+extension RedirectActionStatusCodeEnumValue on RedirectActionStatusCodeEnum {
   String toValue() {
     switch (this) {
       case RedirectActionStatusCodeEnum.http_301:
@@ -4185,7 +4187,7 @@ extension on RedirectActionStatusCodeEnum {
   }
 }
 
-extension on String {
+extension RedirectActionStatusCodeEnumFromString on String {
   RedirectActionStatusCodeEnum toRedirectActionStatusCodeEnum() {
     switch (this) {
       case 'HTTP_301':
@@ -5177,7 +5179,7 @@ enum TargetHealthReasonEnum {
   elbInternalError,
 }
 
-extension on TargetHealthReasonEnum {
+extension TargetHealthReasonEnumValue on TargetHealthReasonEnum {
   String toValue() {
     switch (this) {
       case TargetHealthReasonEnum.elbRegistrationInProgress:
@@ -5208,7 +5210,7 @@ extension on TargetHealthReasonEnum {
   }
 }
 
-extension on String {
+extension TargetHealthReasonEnumFromString on String {
   TargetHealthReasonEnum toTargetHealthReasonEnum() {
     switch (this) {
       case 'Elb.RegistrationInProgress':
@@ -5249,7 +5251,7 @@ enum TargetHealthStateEnum {
   unavailable,
 }
 
-extension on TargetHealthStateEnum {
+extension TargetHealthStateEnumValue on TargetHealthStateEnum {
   String toValue() {
     switch (this) {
       case TargetHealthStateEnum.initial:
@@ -5268,7 +5270,7 @@ extension on TargetHealthStateEnum {
   }
 }
 
-extension on String {
+extension TargetHealthStateEnumFromString on String {
   TargetHealthStateEnum toTargetHealthStateEnum() {
     switch (this) {
       case 'initial':
@@ -5294,7 +5296,7 @@ enum TargetTypeEnum {
   lambda,
 }
 
-extension on TargetTypeEnum {
+extension TargetTypeEnumValue on TargetTypeEnum {
   String toValue() {
     switch (this) {
       case TargetTypeEnum.instance:
@@ -5307,7 +5309,7 @@ extension on TargetTypeEnum {
   }
 }
 
-extension on String {
+extension TargetTypeEnumFromString on String {
   TargetTypeEnum toTargetTypeEnum() {
     switch (this) {
       case 'instance':

--- a/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
+++ b/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
@@ -2757,7 +2757,7 @@ enum ActionOnFailure {
   $continue,
 }
 
-extension ActionOnFailureValue on ActionOnFailure {
+extension ActionOnFailureValueExtension on ActionOnFailure {
   String toValue() {
     switch (this) {
       case ActionOnFailure.terminateJobFlow:
@@ -2872,7 +2872,7 @@ enum AdjustmentType {
   exactCapacity,
 }
 
-extension AdjustmentTypeValue on AdjustmentType {
+extension AdjustmentTypeValueExtension on AdjustmentType {
   String toValue() {
     switch (this) {
       case AdjustmentType.changeInCapacity:
@@ -2964,7 +2964,7 @@ enum AuthMode {
   iam,
 }
 
-extension AuthModeValue on AuthMode {
+extension AuthModeValueExtension on AuthMode {
   String toValue() {
     switch (this) {
       case AuthMode.sso:
@@ -3062,7 +3062,7 @@ enum AutoScalingPolicyState {
   failed,
 }
 
-extension AutoScalingPolicyStateValue on AutoScalingPolicyState {
+extension AutoScalingPolicyStateValueExtension on AutoScalingPolicyState {
   String toValue() {
     switch (this) {
       case AutoScalingPolicyState.pending:
@@ -3134,7 +3134,7 @@ enum AutoScalingPolicyStateChangeReasonCode {
   cleanupFailure,
 }
 
-extension AutoScalingPolicyStateChangeReasonCodeValue
+extension AutoScalingPolicyStateChangeReasonCodeValueExtension
     on AutoScalingPolicyStateChangeReasonCode {
   String toValue() {
     switch (this) {
@@ -3367,7 +3367,7 @@ enum CancelStepsRequestStatus {
   failed,
 }
 
-extension CancelStepsRequestStatusValue on CancelStepsRequestStatus {
+extension CancelStepsRequestStatusValueExtension on CancelStepsRequestStatus {
   String toValue() {
     switch (this) {
       case CancelStepsRequestStatus.submitted:
@@ -3736,7 +3736,7 @@ enum ClusterState {
   terminatedWithErrors,
 }
 
-extension ClusterStateValue on ClusterState {
+extension ClusterStateValueExtension on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.starting:
@@ -3810,7 +3810,8 @@ enum ClusterStateChangeReasonCode {
   allStepsCompleted,
 }
 
-extension ClusterStateChangeReasonCodeValue on ClusterStateChangeReasonCode {
+extension ClusterStateChangeReasonCodeValueExtension
+    on ClusterStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case ClusterStateChangeReasonCode.internalError:
@@ -3995,7 +3996,7 @@ enum ComparisonOperator {
   lessThanOrEqual,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqual:
@@ -4104,7 +4105,7 @@ enum ComputeLimitsUnitType {
   vcpu,
 }
 
-extension ComputeLimitsUnitTypeValue on ComputeLimitsUnitType {
+extension ComputeLimitsUnitTypeValueExtension on ComputeLimitsUnitType {
   String toValue() {
     switch (this) {
       case ComputeLimitsUnitType.instanceFleetUnits:
@@ -4591,7 +4592,7 @@ enum ExecutionEngineType {
   emr,
 }
 
-extension ExecutionEngineTypeValue on ExecutionEngineType {
+extension ExecutionEngineTypeValueExtension on ExecutionEngineType {
   String toValue() {
     switch (this) {
       case ExecutionEngineType.emr:
@@ -4820,7 +4821,7 @@ enum IdentityType {
   group,
 }
 
-extension IdentityTypeValue on IdentityType {
+extension IdentityTypeValueExtension on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.user:
@@ -4925,7 +4926,7 @@ enum InstanceCollectionType {
   instanceGroup,
 }
 
-extension InstanceCollectionTypeValue on InstanceCollectionType {
+extension InstanceCollectionTypeValueExtension on InstanceCollectionType {
   String toValue() {
     switch (this) {
       case InstanceCollectionType.instanceFleet:
@@ -5261,7 +5262,7 @@ enum InstanceFleetState {
   terminated,
 }
 
-extension InstanceFleetStateValue on InstanceFleetState {
+extension InstanceFleetStateValueExtension on InstanceFleetState {
   String toValue() {
     switch (this) {
       case InstanceFleetState.provisioning:
@@ -5335,7 +5336,7 @@ enum InstanceFleetStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension InstanceFleetStateChangeReasonCodeValue
+extension InstanceFleetStateChangeReasonCodeValueExtension
     on InstanceFleetStateChangeReasonCode {
   String toValue() {
     switch (this) {
@@ -5471,7 +5472,7 @@ enum InstanceFleetType {
   task,
 }
 
-extension InstanceFleetTypeValue on InstanceFleetType {
+extension InstanceFleetTypeValueExtension on InstanceFleetType {
   String toValue() {
     switch (this) {
       case InstanceFleetType.master:
@@ -5850,7 +5851,7 @@ enum InstanceGroupState {
   ended,
 }
 
-extension InstanceGroupStateValue on InstanceGroupState {
+extension InstanceGroupStateValueExtension on InstanceGroupState {
   String toValue() {
     switch (this) {
       case InstanceGroupState.provisioning:
@@ -5936,7 +5937,7 @@ enum InstanceGroupStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension InstanceGroupStateChangeReasonCodeValue
+extension InstanceGroupStateChangeReasonCodeValueExtension
     on InstanceGroupStateChangeReasonCode {
   String toValue() {
     switch (this) {
@@ -6031,7 +6032,7 @@ enum InstanceGroupType {
   task,
 }
 
-extension InstanceGroupTypeValue on InstanceGroupType {
+extension InstanceGroupTypeValueExtension on InstanceGroupType {
   String toValue() {
     switch (this) {
       case InstanceGroupType.master:
@@ -6111,7 +6112,7 @@ enum InstanceRoleType {
   task,
 }
 
-extension InstanceRoleTypeValue on InstanceRoleType {
+extension InstanceRoleTypeValueExtension on InstanceRoleType {
   String toValue() {
     switch (this) {
       case InstanceRoleType.master:
@@ -6146,7 +6147,7 @@ enum InstanceState {
   terminated,
 }
 
-extension InstanceStateValue on InstanceState {
+extension InstanceStateValueExtension on InstanceState {
   String toValue() {
     switch (this) {
       case InstanceState.awaitingFulfillment:
@@ -6209,7 +6210,8 @@ enum InstanceStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension InstanceStateChangeReasonCodeValue on InstanceStateChangeReasonCode {
+extension InstanceStateChangeReasonCodeValueExtension
+    on InstanceStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case InstanceStateChangeReasonCode.internalError:
@@ -6576,7 +6578,7 @@ enum JobFlowExecutionState {
   failed,
 }
 
-extension JobFlowExecutionStateValue on JobFlowExecutionState {
+extension JobFlowExecutionStateValueExtension on JobFlowExecutionState {
   String toValue() {
     switch (this) {
       case JobFlowExecutionState.starting:
@@ -7272,7 +7274,7 @@ enum MarketType {
   spot,
 }
 
-extension MarketTypeValue on MarketType {
+extension MarketTypeValueExtension on MarketType {
   String toValue() {
     switch (this) {
       case MarketType.onDemand:
@@ -7491,7 +7493,7 @@ enum NotebookExecutionStatus {
   stopped,
 }
 
-extension NotebookExecutionStatusValue on NotebookExecutionStatus {
+extension NotebookExecutionStatusValueExtension on NotebookExecutionStatus {
   String toValue() {
     switch (this) {
       case NotebookExecutionStatus.startPending:
@@ -7633,7 +7635,7 @@ enum OnDemandProvisioningAllocationStrategy {
   lowestPrice,
 }
 
-extension OnDemandProvisioningAllocationStrategyValue
+extension OnDemandProvisioningAllocationStrategyValueExtension
     on OnDemandProvisioningAllocationStrategy {
   String toValue() {
     switch (this) {
@@ -7736,7 +7738,7 @@ enum PlacementGroupStrategy {
   none,
 }
 
-extension PlacementGroupStrategyValue on PlacementGroupStrategy {
+extension PlacementGroupStrategyValueExtension on PlacementGroupStrategy {
   String toValue() {
     switch (this) {
       case PlacementGroupStrategy.spread:
@@ -7916,7 +7918,7 @@ enum RepoUpgradeOnBoot {
   none,
 }
 
-extension RepoUpgradeOnBootValue on RepoUpgradeOnBoot {
+extension RepoUpgradeOnBootValueExtension on RepoUpgradeOnBoot {
   String toValue() {
     switch (this) {
       case RepoUpgradeOnBoot.security:
@@ -7964,7 +7966,7 @@ enum ScaleDownBehavior {
   terminateAtTaskCompletion,
 }
 
-extension ScaleDownBehaviorValue on ScaleDownBehavior {
+extension ScaleDownBehaviorValueExtension on ScaleDownBehavior {
   String toValue() {
     switch (this) {
       case ScaleDownBehavior.terminateAtInstanceHour:
@@ -8382,7 +8384,7 @@ enum SpotProvisioningAllocationStrategy {
   capacityOptimized,
 }
 
-extension SpotProvisioningAllocationStrategyValue
+extension SpotProvisioningAllocationStrategyValueExtension
     on SpotProvisioningAllocationStrategy {
   String toValue() {
     switch (this) {
@@ -8481,7 +8483,8 @@ enum SpotProvisioningTimeoutAction {
   terminateCluster,
 }
 
-extension SpotProvisioningTimeoutActionValue on SpotProvisioningTimeoutAction {
+extension SpotProvisioningTimeoutActionValueExtension
+    on SpotProvisioningTimeoutAction {
   String toValue() {
     switch (this) {
       case SpotProvisioningTimeoutAction.switchToOnDemand:
@@ -8526,7 +8529,7 @@ enum Statistic {
   maximum,
 }
 
-extension StatisticValue on Statistic {
+extension StatisticValueExtension on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sampleCount:
@@ -8609,7 +8612,7 @@ enum StepCancellationOption {
   terminateProcess,
 }
 
-extension StepCancellationOptionValue on StepCancellationOption {
+extension StepCancellationOptionValueExtension on StepCancellationOption {
   String toValue() {
     switch (this) {
       case StepCancellationOption.sendInterrupt:
@@ -8705,7 +8708,7 @@ enum StepExecutionState {
   interrupted,
 }
 
-extension StepExecutionStateValue on StepExecutionState {
+extension StepExecutionStateValueExtension on StepExecutionState {
   String toValue() {
     switch (this) {
       case StepExecutionState.pending:
@@ -8794,7 +8797,7 @@ enum StepState {
   interrupted,
 }
 
-extension StepStateValue on StepState {
+extension StepStateValueExtension on StepState {
   String toValue() {
     switch (this) {
       case StepState.pending:
@@ -8862,7 +8865,7 @@ enum StepStateChangeReasonCode {
   none,
 }
 
-extension StepStateChangeReasonCodeValue on StepStateChangeReasonCode {
+extension StepStateChangeReasonCodeValueExtension on StepStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case StepStateChangeReasonCode.none:
@@ -9224,7 +9227,7 @@ enum Unit {
   countPerSecond,
 }
 
-extension UnitValue on Unit {
+extension UnitValueExtension on Unit {
   String toValue() {
     switch (this) {
       case Unit.none:

--- a/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
+++ b/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
@@ -2757,7 +2757,7 @@ enum ActionOnFailure {
   $continue,
 }
 
-extension on ActionOnFailure {
+extension ActionOnFailureValue on ActionOnFailure {
   String toValue() {
     switch (this) {
       case ActionOnFailure.terminateJobFlow:
@@ -2772,7 +2772,7 @@ extension on ActionOnFailure {
   }
 }
 
-extension on String {
+extension ActionOnFailureFromString on String {
   ActionOnFailure toActionOnFailure() {
     switch (this) {
       case 'TERMINATE_JOB_FLOW':
@@ -2872,7 +2872,7 @@ enum AdjustmentType {
   exactCapacity,
 }
 
-extension on AdjustmentType {
+extension AdjustmentTypeValue on AdjustmentType {
   String toValue() {
     switch (this) {
       case AdjustmentType.changeInCapacity:
@@ -2885,7 +2885,7 @@ extension on AdjustmentType {
   }
 }
 
-extension on String {
+extension AdjustmentTypeFromString on String {
   AdjustmentType toAdjustmentType() {
     switch (this) {
       case 'CHANGE_IN_CAPACITY':
@@ -2964,7 +2964,7 @@ enum AuthMode {
   iam,
 }
 
-extension on AuthMode {
+extension AuthModeValue on AuthMode {
   String toValue() {
     switch (this) {
       case AuthMode.sso:
@@ -2975,7 +2975,7 @@ extension on AuthMode {
   }
 }
 
-extension on String {
+extension AuthModeFromString on String {
   AuthMode toAuthMode() {
     switch (this) {
       case 'SSO':
@@ -3062,7 +3062,7 @@ enum AutoScalingPolicyState {
   failed,
 }
 
-extension on AutoScalingPolicyState {
+extension AutoScalingPolicyStateValue on AutoScalingPolicyState {
   String toValue() {
     switch (this) {
       case AutoScalingPolicyState.pending:
@@ -3081,7 +3081,7 @@ extension on AutoScalingPolicyState {
   }
 }
 
-extension on String {
+extension AutoScalingPolicyStateFromString on String {
   AutoScalingPolicyState toAutoScalingPolicyState() {
     switch (this) {
       case 'PENDING':
@@ -3134,7 +3134,8 @@ enum AutoScalingPolicyStateChangeReasonCode {
   cleanupFailure,
 }
 
-extension on AutoScalingPolicyStateChangeReasonCode {
+extension AutoScalingPolicyStateChangeReasonCodeValue
+    on AutoScalingPolicyStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case AutoScalingPolicyStateChangeReasonCode.userRequest:
@@ -3147,7 +3148,7 @@ extension on AutoScalingPolicyStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension AutoScalingPolicyStateChangeReasonCodeFromString on String {
   AutoScalingPolicyStateChangeReasonCode
       toAutoScalingPolicyStateChangeReasonCode() {
     switch (this) {
@@ -3366,7 +3367,7 @@ enum CancelStepsRequestStatus {
   failed,
 }
 
-extension on CancelStepsRequestStatus {
+extension CancelStepsRequestStatusValue on CancelStepsRequestStatus {
   String toValue() {
     switch (this) {
       case CancelStepsRequestStatus.submitted:
@@ -3377,7 +3378,7 @@ extension on CancelStepsRequestStatus {
   }
 }
 
-extension on String {
+extension CancelStepsRequestStatusFromString on String {
   CancelStepsRequestStatus toCancelStepsRequestStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -3735,7 +3736,7 @@ enum ClusterState {
   terminatedWithErrors,
 }
 
-extension on ClusterState {
+extension ClusterStateValue on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.starting:
@@ -3756,7 +3757,7 @@ extension on ClusterState {
   }
 }
 
-extension on String {
+extension ClusterStateFromString on String {
   ClusterState toClusterState() {
     switch (this) {
       case 'STARTING':
@@ -3809,7 +3810,7 @@ enum ClusterStateChangeReasonCode {
   allStepsCompleted,
 }
 
-extension on ClusterStateChangeReasonCode {
+extension ClusterStateChangeReasonCodeValue on ClusterStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case ClusterStateChangeReasonCode.internalError:
@@ -3832,7 +3833,7 @@ extension on ClusterStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension ClusterStateChangeReasonCodeFromString on String {
   ClusterStateChangeReasonCode toClusterStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -3994,7 +3995,7 @@ enum ComparisonOperator {
   lessThanOrEqual,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqual:
@@ -4009,7 +4010,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'GREATER_THAN_OR_EQUAL':
@@ -4103,7 +4104,7 @@ enum ComputeLimitsUnitType {
   vcpu,
 }
 
-extension on ComputeLimitsUnitType {
+extension ComputeLimitsUnitTypeValue on ComputeLimitsUnitType {
   String toValue() {
     switch (this) {
       case ComputeLimitsUnitType.instanceFleetUnits:
@@ -4116,7 +4117,7 @@ extension on ComputeLimitsUnitType {
   }
 }
 
-extension on String {
+extension ComputeLimitsUnitTypeFromString on String {
   ComputeLimitsUnitType toComputeLimitsUnitType() {
     switch (this) {
       case 'InstanceFleetUnits':
@@ -4590,7 +4591,7 @@ enum ExecutionEngineType {
   emr,
 }
 
-extension on ExecutionEngineType {
+extension ExecutionEngineTypeValue on ExecutionEngineType {
   String toValue() {
     switch (this) {
       case ExecutionEngineType.emr:
@@ -4599,7 +4600,7 @@ extension on ExecutionEngineType {
   }
 }
 
-extension on String {
+extension ExecutionEngineTypeFromString on String {
   ExecutionEngineType toExecutionEngineType() {
     switch (this) {
       case 'EMR':
@@ -4819,7 +4820,7 @@ enum IdentityType {
   group,
 }
 
-extension on IdentityType {
+extension IdentityTypeValue on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.user:
@@ -4830,7 +4831,7 @@ extension on IdentityType {
   }
 }
 
-extension on String {
+extension IdentityTypeFromString on String {
   IdentityType toIdentityType() {
     switch (this) {
       case 'USER':
@@ -4924,7 +4925,7 @@ enum InstanceCollectionType {
   instanceGroup,
 }
 
-extension on InstanceCollectionType {
+extension InstanceCollectionTypeValue on InstanceCollectionType {
   String toValue() {
     switch (this) {
       case InstanceCollectionType.instanceFleet:
@@ -4935,7 +4936,7 @@ extension on InstanceCollectionType {
   }
 }
 
-extension on String {
+extension InstanceCollectionTypeFromString on String {
   InstanceCollectionType toInstanceCollectionType() {
     switch (this) {
       case 'INSTANCE_FLEET':
@@ -5260,7 +5261,7 @@ enum InstanceFleetState {
   terminated,
 }
 
-extension on InstanceFleetState {
+extension InstanceFleetStateValue on InstanceFleetState {
   String toValue() {
     switch (this) {
       case InstanceFleetState.provisioning:
@@ -5281,7 +5282,7 @@ extension on InstanceFleetState {
   }
 }
 
-extension on String {
+extension InstanceFleetStateFromString on String {
   InstanceFleetState toInstanceFleetState() {
     switch (this) {
       case 'PROVISIONING':
@@ -5334,7 +5335,8 @@ enum InstanceFleetStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension on InstanceFleetStateChangeReasonCode {
+extension InstanceFleetStateChangeReasonCodeValue
+    on InstanceFleetStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case InstanceFleetStateChangeReasonCode.internalError:
@@ -5349,7 +5351,7 @@ extension on InstanceFleetStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension InstanceFleetStateChangeReasonCodeFromString on String {
   InstanceFleetStateChangeReasonCode toInstanceFleetStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -5469,7 +5471,7 @@ enum InstanceFleetType {
   task,
 }
 
-extension on InstanceFleetType {
+extension InstanceFleetTypeValue on InstanceFleetType {
   String toValue() {
     switch (this) {
       case InstanceFleetType.master:
@@ -5482,7 +5484,7 @@ extension on InstanceFleetType {
   }
 }
 
-extension on String {
+extension InstanceFleetTypeFromString on String {
   InstanceFleetType toInstanceFleetType() {
     switch (this) {
       case 'MASTER':
@@ -5848,7 +5850,7 @@ enum InstanceGroupState {
   ended,
 }
 
-extension on InstanceGroupState {
+extension InstanceGroupStateValue on InstanceGroupState {
   String toValue() {
     switch (this) {
       case InstanceGroupState.provisioning:
@@ -5877,7 +5879,7 @@ extension on InstanceGroupState {
   }
 }
 
-extension on String {
+extension InstanceGroupStateFromString on String {
   InstanceGroupState toInstanceGroupState() {
     switch (this) {
       case 'PROVISIONING':
@@ -5934,7 +5936,8 @@ enum InstanceGroupStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension on InstanceGroupStateChangeReasonCode {
+extension InstanceGroupStateChangeReasonCodeValue
+    on InstanceGroupStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case InstanceGroupStateChangeReasonCode.internalError:
@@ -5949,7 +5952,7 @@ extension on InstanceGroupStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension InstanceGroupStateChangeReasonCodeFromString on String {
   InstanceGroupStateChangeReasonCode toInstanceGroupStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -6028,7 +6031,7 @@ enum InstanceGroupType {
   task,
 }
 
-extension on InstanceGroupType {
+extension InstanceGroupTypeValue on InstanceGroupType {
   String toValue() {
     switch (this) {
       case InstanceGroupType.master:
@@ -6041,7 +6044,7 @@ extension on InstanceGroupType {
   }
 }
 
-extension on String {
+extension InstanceGroupTypeFromString on String {
   InstanceGroupType toInstanceGroupType() {
     switch (this) {
       case 'MASTER':
@@ -6108,7 +6111,7 @@ enum InstanceRoleType {
   task,
 }
 
-extension on InstanceRoleType {
+extension InstanceRoleTypeValue on InstanceRoleType {
   String toValue() {
     switch (this) {
       case InstanceRoleType.master:
@@ -6121,7 +6124,7 @@ extension on InstanceRoleType {
   }
 }
 
-extension on String {
+extension InstanceRoleTypeFromString on String {
   InstanceRoleType toInstanceRoleType() {
     switch (this) {
       case 'MASTER':
@@ -6143,7 +6146,7 @@ enum InstanceState {
   terminated,
 }
 
-extension on InstanceState {
+extension InstanceStateValue on InstanceState {
   String toValue() {
     switch (this) {
       case InstanceState.awaitingFulfillment:
@@ -6160,7 +6163,7 @@ extension on InstanceState {
   }
 }
 
-extension on String {
+extension InstanceStateFromString on String {
   InstanceState toInstanceState() {
     switch (this) {
       case 'AWAITING_FULFILLMENT':
@@ -6206,7 +6209,7 @@ enum InstanceStateChangeReasonCode {
   clusterTerminated,
 }
 
-extension on InstanceStateChangeReasonCode {
+extension InstanceStateChangeReasonCodeValue on InstanceStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case InstanceStateChangeReasonCode.internalError:
@@ -6223,7 +6226,7 @@ extension on InstanceStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension InstanceStateChangeReasonCodeFromString on String {
   InstanceStateChangeReasonCode toInstanceStateChangeReasonCode() {
     switch (this) {
       case 'INTERNAL_ERROR':
@@ -6573,7 +6576,7 @@ enum JobFlowExecutionState {
   failed,
 }
 
-extension on JobFlowExecutionState {
+extension JobFlowExecutionStateValue on JobFlowExecutionState {
   String toValue() {
     switch (this) {
       case JobFlowExecutionState.starting:
@@ -6596,7 +6599,7 @@ extension on JobFlowExecutionState {
   }
 }
 
-extension on String {
+extension JobFlowExecutionStateFromString on String {
   JobFlowExecutionState toJobFlowExecutionState() {
     switch (this) {
       case 'STARTING':
@@ -7269,7 +7272,7 @@ enum MarketType {
   spot,
 }
 
-extension on MarketType {
+extension MarketTypeValue on MarketType {
   String toValue() {
     switch (this) {
       case MarketType.onDemand:
@@ -7280,7 +7283,7 @@ extension on MarketType {
   }
 }
 
-extension on String {
+extension MarketTypeFromString on String {
   MarketType toMarketType() {
     switch (this) {
       case 'ON_DEMAND':
@@ -7488,7 +7491,7 @@ enum NotebookExecutionStatus {
   stopped,
 }
 
-extension on NotebookExecutionStatus {
+extension NotebookExecutionStatusValue on NotebookExecutionStatus {
   String toValue() {
     switch (this) {
       case NotebookExecutionStatus.startPending:
@@ -7515,7 +7518,7 @@ extension on NotebookExecutionStatus {
   }
 }
 
-extension on String {
+extension NotebookExecutionStatusFromString on String {
   NotebookExecutionStatus toNotebookExecutionStatus() {
     switch (this) {
       case 'START_PENDING':
@@ -7630,7 +7633,8 @@ enum OnDemandProvisioningAllocationStrategy {
   lowestPrice,
 }
 
-extension on OnDemandProvisioningAllocationStrategy {
+extension OnDemandProvisioningAllocationStrategyValue
+    on OnDemandProvisioningAllocationStrategy {
   String toValue() {
     switch (this) {
       case OnDemandProvisioningAllocationStrategy.lowestPrice:
@@ -7639,7 +7643,7 @@ extension on OnDemandProvisioningAllocationStrategy {
   }
 }
 
-extension on String {
+extension OnDemandProvisioningAllocationStrategyFromString on String {
   OnDemandProvisioningAllocationStrategy
       toOnDemandProvisioningAllocationStrategy() {
     switch (this) {
@@ -7732,7 +7736,7 @@ enum PlacementGroupStrategy {
   none,
 }
 
-extension on PlacementGroupStrategy {
+extension PlacementGroupStrategyValue on PlacementGroupStrategy {
   String toValue() {
     switch (this) {
       case PlacementGroupStrategy.spread:
@@ -7747,7 +7751,7 @@ extension on PlacementGroupStrategy {
   }
 }
 
-extension on String {
+extension PlacementGroupStrategyFromString on String {
   PlacementGroupStrategy toPlacementGroupStrategy() {
     switch (this) {
       case 'SPREAD':
@@ -7912,7 +7916,7 @@ enum RepoUpgradeOnBoot {
   none,
 }
 
-extension on RepoUpgradeOnBoot {
+extension RepoUpgradeOnBootValue on RepoUpgradeOnBoot {
   String toValue() {
     switch (this) {
       case RepoUpgradeOnBoot.security:
@@ -7923,7 +7927,7 @@ extension on RepoUpgradeOnBoot {
   }
 }
 
-extension on String {
+extension RepoUpgradeOnBootFromString on String {
   RepoUpgradeOnBoot toRepoUpgradeOnBoot() {
     switch (this) {
       case 'SECURITY':
@@ -7960,7 +7964,7 @@ enum ScaleDownBehavior {
   terminateAtTaskCompletion,
 }
 
-extension on ScaleDownBehavior {
+extension ScaleDownBehaviorValue on ScaleDownBehavior {
   String toValue() {
     switch (this) {
       case ScaleDownBehavior.terminateAtInstanceHour:
@@ -7971,7 +7975,7 @@ extension on ScaleDownBehavior {
   }
 }
 
-extension on String {
+extension ScaleDownBehaviorFromString on String {
   ScaleDownBehavior toScaleDownBehavior() {
     switch (this) {
       case 'TERMINATE_AT_INSTANCE_HOUR':
@@ -8378,7 +8382,8 @@ enum SpotProvisioningAllocationStrategy {
   capacityOptimized,
 }
 
-extension on SpotProvisioningAllocationStrategy {
+extension SpotProvisioningAllocationStrategyValue
+    on SpotProvisioningAllocationStrategy {
   String toValue() {
     switch (this) {
       case SpotProvisioningAllocationStrategy.capacityOptimized:
@@ -8387,7 +8392,7 @@ extension on SpotProvisioningAllocationStrategy {
   }
 }
 
-extension on String {
+extension SpotProvisioningAllocationStrategyFromString on String {
   SpotProvisioningAllocationStrategy toSpotProvisioningAllocationStrategy() {
     switch (this) {
       case 'capacity-optimized':
@@ -8476,7 +8481,7 @@ enum SpotProvisioningTimeoutAction {
   terminateCluster,
 }
 
-extension on SpotProvisioningTimeoutAction {
+extension SpotProvisioningTimeoutActionValue on SpotProvisioningTimeoutAction {
   String toValue() {
     switch (this) {
       case SpotProvisioningTimeoutAction.switchToOnDemand:
@@ -8487,7 +8492,7 @@ extension on SpotProvisioningTimeoutAction {
   }
 }
 
-extension on String {
+extension SpotProvisioningTimeoutActionFromString on String {
   SpotProvisioningTimeoutAction toSpotProvisioningTimeoutAction() {
     switch (this) {
       case 'SWITCH_TO_ON_DEMAND':
@@ -8521,7 +8526,7 @@ enum Statistic {
   maximum,
 }
 
-extension on Statistic {
+extension StatisticValue on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.sampleCount:
@@ -8538,7 +8543,7 @@ extension on Statistic {
   }
 }
 
-extension on String {
+extension StatisticFromString on String {
   Statistic toStatistic() {
     switch (this) {
       case 'SAMPLE_COUNT':
@@ -8604,7 +8609,7 @@ enum StepCancellationOption {
   terminateProcess,
 }
 
-extension on StepCancellationOption {
+extension StepCancellationOptionValue on StepCancellationOption {
   String toValue() {
     switch (this) {
       case StepCancellationOption.sendInterrupt:
@@ -8615,7 +8620,7 @@ extension on StepCancellationOption {
   }
 }
 
-extension on String {
+extension StepCancellationOptionFromString on String {
   StepCancellationOption toStepCancellationOption() {
     switch (this) {
       case 'SEND_INTERRUPT':
@@ -8700,7 +8705,7 @@ enum StepExecutionState {
   interrupted,
 }
 
-extension on StepExecutionState {
+extension StepExecutionStateValue on StepExecutionState {
   String toValue() {
     switch (this) {
       case StepExecutionState.pending:
@@ -8721,7 +8726,7 @@ extension on StepExecutionState {
   }
 }
 
-extension on String {
+extension StepExecutionStateFromString on String {
   StepExecutionState toStepExecutionState() {
     switch (this) {
       case 'PENDING':
@@ -8789,7 +8794,7 @@ enum StepState {
   interrupted,
 }
 
-extension on StepState {
+extension StepStateValue on StepState {
   String toValue() {
     switch (this) {
       case StepState.pending:
@@ -8810,7 +8815,7 @@ extension on StepState {
   }
 }
 
-extension on String {
+extension StepStateFromString on String {
   StepState toStepState() {
     switch (this) {
       case 'PENDING':
@@ -8857,7 +8862,7 @@ enum StepStateChangeReasonCode {
   none,
 }
 
-extension on StepStateChangeReasonCode {
+extension StepStateChangeReasonCodeValue on StepStateChangeReasonCode {
   String toValue() {
     switch (this) {
       case StepStateChangeReasonCode.none:
@@ -8866,7 +8871,7 @@ extension on StepStateChangeReasonCode {
   }
 }
 
-extension on String {
+extension StepStateChangeReasonCodeFromString on String {
   StepStateChangeReasonCode toStepStateChangeReasonCode() {
     switch (this) {
       case 'NONE':
@@ -9219,7 +9224,7 @@ enum Unit {
   countPerSecond,
 }
 
-extension on Unit {
+extension UnitValue on Unit {
   String toValue() {
     switch (this) {
       case Unit.none:
@@ -9280,7 +9285,7 @@ extension on Unit {
   }
 }
 
-extension on String {
+extension UnitFromString on String {
   Unit toUnit() {
     switch (this) {
       case 'NONE':

--- a/generated/aws_es_api/README.md
+++ b/generated/aws_es_api/README.md
@@ -1,10 +1,10 @@
-# AWS API client for Amazon OpenSearch Service
+# AWS API client for Amazon Elasticsearch Service
 
 **Generated Dart library from API specification**
 
 *About the service:*
-Use the Amazon OpenSearch configuration API to create, configure, and manage
-Amazon OpenSearch Service domains.
+Use the Amazon Elasticsearch Configuration API to create, configure, and
+manage Elasticsearch domains.
 
 ## Links
 

--- a/generated/aws_es_api/README.md
+++ b/generated/aws_es_api/README.md
@@ -1,10 +1,10 @@
-# AWS API client for Amazon Elasticsearch Service
+# AWS API client for Amazon OpenSearch Service
 
 **Generated Dart library from API specification**
 
 *About the service:*
-Use the Amazon Elasticsearch Configuration API to create, configure, and
-manage Elasticsearch domains.
+Use the Amazon OpenSearch configuration API to create, configure, and manage
+Amazon OpenSearch Service domains.
 
 ## Links
 

--- a/generated/aws_es_api/example/README.md
+++ b/generated/aws_es_api/example/README.md
@@ -1,9 +1,9 @@
 ```dart
-import 'package:aws_es_api/opensearch-2021-01-01.dart';
+import 'package:aws_es_api/es-2015-01-01.dart';
 
 void main() {
-  final service = OpenSearchService(region: 'eu-west-1');
+  final service = ElasticsearchService(region: 'eu-west-1');
 }
 ```
 
-See [API reference](https://pub.dev/documentation/aws_es_api/latest/opensearch-2021-01-01/OpenSearchService-class.html) on how to use OpenSearchService
+See [API reference](https://pub.dev/documentation/aws_es_api/latest/es-2015-01-01/ElasticsearchService-class.html) on how to use ElasticsearchService

--- a/generated/aws_es_api/example/README.md
+++ b/generated/aws_es_api/example/README.md
@@ -1,9 +1,9 @@
 ```dart
-import 'package:aws_es_api/es-2015-01-01.dart';
+import 'package:aws_es_api/opensearch-2021-01-01.dart';
 
 void main() {
-  final service = ElasticsearchService(region: 'eu-west-1');
+  final service = OpenSearchService(region: 'eu-west-1');
 }
 ```
 
-See [API reference](https://pub.dev/documentation/aws_es_api/latest/es-2015-01-01/ElasticsearchService-class.html) on how to use ElasticsearchService
+See [API reference](https://pub.dev/documentation/aws_es_api/latest/opensearch-2021-01-01/OpenSearchService-class.html) on how to use OpenSearchService

--- a/generated/aws_es_api/lib/es-2015-01-01.dart
+++ b/generated/aws_es_api/lib/es-2015-01-01.dart
@@ -2222,7 +2222,7 @@ enum DeploymentStatus {
   eligible,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pendingUpdate:
@@ -2425,7 +2425,8 @@ enum DescribePackagesFilterName {
   packageStatus,
 }
 
-extension DescribePackagesFilterNameValue on DescribePackagesFilterName {
+extension DescribePackagesFilterNameValueExtension
+    on DescribePackagesFilterName {
   String toValue() {
     switch (this) {
       case DescribePackagesFilterName.packageID:
@@ -2745,7 +2746,7 @@ enum DomainPackageStatus {
   dissociationFailed,
 }
 
-extension DomainPackageStatusValue on DomainPackageStatus {
+extension DomainPackageStatusValueExtension on DomainPackageStatus {
   String toValue() {
     switch (this) {
       case DomainPackageStatus.associating:
@@ -2908,7 +2909,7 @@ enum ESPartitionInstanceType {
   i3_16xlargeElasticsearch,
 }
 
-extension ESPartitionInstanceTypeValue on ESPartitionInstanceType {
+extension ESPartitionInstanceTypeValueExtension on ESPartitionInstanceType {
   String toValue() {
     switch (this) {
       case ESPartitionInstanceType.m3MediumElasticsearch:
@@ -3160,7 +3161,8 @@ enum ESWarmPartitionInstanceType {
   ultrawarm1LargeElasticsearch,
 }
 
-extension ESWarmPartitionInstanceTypeValue on ESWarmPartitionInstanceType {
+extension ESWarmPartitionInstanceTypeValueExtension
+    on ESWarmPartitionInstanceType {
   String toValue() {
     switch (this) {
       case ESWarmPartitionInstanceType.ultrawarm1MediumElasticsearch:
@@ -3933,7 +3935,7 @@ enum InboundCrossClusterSearchConnectionStatusCode {
   deleted,
 }
 
-extension InboundCrossClusterSearchConnectionStatusCodeValue
+extension InboundCrossClusterSearchConnectionStatusCodeValueExtension
     on InboundCrossClusterSearchConnectionStatusCode {
   String toValue() {
     switch (this) {
@@ -4263,7 +4265,7 @@ enum LogType {
   auditLogs,
 }
 
-extension LogTypeValue on LogType {
+extension LogTypeValueExtension on LogType {
   String toValue() {
     switch (this) {
       case LogType.indexSlowLogs:
@@ -4384,7 +4386,7 @@ enum OptionState {
   active,
 }
 
-extension OptionStateValue on OptionState {
+extension OptionStateValueExtension on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -4545,7 +4547,7 @@ enum OutboundCrossClusterSearchConnectionStatusCode {
   deleted,
 }
 
-extension OutboundCrossClusterSearchConnectionStatusCodeValue
+extension OutboundCrossClusterSearchConnectionStatusCodeValueExtension
     on OutboundCrossClusterSearchConnectionStatusCode {
   String toValue() {
     switch (this) {
@@ -4684,7 +4686,7 @@ enum PackageStatus {
   deleteFailed,
 }
 
-extension PackageStatusValue on PackageStatus {
+extension PackageStatusValueExtension on PackageStatus {
   String toValue() {
     switch (this) {
       case PackageStatus.copying:
@@ -4735,7 +4737,7 @@ enum PackageType {
   txtDictionary,
 }
 
-extension PackageTypeValue on PackageType {
+extension PackageTypeValueExtension on PackageType {
   String toValue() {
     switch (this) {
       case PackageType.txtDictionary:
@@ -4999,7 +5001,7 @@ enum ReservedElasticsearchInstancePaymentOption {
   noUpfront,
 }
 
-extension ReservedElasticsearchInstancePaymentOptionValue
+extension ReservedElasticsearchInstancePaymentOptionValueExtension
     on ReservedElasticsearchInstancePaymentOption {
   String toValue() {
     switch (this) {
@@ -5343,7 +5345,7 @@ enum TLSSecurityPolicy {
   policyMinTls_1_2_2019_07,
 }
 
-extension TLSSecurityPolicyValue on TLSSecurityPolicy {
+extension TLSSecurityPolicyValueExtension on TLSSecurityPolicy {
   String toValue() {
     switch (this) {
       case TLSSecurityPolicy.policyMinTls_1_0_2019_07:
@@ -5513,7 +5515,7 @@ enum UpgradeStatus {
   failed,
 }
 
-extension UpgradeStatusValue on UpgradeStatus {
+extension UpgradeStatusValueExtension on UpgradeStatus {
   String toValue() {
     switch (this) {
       case UpgradeStatus.inProgress:
@@ -5550,7 +5552,7 @@ enum UpgradeStep {
   upgrade,
 }
 
-extension UpgradeStepValue on UpgradeStep {
+extension UpgradeStepValueExtension on UpgradeStep {
   String toValue() {
     switch (this) {
       case UpgradeStep.preUpgradeCheck:
@@ -5726,7 +5728,7 @@ enum VolumeType {
   io1,
 }
 
-extension VolumeTypeValue on VolumeType {
+extension VolumeTypeValueExtension on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.standard:

--- a/generated/aws_es_api/lib/es-2015-01-01.dart
+++ b/generated/aws_es_api/lib/es-2015-01-01.dart
@@ -2222,7 +2222,7 @@ enum DeploymentStatus {
   eligible,
 }
 
-extension on DeploymentStatus {
+extension DeploymentStatusValue on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pendingUpdate:
@@ -2239,7 +2239,7 @@ extension on DeploymentStatus {
   }
 }
 
-extension on String {
+extension DeploymentStatusFromString on String {
   DeploymentStatus toDeploymentStatus() {
     switch (this) {
       case 'PENDING_UPDATE':
@@ -2425,7 +2425,7 @@ enum DescribePackagesFilterName {
   packageStatus,
 }
 
-extension on DescribePackagesFilterName {
+extension DescribePackagesFilterNameValue on DescribePackagesFilterName {
   String toValue() {
     switch (this) {
       case DescribePackagesFilterName.packageID:
@@ -2438,7 +2438,7 @@ extension on DescribePackagesFilterName {
   }
 }
 
-extension on String {
+extension DescribePackagesFilterNameFromString on String {
   DescribePackagesFilterName toDescribePackagesFilterName() {
     switch (this) {
       case 'PackageID':
@@ -2745,7 +2745,7 @@ enum DomainPackageStatus {
   dissociationFailed,
 }
 
-extension on DomainPackageStatus {
+extension DomainPackageStatusValue on DomainPackageStatus {
   String toValue() {
     switch (this) {
       case DomainPackageStatus.associating:
@@ -2762,7 +2762,7 @@ extension on DomainPackageStatus {
   }
 }
 
-extension on String {
+extension DomainPackageStatusFromString on String {
   DomainPackageStatus toDomainPackageStatus() {
     switch (this) {
       case 'ASSOCIATING':
@@ -2908,7 +2908,7 @@ enum ESPartitionInstanceType {
   i3_16xlargeElasticsearch,
 }
 
-extension on ESPartitionInstanceType {
+extension ESPartitionInstanceTypeValue on ESPartitionInstanceType {
   String toValue() {
     switch (this) {
       case ESPartitionInstanceType.m3MediumElasticsearch:
@@ -3031,7 +3031,7 @@ extension on ESPartitionInstanceType {
   }
 }
 
-extension on String {
+extension ESPartitionInstanceTypeFromString on String {
   ESPartitionInstanceType toESPartitionInstanceType() {
     switch (this) {
       case 'm3.medium.elasticsearch':
@@ -3160,7 +3160,7 @@ enum ESWarmPartitionInstanceType {
   ultrawarm1LargeElasticsearch,
 }
 
-extension on ESWarmPartitionInstanceType {
+extension ESWarmPartitionInstanceTypeValue on ESWarmPartitionInstanceType {
   String toValue() {
     switch (this) {
       case ESWarmPartitionInstanceType.ultrawarm1MediumElasticsearch:
@@ -3171,7 +3171,7 @@ extension on ESWarmPartitionInstanceType {
   }
 }
 
-extension on String {
+extension ESWarmPartitionInstanceTypeFromString on String {
   ESWarmPartitionInstanceType toESWarmPartitionInstanceType() {
     switch (this) {
       case 'ultrawarm1.medium.elasticsearch':
@@ -3933,7 +3933,8 @@ enum InboundCrossClusterSearchConnectionStatusCode {
   deleted,
 }
 
-extension on InboundCrossClusterSearchConnectionStatusCode {
+extension InboundCrossClusterSearchConnectionStatusCodeValue
+    on InboundCrossClusterSearchConnectionStatusCode {
   String toValue() {
     switch (this) {
       case InboundCrossClusterSearchConnectionStatusCode.pendingAcceptance:
@@ -3952,7 +3953,7 @@ extension on InboundCrossClusterSearchConnectionStatusCode {
   }
 }
 
-extension on String {
+extension InboundCrossClusterSearchConnectionStatusCodeFromString on String {
   InboundCrossClusterSearchConnectionStatusCode
       toInboundCrossClusterSearchConnectionStatusCode() {
     switch (this) {
@@ -4262,7 +4263,7 @@ enum LogType {
   auditLogs,
 }
 
-extension on LogType {
+extension LogTypeValue on LogType {
   String toValue() {
     switch (this) {
       case LogType.indexSlowLogs:
@@ -4277,7 +4278,7 @@ extension on LogType {
   }
 }
 
-extension on String {
+extension LogTypeFromString on String {
   LogType toLogType() {
     switch (this) {
       case 'INDEX_SLOW_LOGS':
@@ -4383,7 +4384,7 @@ enum OptionState {
   active,
 }
 
-extension on OptionState {
+extension OptionStateValue on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -4396,7 +4397,7 @@ extension on OptionState {
   }
 }
 
-extension on String {
+extension OptionStateFromString on String {
   OptionState toOptionState() {
     switch (this) {
       case 'RequiresIndexDocuments':
@@ -4544,7 +4545,8 @@ enum OutboundCrossClusterSearchConnectionStatusCode {
   deleted,
 }
 
-extension on OutboundCrossClusterSearchConnectionStatusCode {
+extension OutboundCrossClusterSearchConnectionStatusCodeValue
+    on OutboundCrossClusterSearchConnectionStatusCode {
   String toValue() {
     switch (this) {
       case OutboundCrossClusterSearchConnectionStatusCode.pendingAcceptance:
@@ -4567,7 +4569,7 @@ extension on OutboundCrossClusterSearchConnectionStatusCode {
   }
 }
 
-extension on String {
+extension OutboundCrossClusterSearchConnectionStatusCodeFromString on String {
   OutboundCrossClusterSearchConnectionStatusCode
       toOutboundCrossClusterSearchConnectionStatusCode() {
     switch (this) {
@@ -4682,7 +4684,7 @@ enum PackageStatus {
   deleteFailed,
 }
 
-extension on PackageStatus {
+extension PackageStatusValue on PackageStatus {
   String toValue() {
     switch (this) {
       case PackageStatus.copying:
@@ -4705,7 +4707,7 @@ extension on PackageStatus {
   }
 }
 
-extension on String {
+extension PackageStatusFromString on String {
   PackageStatus toPackageStatus() {
     switch (this) {
       case 'COPYING':
@@ -4733,7 +4735,7 @@ enum PackageType {
   txtDictionary,
 }
 
-extension on PackageType {
+extension PackageTypeValue on PackageType {
   String toValue() {
     switch (this) {
       case PackageType.txtDictionary:
@@ -4742,7 +4744,7 @@ extension on PackageType {
   }
 }
 
-extension on String {
+extension PackageTypeFromString on String {
   PackageType toPackageType() {
     switch (this) {
       case 'TXT-DICTIONARY':
@@ -4997,7 +4999,8 @@ enum ReservedElasticsearchInstancePaymentOption {
   noUpfront,
 }
 
-extension on ReservedElasticsearchInstancePaymentOption {
+extension ReservedElasticsearchInstancePaymentOptionValue
+    on ReservedElasticsearchInstancePaymentOption {
   String toValue() {
     switch (this) {
       case ReservedElasticsearchInstancePaymentOption.allUpfront:
@@ -5010,7 +5013,7 @@ extension on ReservedElasticsearchInstancePaymentOption {
   }
 }
 
-extension on String {
+extension ReservedElasticsearchInstancePaymentOptionFromString on String {
   ReservedElasticsearchInstancePaymentOption
       toReservedElasticsearchInstancePaymentOption() {
     switch (this) {
@@ -5340,7 +5343,7 @@ enum TLSSecurityPolicy {
   policyMinTls_1_2_2019_07,
 }
 
-extension on TLSSecurityPolicy {
+extension TLSSecurityPolicyValue on TLSSecurityPolicy {
   String toValue() {
     switch (this) {
       case TLSSecurityPolicy.policyMinTls_1_0_2019_07:
@@ -5351,7 +5354,7 @@ extension on TLSSecurityPolicy {
   }
 }
 
-extension on String {
+extension TLSSecurityPolicyFromString on String {
   TLSSecurityPolicy toTLSSecurityPolicy() {
     switch (this) {
       case 'Policy-Min-TLS-1-0-2019-07':
@@ -5510,7 +5513,7 @@ enum UpgradeStatus {
   failed,
 }
 
-extension on UpgradeStatus {
+extension UpgradeStatusValue on UpgradeStatus {
   String toValue() {
     switch (this) {
       case UpgradeStatus.inProgress:
@@ -5525,7 +5528,7 @@ extension on UpgradeStatus {
   }
 }
 
-extension on String {
+extension UpgradeStatusFromString on String {
   UpgradeStatus toUpgradeStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -5547,7 +5550,7 @@ enum UpgradeStep {
   upgrade,
 }
 
-extension on UpgradeStep {
+extension UpgradeStepValue on UpgradeStep {
   String toValue() {
     switch (this) {
       case UpgradeStep.preUpgradeCheck:
@@ -5560,7 +5563,7 @@ extension on UpgradeStep {
   }
 }
 
-extension on String {
+extension UpgradeStepFromString on String {
   UpgradeStep toUpgradeStep() {
     switch (this) {
       case 'PRE_UPGRADE_CHECK':
@@ -5723,7 +5726,7 @@ enum VolumeType {
   io1,
 }
 
-extension on VolumeType {
+extension VolumeTypeValue on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.standard:
@@ -5736,7 +5739,7 @@ extension on VolumeType {
   }
 }
 
-extension on String {
+extension VolumeTypeFromString on String {
   VolumeType toVolumeType() {
     switch (this) {
       case 'standard':

--- a/generated/aws_es_api/lib/opensearch-2021-01-01.dart
+++ b/generated/aws_es_api/lib/opensearch-2021-01-01.dart
@@ -1,0 +1,7159 @@
+// ignore_for_file: unused_element
+// ignore_for_file: unused_field
+// ignore_for_file: unused_import
+// ignore_for_file: unused_local_variable
+// ignore_for_file: unused_shown_name
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:shared_aws_api/shared.dart' as _s;
+import 'package:shared_aws_api/shared.dart'
+    show
+        rfc822ToJson,
+        iso8601ToJson,
+        unixTimestampToJson,
+        nonNullableTimeStampFromJson,
+        timeStampFromJson;
+
+export 'package:shared_aws_api/shared.dart' show AwsClientCredentials;
+
+/// Use the Amazon OpenSearch configuration API to create, configure, and manage
+/// Amazon OpenSearch Service domains.
+class OpenSearchService {
+  final _s.RestJsonProtocol _protocol;
+  OpenSearchService({
+    required String region,
+    _s.AwsClientCredentials? credentials,
+    _s.AwsClientCredentialsProvider? credentialsProvider,
+    _s.Client? client,
+    String? endpointUrl,
+  }) : _protocol = _s.RestJsonProtocol(
+          client: client,
+          service: _s.ServiceMetadata(
+            endpointPrefix: 'es',
+          ),
+          region: region,
+          credentials: credentials,
+          credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
+        );
+
+  /// Closes the internal HTTP client if none was provided at creation.
+  /// If a client was passed as a constructor argument, this becomes a noop.
+  ///
+  /// It's important to close all clients when it's done being used; failing to
+  /// do so can cause the Dart process to hang.
+  void close() {
+    _protocol.close();
+  }
+
+  /// Allows the remote domain owner to accept an inbound cross-cluster
+  /// connection request.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [LimitExceededException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [connectionId] :
+  /// The ID of the inbound connection you want to accept.
+  Future<AcceptInboundConnectionResponse> acceptInboundConnection({
+    required String connectionId,
+  }) async {
+    ArgumentError.checkNotNull(connectionId, 'connectionId');
+    _s.validateStringLength(
+      'connectionId',
+      connectionId,
+      10,
+      256,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'PUT',
+      requestUri:
+          '/2021-01-01/opensearch/cc/inboundConnection/${Uri.encodeComponent(connectionId)}/accept',
+      exceptionFnMap: _exceptionFns,
+    );
+    return AcceptInboundConnectionResponse.fromJson(response);
+  }
+
+  /// Attaches tags to an existing domain. Tags are a set of case-sensitive key
+  /// value pairs. An domain can have up to 10 tags. See <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains.html#managedomains-awsresorcetagging"
+  /// target="_blank"> Tagging Amazon OpenSearch Service domains</a> for more
+  /// information.
+  ///
+  /// May throw [BaseException].
+  /// May throw [LimitExceededException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [arn] :
+  /// Specify the <code>ARN</code> of the domain you want to add tags to.
+  ///
+  /// Parameter [tagList] :
+  /// List of <code>Tag</code> to add to the domain.
+  Future<void> addTags({
+    required String arn,
+    required List<Tag> tagList,
+  }) async {
+    ArgumentError.checkNotNull(arn, 'arn');
+    _s.validateStringLength(
+      'arn',
+      arn,
+      20,
+      2048,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(tagList, 'tagList');
+    final $payload = <String, dynamic>{
+      'ARN': arn,
+      'TagList': tagList,
+    };
+    await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/tags',
+      exceptionFnMap: _exceptionFns,
+    );
+  }
+
+  /// Associates a package with an Amazon OpenSearch Service domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  /// May throw [ConflictException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain to associate the package with.
+  ///
+  /// Parameter [packageID] :
+  /// Internal ID of the package to associate with a domain. Use
+  /// <code>DescribePackages</code> to find this value.
+  Future<AssociatePackageResponse> associatePackage({
+    required String domainName,
+    required String packageID,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    final response = await _protocol.send(
+      payload: null,
+      method: 'POST',
+      requestUri:
+          '/2021-01-01/packages/associate/${Uri.encodeComponent(packageID)}/${Uri.encodeComponent(domainName)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return AssociatePackageResponse.fromJson(response);
+  }
+
+  /// Cancels a scheduled service software update for an Amazon OpenSearch
+  /// Service domain. You can only perform this operation before the
+  /// <code>AutomatedUpdateDate</code> and when the <code>UpdateStatus</code> is
+  /// in the <code>PENDING_UPDATE</code> state.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain that you want to stop the latest service software
+  /// update on.
+  Future<CancelServiceSoftwareUpdateResponse> cancelServiceSoftwareUpdate({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final $payload = <String, dynamic>{
+      'DomainName': domainName,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/serviceSoftwareUpdate/cancel',
+      exceptionFnMap: _exceptionFns,
+    );
+    return CancelServiceSoftwareUpdateResponse.fromJson(response);
+  }
+
+  /// Creates a new Amazon OpenSearch Service domain. For more information, see
+  /// <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html"
+  /// target="_blank">Creating and managing Amazon OpenSearch Service domains
+  /// </a> in the <i>Amazon OpenSearch Service Developer Guide</i>.
+  ///
+  /// May throw [BaseException].
+  /// May throw [DisabledOperationException].
+  /// May throw [InternalException].
+  /// May throw [InvalidTypeException].
+  /// May throw [LimitExceededException].
+  /// May throw [ResourceAlreadyExistsException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the Amazon OpenSearch Service domain you're creating. Domain
+  /// names are unique across the domains owned by an account within an AWS
+  /// region. Domain names must start with a lowercase letter and can contain
+  /// the following characters: a-z (lowercase), 0-9, and - (hyphen).
+  ///
+  /// Parameter [accessPolicies] :
+  /// IAM access policy as a JSON-formatted string.
+  ///
+  /// Parameter [advancedOptions] :
+  /// Option to allow references to indices in an HTTP request body. Must be
+  /// <code>false</code> when configuring access to individual sub-resources. By
+  /// default, the value is <code>true</code>. See <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-advanced-options"
+  /// target="_blank">Advanced cluster parameters </a> for more information.
+  ///
+  /// Parameter [advancedSecurityOptions] :
+  /// Specifies advanced security options.
+  ///
+  /// Parameter [autoTuneOptions] :
+  /// Specifies Auto-Tune options.
+  ///
+  /// Parameter [clusterConfig] :
+  /// Configuration options for a domain. Specifies the instance type and number
+  /// of instances in the domain.
+  ///
+  /// Parameter [cognitoOptions] :
+  /// Options to specify the Cognito user and identity pools for OpenSearch
+  /// Dashboards authentication. For more information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html"
+  /// target="_blank">Configuring Amazon Cognito authentication for OpenSearch
+  /// Dashboards</a>.
+  ///
+  /// Parameter [domainEndpointOptions] :
+  /// Options to specify configurations that will be applied to the domain
+  /// endpoint.
+  ///
+  /// Parameter [eBSOptions] :
+  /// Options to enable, disable, and specify the type and size of EBS storage
+  /// volumes.
+  ///
+  /// Parameter [encryptionAtRestOptions] :
+  /// Options for encryption of data at rest.
+  ///
+  /// Parameter [engineVersion] :
+  /// String of format Elasticsearch_X.Y or OpenSearch_X.Y to specify the engine
+  /// version for the Amazon OpenSearch Service domain. For example,
+  /// "OpenSearch_1.0" or "Elasticsearch_7.9". For more information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomains"
+  /// target="_blank">Creating and managing Amazon OpenSearch Service domains
+  /// </a>.
+  ///
+  /// Parameter [logPublishingOptions] :
+  /// Map of <code>LogType</code> and <code>LogPublishingOption</code>, each
+  /// containing options to publish a given type of OpenSearch log.
+  ///
+  /// Parameter [nodeToNodeEncryptionOptions] :
+  /// Node-to-node encryption options.
+  ///
+  /// Parameter [snapshotOptions] :
+  /// Option to set time, in UTC format, of the daily automated snapshot.
+  /// Default value is 0 hours.
+  ///
+  /// Parameter [tagList] :
+  /// A list of <code>Tag</code> added during domain creation.
+  ///
+  /// Parameter [vPCOptions] :
+  /// Options to specify the subnets and security groups for a VPC endpoint. For
+  /// more information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+  /// target="_blank">Launching your Amazon OpenSearch Service domains using a
+  /// VPC </a>.
+  Future<CreateDomainResponse> createDomain({
+    required String domainName,
+    String? accessPolicies,
+    Map<String, String>? advancedOptions,
+    AdvancedSecurityOptionsInput? advancedSecurityOptions,
+    AutoTuneOptionsInput? autoTuneOptions,
+    ClusterConfig? clusterConfig,
+    CognitoOptions? cognitoOptions,
+    DomainEndpointOptions? domainEndpointOptions,
+    EBSOptions? eBSOptions,
+    EncryptionAtRestOptions? encryptionAtRestOptions,
+    String? engineVersion,
+    Map<LogType, LogPublishingOption>? logPublishingOptions,
+    NodeToNodeEncryptionOptions? nodeToNodeEncryptionOptions,
+    SnapshotOptions? snapshotOptions,
+    List<Tag>? tagList,
+    VPCOptions? vPCOptions,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateStringLength(
+      'accessPolicies',
+      accessPolicies,
+      0,
+      102400,
+    );
+    _s.validateStringLength(
+      'engineVersion',
+      engineVersion,
+      14,
+      18,
+    );
+    final $payload = <String, dynamic>{
+      'DomainName': domainName,
+      if (accessPolicies != null) 'AccessPolicies': accessPolicies,
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (advancedSecurityOptions != null)
+        'AdvancedSecurityOptions': advancedSecurityOptions,
+      if (autoTuneOptions != null) 'AutoTuneOptions': autoTuneOptions,
+      if (clusterConfig != null) 'ClusterConfig': clusterConfig,
+      if (cognitoOptions != null) 'CognitoOptions': cognitoOptions,
+      if (domainEndpointOptions != null)
+        'DomainEndpointOptions': domainEndpointOptions,
+      if (eBSOptions != null) 'EBSOptions': eBSOptions,
+      if (encryptionAtRestOptions != null)
+        'EncryptionAtRestOptions': encryptionAtRestOptions,
+      if (engineVersion != null) 'EngineVersion': engineVersion,
+      if (logPublishingOptions != null)
+        'LogPublishingOptions':
+            logPublishingOptions.map((k, e) => MapEntry(k.toValue(), e)),
+      if (nodeToNodeEncryptionOptions != null)
+        'NodeToNodeEncryptionOptions': nodeToNodeEncryptionOptions,
+      if (snapshotOptions != null) 'SnapshotOptions': snapshotOptions,
+      if (tagList != null) 'TagList': tagList,
+      if (vPCOptions != null) 'VPCOptions': vPCOptions,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/domain',
+      exceptionFnMap: _exceptionFns,
+    );
+    return CreateDomainResponse.fromJson(response);
+  }
+
+  /// Creates a new cross-cluster connection from a local OpenSearch domain to a
+  /// remote OpenSearch domain.
+  ///
+  /// May throw [LimitExceededException].
+  /// May throw [InternalException].
+  /// May throw [ResourceAlreadyExistsException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [connectionAlias] :
+  /// The connection alias used used by the customer for this cross-cluster
+  /// connection.
+  ///
+  /// Parameter [localDomainInfo] :
+  /// The <code> <a>AWSDomainInformation</a> </code> for the local OpenSearch
+  /// domain.
+  ///
+  /// Parameter [remoteDomainInfo] :
+  /// The <code> <a>AWSDomainInformation</a> </code> for the remote OpenSearch
+  /// domain.
+  Future<CreateOutboundConnectionResponse> createOutboundConnection({
+    required String connectionAlias,
+    required DomainInformationContainer localDomainInfo,
+    required DomainInformationContainer remoteDomainInfo,
+  }) async {
+    ArgumentError.checkNotNull(connectionAlias, 'connectionAlias');
+    _s.validateStringLength(
+      'connectionAlias',
+      connectionAlias,
+      2,
+      100,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(localDomainInfo, 'localDomainInfo');
+    ArgumentError.checkNotNull(remoteDomainInfo, 'remoteDomainInfo');
+    final $payload = <String, dynamic>{
+      'ConnectionAlias': connectionAlias,
+      'LocalDomainInfo': localDomainInfo,
+      'RemoteDomainInfo': remoteDomainInfo,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/cc/outboundConnection',
+      exceptionFnMap: _exceptionFns,
+    );
+    return CreateOutboundConnectionResponse.fromJson(response);
+  }
+
+  /// Create a package for use with Amazon OpenSearch Service domains.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [LimitExceededException].
+  /// May throw [InvalidTypeException].
+  /// May throw [ResourceAlreadyExistsException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [packageName] :
+  /// Unique identifier for the package.
+  ///
+  /// Parameter [packageSource] :
+  /// The Amazon S3 location from which to import the package.
+  ///
+  /// Parameter [packageType] :
+  /// Type of package. Currently supports only TXT-DICTIONARY.
+  ///
+  /// Parameter [packageDescription] :
+  /// Description of the package.
+  Future<CreatePackageResponse> createPackage({
+    required String packageName,
+    required PackageSource packageSource,
+    required PackageType packageType,
+    String? packageDescription,
+  }) async {
+    ArgumentError.checkNotNull(packageName, 'packageName');
+    _s.validateStringLength(
+      'packageName',
+      packageName,
+      3,
+      28,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(packageSource, 'packageSource');
+    ArgumentError.checkNotNull(packageType, 'packageType');
+    _s.validateStringLength(
+      'packageDescription',
+      packageDescription,
+      0,
+      1024,
+    );
+    final $payload = <String, dynamic>{
+      'PackageName': packageName,
+      'PackageSource': packageSource,
+      'PackageType': packageType.toValue(),
+      if (packageDescription != null) 'PackageDescription': packageDescription,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/packages',
+      exceptionFnMap: _exceptionFns,
+    );
+    return CreatePackageResponse.fromJson(response);
+  }
+
+  /// Permanently deletes the specified domain and all of its data. Once a
+  /// domain is deleted, it cannot be recovered.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain you want to permanently delete.
+  Future<DeleteDomainResponse> deleteDomain({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'DELETE',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DeleteDomainResponse.fromJson(response);
+  }
+
+  /// Allows the remote domain owner to delete an existing inbound cross-cluster
+  /// connection.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [connectionId] :
+  /// The ID of the inbound connection to permanently delete.
+  Future<DeleteInboundConnectionResponse> deleteInboundConnection({
+    required String connectionId,
+  }) async {
+    ArgumentError.checkNotNull(connectionId, 'connectionId');
+    _s.validateStringLength(
+      'connectionId',
+      connectionId,
+      10,
+      256,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'DELETE',
+      requestUri:
+          '/2021-01-01/opensearch/cc/inboundConnection/${Uri.encodeComponent(connectionId)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DeleteInboundConnectionResponse.fromJson(response);
+  }
+
+  /// Allows the local domain owner to delete an existing outbound cross-cluster
+  /// connection.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [connectionId] :
+  /// The ID of the outbound connection you want to permanently delete.
+  Future<DeleteOutboundConnectionResponse> deleteOutboundConnection({
+    required String connectionId,
+  }) async {
+    ArgumentError.checkNotNull(connectionId, 'connectionId');
+    _s.validateStringLength(
+      'connectionId',
+      connectionId,
+      10,
+      256,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'DELETE',
+      requestUri:
+          '/2021-01-01/opensearch/cc/outboundConnection/${Uri.encodeComponent(connectionId)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DeleteOutboundConnectionResponse.fromJson(response);
+  }
+
+  /// Deletes the package.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  /// May throw [ConflictException].
+  ///
+  /// Parameter [packageID] :
+  /// The internal ID of the package you want to delete. Use
+  /// <code>DescribePackages</code> to find this value.
+  Future<DeletePackageResponse> deletePackage({
+    required String packageID,
+  }) async {
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    final response = await _protocol.send(
+      payload: null,
+      method: 'DELETE',
+      requestUri: '/2021-01-01/packages/${Uri.encodeComponent(packageID)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DeletePackageResponse.fromJson(response);
+  }
+
+  /// Returns domain configuration information about the specified domain,
+  /// including the domain ID, domain endpoint, and domain ARN.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain for which you want information.
+  Future<DescribeDomainResponse> describeDomain({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeDomainResponse.fromJson(response);
+  }
+
+  /// Provides scheduled Auto-Tune action details for the domain, such as
+  /// Auto-Tune action type, description, severity, and scheduled date.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The domain name for which you want Auto-Tune action details.
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. If not specified,
+  /// defaults to 100.
+  ///
+  /// Parameter [nextToken] :
+  /// NextToken is sent in case the earlier API call results contain the
+  /// NextToken. Used for pagination.
+  Future<DescribeDomainAutoTunesResponse> describeDomainAutoTunes({
+    required String domainName,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}/autoTunes',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeDomainAutoTunesResponse.fromJson(response);
+  }
+
+  /// Returns information about the current blue/green deployment happening on a
+  /// domain, including a change ID, status, and progress stages.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The domain you want to get the progress information about.
+  ///
+  /// Parameter [changeId] :
+  /// The specific change ID for which you want to get progress information.
+  /// This is an optional parameter. If omitted, the service returns information
+  /// about the most recent configuration change.
+  Future<DescribeDomainChangeProgressResponse> describeDomainChangeProgress({
+    required String domainName,
+    String? changeId,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateStringLength(
+      'changeId',
+      changeId,
+      36,
+      36,
+    );
+    final $query = <String, List<String>>{
+      if (changeId != null) 'changeid': [changeId],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}/progress',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeDomainChangeProgressResponse.fromJson(response);
+  }
+
+  /// Provides cluster configuration information about the specified domain,
+  /// such as the state, creation date, update version, and update date for
+  /// cluster options.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The domain you want to get information about.
+  Future<DescribeDomainConfigResponse> describeDomainConfig({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}/config',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeDomainConfigResponse.fromJson(response);
+  }
+
+  /// Returns domain configuration information about the specified domains,
+  /// including the domain ID, domain endpoint, and domain ARN.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainNames] :
+  /// The domains for which you want information.
+  Future<DescribeDomainsResponse> describeDomains({
+    required List<String> domainNames,
+  }) async {
+    ArgumentError.checkNotNull(domainNames, 'domainNames');
+    final $payload = <String, dynamic>{
+      'DomainNames': domainNames,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/domain-info',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeDomainsResponse.fromJson(response);
+  }
+
+  /// Lists all the inbound cross-cluster connections for a remote domain.
+  ///
+  /// May throw [InvalidPaginationTokenException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [filters] :
+  /// A list of filters used to match properties for inbound cross-cluster
+  /// connections. Available <code> <a>Filter</a> </code> values are:
+  /// <ul>
+  /// <li>connection-id</li>
+  /// <li>local-domain-info.domain-name</li>
+  /// <li>local-domain-info.owner-id</li>
+  /// <li>local-domain-info.region</li>
+  /// <li>remote-domain-info.domain-name</li>
+  /// </ul>
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. If not specified,
+  /// defaults to 100.
+  ///
+  /// Parameter [nextToken] :
+  /// If more results are available and NextToken is present, make the next
+  /// request to the same API with the received NextToken to paginate the
+  /// remaining results.
+  Future<DescribeInboundConnectionsResponse> describeInboundConnections({
+    List<Filter>? filters,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $payload = <String, dynamic>{
+      if (filters != null) 'Filters': filters,
+      if (maxResults != null) 'MaxResults': maxResults,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/cc/inboundConnection/search',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeInboundConnectionsResponse.fromJson(response);
+  }
+
+  /// Describe the limits for a given instance type and OpenSearch or
+  /// Elasticsearch version. When modifying an existing domain, specify the
+  /// <code> <a>DomainName</a> </code> to see which limits you can modify.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [InvalidTypeException].
+  /// May throw [LimitExceededException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [engineVersion] :
+  /// Version of OpenSearch for which <code> <a>Limits</a> </code> are needed.
+  ///
+  /// Parameter [instanceType] :
+  /// The instance type for an OpenSearch cluster for which OpenSearch <code>
+  /// <a>Limits</a> </code> are needed.
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain you want to modify. Only include this value if
+  /// you're querying OpenSearch <code> <a>Limits</a> </code> for an existing
+  /// domain.
+  Future<DescribeInstanceTypeLimitsResponse> describeInstanceTypeLimits({
+    required String engineVersion,
+    required OpenSearchPartitionInstanceType instanceType,
+    String? domainName,
+  }) async {
+    ArgumentError.checkNotNull(engineVersion, 'engineVersion');
+    _s.validateStringLength(
+      'engineVersion',
+      engineVersion,
+      14,
+      18,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(instanceType, 'instanceType');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+    );
+    final $query = <String, List<String>>{
+      if (domainName != null) 'domainName': [domainName],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/instanceTypeLimits/${Uri.encodeComponent(engineVersion)}/${Uri.encodeComponent(instanceType.toValue())}',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeInstanceTypeLimitsResponse.fromJson(response);
+  }
+
+  /// Lists all the outbound cross-cluster connections for a local domain.
+  ///
+  /// May throw [InvalidPaginationTokenException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [filters] :
+  /// A list of filters used to match properties for outbound cross-cluster
+  /// connections. Available <code> <a>Filter</a> </code> names for this
+  /// operation are:
+  /// <ul>
+  /// <li>connection-id</li>
+  /// <li>remote-domain-info.domain-name</li>
+  /// <li>remote-domain-info.owner-id</li>
+  /// <li>remote-domain-info.region</li>
+  /// <li>local-domain-info.domain-name</li>
+  /// </ul>
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. If not specified,
+  /// defaults to 100.
+  ///
+  /// Parameter [nextToken] :
+  /// NextToken is sent in case the earlier API call results contain the
+  /// NextToken parameter. Used for pagination.
+  Future<DescribeOutboundConnectionsResponse> describeOutboundConnections({
+    List<Filter>? filters,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $payload = <String, dynamic>{
+      if (filters != null) 'Filters': filters,
+      if (maxResults != null) 'MaxResults': maxResults,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/cc/outboundConnection/search',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeOutboundConnectionsResponse.fromJson(response);
+  }
+
+  /// Describes all packages available to Amazon OpenSearch Service domains.
+  /// Includes options for filtering, limiting the number of results, and
+  /// pagination.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [filters] :
+  /// Only returns packages that match the
+  /// <code>DescribePackagesFilterList</code> values.
+  ///
+  /// Parameter [maxResults] :
+  /// Limits results to a maximum number of packages.
+  ///
+  /// Parameter [nextToken] :
+  /// Used for pagination. Only necessary if a previous API call includes a
+  /// non-null NextToken value. If provided, returns results for the next page.
+  Future<DescribePackagesResponse> describePackages({
+    List<DescribePackagesFilter>? filters,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $payload = <String, dynamic>{
+      if (filters != null) 'Filters': filters,
+      if (maxResults != null) 'MaxResults': maxResults,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/packages/describe',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribePackagesResponse.fromJson(response);
+  }
+
+  /// Lists available reserved OpenSearch instance offerings.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  /// May throw [DisabledOperationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. If not specified,
+  /// defaults to 100.
+  ///
+  /// Parameter [nextToken] :
+  /// Provides an identifier to allow retrieval of paginated results.
+  ///
+  /// Parameter [reservedInstanceOfferingId] :
+  /// The offering identifier filter value. Use this parameter to show only the
+  /// available offering that matches the specified reservation identifier.
+  Future<DescribeReservedInstanceOfferingsResponse>
+      describeReservedInstanceOfferings({
+    int? maxResults,
+    String? nextToken,
+    String? reservedInstanceOfferingId,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    _s.validateStringLength(
+      'reservedInstanceOfferingId',
+      reservedInstanceOfferingId,
+      36,
+      36,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+      if (reservedInstanceOfferingId != null)
+        'offeringId': [reservedInstanceOfferingId],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/opensearch/reservedInstanceOfferings',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeReservedInstanceOfferingsResponse.fromJson(response);
+  }
+
+  /// Returns information about reserved OpenSearch instances for this account.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [InternalException].
+  /// May throw [ValidationException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. If not specified,
+  /// defaults to 100.
+  ///
+  /// Parameter [nextToken] :
+  /// Provides an identifier to allow retrieval of paginated results.
+  ///
+  /// Parameter [reservedInstanceId] :
+  /// The reserved instance identifier filter value. Use this parameter to show
+  /// only the reservation that matches the specified reserved OpenSearch
+  /// instance ID.
+  Future<DescribeReservedInstancesResponse> describeReservedInstances({
+    int? maxResults,
+    String? nextToken,
+    String? reservedInstanceId,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    _s.validateStringLength(
+      'reservedInstanceId',
+      reservedInstanceId,
+      36,
+      36,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+      if (reservedInstanceId != null) 'reservationId': [reservedInstanceId],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/opensearch/reservedInstances',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return DescribeReservedInstancesResponse.fromJson(response);
+  }
+
+  /// Dissociates a package from the Amazon OpenSearch Service domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  /// May throw [ConflictException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain to associate the package with.
+  ///
+  /// Parameter [packageID] :
+  /// The internal ID of the package to associate with a domain. Use
+  /// <code>DescribePackages</code> to find this value.
+  Future<DissociatePackageResponse> dissociatePackage({
+    required String domainName,
+    required String packageID,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    final response = await _protocol.send(
+      payload: null,
+      method: 'POST',
+      requestUri:
+          '/2021-01-01/packages/dissociate/${Uri.encodeComponent(packageID)}/${Uri.encodeComponent(domainName)}',
+      exceptionFnMap: _exceptionFns,
+    );
+    return DissociatePackageResponse.fromJson(response);
+  }
+
+  /// Returns a list of upgrade-compatible versions of OpenSearch/Elasticsearch.
+  /// You can optionally pass a <code> <a>DomainName</a> </code> to get all
+  /// upgrade-compatible versions of OpenSearch/Elasticsearch for that specific
+  /// domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  Future<GetCompatibleVersionsResponse> getCompatibleVersions({
+    String? domainName,
+  }) async {
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+    );
+    final $query = <String, List<String>>{
+      if (domainName != null) 'domainName': [domainName],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/opensearch/compatibleVersions',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return GetCompatibleVersionsResponse.fromJson(response);
+  }
+
+  /// Returns a list of package versions, along with their creation time and
+  /// commit message.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [packageID] :
+  /// Returns an audit history of package versions.
+  ///
+  /// Parameter [maxResults] :
+  /// Limits results to a maximum number of package versions.
+  ///
+  /// Parameter [nextToken] :
+  /// Used for pagination. Only necessary if a previous API call includes a
+  /// non-null NextToken value. If provided, returns results for the next page.
+  Future<GetPackageVersionHistoryResponse> getPackageVersionHistory({
+    required String packageID,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/packages/${Uri.encodeComponent(packageID)}/history',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return GetPackageVersionHistoryResponse.fromJson(response);
+  }
+
+  /// Retrieves the complete history of the last 10 upgrades performed on the
+  /// domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  Future<GetUpgradeHistoryResponse> getUpgradeHistory({
+    required String domainName,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/upgradeDomain/${Uri.encodeComponent(domainName)}/history',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return GetUpgradeHistoryResponse.fromJson(response);
+  }
+
+  /// Retrieves the latest status of the last upgrade or upgrade eligibility
+  /// check performed on the domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  Future<GetUpgradeStatusResponse> getUpgradeStatus({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/upgradeDomain/${Uri.encodeComponent(domainName)}/status',
+      exceptionFnMap: _exceptionFns,
+    );
+    return GetUpgradeStatusResponse.fromJson(response);
+  }
+
+  /// Returns the names of all domains owned by the current user's account.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [engineType] :
+  /// Optional parameter to filter the output by domain engine type. Acceptable
+  /// values are 'Elasticsearch' and 'OpenSearch'.
+  Future<ListDomainNamesResponse> listDomainNames({
+    EngineType? engineType,
+  }) async {
+    final $query = <String, List<String>>{
+      if (engineType != null) 'engineType': [engineType.toValue()],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/domain',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListDomainNamesResponse.fromJson(response);
+  }
+
+  /// Lists all Amazon OpenSearch Service domains associated with the package.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [packageID] :
+  /// The package for which to list associated domains.
+  ///
+  /// Parameter [maxResults] :
+  /// Limits the results to a maximum number of domains.
+  ///
+  /// Parameter [nextToken] :
+  /// Used for pagination. Only necessary if a previous API call includes a
+  /// non-null NextToken value. If provided, returns results for the next page.
+  Future<ListDomainsForPackageResponse> listDomainsForPackage({
+    required String packageID,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/packages/${Uri.encodeComponent(packageID)}/domains',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListDomainsForPackageResponse.fromJson(response);
+  }
+
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  Future<ListInstanceTypeDetailsResponse> listInstanceTypeDetails({
+    required String engineVersion,
+    String? domainName,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(engineVersion, 'engineVersion');
+    _s.validateStringLength(
+      'engineVersion',
+      engineVersion,
+      14,
+      18,
+      isRequired: true,
+    );
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+    );
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (domainName != null) 'domainName': [domainName],
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/opensearch/instanceTypeDetails/${Uri.encodeComponent(engineVersion)}',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListInstanceTypeDetailsResponse.fromJson(response);
+  }
+
+  /// Lists all packages associated with the Amazon OpenSearch Service domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain for which you want to list associated packages.
+  ///
+  /// Parameter [maxResults] :
+  /// Limits results to a maximum number of packages.
+  ///
+  /// Parameter [nextToken] :
+  /// Used for pagination. Only necessary if a previous API call includes a
+  /// non-null NextToken value. If provided, returns results for the next page.
+  Future<ListPackagesForDomainResponse> listPackagesForDomain({
+    required String domainName,
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri:
+          '/2021-01-01/domain/${Uri.encodeComponent(domainName)}/packages',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListPackagesForDomainResponse.fromJson(response);
+  }
+
+  /// Returns all tags for the given domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [arn] :
+  /// Specify the <code>ARN</code> of the domain that the tags you want to view
+  /// are attached to.
+  Future<ListTagsResponse> listTags({
+    required String arn,
+  }) async {
+    ArgumentError.checkNotNull(arn, 'arn');
+    _s.validateStringLength(
+      'arn',
+      arn,
+      20,
+      2048,
+      isRequired: true,
+    );
+    final $query = <String, List<String>>{
+      'arn': [arn],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/tags/',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListTagsResponse.fromJson(response);
+  }
+
+  /// List all supported versions of OpenSearch and Elasticsearch.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [maxResults] :
+  /// Set this value to limit the number of results returned. Value must be
+  /// greater than 10 or it won't be honored.
+  Future<ListVersionsResponse> listVersions({
+    int? maxResults,
+    String? nextToken,
+  }) async {
+    _s.validateNumRange(
+      'maxResults',
+      maxResults,
+      0,
+      100,
+    );
+    final $query = <String, List<String>>{
+      if (maxResults != null) 'maxResults': [maxResults.toString()],
+      if (nextToken != null) 'nextToken': [nextToken],
+    };
+    final response = await _protocol.send(
+      payload: null,
+      method: 'GET',
+      requestUri: '/2021-01-01/opensearch/versions',
+      queryParams: $query,
+      exceptionFnMap: _exceptionFns,
+    );
+    return ListVersionsResponse.fromJson(response);
+  }
+
+  /// Allows you to purchase reserved OpenSearch instances.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ResourceAlreadyExistsException].
+  /// May throw [LimitExceededException].
+  /// May throw [DisabledOperationException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [reservationName] :
+  /// A customer-specified identifier to track this reservation.
+  ///
+  /// Parameter [reservedInstanceOfferingId] :
+  /// The ID of the reserved OpenSearch instance offering to purchase.
+  ///
+  /// Parameter [instanceCount] :
+  /// The number of OpenSearch instances to reserve.
+  Future<PurchaseReservedInstanceOfferingResponse>
+      purchaseReservedInstanceOffering({
+    required String reservationName,
+    required String reservedInstanceOfferingId,
+    int? instanceCount,
+  }) async {
+    ArgumentError.checkNotNull(reservationName, 'reservationName');
+    _s.validateStringLength(
+      'reservationName',
+      reservationName,
+      5,
+      64,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(
+        reservedInstanceOfferingId, 'reservedInstanceOfferingId');
+    _s.validateStringLength(
+      'reservedInstanceOfferingId',
+      reservedInstanceOfferingId,
+      36,
+      36,
+      isRequired: true,
+    );
+    _s.validateNumRange(
+      'instanceCount',
+      instanceCount,
+      1,
+      1152921504606846976,
+    );
+    final $payload = <String, dynamic>{
+      'ReservationName': reservationName,
+      'ReservedInstanceOfferingId': reservedInstanceOfferingId,
+      if (instanceCount != null) 'InstanceCount': instanceCount,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/purchaseReservedInstanceOffering',
+      exceptionFnMap: _exceptionFns,
+    );
+    return PurchaseReservedInstanceOfferingResponse.fromJson(response);
+  }
+
+  /// Allows the remote domain owner to reject an inbound cross-cluster
+  /// connection request.
+  ///
+  /// May throw [ResourceNotFoundException].
+  /// May throw [DisabledOperationException].
+  ///
+  /// Parameter [connectionId] :
+  /// The ID of the inbound connection to reject.
+  Future<RejectInboundConnectionResponse> rejectInboundConnection({
+    required String connectionId,
+  }) async {
+    ArgumentError.checkNotNull(connectionId, 'connectionId');
+    _s.validateStringLength(
+      'connectionId',
+      connectionId,
+      10,
+      256,
+      isRequired: true,
+    );
+    final response = await _protocol.send(
+      payload: null,
+      method: 'PUT',
+      requestUri:
+          '/2021-01-01/opensearch/cc/inboundConnection/${Uri.encodeComponent(connectionId)}/reject',
+      exceptionFnMap: _exceptionFns,
+    );
+    return RejectInboundConnectionResponse.fromJson(response);
+  }
+
+  /// Removes the specified set of tags from the given domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [arn] :
+  /// The <code>ARN</code> of the domain from which you want to delete the
+  /// specified tags.
+  ///
+  /// Parameter [tagKeys] :
+  /// The <code>TagKey</code> list you want to remove from the domain.
+  Future<void> removeTags({
+    required String arn,
+    required List<String> tagKeys,
+  }) async {
+    ArgumentError.checkNotNull(arn, 'arn');
+    _s.validateStringLength(
+      'arn',
+      arn,
+      20,
+      2048,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
+    final $payload = <String, dynamic>{
+      'ARN': arn,
+      'TagKeys': tagKeys,
+    };
+    await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/tags-removal',
+      exceptionFnMap: _exceptionFns,
+    );
+  }
+
+  /// Schedules a service software update for an Amazon OpenSearch Service
+  /// domain.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain that you want to update to the latest service
+  /// software.
+  Future<StartServiceSoftwareUpdateResponse> startServiceSoftwareUpdate({
+    required String domainName,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    final $payload = <String, dynamic>{
+      'DomainName': domainName,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/serviceSoftwareUpdate/start',
+      exceptionFnMap: _exceptionFns,
+    );
+    return StartServiceSoftwareUpdateResponse.fromJson(response);
+  }
+
+  /// Modifies the cluster configuration of the specified domain, such as
+  /// setting the instance type and the number of instances.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [InvalidTypeException].
+  /// May throw [LimitExceededException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [domainName] :
+  /// The name of the domain you're updating.
+  ///
+  /// Parameter [accessPolicies] :
+  /// IAM access policy as a JSON-formatted string.
+  ///
+  /// Parameter [advancedOptions] :
+  /// Modifies the advanced option to allow references to indices in an HTTP
+  /// request body. Must be <code>false</code> when configuring access to
+  /// individual sub-resources. By default, the value is <code>true</code>. See
+  /// <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-advanced-options"
+  /// target="_blank">Advanced options </a> for more information.
+  ///
+  /// Parameter [advancedSecurityOptions] :
+  /// Specifies advanced security options.
+  ///
+  /// Parameter [autoTuneOptions] :
+  /// Specifies Auto-Tune options.
+  ///
+  /// Parameter [clusterConfig] :
+  /// The type and number of instances to instantiate for the domain cluster.
+  ///
+  /// Parameter [cognitoOptions] :
+  /// Options to specify the Cognito user and identity pools for OpenSearch
+  /// Dashboards authentication. For more information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html"
+  /// target="_blank">Configuring Amazon Cognito authentication for OpenSearch
+  /// Dashboards</a>.
+  ///
+  /// Parameter [domainEndpointOptions] :
+  /// Options to specify configuration that will be applied to the domain
+  /// endpoint.
+  ///
+  /// Parameter [dryRun] :
+  /// This flag, when set to True, specifies whether the
+  /// <code>UpdateDomain</code> request should return the results of validation
+  /// checks (DryRunResults) without actually applying the change.
+  ///
+  /// Parameter [eBSOptions] :
+  /// Specify the type and size of the EBS volume to use.
+  ///
+  /// Parameter [encryptionAtRestOptions] :
+  /// Specifies encryption of data at rest options.
+  ///
+  /// Parameter [logPublishingOptions] :
+  /// Map of <code>LogType</code> and <code>LogPublishingOption</code>, each
+  /// containing options to publish a given type of OpenSearch log.
+  ///
+  /// Parameter [nodeToNodeEncryptionOptions] :
+  /// Specifies node-to-node encryption options.
+  ///
+  /// Parameter [snapshotOptions] :
+  /// Option to set the time, in UTC format, for the daily automated snapshot.
+  /// Default value is <code>0</code> hours.
+  ///
+  /// Parameter [vPCOptions] :
+  /// Options to specify the subnets and security groups for the VPC endpoint.
+  /// For more information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+  /// target="_blank">Launching your Amazon OpenSearch Service domains using a
+  /// VPC </a>.
+  Future<UpdateDomainConfigResponse> updateDomainConfig({
+    required String domainName,
+    String? accessPolicies,
+    Map<String, String>? advancedOptions,
+    AdvancedSecurityOptionsInput? advancedSecurityOptions,
+    AutoTuneOptions? autoTuneOptions,
+    ClusterConfig? clusterConfig,
+    CognitoOptions? cognitoOptions,
+    DomainEndpointOptions? domainEndpointOptions,
+    bool? dryRun,
+    EBSOptions? eBSOptions,
+    EncryptionAtRestOptions? encryptionAtRestOptions,
+    Map<LogType, LogPublishingOption>? logPublishingOptions,
+    NodeToNodeEncryptionOptions? nodeToNodeEncryptionOptions,
+    SnapshotOptions? snapshotOptions,
+    VPCOptions? vPCOptions,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    _s.validateStringLength(
+      'accessPolicies',
+      accessPolicies,
+      0,
+      102400,
+    );
+    final $payload = <String, dynamic>{
+      if (accessPolicies != null) 'AccessPolicies': accessPolicies,
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (advancedSecurityOptions != null)
+        'AdvancedSecurityOptions': advancedSecurityOptions,
+      if (autoTuneOptions != null) 'AutoTuneOptions': autoTuneOptions,
+      if (clusterConfig != null) 'ClusterConfig': clusterConfig,
+      if (cognitoOptions != null) 'CognitoOptions': cognitoOptions,
+      if (domainEndpointOptions != null)
+        'DomainEndpointOptions': domainEndpointOptions,
+      if (dryRun != null) 'DryRun': dryRun,
+      if (eBSOptions != null) 'EBSOptions': eBSOptions,
+      if (encryptionAtRestOptions != null)
+        'EncryptionAtRestOptions': encryptionAtRestOptions,
+      if (logPublishingOptions != null)
+        'LogPublishingOptions':
+            logPublishingOptions.map((k, e) => MapEntry(k.toValue(), e)),
+      if (nodeToNodeEncryptionOptions != null)
+        'NodeToNodeEncryptionOptions': nodeToNodeEncryptionOptions,
+      if (snapshotOptions != null) 'SnapshotOptions': snapshotOptions,
+      if (vPCOptions != null) 'VPCOptions': vPCOptions,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri:
+          '/2021-01-01/opensearch/domain/${Uri.encodeComponent(domainName)}/config',
+      exceptionFnMap: _exceptionFns,
+    );
+    return UpdateDomainConfigResponse.fromJson(response);
+  }
+
+  /// Updates a package for use with Amazon OpenSearch Service domains.
+  ///
+  /// May throw [BaseException].
+  /// May throw [InternalException].
+  /// May throw [LimitExceededException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [AccessDeniedException].
+  /// May throw [ValidationException].
+  ///
+  /// Parameter [packageID] :
+  /// The unique identifier for the package.
+  ///
+  /// Parameter [commitMessage] :
+  /// A commit message for the new version which is shown as part of
+  /// <code>GetPackageVersionHistoryResponse</code>.
+  ///
+  /// Parameter [packageDescription] :
+  /// A new description of the package.
+  Future<UpdatePackageResponse> updatePackage({
+    required String packageID,
+    required PackageSource packageSource,
+    String? commitMessage,
+    String? packageDescription,
+  }) async {
+    ArgumentError.checkNotNull(packageID, 'packageID');
+    ArgumentError.checkNotNull(packageSource, 'packageSource');
+    _s.validateStringLength(
+      'commitMessage',
+      commitMessage,
+      0,
+      160,
+    );
+    _s.validateStringLength(
+      'packageDescription',
+      packageDescription,
+      0,
+      1024,
+    );
+    final $payload = <String, dynamic>{
+      'PackageID': packageID,
+      'PackageSource': packageSource,
+      if (commitMessage != null) 'CommitMessage': commitMessage,
+      if (packageDescription != null) 'PackageDescription': packageDescription,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/packages/update',
+      exceptionFnMap: _exceptionFns,
+    );
+    return UpdatePackageResponse.fromJson(response);
+  }
+
+  /// Allows you to either upgrade your domain or perform an upgrade eligibility
+  /// check to a compatible version of OpenSearch or Elasticsearch.
+  ///
+  /// May throw [BaseException].
+  /// May throw [ResourceNotFoundException].
+  /// May throw [ResourceAlreadyExistsException].
+  /// May throw [DisabledOperationException].
+  /// May throw [ValidationException].
+  /// May throw [InternalException].
+  ///
+  /// Parameter [targetVersion] :
+  /// The version of OpenSearch you intend to upgrade the domain to.
+  ///
+  /// Parameter [performCheckOnly] :
+  /// When true, indicates that an upgrade eligibility check needs to be
+  /// performed. Does not actually perform the upgrade.
+  Future<UpgradeDomainResponse> upgradeDomain({
+    required String domainName,
+    required String targetVersion,
+    Map<String, String>? advancedOptions,
+    bool? performCheckOnly,
+  }) async {
+    ArgumentError.checkNotNull(domainName, 'domainName');
+    _s.validateStringLength(
+      'domainName',
+      domainName,
+      3,
+      28,
+      isRequired: true,
+    );
+    ArgumentError.checkNotNull(targetVersion, 'targetVersion');
+    _s.validateStringLength(
+      'targetVersion',
+      targetVersion,
+      14,
+      18,
+      isRequired: true,
+    );
+    final $payload = <String, dynamic>{
+      'DomainName': domainName,
+      'TargetVersion': targetVersion,
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (performCheckOnly != null) 'PerformCheckOnly': performCheckOnly,
+    };
+    final response = await _protocol.send(
+      payload: $payload,
+      method: 'POST',
+      requestUri: '/2021-01-01/opensearch/upgradeDomain',
+      exceptionFnMap: _exceptionFns,
+    );
+    return UpgradeDomainResponse.fromJson(response);
+  }
+}
+
+class AWSDomainInformation {
+  final String domainName;
+  final String? ownerId;
+  final String? region;
+
+  AWSDomainInformation({
+    required this.domainName,
+    this.ownerId,
+    this.region,
+  });
+  factory AWSDomainInformation.fromJson(Map<String, dynamic> json) {
+    return AWSDomainInformation(
+      domainName: json['DomainName'] as String,
+      ownerId: json['OwnerId'] as String?,
+      region: json['Region'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainName = this.domainName;
+    final ownerId = this.ownerId;
+    final region = this.region;
+    return {
+      'DomainName': domainName,
+      if (ownerId != null) 'OwnerId': ownerId,
+      if (region != null) 'Region': region,
+    };
+  }
+}
+
+/// The result of an <code> <a>AcceptInboundConnection</a> </code> operation.
+/// Contains details about the accepted inbound connection.
+class AcceptInboundConnectionResponse {
+  /// The <code> <a>InboundConnection</a> </code> of the accepted inbound
+  /// connection.
+  final InboundConnection? connection;
+
+  AcceptInboundConnectionResponse({
+    this.connection,
+  });
+  factory AcceptInboundConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return AcceptInboundConnectionResponse(
+      connection: json['Connection'] != null
+          ? InboundConnection.fromJson(
+              json['Connection'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The configured access rules for the domain's document and search endpoints,
+/// and the current status of those rules.
+class AccessPoliciesStatus {
+  /// The access policy configured for the domain. Access policies can be
+  /// resource-based, IP-based, or IAM-based. See <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-access-policies"
+  /// target="_blank"> Configuring access policies</a>for more information.
+  final String options;
+
+  /// The status of the access policy for the domain. See
+  /// <code>OptionStatus</code> for the status information that's included.
+  final OptionStatus status;
+
+  AccessPoliciesStatus({
+    required this.options,
+    required this.status,
+  });
+  factory AccessPoliciesStatus.fromJson(Map<String, dynamic> json) {
+    return AccessPoliciesStatus(
+      options: json['Options'] as String,
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// List of limits that are specific to a given InstanceType and for each of its
+/// <code> <a>InstanceRole</a> </code> .
+class AdditionalLimit {
+  /// Additional limit is specific to a given InstanceType and for each of its
+  /// <code> <a>InstanceRole</a> </code> etc. <br/> Attributes and their details:
+  /// <br/>
+  /// <ul>
+  /// <li>MaximumNumberOfDataNodesSupported</li> This attribute is present on the
+  /// master node only to specify how much data nodes up to which given <code>
+  /// <a>ESPartitionInstanceType</a> </code> can support as master node.
+  /// <li>MaximumNumberOfDataNodesWithoutMasterNode</li> This attribute is present
+  /// on data node only to specify how much data nodes of given <code>
+  /// <a>ESPartitionInstanceType</a> </code> up to which you don't need any master
+  /// nodes to govern them.
+  /// </ul>
+  final String? limitName;
+
+  /// Value for a given <code> <a>AdditionalLimit$LimitName</a> </code> .
+  final List<String>? limitValues;
+
+  AdditionalLimit({
+    this.limitName,
+    this.limitValues,
+  });
+  factory AdditionalLimit.fromJson(Map<String, dynamic> json) {
+    return AdditionalLimit(
+      limitName: json['LimitName'] as String?,
+      limitValues: (json['LimitValues'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+    );
+  }
+}
+
+/// Status of the advanced options for the specified domain. Currently, the
+/// following advanced options are available:
+///
+/// <ul>
+/// <li>Option to allow references to indices in an HTTP request body. Must be
+/// <code>false</code> when configuring access to individual sub-resources. By
+/// default, the value is <code>true</code>. See <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-advanced-options"
+/// target="_blank">Advanced cluster parameters </a> for more information. </li>
+/// <li>Option to specify the percentage of heap space allocated to field data.
+/// By default, this setting is unbounded. </li>
+/// </ul>
+/// For more information, see <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-advanced-options">
+/// Advanced cluster parameters</a>.
+class AdvancedOptionsStatus {
+  /// The status of advanced options for the specified domain.
+  final Map<String, String> options;
+
+  /// The <code>OptionStatus</code> for advanced options for the specified domain.
+  final OptionStatus status;
+
+  AdvancedOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory AdvancedOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return AdvancedOptionsStatus(
+      options: (json['Options'] as Map<String, dynamic>)
+          .map((k, e) => MapEntry(k, e as String)),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// The advanced security configuration: whether advanced security is enabled,
+/// whether the internal database option is enabled.
+class AdvancedSecurityOptions {
+  /// Specifies the Anonymous Auth Disable Date when Anonymous Auth is enabled.
+  final DateTime? anonymousAuthDisableDate;
+
+  /// True if Anonymous auth is enabled. Anonymous auth can be enabled only when
+  /// AdvancedSecurity is enabled on existing domains.
+  final bool? anonymousAuthEnabled;
+
+  /// True if advanced security is enabled.
+  final bool? enabled;
+
+  /// True if the internal user database is enabled.
+  final bool? internalUserDatabaseEnabled;
+
+  /// Describes the SAML application configured for a domain.
+  final SAMLOptionsOutput? sAMLOptions;
+
+  AdvancedSecurityOptions({
+    this.anonymousAuthDisableDate,
+    this.anonymousAuthEnabled,
+    this.enabled,
+    this.internalUserDatabaseEnabled,
+    this.sAMLOptions,
+  });
+  factory AdvancedSecurityOptions.fromJson(Map<String, dynamic> json) {
+    return AdvancedSecurityOptions(
+      anonymousAuthDisableDate:
+          timeStampFromJson(json['AnonymousAuthDisableDate']),
+      anonymousAuthEnabled: json['AnonymousAuthEnabled'] as bool?,
+      enabled: json['Enabled'] as bool?,
+      internalUserDatabaseEnabled: json['InternalUserDatabaseEnabled'] as bool?,
+      sAMLOptions: json['SAMLOptions'] != null
+          ? SAMLOptionsOutput.fromJson(
+              json['SAMLOptions'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The advanced security configuration: whether advanced security is enabled,
+/// whether the internal database option is enabled, master username and
+/// password (if internal database is enabled), and master user ARN (if IAM is
+/// enabled).
+class AdvancedSecurityOptionsInput {
+  /// True if Anonymous auth is enabled. Anonymous auth can be enabled only when
+  /// AdvancedSecurity is enabled on existing domains.
+  final bool? anonymousAuthEnabled;
+
+  /// True if advanced security is enabled.
+  final bool? enabled;
+
+  /// True if the internal user database is enabled.
+  final bool? internalUserDatabaseEnabled;
+
+  /// Credentials for the master user: username and password, ARN, or both.
+  final MasterUserOptions? masterUserOptions;
+
+  /// The SAML application configuration for the domain.
+  final SAMLOptionsInput? sAMLOptions;
+
+  AdvancedSecurityOptionsInput({
+    this.anonymousAuthEnabled,
+    this.enabled,
+    this.internalUserDatabaseEnabled,
+    this.masterUserOptions,
+    this.sAMLOptions,
+  });
+  Map<String, dynamic> toJson() {
+    final anonymousAuthEnabled = this.anonymousAuthEnabled;
+    final enabled = this.enabled;
+    final internalUserDatabaseEnabled = this.internalUserDatabaseEnabled;
+    final masterUserOptions = this.masterUserOptions;
+    final sAMLOptions = this.sAMLOptions;
+    return {
+      if (anonymousAuthEnabled != null)
+        'AnonymousAuthEnabled': anonymousAuthEnabled,
+      if (enabled != null) 'Enabled': enabled,
+      if (internalUserDatabaseEnabled != null)
+        'InternalUserDatabaseEnabled': internalUserDatabaseEnabled,
+      if (masterUserOptions != null) 'MasterUserOptions': masterUserOptions,
+      if (sAMLOptions != null) 'SAMLOptions': sAMLOptions,
+    };
+  }
+}
+
+/// The status of advanced security options for the specified domain.
+class AdvancedSecurityOptionsStatus {
+  /// Advanced security options for the specified domain.
+  final AdvancedSecurityOptions options;
+
+  /// Status of the advanced security options for the specified domain.
+  final OptionStatus status;
+
+  AdvancedSecurityOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory AdvancedSecurityOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return AdvancedSecurityOptionsStatus(
+      options: AdvancedSecurityOptions.fromJson(
+          json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Container for the response returned by <code> <a>AssociatePackage</a>
+/// </code> operation.
+class AssociatePackageResponse {
+  /// <code>DomainPackageDetails</code>
+  final DomainPackageDetails? domainPackageDetails;
+
+  AssociatePackageResponse({
+    this.domainPackageDetails,
+  });
+  factory AssociatePackageResponse.fromJson(Map<String, dynamic> json) {
+    return AssociatePackageResponse(
+      domainPackageDetails: json['DomainPackageDetails'] != null
+          ? DomainPackageDetails.fromJson(
+              json['DomainPackageDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Specifies the Auto-Tune type and Auto-Tune action details.
+class AutoTune {
+  /// Specifies details about the Auto-Tune action. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final AutoTuneDetails? autoTuneDetails;
+
+  /// Specifies the Auto-Tune type. Valid value is SCHEDULED_ACTION.
+  final AutoTuneType? autoTuneType;
+
+  AutoTune({
+    this.autoTuneDetails,
+    this.autoTuneType,
+  });
+  factory AutoTune.fromJson(Map<String, dynamic> json) {
+    return AutoTune(
+      autoTuneDetails: json['AutoTuneDetails'] != null
+          ? AutoTuneDetails.fromJson(
+              json['AutoTuneDetails'] as Map<String, dynamic>)
+          : null,
+      autoTuneType: (json['AutoTuneType'] as String?)?.toAutoTuneType(),
+    );
+  }
+}
+
+/// The Auto-Tune desired state. Valid values are ENABLED and DISABLED.
+enum AutoTuneDesiredState {
+  enabled,
+  disabled,
+}
+
+extension AutoTuneDesiredStateValue on AutoTuneDesiredState {
+  String toValue() {
+    switch (this) {
+      case AutoTuneDesiredState.enabled:
+        return 'ENABLED';
+      case AutoTuneDesiredState.disabled:
+        return 'DISABLED';
+    }
+  }
+}
+
+extension AutoTuneDesiredStateFromString on String {
+  AutoTuneDesiredState toAutoTuneDesiredState() {
+    switch (this) {
+      case 'ENABLED':
+        return AutoTuneDesiredState.enabled;
+      case 'DISABLED':
+        return AutoTuneDesiredState.disabled;
+    }
+    throw Exception('$this is not known in enum AutoTuneDesiredState');
+  }
+}
+
+/// Specifies details about the Auto-Tune action. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+class AutoTuneDetails {
+  final ScheduledAutoTuneDetails? scheduledAutoTuneDetails;
+
+  AutoTuneDetails({
+    this.scheduledAutoTuneDetails,
+  });
+  factory AutoTuneDetails.fromJson(Map<String, dynamic> json) {
+    return AutoTuneDetails(
+      scheduledAutoTuneDetails: json['ScheduledAutoTuneDetails'] != null
+          ? ScheduledAutoTuneDetails.fromJson(
+              json['ScheduledAutoTuneDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Specifies the Auto-Tune maintenance schedule. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+class AutoTuneMaintenanceSchedule {
+  /// A cron expression for a recurring maintenance schedule. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final String? cronExpressionForRecurrence;
+
+  /// Specifies maintenance schedule duration: duration value and duration unit.
+  /// See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final Duration? duration;
+
+  /// The timestamp at which the Auto-Tune maintenance schedule starts.
+  final DateTime? startAt;
+
+  AutoTuneMaintenanceSchedule({
+    this.cronExpressionForRecurrence,
+    this.duration,
+    this.startAt,
+  });
+  factory AutoTuneMaintenanceSchedule.fromJson(Map<String, dynamic> json) {
+    return AutoTuneMaintenanceSchedule(
+      cronExpressionForRecurrence:
+          json['CronExpressionForRecurrence'] as String?,
+      duration: json['Duration'] != null
+          ? Duration.fromJson(json['Duration'] as Map<String, dynamic>)
+          : null,
+      startAt: timeStampFromJson(json['StartAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final cronExpressionForRecurrence = this.cronExpressionForRecurrence;
+    final duration = this.duration;
+    final startAt = this.startAt;
+    return {
+      if (cronExpressionForRecurrence != null)
+        'CronExpressionForRecurrence': cronExpressionForRecurrence,
+      if (duration != null) 'Duration': duration,
+      if (startAt != null) 'StartAt': unixTimestampToJson(startAt),
+    };
+  }
+}
+
+/// The Auto-Tune options: the Auto-Tune desired state for the domain, rollback
+/// state when disabling Auto-Tune options and list of maintenance schedules.
+class AutoTuneOptions {
+  /// The Auto-Tune desired state. Valid values are ENABLED and DISABLED.
+  final AutoTuneDesiredState? desiredState;
+
+  /// A list of maintenance schedules. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final List<AutoTuneMaintenanceSchedule>? maintenanceSchedules;
+
+  /// The rollback state while disabling Auto-Tune for the domain. Valid values
+  /// are NO_ROLLBACK and DEFAULT_ROLLBACK.
+  final RollbackOnDisable? rollbackOnDisable;
+
+  AutoTuneOptions({
+    this.desiredState,
+    this.maintenanceSchedules,
+    this.rollbackOnDisable,
+  });
+  factory AutoTuneOptions.fromJson(Map<String, dynamic> json) {
+    return AutoTuneOptions(
+      desiredState: (json['DesiredState'] as String?)?.toAutoTuneDesiredState(),
+      maintenanceSchedules: (json['MaintenanceSchedules'] as List?)
+          ?.whereNotNull()
+          .map((e) =>
+              AutoTuneMaintenanceSchedule.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      rollbackOnDisable:
+          (json['RollbackOnDisable'] as String?)?.toRollbackOnDisable(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final desiredState = this.desiredState;
+    final maintenanceSchedules = this.maintenanceSchedules;
+    final rollbackOnDisable = this.rollbackOnDisable;
+    return {
+      if (desiredState != null) 'DesiredState': desiredState.toValue(),
+      if (maintenanceSchedules != null)
+        'MaintenanceSchedules': maintenanceSchedules,
+      if (rollbackOnDisable != null)
+        'RollbackOnDisable': rollbackOnDisable.toValue(),
+    };
+  }
+}
+
+/// The Auto-Tune options: the Auto-Tune desired state for the domain and list
+/// of maintenance schedules.
+class AutoTuneOptionsInput {
+  /// The Auto-Tune desired state. Valid values are ENABLED and DISABLED.
+  final AutoTuneDesiredState? desiredState;
+
+  /// A list of maintenance schedules. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final List<AutoTuneMaintenanceSchedule>? maintenanceSchedules;
+
+  AutoTuneOptionsInput({
+    this.desiredState,
+    this.maintenanceSchedules,
+  });
+  Map<String, dynamic> toJson() {
+    final desiredState = this.desiredState;
+    final maintenanceSchedules = this.maintenanceSchedules;
+    return {
+      if (desiredState != null) 'DesiredState': desiredState.toValue(),
+      if (maintenanceSchedules != null)
+        'MaintenanceSchedules': maintenanceSchedules,
+    };
+  }
+}
+
+/// The Auto-Tune options: the Auto-Tune desired state for the domain and list
+/// of maintenance schedules.
+class AutoTuneOptionsOutput {
+  /// The error message while enabling or disabling Auto-Tune.
+  final String? errorMessage;
+
+  /// The <code>AutoTuneState</code> for the domain.
+  final AutoTuneState? state;
+
+  AutoTuneOptionsOutput({
+    this.errorMessage,
+    this.state,
+  });
+  factory AutoTuneOptionsOutput.fromJson(Map<String, dynamic> json) {
+    return AutoTuneOptionsOutput(
+      errorMessage: json['ErrorMessage'] as String?,
+      state: (json['State'] as String?)?.toAutoTuneState(),
+    );
+  }
+}
+
+/// The Auto-Tune status for the domain.
+class AutoTuneOptionsStatus {
+  /// Specifies Auto-Tune options for the domain.
+  final AutoTuneOptions? options;
+
+  /// The status of the Auto-Tune options for the domain.
+  final AutoTuneStatus? status;
+
+  AutoTuneOptionsStatus({
+    this.options,
+    this.status,
+  });
+  factory AutoTuneOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return AutoTuneOptionsStatus(
+      options: json['Options'] != null
+          ? AutoTuneOptions.fromJson(json['Options'] as Map<String, dynamic>)
+          : null,
+      status: json['Status'] != null
+          ? AutoTuneStatus.fromJson(json['Status'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The Auto-Tune state for the domain. For valid states see <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service</a>.
+enum AutoTuneState {
+  enabled,
+  disabled,
+  enableInProgress,
+  disableInProgress,
+  disabledAndRollbackScheduled,
+  disabledAndRollbackInProgress,
+  disabledAndRollbackComplete,
+  disabledAndRollbackError,
+  error,
+}
+
+extension AutoTuneStateValue on AutoTuneState {
+  String toValue() {
+    switch (this) {
+      case AutoTuneState.enabled:
+        return 'ENABLED';
+      case AutoTuneState.disabled:
+        return 'DISABLED';
+      case AutoTuneState.enableInProgress:
+        return 'ENABLE_IN_PROGRESS';
+      case AutoTuneState.disableInProgress:
+        return 'DISABLE_IN_PROGRESS';
+      case AutoTuneState.disabledAndRollbackScheduled:
+        return 'DISABLED_AND_ROLLBACK_SCHEDULED';
+      case AutoTuneState.disabledAndRollbackInProgress:
+        return 'DISABLED_AND_ROLLBACK_IN_PROGRESS';
+      case AutoTuneState.disabledAndRollbackComplete:
+        return 'DISABLED_AND_ROLLBACK_COMPLETE';
+      case AutoTuneState.disabledAndRollbackError:
+        return 'DISABLED_AND_ROLLBACK_ERROR';
+      case AutoTuneState.error:
+        return 'ERROR';
+    }
+  }
+}
+
+extension AutoTuneStateFromString on String {
+  AutoTuneState toAutoTuneState() {
+    switch (this) {
+      case 'ENABLED':
+        return AutoTuneState.enabled;
+      case 'DISABLED':
+        return AutoTuneState.disabled;
+      case 'ENABLE_IN_PROGRESS':
+        return AutoTuneState.enableInProgress;
+      case 'DISABLE_IN_PROGRESS':
+        return AutoTuneState.disableInProgress;
+      case 'DISABLED_AND_ROLLBACK_SCHEDULED':
+        return AutoTuneState.disabledAndRollbackScheduled;
+      case 'DISABLED_AND_ROLLBACK_IN_PROGRESS':
+        return AutoTuneState.disabledAndRollbackInProgress;
+      case 'DISABLED_AND_ROLLBACK_COMPLETE':
+        return AutoTuneState.disabledAndRollbackComplete;
+      case 'DISABLED_AND_ROLLBACK_ERROR':
+        return AutoTuneState.disabledAndRollbackError;
+      case 'ERROR':
+        return AutoTuneState.error;
+    }
+    throw Exception('$this is not known in enum AutoTuneState');
+  }
+}
+
+/// Provides the current Auto-Tune status for the domain.
+class AutoTuneStatus {
+  /// The timestamp of the Auto-Tune options creation date.
+  final DateTime creationDate;
+
+  /// The <code>AutoTuneState</code> for the domain.
+  final AutoTuneState state;
+
+  /// The timestamp of when the Auto-Tune options were last updated.
+  final DateTime updateDate;
+
+  /// The error message while enabling or disabling Auto-Tune.
+  final String? errorMessage;
+
+  /// Indicates whether the domain is being deleted.
+  final bool? pendingDeletion;
+
+  /// The latest version of the Auto-Tune options.
+  final int? updateVersion;
+
+  AutoTuneStatus({
+    required this.creationDate,
+    required this.state,
+    required this.updateDate,
+    this.errorMessage,
+    this.pendingDeletion,
+    this.updateVersion,
+  });
+  factory AutoTuneStatus.fromJson(Map<String, dynamic> json) {
+    return AutoTuneStatus(
+      creationDate:
+          nonNullableTimeStampFromJson(json['CreationDate'] as Object),
+      state: (json['State'] as String).toAutoTuneState(),
+      updateDate: nonNullableTimeStampFromJson(json['UpdateDate'] as Object),
+      errorMessage: json['ErrorMessage'] as String?,
+      pendingDeletion: json['PendingDeletion'] as bool?,
+      updateVersion: json['UpdateVersion'] as int?,
+    );
+  }
+}
+
+/// Specifies the Auto-Tune type. Valid value is SCHEDULED_ACTION.
+enum AutoTuneType {
+  scheduledAction,
+}
+
+extension AutoTuneTypeValue on AutoTuneType {
+  String toValue() {
+    switch (this) {
+      case AutoTuneType.scheduledAction:
+        return 'SCHEDULED_ACTION';
+    }
+  }
+}
+
+extension AutoTuneTypeFromString on String {
+  AutoTuneType toAutoTuneType() {
+    switch (this) {
+      case 'SCHEDULED_ACTION':
+        return AutoTuneType.scheduledAction;
+    }
+    throw Exception('$this is not known in enum AutoTuneType');
+  }
+}
+
+/// The result of a <code>CancelServiceSoftwareUpdate</code> operation. Contains
+/// the status of the update.
+class CancelServiceSoftwareUpdateResponse {
+  /// The current status of the OpenSearch service software update.
+  final ServiceSoftwareOptions? serviceSoftwareOptions;
+
+  CancelServiceSoftwareUpdateResponse({
+    this.serviceSoftwareOptions,
+  });
+  factory CancelServiceSoftwareUpdateResponse.fromJson(
+      Map<String, dynamic> json) {
+    return CancelServiceSoftwareUpdateResponse(
+      serviceSoftwareOptions: json['ServiceSoftwareOptions'] != null
+          ? ServiceSoftwareOptions.fromJson(
+              json['ServiceSoftwareOptions'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Specifies change details of the domain configuration change.
+class ChangeProgressDetails {
+  /// The unique change identifier associated with a specific domain configuration
+  /// change.
+  final String? changeId;
+
+  /// Contains an optional message associated with the domain configuration
+  /// change.
+  final String? message;
+
+  ChangeProgressDetails({
+    this.changeId,
+    this.message,
+  });
+  factory ChangeProgressDetails.fromJson(Map<String, dynamic> json) {
+    return ChangeProgressDetails(
+      changeId: json['ChangeId'] as String?,
+      message: json['Message'] as String?,
+    );
+  }
+}
+
+/// A progress stage details of a specific domain configuration change.
+class ChangeProgressStage {
+  /// The description of the progress stage.
+  final String? description;
+
+  /// The last updated timestamp of the progress stage.
+  final DateTime? lastUpdated;
+
+  /// The name of the specific progress stage.
+  final String? name;
+
+  /// The overall status of a specific progress stage.
+  final String? status;
+
+  ChangeProgressStage({
+    this.description,
+    this.lastUpdated,
+    this.name,
+    this.status,
+  });
+  factory ChangeProgressStage.fromJson(Map<String, dynamic> json) {
+    return ChangeProgressStage(
+      description: json['Description'] as String?,
+      lastUpdated: timeStampFromJson(json['LastUpdated']),
+      name: json['Name'] as String?,
+      status: json['Status'] as String?,
+    );
+  }
+}
+
+/// The progress details of a specific domain configuration change.
+class ChangeProgressStatusDetails {
+  /// The unique change identifier associated with a specific domain configuration
+  /// change.
+  final String? changeId;
+
+  /// The specific stages that the domain is going through to perform the
+  /// configuration change.
+  final List<ChangeProgressStage>? changeProgressStages;
+
+  /// The list of properties involved in the domain configuration change that are
+  /// completed.
+  final List<String>? completedProperties;
+
+  /// The list of properties involved in the domain configuration change that are
+  /// still in pending.
+  final List<String>? pendingProperties;
+
+  /// The time at which the configuration change is made on the domain.
+  final DateTime? startTime;
+
+  /// The overall status of the domain configuration change. This field can take
+  /// the following values: <code>PENDING</code>, <code>PROCESSING</code>,
+  /// <code>COMPLETED</code> and <code>FAILED</code>
+  final OverallChangeStatus? status;
+
+  /// The total number of stages required for the configuration change.
+  final int? totalNumberOfStages;
+
+  ChangeProgressStatusDetails({
+    this.changeId,
+    this.changeProgressStages,
+    this.completedProperties,
+    this.pendingProperties,
+    this.startTime,
+    this.status,
+    this.totalNumberOfStages,
+  });
+  factory ChangeProgressStatusDetails.fromJson(Map<String, dynamic> json) {
+    return ChangeProgressStatusDetails(
+      changeId: json['ChangeId'] as String?,
+      changeProgressStages: (json['ChangeProgressStages'] as List?)
+          ?.whereNotNull()
+          .map((e) => ChangeProgressStage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      completedProperties: (json['CompletedProperties'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      pendingProperties: (json['PendingProperties'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      startTime: timeStampFromJson(json['StartTime']),
+      status: (json['Status'] as String?)?.toOverallChangeStatus(),
+      totalNumberOfStages: json['TotalNumberOfStages'] as int?,
+    );
+  }
+}
+
+/// The configuration for the domain cluster, such as the type and number of
+/// instances.
+class ClusterConfig {
+  /// Specifies the <code>ColdStorageOptions</code> config for a Domain
+  final ColdStorageOptions? coldStorageOptions;
+
+  /// Total number of dedicated master nodes, active and on standby, for the
+  /// cluster.
+  final int? dedicatedMasterCount;
+
+  /// A boolean value to indicate whether a dedicated master node is enabled. See
+  /// <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains.html#managedomains-dedicatedmasternodes"
+  /// target="_blank">Dedicated master nodes in Amazon OpenSearch Service </a> for
+  /// more information.
+  final bool? dedicatedMasterEnabled;
+
+  /// The instance type for a dedicated master node.
+  final OpenSearchPartitionInstanceType? dedicatedMasterType;
+
+  /// The number of instances in the specified domain cluster.
+  final int? instanceCount;
+
+  /// The instance type for an OpenSearch cluster. UltraWarm instance types are
+  /// not supported for data instances.
+  final OpenSearchPartitionInstanceType? instanceType;
+
+  /// The number of UltraWarm nodes in the cluster.
+  final int? warmCount;
+
+  /// True to enable UltraWarm storage.
+  final bool? warmEnabled;
+
+  /// The instance type for the OpenSearch cluster's warm nodes.
+  final OpenSearchWarmPartitionInstanceType? warmType;
+
+  /// The zone awareness configuration for a domain when zone awareness is
+  /// enabled.
+  final ZoneAwarenessConfig? zoneAwarenessConfig;
+
+  /// A boolean value to indicate whether zone awareness is enabled. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-multiaz.html"
+  /// target="_blank">Configuring a multi-AZ domain in Amazon OpenSearch Service
+  /// </a> for more information.
+  final bool? zoneAwarenessEnabled;
+
+  ClusterConfig({
+    this.coldStorageOptions,
+    this.dedicatedMasterCount,
+    this.dedicatedMasterEnabled,
+    this.dedicatedMasterType,
+    this.instanceCount,
+    this.instanceType,
+    this.warmCount,
+    this.warmEnabled,
+    this.warmType,
+    this.zoneAwarenessConfig,
+    this.zoneAwarenessEnabled,
+  });
+  factory ClusterConfig.fromJson(Map<String, dynamic> json) {
+    return ClusterConfig(
+      coldStorageOptions: json['ColdStorageOptions'] != null
+          ? ColdStorageOptions.fromJson(
+              json['ColdStorageOptions'] as Map<String, dynamic>)
+          : null,
+      dedicatedMasterCount: json['DedicatedMasterCount'] as int?,
+      dedicatedMasterEnabled: json['DedicatedMasterEnabled'] as bool?,
+      dedicatedMasterType: (json['DedicatedMasterType'] as String?)
+          ?.toOpenSearchPartitionInstanceType(),
+      instanceCount: json['InstanceCount'] as int?,
+      instanceType: (json['InstanceType'] as String?)
+          ?.toOpenSearchPartitionInstanceType(),
+      warmCount: json['WarmCount'] as int?,
+      warmEnabled: json['WarmEnabled'] as bool?,
+      warmType: (json['WarmType'] as String?)
+          ?.toOpenSearchWarmPartitionInstanceType(),
+      zoneAwarenessConfig: json['ZoneAwarenessConfig'] != null
+          ? ZoneAwarenessConfig.fromJson(
+              json['ZoneAwarenessConfig'] as Map<String, dynamic>)
+          : null,
+      zoneAwarenessEnabled: json['ZoneAwarenessEnabled'] as bool?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final coldStorageOptions = this.coldStorageOptions;
+    final dedicatedMasterCount = this.dedicatedMasterCount;
+    final dedicatedMasterEnabled = this.dedicatedMasterEnabled;
+    final dedicatedMasterType = this.dedicatedMasterType;
+    final instanceCount = this.instanceCount;
+    final instanceType = this.instanceType;
+    final warmCount = this.warmCount;
+    final warmEnabled = this.warmEnabled;
+    final warmType = this.warmType;
+    final zoneAwarenessConfig = this.zoneAwarenessConfig;
+    final zoneAwarenessEnabled = this.zoneAwarenessEnabled;
+    return {
+      if (coldStorageOptions != null) 'ColdStorageOptions': coldStorageOptions,
+      if (dedicatedMasterCount != null)
+        'DedicatedMasterCount': dedicatedMasterCount,
+      if (dedicatedMasterEnabled != null)
+        'DedicatedMasterEnabled': dedicatedMasterEnabled,
+      if (dedicatedMasterType != null)
+        'DedicatedMasterType': dedicatedMasterType.toValue(),
+      if (instanceCount != null) 'InstanceCount': instanceCount,
+      if (instanceType != null) 'InstanceType': instanceType.toValue(),
+      if (warmCount != null) 'WarmCount': warmCount,
+      if (warmEnabled != null) 'WarmEnabled': warmEnabled,
+      if (warmType != null) 'WarmType': warmType.toValue(),
+      if (zoneAwarenessConfig != null)
+        'ZoneAwarenessConfig': zoneAwarenessConfig,
+      if (zoneAwarenessEnabled != null)
+        'ZoneAwarenessEnabled': zoneAwarenessEnabled,
+    };
+  }
+}
+
+/// The configuration status for the specified domain.
+class ClusterConfigStatus {
+  /// The cluster configuration for the specified domain.
+  final ClusterConfig options;
+
+  /// The cluster configuration status for the specified domain.
+  final OptionStatus status;
+
+  ClusterConfigStatus({
+    required this.options,
+    required this.status,
+  });
+  factory ClusterConfigStatus.fromJson(Map<String, dynamic> json) {
+    return ClusterConfigStatus(
+      options: ClusterConfig.fromJson(json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Options to specify the Cognito user and identity pools for OpenSearch
+/// Dashboards authentication. For more information, see <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html"
+/// target="_blank">Configuring Amazon Cognito authentication for OpenSearch
+/// Dashboards</a>.
+class CognitoOptions {
+  /// The option to enable Cognito for OpenSearch Dashboards authentication.
+  final bool? enabled;
+
+  /// The Cognito identity pool ID for OpenSearch Dashboards authentication.
+  final String? identityPoolId;
+
+  /// The role ARN that provides OpenSearch permissions for accessing Cognito
+  /// resources.
+  final String? roleArn;
+
+  /// The Cognito user pool ID for OpenSearch Dashboards authentication.
+  final String? userPoolId;
+
+  CognitoOptions({
+    this.enabled,
+    this.identityPoolId,
+    this.roleArn,
+    this.userPoolId,
+  });
+  factory CognitoOptions.fromJson(Map<String, dynamic> json) {
+    return CognitoOptions(
+      enabled: json['Enabled'] as bool?,
+      identityPoolId: json['IdentityPoolId'] as String?,
+      roleArn: json['RoleArn'] as String?,
+      userPoolId: json['UserPoolId'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    final identityPoolId = this.identityPoolId;
+    final roleArn = this.roleArn;
+    final userPoolId = this.userPoolId;
+    return {
+      if (enabled != null) 'Enabled': enabled,
+      if (identityPoolId != null) 'IdentityPoolId': identityPoolId,
+      if (roleArn != null) 'RoleArn': roleArn,
+      if (userPoolId != null) 'UserPoolId': userPoolId,
+    };
+  }
+}
+
+/// The status of the Cognito options for the specified domain.
+class CognitoOptionsStatus {
+  /// Cognito options for the specified domain.
+  final CognitoOptions options;
+
+  /// The status of the Cognito options for the specified domain.
+  final OptionStatus status;
+
+  CognitoOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory CognitoOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return CognitoOptionsStatus(
+      options: CognitoOptions.fromJson(json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Specifies the configuration for cold storage options such as enabled
+class ColdStorageOptions {
+  /// Enable cold storage option. Accepted values true or false
+  final bool enabled;
+
+  ColdStorageOptions({
+    required this.enabled,
+  });
+  factory ColdStorageOptions.fromJson(Map<String, dynamic> json) {
+    return ColdStorageOptions(
+      enabled: json['Enabled'] as bool,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    return {
+      'Enabled': enabled,
+    };
+  }
+}
+
+/// A map from an <code> <a>EngineVersion</a> </code> to a list of compatible
+/// <code> <a>EngineVersion</a> </code> s to which the domain can be upgraded.
+class CompatibleVersionsMap {
+  /// The current version of OpenSearch a domain is on.
+  final String? sourceVersion;
+  final List<String>? targetVersions;
+
+  CompatibleVersionsMap({
+    this.sourceVersion,
+    this.targetVersions,
+  });
+  factory CompatibleVersionsMap.fromJson(Map<String, dynamic> json) {
+    return CompatibleVersionsMap(
+      sourceVersion: json['SourceVersion'] as String?,
+      targetVersions: (json['TargetVersions'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+    );
+  }
+}
+
+/// The result of a <code>CreateDomain</code> operation. Contains the status of
+/// the newly created Amazon OpenSearch Service domain.
+class CreateDomainResponse {
+  /// The status of the newly created domain.
+  final DomainStatus? domainStatus;
+
+  CreateDomainResponse({
+    this.domainStatus,
+  });
+  factory CreateDomainResponse.fromJson(Map<String, dynamic> json) {
+    return CreateDomainResponse(
+      domainStatus: json['DomainStatus'] != null
+          ? DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The result of a <code> <a>CreateOutboundConnection</a> </code> request.
+/// Contains the details about the newly created cross-cluster connection.
+class CreateOutboundConnectionResponse {
+  /// The connection alias provided during the create connection request.
+  final String? connectionAlias;
+
+  /// The unique ID for the created outbound connection, which is used for
+  /// subsequent operations on the connection.
+  final String? connectionId;
+
+  /// The <code> <a>OutboundConnectionStatus</a> </code> for the newly created
+  /// connection.
+  final OutboundConnectionStatus? connectionStatus;
+
+  /// The <code> <a>AWSDomainInformation</a> </code> for the local OpenSearch
+  /// domain.
+  final DomainInformationContainer? localDomainInfo;
+
+  /// The <code> <a>AWSDomainInformation</a> </code> for the remote OpenSearch
+  /// domain.
+  final DomainInformationContainer? remoteDomainInfo;
+
+  CreateOutboundConnectionResponse({
+    this.connectionAlias,
+    this.connectionId,
+    this.connectionStatus,
+    this.localDomainInfo,
+    this.remoteDomainInfo,
+  });
+  factory CreateOutboundConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return CreateOutboundConnectionResponse(
+      connectionAlias: json['ConnectionAlias'] as String?,
+      connectionId: json['ConnectionId'] as String?,
+      connectionStatus: json['ConnectionStatus'] != null
+          ? OutboundConnectionStatus.fromJson(
+              json['ConnectionStatus'] as Map<String, dynamic>)
+          : null,
+      localDomainInfo: json['LocalDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['LocalDomainInfo'] as Map<String, dynamic>)
+          : null,
+      remoteDomainInfo: json['RemoteDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['RemoteDomainInfo'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Container for the response returned by the <code> <a>CreatePackage</a>
+/// </code> operation.
+class CreatePackageResponse {
+  /// Information about the package.
+  final PackageDetails? packageDetails;
+
+  CreatePackageResponse({
+    this.packageDetails,
+  });
+  factory CreatePackageResponse.fromJson(Map<String, dynamic> json) {
+    return CreatePackageResponse(
+      packageDetails: json['PackageDetails'] != null
+          ? PackageDetails.fromJson(
+              json['PackageDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The result of a <code>DeleteDomain</code> request. Contains the status of
+/// the pending deletion, or a "domain not found" error if the domain and all of
+/// its resources have been deleted.
+class DeleteDomainResponse {
+  /// The status of the domain being deleted.
+  final DomainStatus? domainStatus;
+
+  DeleteDomainResponse({
+    this.domainStatus,
+  });
+  factory DeleteDomainResponse.fromJson(Map<String, dynamic> json) {
+    return DeleteDomainResponse(
+      domainStatus: json['DomainStatus'] != null
+          ? DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The result of a <code> <a>DeleteInboundConnection</a> </code> operation.
+/// Contains details about the deleted inbound connection.
+class DeleteInboundConnectionResponse {
+  /// The <code> <a>InboundConnection</a> </code> of the deleted inbound
+  /// connection.
+  final InboundConnection? connection;
+
+  DeleteInboundConnectionResponse({
+    this.connection,
+  });
+  factory DeleteInboundConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return DeleteInboundConnectionResponse(
+      connection: json['Connection'] != null
+          ? InboundConnection.fromJson(
+              json['Connection'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The result of a <code> <a>DeleteOutboundConnection</a> </code> operation.
+/// Contains details about the deleted outbound connection.
+class DeleteOutboundConnectionResponse {
+  /// The <code> <a>OutboundConnection</a> </code> of the deleted outbound
+  /// connection.
+  final OutboundConnection? connection;
+
+  DeleteOutboundConnectionResponse({
+    this.connection,
+  });
+  factory DeleteOutboundConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return DeleteOutboundConnectionResponse(
+      connection: json['Connection'] != null
+          ? OutboundConnection.fromJson(
+              json['Connection'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Container for the response parameters to the <code> <a>DeletePackage</a>
+/// </code> operation.
+class DeletePackageResponse {
+  /// <code>PackageDetails</code>
+  final PackageDetails? packageDetails;
+
+  DeletePackageResponse({
+    this.packageDetails,
+  });
+  factory DeletePackageResponse.fromJson(Map<String, dynamic> json) {
+    return DeletePackageResponse(
+      packageDetails: json['PackageDetails'] != null
+          ? PackageDetails.fromJson(
+              json['PackageDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+enum DeploymentStatus {
+  pendingUpdate,
+  inProgress,
+  completed,
+  notEligible,
+  eligible,
+}
+
+extension DeploymentStatusValue on DeploymentStatus {
+  String toValue() {
+    switch (this) {
+      case DeploymentStatus.pendingUpdate:
+        return 'PENDING_UPDATE';
+      case DeploymentStatus.inProgress:
+        return 'IN_PROGRESS';
+      case DeploymentStatus.completed:
+        return 'COMPLETED';
+      case DeploymentStatus.notEligible:
+        return 'NOT_ELIGIBLE';
+      case DeploymentStatus.eligible:
+        return 'ELIGIBLE';
+    }
+  }
+}
+
+extension DeploymentStatusFromString on String {
+  DeploymentStatus toDeploymentStatus() {
+    switch (this) {
+      case 'PENDING_UPDATE':
+        return DeploymentStatus.pendingUpdate;
+      case 'IN_PROGRESS':
+        return DeploymentStatus.inProgress;
+      case 'COMPLETED':
+        return DeploymentStatus.completed;
+      case 'NOT_ELIGIBLE':
+        return DeploymentStatus.notEligible;
+      case 'ELIGIBLE':
+        return DeploymentStatus.eligible;
+    }
+    throw Exception('$this is not known in enum DeploymentStatus');
+  }
+}
+
+/// The result of a <code>DescribeDomainAutoTunes</code> request. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+class DescribeDomainAutoTunesResponse {
+  /// The list of setting adjustments that Auto-Tune has made to the domain. See
+  /// <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final List<AutoTune>? autoTunes;
+
+  /// An identifier to allow retrieval of paginated results.
+  final String? nextToken;
+
+  DescribeDomainAutoTunesResponse({
+    this.autoTunes,
+    this.nextToken,
+  });
+  factory DescribeDomainAutoTunesResponse.fromJson(Map<String, dynamic> json) {
+    return DescribeDomainAutoTunesResponse(
+      autoTunes: (json['AutoTunes'] as List?)
+          ?.whereNotNull()
+          .map((e) => AutoTune.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+/// The result of a <code>DescribeDomainChangeProgress</code> request. Contains
+/// the progress information of the requested domain change.
+class DescribeDomainChangeProgressResponse {
+  /// Progress information for the configuration change that is requested in the
+  /// <code>DescribeDomainChangeProgress</code> request.
+  final ChangeProgressStatusDetails? changeProgressStatus;
+
+  DescribeDomainChangeProgressResponse({
+    this.changeProgressStatus,
+  });
+  factory DescribeDomainChangeProgressResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeDomainChangeProgressResponse(
+      changeProgressStatus: json['ChangeProgressStatus'] != null
+          ? ChangeProgressStatusDetails.fromJson(
+              json['ChangeProgressStatus'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The result of a <code>DescribeDomainConfig</code> request. Contains the
+/// configuration information of the requested domain.
+class DescribeDomainConfigResponse {
+  /// The configuration information of the domain requested in the
+  /// <code>DescribeDomainConfig</code> request.
+  final DomainConfig domainConfig;
+
+  DescribeDomainConfigResponse({
+    required this.domainConfig,
+  });
+  factory DescribeDomainConfigResponse.fromJson(Map<String, dynamic> json) {
+    return DescribeDomainConfigResponse(
+      domainConfig:
+          DomainConfig.fromJson(json['DomainConfig'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// The result of a <code>DescribeDomain</code> request. Contains the status of
+/// the domain specified in the request.
+class DescribeDomainResponse {
+  /// The current status of the domain.
+  final DomainStatus domainStatus;
+
+  DescribeDomainResponse({
+    required this.domainStatus,
+  });
+  factory DescribeDomainResponse.fromJson(Map<String, dynamic> json) {
+    return DescribeDomainResponse(
+      domainStatus:
+          DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// The result of a <code>DescribeDomains</code> request. Contains the status of
+/// the specified domains or all domains owned by the account.
+class DescribeDomainsResponse {
+  /// The status of the domains requested in the <code>DescribeDomains</code>
+  /// request.
+  final List<DomainStatus> domainStatusList;
+
+  DescribeDomainsResponse({
+    required this.domainStatusList,
+  });
+  factory DescribeDomainsResponse.fromJson(Map<String, dynamic> json) {
+    return DescribeDomainsResponse(
+      domainStatusList: (json['DomainStatusList'] as List)
+          .whereNotNull()
+          .map((e) => DomainStatus.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// The result of a <code> <a>DescribeInboundConnections</a> </code> request.
+/// Contains a list of connections matching the filter criteria.
+class DescribeInboundConnectionsResponse {
+  /// A list of <code> <a>InboundConnection</a> </code> matching the specified
+  /// filter criteria.
+  final List<InboundConnection>? connections;
+
+  /// If more results are available and NextToken is present, make the next
+  /// request to the same API with the received NextToken to paginate the
+  /// remaining results.
+  final String? nextToken;
+
+  DescribeInboundConnectionsResponse({
+    this.connections,
+    this.nextToken,
+  });
+  factory DescribeInboundConnectionsResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeInboundConnectionsResponse(
+      connections: (json['Connections'] as List?)
+          ?.whereNotNull()
+          .map((e) => InboundConnection.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+/// Container for the parameters received from the <code>
+/// <a>DescribeInstanceTypeLimits</a> </code> operation.
+class DescribeInstanceTypeLimitsResponse {
+  final Map<String, Limits>? limitsByRole;
+
+  DescribeInstanceTypeLimitsResponse({
+    this.limitsByRole,
+  });
+  factory DescribeInstanceTypeLimitsResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeInstanceTypeLimitsResponse(
+      limitsByRole: (json['LimitsByRole'] as Map<String, dynamic>?)?.map(
+          (k, e) => MapEntry(k, Limits.fromJson(e as Map<String, dynamic>))),
+    );
+  }
+}
+
+/// The result of a <code> <a>DescribeOutboundConnections</a> </code> request.
+/// Contains the list of connections matching the filter criteria.
+class DescribeOutboundConnectionsResponse {
+  /// A list of <code> <a>OutboundConnection</a> </code> matching the specified
+  /// filter criteria.
+  final List<OutboundConnection>? connections;
+
+  /// If more results are available and NextToken is present, make the next
+  /// request to the same API with the received NextToken to paginate the
+  /// remaining results.
+  final String? nextToken;
+
+  DescribeOutboundConnectionsResponse({
+    this.connections,
+    this.nextToken,
+  });
+  factory DescribeOutboundConnectionsResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeOutboundConnectionsResponse(
+      connections: (json['Connections'] as List?)
+          ?.whereNotNull()
+          .map((e) => OutboundConnection.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+/// A filter to apply to the <code>DescribePackage</code> response.
+class DescribePackagesFilter {
+  /// Any field from <code>PackageDetails</code>.
+  final DescribePackagesFilterName? name;
+
+  /// A list of values for the specified field.
+  final List<String>? value;
+
+  DescribePackagesFilter({
+    this.name,
+    this.value,
+  });
+  Map<String, dynamic> toJson() {
+    final name = this.name;
+    final value = this.value;
+    return {
+      if (name != null) 'Name': name.toValue(),
+      if (value != null) 'Value': value,
+    };
+  }
+}
+
+enum DescribePackagesFilterName {
+  packageID,
+  packageName,
+  packageStatus,
+}
+
+extension DescribePackagesFilterNameValue on DescribePackagesFilterName {
+  String toValue() {
+    switch (this) {
+      case DescribePackagesFilterName.packageID:
+        return 'PackageID';
+      case DescribePackagesFilterName.packageName:
+        return 'PackageName';
+      case DescribePackagesFilterName.packageStatus:
+        return 'PackageStatus';
+    }
+  }
+}
+
+extension DescribePackagesFilterNameFromString on String {
+  DescribePackagesFilterName toDescribePackagesFilterName() {
+    switch (this) {
+      case 'PackageID':
+        return DescribePackagesFilterName.packageID;
+      case 'PackageName':
+        return DescribePackagesFilterName.packageName;
+      case 'PackageStatus':
+        return DescribePackagesFilterName.packageStatus;
+    }
+    throw Exception('$this is not known in enum DescribePackagesFilterName');
+  }
+}
+
+/// Container for the response returned by the <code> <a>DescribePackages</a>
+/// </code> operation.
+class DescribePackagesResponse {
+  final String? nextToken;
+
+  /// List of <code>PackageDetails</code> objects.
+  final List<PackageDetails>? packageDetailsList;
+
+  DescribePackagesResponse({
+    this.nextToken,
+    this.packageDetailsList,
+  });
+  factory DescribePackagesResponse.fromJson(Map<String, dynamic> json) {
+    return DescribePackagesResponse(
+      nextToken: json['NextToken'] as String?,
+      packageDetailsList: (json['PackageDetailsList'] as List?)
+          ?.whereNotNull()
+          .map((e) => PackageDetails.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for results from <code>DescribeReservedInstanceOfferings</code>
+class DescribeReservedInstanceOfferingsResponse {
+  /// Provides an identifier to allow retrieval of paginated results.
+  final String? nextToken;
+
+  /// List of reserved OpenSearch instance offerings
+  final List<ReservedInstanceOffering>? reservedInstanceOfferings;
+
+  DescribeReservedInstanceOfferingsResponse({
+    this.nextToken,
+    this.reservedInstanceOfferings,
+  });
+  factory DescribeReservedInstanceOfferingsResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeReservedInstanceOfferingsResponse(
+      nextToken: json['NextToken'] as String?,
+      reservedInstanceOfferings: (json['ReservedInstanceOfferings'] as List?)
+          ?.whereNotNull()
+          .map((e) =>
+              ReservedInstanceOffering.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for results from <code>DescribeReservedInstances</code>
+class DescribeReservedInstancesResponse {
+  /// Provides an identifier to allow retrieval of paginated results.
+  final String? nextToken;
+
+  /// List of reserved OpenSearch instances.
+  final List<ReservedInstance>? reservedInstances;
+
+  DescribeReservedInstancesResponse({
+    this.nextToken,
+    this.reservedInstances,
+  });
+  factory DescribeReservedInstancesResponse.fromJson(
+      Map<String, dynamic> json) {
+    return DescribeReservedInstancesResponse(
+      nextToken: json['NextToken'] as String?,
+      reservedInstances: (json['ReservedInstances'] as List?)
+          ?.whereNotNull()
+          .map((e) => ReservedInstance.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for the response returned by <code> <a>DissociatePackage</a>
+/// </code> operation.
+class DissociatePackageResponse {
+  /// <code>DomainPackageDetails</code>
+  final DomainPackageDetails? domainPackageDetails;
+
+  DissociatePackageResponse({
+    this.domainPackageDetails,
+  });
+  factory DissociatePackageResponse.fromJson(Map<String, dynamic> json) {
+    return DissociatePackageResponse(
+      domainPackageDetails: json['DomainPackageDetails'] != null
+          ? DomainPackageDetails.fromJson(
+              json['DomainPackageDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The configuration of a domain.
+class DomainConfig {
+  /// IAM access policy as a JSON-formatted string.
+  final AccessPoliciesStatus? accessPolicies;
+
+  /// The <code>AdvancedOptions</code> for the domain. See <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/createupdatedomains.html#createdomain-configure-advanced-options"
+  /// target="_blank">Advanced options </a> for more information.
+  final AdvancedOptionsStatus? advancedOptions;
+
+  /// Specifies <code>AdvancedSecurityOptions</code> for the domain.
+  final AdvancedSecurityOptionsStatus? advancedSecurityOptions;
+
+  /// Specifies <code>AutoTuneOptions</code> for the domain.
+  final AutoTuneOptionsStatus? autoTuneOptions;
+
+  /// Specifies change details of the domain configuration change.
+  final ChangeProgressDetails? changeProgressDetails;
+
+  /// The <code>ClusterConfig</code> for the domain.
+  final ClusterConfigStatus? clusterConfig;
+
+  /// The <code>CognitoOptions</code> for the specified domain. For more
+  /// information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html"
+  /// target="_blank">Configuring Amazon Cognito authentication for OpenSearch
+  /// Dashboards</a>.
+  final CognitoOptionsStatus? cognitoOptions;
+
+  /// The <code>DomainEndpointOptions</code> for the domain.
+  final DomainEndpointOptionsStatus? domainEndpointOptions;
+
+  /// The <code>EBSOptions</code> for the domain.
+  final EBSOptionsStatus? eBSOptions;
+
+  /// The <code>EncryptionAtRestOptions</code> for the domain.
+  final EncryptionAtRestOptionsStatus? encryptionAtRestOptions;
+
+  /// String of format Elasticsearch_X.Y or OpenSearch_X.Y to specify the engine
+  /// version for the OpenSearch or Elasticsearch domain.
+  final VersionStatus? engineVersion;
+
+  /// Log publishing options for the given domain.
+  final LogPublishingOptionsStatus? logPublishingOptions;
+
+  /// The <code>NodeToNodeEncryptionOptions</code> for the domain.
+  final NodeToNodeEncryptionOptionsStatus? nodeToNodeEncryptionOptions;
+
+  /// The <code>SnapshotOptions</code> for the domain.
+  final SnapshotOptionsStatus? snapshotOptions;
+
+  /// The <code>VPCOptions</code> for the specified domain. For more information,
+  /// see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+  /// target="_blank"> Launching your Amazon OpenSearch Service domains using a
+  /// VPC</a>.
+  final VPCDerivedInfoStatus? vPCOptions;
+
+  DomainConfig({
+    this.accessPolicies,
+    this.advancedOptions,
+    this.advancedSecurityOptions,
+    this.autoTuneOptions,
+    this.changeProgressDetails,
+    this.clusterConfig,
+    this.cognitoOptions,
+    this.domainEndpointOptions,
+    this.eBSOptions,
+    this.encryptionAtRestOptions,
+    this.engineVersion,
+    this.logPublishingOptions,
+    this.nodeToNodeEncryptionOptions,
+    this.snapshotOptions,
+    this.vPCOptions,
+  });
+  factory DomainConfig.fromJson(Map<String, dynamic> json) {
+    return DomainConfig(
+      accessPolicies: json['AccessPolicies'] != null
+          ? AccessPoliciesStatus.fromJson(
+              json['AccessPolicies'] as Map<String, dynamic>)
+          : null,
+      advancedOptions: json['AdvancedOptions'] != null
+          ? AdvancedOptionsStatus.fromJson(
+              json['AdvancedOptions'] as Map<String, dynamic>)
+          : null,
+      advancedSecurityOptions: json['AdvancedSecurityOptions'] != null
+          ? AdvancedSecurityOptionsStatus.fromJson(
+              json['AdvancedSecurityOptions'] as Map<String, dynamic>)
+          : null,
+      autoTuneOptions: json['AutoTuneOptions'] != null
+          ? AutoTuneOptionsStatus.fromJson(
+              json['AutoTuneOptions'] as Map<String, dynamic>)
+          : null,
+      changeProgressDetails: json['ChangeProgressDetails'] != null
+          ? ChangeProgressDetails.fromJson(
+              json['ChangeProgressDetails'] as Map<String, dynamic>)
+          : null,
+      clusterConfig: json['ClusterConfig'] != null
+          ? ClusterConfigStatus.fromJson(
+              json['ClusterConfig'] as Map<String, dynamic>)
+          : null,
+      cognitoOptions: json['CognitoOptions'] != null
+          ? CognitoOptionsStatus.fromJson(
+              json['CognitoOptions'] as Map<String, dynamic>)
+          : null,
+      domainEndpointOptions: json['DomainEndpointOptions'] != null
+          ? DomainEndpointOptionsStatus.fromJson(
+              json['DomainEndpointOptions'] as Map<String, dynamic>)
+          : null,
+      eBSOptions: json['EBSOptions'] != null
+          ? EBSOptionsStatus.fromJson(
+              json['EBSOptions'] as Map<String, dynamic>)
+          : null,
+      encryptionAtRestOptions: json['EncryptionAtRestOptions'] != null
+          ? EncryptionAtRestOptionsStatus.fromJson(
+              json['EncryptionAtRestOptions'] as Map<String, dynamic>)
+          : null,
+      engineVersion: json['EngineVersion'] != null
+          ? VersionStatus.fromJson(
+              json['EngineVersion'] as Map<String, dynamic>)
+          : null,
+      logPublishingOptions: json['LogPublishingOptions'] != null
+          ? LogPublishingOptionsStatus.fromJson(
+              json['LogPublishingOptions'] as Map<String, dynamic>)
+          : null,
+      nodeToNodeEncryptionOptions: json['NodeToNodeEncryptionOptions'] != null
+          ? NodeToNodeEncryptionOptionsStatus.fromJson(
+              json['NodeToNodeEncryptionOptions'] as Map<String, dynamic>)
+          : null,
+      snapshotOptions: json['SnapshotOptions'] != null
+          ? SnapshotOptionsStatus.fromJson(
+              json['SnapshotOptions'] as Map<String, dynamic>)
+          : null,
+      vPCOptions: json['VPCOptions'] != null
+          ? VPCDerivedInfoStatus.fromJson(
+              json['VPCOptions'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Options to configure the endpoint for the domain.
+class DomainEndpointOptions {
+  /// The fully qualified domain for your custom endpoint.
+  final String? customEndpoint;
+
+  /// The ACM certificate ARN for your custom endpoint.
+  final String? customEndpointCertificateArn;
+
+  /// Whether to enable a custom endpoint for the domain.
+  final bool? customEndpointEnabled;
+
+  /// Whether only HTTPS endpoint should be enabled for the domain.
+  final bool? enforceHTTPS;
+
+  /// Specify the TLS security policy to apply to the HTTPS endpoint of the
+  /// domain. <br/> Can be one of the following values:
+  /// <ul>
+  /// <li> <b>Policy-Min-TLS-1-0-2019-07:</b> TLS security policy which supports
+  /// TLSv1.0 and higher. </li>
+  /// <li> <b>Policy-Min-TLS-1-2-2019-07:</b> TLS security policy which supports
+  /// only TLSv1.2 </li>
+  /// </ul>
+  final TLSSecurityPolicy? tLSSecurityPolicy;
+
+  DomainEndpointOptions({
+    this.customEndpoint,
+    this.customEndpointCertificateArn,
+    this.customEndpointEnabled,
+    this.enforceHTTPS,
+    this.tLSSecurityPolicy,
+  });
+  factory DomainEndpointOptions.fromJson(Map<String, dynamic> json) {
+    return DomainEndpointOptions(
+      customEndpoint: json['CustomEndpoint'] as String?,
+      customEndpointCertificateArn:
+          json['CustomEndpointCertificateArn'] as String?,
+      customEndpointEnabled: json['CustomEndpointEnabled'] as bool?,
+      enforceHTTPS: json['EnforceHTTPS'] as bool?,
+      tLSSecurityPolicy:
+          (json['TLSSecurityPolicy'] as String?)?.toTLSSecurityPolicy(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final customEndpoint = this.customEndpoint;
+    final customEndpointCertificateArn = this.customEndpointCertificateArn;
+    final customEndpointEnabled = this.customEndpointEnabled;
+    final enforceHTTPS = this.enforceHTTPS;
+    final tLSSecurityPolicy = this.tLSSecurityPolicy;
+    return {
+      if (customEndpoint != null) 'CustomEndpoint': customEndpoint,
+      if (customEndpointCertificateArn != null)
+        'CustomEndpointCertificateArn': customEndpointCertificateArn,
+      if (customEndpointEnabled != null)
+        'CustomEndpointEnabled': customEndpointEnabled,
+      if (enforceHTTPS != null) 'EnforceHTTPS': enforceHTTPS,
+      if (tLSSecurityPolicy != null)
+        'TLSSecurityPolicy': tLSSecurityPolicy.toValue(),
+    };
+  }
+}
+
+/// The configured endpoint options for the domain and their current status.
+class DomainEndpointOptionsStatus {
+  /// Options to configure the endpoint for the domain.
+  final DomainEndpointOptions options;
+
+  /// The status of the endpoint options for the domain. See
+  /// <code>OptionStatus</code> for the status information that's included.
+  final OptionStatus status;
+
+  DomainEndpointOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory DomainEndpointOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return DomainEndpointOptionsStatus(
+      options: DomainEndpointOptions.fromJson(
+          json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+class DomainInfo {
+  /// The <code>DomainName</code>.
+  final String? domainName;
+
+  /// Specifies the <code>EngineType</code> of the domain.
+  final EngineType? engineType;
+
+  DomainInfo({
+    this.domainName,
+    this.engineType,
+  });
+  factory DomainInfo.fromJson(Map<String, dynamic> json) {
+    return DomainInfo(
+      domainName: json['DomainName'] as String?,
+      engineType: (json['EngineType'] as String?)?.toEngineType(),
+    );
+  }
+}
+
+class DomainInformationContainer {
+  final AWSDomainInformation? awsDomainInformation;
+
+  DomainInformationContainer({
+    this.awsDomainInformation,
+  });
+  factory DomainInformationContainer.fromJson(Map<String, dynamic> json) {
+    return DomainInformationContainer(
+      awsDomainInformation: json['AWSDomainInformation'] != null
+          ? AWSDomainInformation.fromJson(
+              json['AWSDomainInformation'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final awsDomainInformation = this.awsDomainInformation;
+    return {
+      if (awsDomainInformation != null)
+        'AWSDomainInformation': awsDomainInformation,
+    };
+  }
+}
+
+/// Information on a package associated with a domain.
+class DomainPackageDetails {
+  /// The name of the domain you've associated a package with.
+  final String? domainName;
+
+  /// State of the association. Values are ASSOCIATING, ASSOCIATION_FAILED,
+  /// ACTIVE, DISSOCIATING, and DISSOCIATION_FAILED.
+  final DomainPackageStatus? domainPackageStatus;
+
+  /// Additional information if the package is in an error state. Null otherwise.
+  final ErrorDetails? errorDetails;
+
+  /// The timestamp of the most recent update to the package association status.
+  final DateTime? lastUpdated;
+
+  /// The internal ID of the package.
+  final String? packageID;
+
+  /// User-specified name of the package.
+  final String? packageName;
+
+  /// Currently supports only TXT-DICTIONARY.
+  final PackageType? packageType;
+  final String? packageVersion;
+
+  /// The relative path on Amazon OpenSearch Service nodes, which can be used as
+  /// synonym_path when the package is a synonym file.
+  final String? referencePath;
+
+  DomainPackageDetails({
+    this.domainName,
+    this.domainPackageStatus,
+    this.errorDetails,
+    this.lastUpdated,
+    this.packageID,
+    this.packageName,
+    this.packageType,
+    this.packageVersion,
+    this.referencePath,
+  });
+  factory DomainPackageDetails.fromJson(Map<String, dynamic> json) {
+    return DomainPackageDetails(
+      domainName: json['DomainName'] as String?,
+      domainPackageStatus:
+          (json['DomainPackageStatus'] as String?)?.toDomainPackageStatus(),
+      errorDetails: json['ErrorDetails'] != null
+          ? ErrorDetails.fromJson(json['ErrorDetails'] as Map<String, dynamic>)
+          : null,
+      lastUpdated: timeStampFromJson(json['LastUpdated']),
+      packageID: json['PackageID'] as String?,
+      packageName: json['PackageName'] as String?,
+      packageType: (json['PackageType'] as String?)?.toPackageType(),
+      packageVersion: json['PackageVersion'] as String?,
+      referencePath: json['ReferencePath'] as String?,
+    );
+  }
+}
+
+enum DomainPackageStatus {
+  associating,
+  associationFailed,
+  active,
+  dissociating,
+  dissociationFailed,
+}
+
+extension DomainPackageStatusValue on DomainPackageStatus {
+  String toValue() {
+    switch (this) {
+      case DomainPackageStatus.associating:
+        return 'ASSOCIATING';
+      case DomainPackageStatus.associationFailed:
+        return 'ASSOCIATION_FAILED';
+      case DomainPackageStatus.active:
+        return 'ACTIVE';
+      case DomainPackageStatus.dissociating:
+        return 'DISSOCIATING';
+      case DomainPackageStatus.dissociationFailed:
+        return 'DISSOCIATION_FAILED';
+    }
+  }
+}
+
+extension DomainPackageStatusFromString on String {
+  DomainPackageStatus toDomainPackageStatus() {
+    switch (this) {
+      case 'ASSOCIATING':
+        return DomainPackageStatus.associating;
+      case 'ASSOCIATION_FAILED':
+        return DomainPackageStatus.associationFailed;
+      case 'ACTIVE':
+        return DomainPackageStatus.active;
+      case 'DISSOCIATING':
+        return DomainPackageStatus.dissociating;
+      case 'DISSOCIATION_FAILED':
+        return DomainPackageStatus.dissociationFailed;
+    }
+    throw Exception('$this is not known in enum DomainPackageStatus');
+  }
+}
+
+/// The current status of a domain.
+class DomainStatus {
+  /// The Amazon Resource Name (ARN) of a domain. See <a
+  /// href="https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html"
+  /// target="_blank">IAM identifiers </a> in the <i>AWS Identity and Access
+  /// Management User Guide</i> for more information.
+  final String arn;
+
+  /// The type and number of instances in the domain.
+  final ClusterConfig clusterConfig;
+
+  /// The unique identifier for the specified domain.
+  final String domainId;
+
+  /// The name of a domain. Domain names are unique across the domains owned by an
+  /// account within an AWS region. Domain names start with a letter or number and
+  /// can contain the following characters: a-z (lowercase), 0-9, and - (hyphen).
+  final String domainName;
+
+  /// IAM access policy as a JSON-formatted string.
+  final String? accessPolicies;
+
+  /// The status of the <code>AdvancedOptions</code>.
+  final Map<String, String>? advancedOptions;
+
+  /// The current status of the domain's advanced security options.
+  final AdvancedSecurityOptions? advancedSecurityOptions;
+
+  /// The current status of the domain's Auto-Tune options.
+  final AutoTuneOptionsOutput? autoTuneOptions;
+
+  /// Specifies change details of the domain configuration change.
+  final ChangeProgressDetails? changeProgressDetails;
+
+  /// The <code>CognitoOptions</code> for the specified domain. For more
+  /// information, see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html"
+  /// target="_blank">Configuring Amazon Cognito authentication for OpenSearch
+  /// Dashboards</a>.
+  final CognitoOptions? cognitoOptions;
+
+  /// The domain creation status. <code>True</code> if the creation of a domain is
+  /// complete. <code> False </code> if domain creation is still in progress.
+  final bool? created;
+
+  /// The domain deletion status. <code>True</code> if a delete request has been
+  /// received for the domain but resource cleanup is still in progress.
+  /// <code>False</code> if the domain has not been deleted. Once domain deletion
+  /// is complete, the status of the domain is no longer returned.
+  final bool? deleted;
+
+  /// The current status of the domain's endpoint options.
+  final DomainEndpointOptions? domainEndpointOptions;
+
+  /// The <code>EBSOptions</code> for the specified domain.
+  final EBSOptions? eBSOptions;
+
+  /// The status of the <code>EncryptionAtRestOptions</code>.
+  final EncryptionAtRestOptions? encryptionAtRestOptions;
+
+  /// The domain endpoint that you use to submit index and search requests.
+  final String? endpoint;
+
+  /// Map containing the domain endpoints used to submit index and search
+  /// requests. Example <code>key, value</code>:
+  /// <code>'vpc','vpc-endpoint-h2dsd34efgyghrtguk5gt6j2foh4.us-east-1.es.amazonaws.com'</code>.
+  final Map<String, String>? endpoints;
+  final String? engineVersion;
+
+  /// Log publishing options for the given domain.
+  final Map<LogType, LogPublishingOption>? logPublishingOptions;
+
+  /// The status of the <code>NodeToNodeEncryptionOptions</code>.
+  final NodeToNodeEncryptionOptions? nodeToNodeEncryptionOptions;
+
+  /// The status of the domain configuration. <code>True</code> if Amazon
+  /// OpenSearch Service is processing configuration changes. <code>False</code>
+  /// if the configuration is active.
+  final bool? processing;
+
+  /// The current status of the domain's service software.
+  final ServiceSoftwareOptions? serviceSoftwareOptions;
+
+  /// The status of the <code>SnapshotOptions</code>.
+  final SnapshotOptions? snapshotOptions;
+
+  /// The status of a domain version upgrade. <code>True</code> if Amazon
+  /// OpenSearch Service is undergoing a version upgrade. <code>False</code> if
+  /// the configuration is active.
+  final bool? upgradeProcessing;
+
+  /// The <code>VPCOptions</code> for the specified domain. For more information,
+  /// see <a
+  /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+  /// target="_blank"> Launching your Amazon OpenSearch Service domains using a
+  /// VPC</a>.
+  final VPCDerivedInfo? vPCOptions;
+
+  DomainStatus({
+    required this.arn,
+    required this.clusterConfig,
+    required this.domainId,
+    required this.domainName,
+    this.accessPolicies,
+    this.advancedOptions,
+    this.advancedSecurityOptions,
+    this.autoTuneOptions,
+    this.changeProgressDetails,
+    this.cognitoOptions,
+    this.created,
+    this.deleted,
+    this.domainEndpointOptions,
+    this.eBSOptions,
+    this.encryptionAtRestOptions,
+    this.endpoint,
+    this.endpoints,
+    this.engineVersion,
+    this.logPublishingOptions,
+    this.nodeToNodeEncryptionOptions,
+    this.processing,
+    this.serviceSoftwareOptions,
+    this.snapshotOptions,
+    this.upgradeProcessing,
+    this.vPCOptions,
+  });
+  factory DomainStatus.fromJson(Map<String, dynamic> json) {
+    return DomainStatus(
+      arn: json['ARN'] as String,
+      clusterConfig:
+          ClusterConfig.fromJson(json['ClusterConfig'] as Map<String, dynamic>),
+      domainId: json['DomainId'] as String,
+      domainName: json['DomainName'] as String,
+      accessPolicies: json['AccessPolicies'] as String?,
+      advancedOptions: (json['AdvancedOptions'] as Map<String, dynamic>?)
+          ?.map((k, e) => MapEntry(k, e as String)),
+      advancedSecurityOptions: json['AdvancedSecurityOptions'] != null
+          ? AdvancedSecurityOptions.fromJson(
+              json['AdvancedSecurityOptions'] as Map<String, dynamic>)
+          : null,
+      autoTuneOptions: json['AutoTuneOptions'] != null
+          ? AutoTuneOptionsOutput.fromJson(
+              json['AutoTuneOptions'] as Map<String, dynamic>)
+          : null,
+      changeProgressDetails: json['ChangeProgressDetails'] != null
+          ? ChangeProgressDetails.fromJson(
+              json['ChangeProgressDetails'] as Map<String, dynamic>)
+          : null,
+      cognitoOptions: json['CognitoOptions'] != null
+          ? CognitoOptions.fromJson(
+              json['CognitoOptions'] as Map<String, dynamic>)
+          : null,
+      created: json['Created'] as bool?,
+      deleted: json['Deleted'] as bool?,
+      domainEndpointOptions: json['DomainEndpointOptions'] != null
+          ? DomainEndpointOptions.fromJson(
+              json['DomainEndpointOptions'] as Map<String, dynamic>)
+          : null,
+      eBSOptions: json['EBSOptions'] != null
+          ? EBSOptions.fromJson(json['EBSOptions'] as Map<String, dynamic>)
+          : null,
+      encryptionAtRestOptions: json['EncryptionAtRestOptions'] != null
+          ? EncryptionAtRestOptions.fromJson(
+              json['EncryptionAtRestOptions'] as Map<String, dynamic>)
+          : null,
+      endpoint: json['Endpoint'] as String?,
+      endpoints: (json['Endpoints'] as Map<String, dynamic>?)
+          ?.map((k, e) => MapEntry(k, e as String)),
+      engineVersion: json['EngineVersion'] as String?,
+      logPublishingOptions:
+          (json['LogPublishingOptions'] as Map<String, dynamic>?)?.map((k, e) =>
+              MapEntry(k.toLogType(),
+                  LogPublishingOption.fromJson(e as Map<String, dynamic>))),
+      nodeToNodeEncryptionOptions: json['NodeToNodeEncryptionOptions'] != null
+          ? NodeToNodeEncryptionOptions.fromJson(
+              json['NodeToNodeEncryptionOptions'] as Map<String, dynamic>)
+          : null,
+      processing: json['Processing'] as bool?,
+      serviceSoftwareOptions: json['ServiceSoftwareOptions'] != null
+          ? ServiceSoftwareOptions.fromJson(
+              json['ServiceSoftwareOptions'] as Map<String, dynamic>)
+          : null,
+      snapshotOptions: json['SnapshotOptions'] != null
+          ? SnapshotOptions.fromJson(
+              json['SnapshotOptions'] as Map<String, dynamic>)
+          : null,
+      upgradeProcessing: json['UpgradeProcessing'] as bool?,
+      vPCOptions: json['VPCOptions'] != null
+          ? VPCDerivedInfo.fromJson(json['VPCOptions'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+class DryRunResults {
+  /// Specifies the way in which Amazon OpenSearch Service applies the update.
+  /// Possible responses are <code>Blue/Green</code> (the update requires a
+  /// blue/green deployment), <code>DynamicUpdate</code> (no blue/green required),
+  /// <code>Undetermined</code> (the domain is undergoing an update and can't
+  /// predict the deployment type; try again after the update is complete), and
+  /// <code>None</code> (the request doesn't include any configuration changes).
+  final String? deploymentType;
+
+  /// Contains an optional message associated with the DryRunResults.
+  final String? message;
+
+  DryRunResults({
+    this.deploymentType,
+    this.message,
+  });
+  factory DryRunResults.fromJson(Map<String, dynamic> json) {
+    return DryRunResults(
+      deploymentType: json['DeploymentType'] as String?,
+      message: json['Message'] as String?,
+    );
+  }
+}
+
+/// The maintenance schedule duration: duration value and duration unit. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+class Duration {
+  /// The unit of a maintenance schedule duration. Valid value is HOURS. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final TimeUnit? unit;
+
+  /// Integer to specify the value of a maintenance schedule duration. See <a
+  /// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+  /// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+  /// information.
+  final int? value;
+
+  Duration({
+    this.unit,
+    this.value,
+  });
+  factory Duration.fromJson(Map<String, dynamic> json) {
+    return Duration(
+      unit: (json['Unit'] as String?)?.toTimeUnit(),
+      value: json['Value'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final unit = this.unit;
+    final value = this.value;
+    return {
+      if (unit != null) 'Unit': unit.toValue(),
+      if (value != null) 'Value': value,
+    };
+  }
+}
+
+/// Options to enable, disable, and specify the properties of EBS storage
+/// volumes.
+class EBSOptions {
+  /// Whether EBS-based storage is enabled.
+  final bool? eBSEnabled;
+
+  /// The IOPD for a Provisioned IOPS EBS volume (SSD).
+  final int? iops;
+
+  /// Integer to specify the size of an EBS volume.
+  final int? volumeSize;
+
+  /// The volume type for EBS-based storage.
+  final VolumeType? volumeType;
+
+  EBSOptions({
+    this.eBSEnabled,
+    this.iops,
+    this.volumeSize,
+    this.volumeType,
+  });
+  factory EBSOptions.fromJson(Map<String, dynamic> json) {
+    return EBSOptions(
+      eBSEnabled: json['EBSEnabled'] as bool?,
+      iops: json['Iops'] as int?,
+      volumeSize: json['VolumeSize'] as int?,
+      volumeType: (json['VolumeType'] as String?)?.toVolumeType(),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final eBSEnabled = this.eBSEnabled;
+    final iops = this.iops;
+    final volumeSize = this.volumeSize;
+    final volumeType = this.volumeType;
+    return {
+      if (eBSEnabled != null) 'EBSEnabled': eBSEnabled,
+      if (iops != null) 'Iops': iops,
+      if (volumeSize != null) 'VolumeSize': volumeSize,
+      if (volumeType != null) 'VolumeType': volumeType.toValue(),
+    };
+  }
+}
+
+/// Status of the EBS options for the specified domain.
+class EBSOptionsStatus {
+  /// The EBS options for the specified domain.
+  final EBSOptions options;
+
+  /// The status of the EBS options for the specified domain.
+  final OptionStatus status;
+
+  EBSOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory EBSOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return EBSOptionsStatus(
+      options: EBSOptions.fromJson(json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Specifies encryption at rest options.
+class EncryptionAtRestOptions {
+  /// The option to enable encryption at rest.
+  final bool? enabled;
+
+  /// The KMS key ID for encryption at rest options.
+  final String? kmsKeyId;
+
+  EncryptionAtRestOptions({
+    this.enabled,
+    this.kmsKeyId,
+  });
+  factory EncryptionAtRestOptions.fromJson(Map<String, dynamic> json) {
+    return EncryptionAtRestOptions(
+      enabled: json['Enabled'] as bool?,
+      kmsKeyId: json['KmsKeyId'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    final kmsKeyId = this.kmsKeyId;
+    return {
+      if (enabled != null) 'Enabled': enabled,
+      if (kmsKeyId != null) 'KmsKeyId': kmsKeyId,
+    };
+  }
+}
+
+/// Status of the encryption At Rest options for the specified domain.
+class EncryptionAtRestOptionsStatus {
+  /// The Encryption At Rest options for the specified domain.
+  final EncryptionAtRestOptions options;
+
+  /// The status of the Encryption At Rest options for the specified domain.
+  final OptionStatus status;
+
+  EncryptionAtRestOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory EncryptionAtRestOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return EncryptionAtRestOptionsStatus(
+      options: EncryptionAtRestOptions.fromJson(
+          json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+enum EngineType {
+  openSearch,
+  elasticsearch,
+}
+
+extension EngineTypeValue on EngineType {
+  String toValue() {
+    switch (this) {
+      case EngineType.openSearch:
+        return 'OpenSearch';
+      case EngineType.elasticsearch:
+        return 'Elasticsearch';
+    }
+  }
+}
+
+extension EngineTypeFromString on String {
+  EngineType toEngineType() {
+    switch (this) {
+      case 'OpenSearch':
+        return EngineType.openSearch;
+      case 'Elasticsearch':
+        return EngineType.elasticsearch;
+    }
+    throw Exception('$this is not known in enum EngineType');
+  }
+}
+
+class ErrorDetails {
+  final String? errorMessage;
+  final String? errorType;
+
+  ErrorDetails({
+    this.errorMessage,
+    this.errorType,
+  });
+  factory ErrorDetails.fromJson(Map<String, dynamic> json) {
+    return ErrorDetails(
+      errorMessage: json['ErrorMessage'] as String?,
+      errorType: json['ErrorType'] as String?,
+    );
+  }
+}
+
+/// A filter used to limit results when describing inbound or outbound
+/// cross-cluster connections. Multiple values can be specified per filter. A
+/// cross-cluster connection must match at least one of the specified values for
+/// it to be returned from an operation.
+class Filter {
+  /// The name of the filter.
+  final String? name;
+
+  /// Contains one or more values for the filter.
+  final List<String>? values;
+
+  Filter({
+    this.name,
+    this.values,
+  });
+  Map<String, dynamic> toJson() {
+    final name = this.name;
+    final values = this.values;
+    return {
+      if (name != null) 'Name': name,
+      if (values != null) 'Values': values,
+    };
+  }
+}
+
+/// Container for the response returned by the <code>
+/// <a>GetCompatibleVersions</a> </code> operation.
+class GetCompatibleVersionsResponse {
+  /// A map of compatible OpenSearch versions returned as part of the <code>
+  /// <a>GetCompatibleVersions</a> </code> operation.
+  final List<CompatibleVersionsMap>? compatibleVersions;
+
+  GetCompatibleVersionsResponse({
+    this.compatibleVersions,
+  });
+  factory GetCompatibleVersionsResponse.fromJson(Map<String, dynamic> json) {
+    return GetCompatibleVersionsResponse(
+      compatibleVersions: (json['CompatibleVersions'] as List?)
+          ?.whereNotNull()
+          .map((e) => CompatibleVersionsMap.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for response returned by <code> <a>GetPackageVersionHistory</a>
+/// </code> operation.
+class GetPackageVersionHistoryResponse {
+  final String? nextToken;
+  final String? packageID;
+
+  /// List of <code>PackageVersionHistory</code> objects.
+  final List<PackageVersionHistory>? packageVersionHistoryList;
+
+  GetPackageVersionHistoryResponse({
+    this.nextToken,
+    this.packageID,
+    this.packageVersionHistoryList,
+  });
+  factory GetPackageVersionHistoryResponse.fromJson(Map<String, dynamic> json) {
+    return GetPackageVersionHistoryResponse(
+      nextToken: json['NextToken'] as String?,
+      packageID: json['PackageID'] as String?,
+      packageVersionHistoryList: (json['PackageVersionHistoryList'] as List?)
+          ?.whereNotNull()
+          .map((e) => PackageVersionHistory.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for the response returned by the <code> <a>GetUpgradeHistory</a>
+/// </code> operation.
+class GetUpgradeHistoryResponse {
+  /// Pagination token that needs to be supplied to the next call to get the next
+  /// page of results.
+  final String? nextToken;
+
+  /// A list of <code> <a>UpgradeHistory</a> </code> objects corresponding to each
+  /// upgrade or upgrade eligibility check performed on a domain returned as part
+  /// of the <code> <a>GetUpgradeHistoryResponse</a> </code> object.
+  final List<UpgradeHistory>? upgradeHistories;
+
+  GetUpgradeHistoryResponse({
+    this.nextToken,
+    this.upgradeHistories,
+  });
+  factory GetUpgradeHistoryResponse.fromJson(Map<String, dynamic> json) {
+    return GetUpgradeHistoryResponse(
+      nextToken: json['NextToken'] as String?,
+      upgradeHistories: (json['UpgradeHistories'] as List?)
+          ?.whereNotNull()
+          .map((e) => UpgradeHistory.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for the response returned by the <code> <a>GetUpgradeStatus</a>
+/// </code> operation.
+class GetUpgradeStatusResponse {
+  /// One of four statuses an upgrade have, returned as part of the <code>
+  /// <a>GetUpgradeStatusResponse</a> </code> object. The status can take one of
+  /// the following values:
+  /// <ul>
+  /// <li>In Progress</li>
+  /// <li>Succeeded</li>
+  /// <li>Succeeded with Issues</li>
+  /// <li>Failed</li>
+  /// </ul>
+  final UpgradeStatus? stepStatus;
+
+  /// A string that briefly describes the update.
+  final String? upgradeName;
+
+  /// One of three steps an upgrade or upgrade eligibility check goes through:
+  /// <ul>
+  /// <li>PreUpgradeCheck</li>
+  /// <li>Snapshot</li>
+  /// <li>Upgrade</li>
+  /// </ul>
+  final UpgradeStep? upgradeStep;
+
+  GetUpgradeStatusResponse({
+    this.stepStatus,
+    this.upgradeName,
+    this.upgradeStep,
+  });
+  factory GetUpgradeStatusResponse.fromJson(Map<String, dynamic> json) {
+    return GetUpgradeStatusResponse(
+      stepStatus: (json['StepStatus'] as String?)?.toUpgradeStatus(),
+      upgradeName: json['UpgradeName'] as String?,
+      upgradeStep: (json['UpgradeStep'] as String?)?.toUpgradeStep(),
+    );
+  }
+}
+
+/// Details of an inbound connection.
+class InboundConnection {
+  /// The connection ID for the inbound cross-cluster connection.
+  final String? connectionId;
+
+  /// The <code> <a>InboundConnectionStatus</a> </code> for the outbound
+  /// connection.
+  final InboundConnectionStatus? connectionStatus;
+
+  /// The <code> <a>AWSDomainInformation</a> </code> for the local OpenSearch
+  /// domain.
+  final DomainInformationContainer? localDomainInfo;
+
+  /// The <code> <a>AWSDomainInformation</a> </code> for the remote OpenSearch
+  /// domain.
+  final DomainInformationContainer? remoteDomainInfo;
+
+  InboundConnection({
+    this.connectionId,
+    this.connectionStatus,
+    this.localDomainInfo,
+    this.remoteDomainInfo,
+  });
+  factory InboundConnection.fromJson(Map<String, dynamic> json) {
+    return InboundConnection(
+      connectionId: json['ConnectionId'] as String?,
+      connectionStatus: json['ConnectionStatus'] != null
+          ? InboundConnectionStatus.fromJson(
+              json['ConnectionStatus'] as Map<String, dynamic>)
+          : null,
+      localDomainInfo: json['LocalDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['LocalDomainInfo'] as Map<String, dynamic>)
+          : null,
+      remoteDomainInfo: json['RemoteDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['RemoteDomainInfo'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The connection status of an inbound cross-cluster connection.
+class InboundConnectionStatus {
+  /// Verbose information for the inbound connection status.
+  final String? message;
+
+  /// The state code for the inbound connection. Can be one of the following:
+  ///
+  /// <ul>
+  /// <li>PENDING_ACCEPTANCE: Inbound connection is not yet accepted by the remote
+  /// domain owner.</li>
+  /// <li>APPROVED: Inbound connection is pending acceptance by the remote domain
+  /// owner.</li>
+  /// <li>PROVISIONING: Inbound connection provisioning is in progress.</li>
+  /// <li>ACTIVE: Inbound connection is active and ready to use.</li>
+  /// <li>REJECTING: Inbound connection rejection is in process.</li>
+  /// <li>REJECTED: Inbound connection is rejected.</li>
+  /// <li>DELETING: Inbound connection deletion is in progress.</li>
+  /// <li>DELETED: Inbound connection is deleted and can no longer be used.</li>
+  /// </ul>
+  final InboundConnectionStatusCode? statusCode;
+
+  InboundConnectionStatus({
+    this.message,
+    this.statusCode,
+  });
+  factory InboundConnectionStatus.fromJson(Map<String, dynamic> json) {
+    return InboundConnectionStatus(
+      message: json['Message'] as String?,
+      statusCode:
+          (json['StatusCode'] as String?)?.toInboundConnectionStatusCode(),
+    );
+  }
+}
+
+enum InboundConnectionStatusCode {
+  pendingAcceptance,
+  approved,
+  provisioning,
+  active,
+  rejecting,
+  rejected,
+  deleting,
+  deleted,
+}
+
+extension InboundConnectionStatusCodeValue on InboundConnectionStatusCode {
+  String toValue() {
+    switch (this) {
+      case InboundConnectionStatusCode.pendingAcceptance:
+        return 'PENDING_ACCEPTANCE';
+      case InboundConnectionStatusCode.approved:
+        return 'APPROVED';
+      case InboundConnectionStatusCode.provisioning:
+        return 'PROVISIONING';
+      case InboundConnectionStatusCode.active:
+        return 'ACTIVE';
+      case InboundConnectionStatusCode.rejecting:
+        return 'REJECTING';
+      case InboundConnectionStatusCode.rejected:
+        return 'REJECTED';
+      case InboundConnectionStatusCode.deleting:
+        return 'DELETING';
+      case InboundConnectionStatusCode.deleted:
+        return 'DELETED';
+    }
+  }
+}
+
+extension InboundConnectionStatusCodeFromString on String {
+  InboundConnectionStatusCode toInboundConnectionStatusCode() {
+    switch (this) {
+      case 'PENDING_ACCEPTANCE':
+        return InboundConnectionStatusCode.pendingAcceptance;
+      case 'APPROVED':
+        return InboundConnectionStatusCode.approved;
+      case 'PROVISIONING':
+        return InboundConnectionStatusCode.provisioning;
+      case 'ACTIVE':
+        return InboundConnectionStatusCode.active;
+      case 'REJECTING':
+        return InboundConnectionStatusCode.rejecting;
+      case 'REJECTED':
+        return InboundConnectionStatusCode.rejected;
+      case 'DELETING':
+        return InboundConnectionStatusCode.deleting;
+      case 'DELETED':
+        return InboundConnectionStatusCode.deleted;
+    }
+    throw Exception('$this is not known in enum InboundConnectionStatusCode');
+  }
+}
+
+/// InstanceCountLimits represents the limits on the number of instances that
+/// can be created in Amazon OpenSearch Service for a given InstanceType.
+class InstanceCountLimits {
+  final int? maximumInstanceCount;
+  final int? minimumInstanceCount;
+
+  InstanceCountLimits({
+    this.maximumInstanceCount,
+    this.minimumInstanceCount,
+  });
+  factory InstanceCountLimits.fromJson(Map<String, dynamic> json) {
+    return InstanceCountLimits(
+      maximumInstanceCount: json['MaximumInstanceCount'] as int?,
+      minimumInstanceCount: json['MinimumInstanceCount'] as int?,
+    );
+  }
+}
+
+/// InstanceLimits represents the list of instance-related attributes that are
+/// available for a given InstanceType.
+class InstanceLimits {
+  final InstanceCountLimits? instanceCountLimits;
+
+  InstanceLimits({
+    this.instanceCountLimits,
+  });
+  factory InstanceLimits.fromJson(Map<String, dynamic> json) {
+    return InstanceLimits(
+      instanceCountLimits: json['InstanceCountLimits'] != null
+          ? InstanceCountLimits.fromJson(
+              json['InstanceCountLimits'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+class InstanceTypeDetails {
+  final bool? advancedSecurityEnabled;
+  final bool? appLogsEnabled;
+  final bool? cognitoEnabled;
+  final bool? encryptionEnabled;
+  final List<String>? instanceRole;
+  final OpenSearchPartitionInstanceType? instanceType;
+  final bool? warmEnabled;
+
+  InstanceTypeDetails({
+    this.advancedSecurityEnabled,
+    this.appLogsEnabled,
+    this.cognitoEnabled,
+    this.encryptionEnabled,
+    this.instanceRole,
+    this.instanceType,
+    this.warmEnabled,
+  });
+  factory InstanceTypeDetails.fromJson(Map<String, dynamic> json) {
+    return InstanceTypeDetails(
+      advancedSecurityEnabled: json['AdvancedSecurityEnabled'] as bool?,
+      appLogsEnabled: json['AppLogsEnabled'] as bool?,
+      cognitoEnabled: json['CognitoEnabled'] as bool?,
+      encryptionEnabled: json['EncryptionEnabled'] as bool?,
+      instanceRole: (json['InstanceRole'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      instanceType: (json['InstanceType'] as String?)
+          ?.toOpenSearchPartitionInstanceType(),
+      warmEnabled: json['WarmEnabled'] as bool?,
+    );
+  }
+}
+
+/// Limits for a given InstanceType and for each of its roles. <br/> Limits
+/// contains the following: <code> <a>StorageTypes</a> </code>, <code>
+/// <a>InstanceLimits</a> </code>, and <code> <a>AdditionalLimits</a> </code>
+class Limits {
+  /// List of additional limits that are specific to a given InstanceType and for
+  /// each of its <code> <a>InstanceRole</a> </code> .
+  final List<AdditionalLimit>? additionalLimits;
+  final InstanceLimits? instanceLimits;
+
+  /// Storage-related types and attributes that are available for a given
+  /// InstanceType.
+  final List<StorageType>? storageTypes;
+
+  Limits({
+    this.additionalLimits,
+    this.instanceLimits,
+    this.storageTypes,
+  });
+  factory Limits.fromJson(Map<String, dynamic> json) {
+    return Limits(
+      additionalLimits: (json['AdditionalLimits'] as List?)
+          ?.whereNotNull()
+          .map((e) => AdditionalLimit.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      instanceLimits: json['InstanceLimits'] != null
+          ? InstanceLimits.fromJson(
+              json['InstanceLimits'] as Map<String, dynamic>)
+          : null,
+      storageTypes: (json['StorageTypes'] as List?)
+          ?.whereNotNull()
+          .map((e) => StorageType.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// The result of a <code>ListDomainNames</code> operation. Contains the names
+/// of all domains owned by this account and their respective engine types.
+class ListDomainNamesResponse {
+  /// List of domain names and respective engine types.
+  final List<DomainInfo>? domainNames;
+
+  ListDomainNamesResponse({
+    this.domainNames,
+  });
+  factory ListDomainNamesResponse.fromJson(Map<String, dynamic> json) {
+    return ListDomainNamesResponse(
+      domainNames: (json['DomainNames'] as List?)
+          ?.whereNotNull()
+          .map((e) => DomainInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for the response parameters to the <code>
+/// <a>ListDomainsForPackage</a> </code> operation.
+class ListDomainsForPackageResponse {
+  /// List of <code>DomainPackageDetails</code> objects.
+  final List<DomainPackageDetails>? domainPackageDetailsList;
+  final String? nextToken;
+
+  ListDomainsForPackageResponse({
+    this.domainPackageDetailsList,
+    this.nextToken,
+  });
+  factory ListDomainsForPackageResponse.fromJson(Map<String, dynamic> json) {
+    return ListDomainsForPackageResponse(
+      domainPackageDetailsList: (json['DomainPackageDetailsList'] as List?)
+          ?.whereNotNull()
+          .map((e) => DomainPackageDetails.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+class ListInstanceTypeDetailsResponse {
+  final List<InstanceTypeDetails>? instanceTypeDetails;
+  final String? nextToken;
+
+  ListInstanceTypeDetailsResponse({
+    this.instanceTypeDetails,
+    this.nextToken,
+  });
+  factory ListInstanceTypeDetailsResponse.fromJson(Map<String, dynamic> json) {
+    return ListInstanceTypeDetailsResponse(
+      instanceTypeDetails: (json['InstanceTypeDetails'] as List?)
+          ?.whereNotNull()
+          .map((e) => InstanceTypeDetails.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+/// Container for the response parameters to the <code>
+/// <a>ListPackagesForDomain</a> </code> operation.
+class ListPackagesForDomainResponse {
+  /// List of <code>DomainPackageDetails</code> objects.
+  final List<DomainPackageDetails>? domainPackageDetailsList;
+
+  /// Pagination token to supply to the next call to get the next page of results.
+  final String? nextToken;
+
+  ListPackagesForDomainResponse({
+    this.domainPackageDetailsList,
+    this.nextToken,
+  });
+  factory ListPackagesForDomainResponse.fromJson(Map<String, dynamic> json) {
+    return ListPackagesForDomainResponse(
+      domainPackageDetailsList: (json['DomainPackageDetailsList'] as List?)
+          ?.whereNotNull()
+          .map((e) => DomainPackageDetails.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextToken: json['NextToken'] as String?,
+    );
+  }
+}
+
+/// The result of a <code>ListTags</code> operation. Contains tags for all
+/// requested domains.
+class ListTagsResponse {
+  /// List of <code>Tag</code> for the requested domain.
+  final List<Tag>? tagList;
+
+  ListTagsResponse({
+    this.tagList,
+  });
+  factory ListTagsResponse.fromJson(Map<String, dynamic> json) {
+    return ListTagsResponse(
+      tagList: (json['TagList'] as List?)
+          ?.whereNotNull()
+          .map((e) => Tag.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+/// Container for the parameters for response received from the <code>
+/// <a>ListVersions</a> </code> operation.
+class ListVersionsResponse {
+  final String? nextToken;
+  final List<String>? versions;
+
+  ListVersionsResponse({
+    this.nextToken,
+    this.versions,
+  });
+  factory ListVersionsResponse.fromJson(Map<String, dynamic> json) {
+    return ListVersionsResponse(
+      nextToken: json['NextToken'] as String?,
+      versions: (json['Versions'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+    );
+  }
+}
+
+/// Log Publishing option that is set for a given domain. <br/>Attributes and
+/// their details:
+/// <ul>
+/// <li>CloudWatchLogsLogGroupArn: ARN of the Cloudwatch log group to publish
+/// logs to.</li>
+/// <li>Enabled: Whether the log publishing for a given log type is enabled or
+/// not.</li>
+/// </ul>
+class LogPublishingOption {
+  final String? cloudWatchLogsLogGroupArn;
+
+  /// Whether the given log publishing option is enabled or not.
+  final bool? enabled;
+
+  LogPublishingOption({
+    this.cloudWatchLogsLogGroupArn,
+    this.enabled,
+  });
+  factory LogPublishingOption.fromJson(Map<String, dynamic> json) {
+    return LogPublishingOption(
+      cloudWatchLogsLogGroupArn: json['CloudWatchLogsLogGroupArn'] as String?,
+      enabled: json['Enabled'] as bool?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final cloudWatchLogsLogGroupArn = this.cloudWatchLogsLogGroupArn;
+    final enabled = this.enabled;
+    return {
+      if (cloudWatchLogsLogGroupArn != null)
+        'CloudWatchLogsLogGroupArn': cloudWatchLogsLogGroupArn,
+      if (enabled != null) 'Enabled': enabled,
+    };
+  }
+}
+
+/// The configured log publishing options for the domain and their current
+/// status.
+class LogPublishingOptionsStatus {
+  /// The log publishing options configured for the domain.
+  final Map<LogType, LogPublishingOption>? options;
+
+  /// The status of the log publishing options for the domain. See
+  /// <code>OptionStatus</code> for the status information that's included.
+  final OptionStatus? status;
+
+  LogPublishingOptionsStatus({
+    this.options,
+    this.status,
+  });
+  factory LogPublishingOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return LogPublishingOptionsStatus(
+      options: (json['Options'] as Map<String, dynamic>?)?.map((k, e) =>
+          MapEntry(k.toLogType(),
+              LogPublishingOption.fromJson(e as Map<String, dynamic>))),
+      status: json['Status'] != null
+          ? OptionStatus.fromJson(json['Status'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Type of log file. Can be one of the following:
+/// <ul>
+/// <li>INDEX_SLOW_LOGS: Index slow logs contain insert requests that took more
+/// time than configured index query log threshold to execute. </li>
+/// <li>SEARCH_SLOW_LOGS: Search slow logs contain search queries that took more
+/// time than configured search query log threshold to execute. </li>
+/// <li>ES_APPLICATION_LOGS: OpenSearch application logs contain information
+/// about errors and warnings raised during the operation of the service and can
+/// be useful for troubleshooting. </li>
+/// <li>AUDIT_LOGS: Audit logs contain records of user requests for access from
+/// the domain.</li>
+/// </ul>
+enum LogType {
+  indexSlowLogs,
+  searchSlowLogs,
+  esApplicationLogs,
+  auditLogs,
+}
+
+extension LogTypeValue on LogType {
+  String toValue() {
+    switch (this) {
+      case LogType.indexSlowLogs:
+        return 'INDEX_SLOW_LOGS';
+      case LogType.searchSlowLogs:
+        return 'SEARCH_SLOW_LOGS';
+      case LogType.esApplicationLogs:
+        return 'ES_APPLICATION_LOGS';
+      case LogType.auditLogs:
+        return 'AUDIT_LOGS';
+    }
+  }
+}
+
+extension LogTypeFromString on String {
+  LogType toLogType() {
+    switch (this) {
+      case 'INDEX_SLOW_LOGS':
+        return LogType.indexSlowLogs;
+      case 'SEARCH_SLOW_LOGS':
+        return LogType.searchSlowLogs;
+      case 'ES_APPLICATION_LOGS':
+        return LogType.esApplicationLogs;
+      case 'AUDIT_LOGS':
+        return LogType.auditLogs;
+    }
+    throw Exception('$this is not known in enum LogType');
+  }
+}
+
+/// Credentials for the master user: username and password, ARN, or both.
+class MasterUserOptions {
+  /// ARN for the master user (if IAM is enabled).
+  final String? masterUserARN;
+
+  /// The master user's username, which is stored in the Amazon OpenSearch Service
+  /// domain's internal database.
+  final String? masterUserName;
+
+  /// The master user's password, which is stored in the Amazon OpenSearch Service
+  /// domain's internal database.
+  final String? masterUserPassword;
+
+  MasterUserOptions({
+    this.masterUserARN,
+    this.masterUserName,
+    this.masterUserPassword,
+  });
+  Map<String, dynamic> toJson() {
+    final masterUserARN = this.masterUserARN;
+    final masterUserName = this.masterUserName;
+    final masterUserPassword = this.masterUserPassword;
+    return {
+      if (masterUserARN != null) 'MasterUserARN': masterUserARN,
+      if (masterUserName != null) 'MasterUserName': masterUserName,
+      if (masterUserPassword != null) 'MasterUserPassword': masterUserPassword,
+    };
+  }
+}
+
+/// The node-to-node encryption options.
+class NodeToNodeEncryptionOptions {
+  /// True to enable node-to-node encryption.
+  final bool? enabled;
+
+  NodeToNodeEncryptionOptions({
+    this.enabled,
+  });
+  factory NodeToNodeEncryptionOptions.fromJson(Map<String, dynamic> json) {
+    return NodeToNodeEncryptionOptions(
+      enabled: json['Enabled'] as bool?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    return {
+      if (enabled != null) 'Enabled': enabled,
+    };
+  }
+}
+
+/// Status of the node-to-node encryption options for the specified domain.
+class NodeToNodeEncryptionOptionsStatus {
+  /// The node-to-node encryption options for the specified domain.
+  final NodeToNodeEncryptionOptions options;
+
+  /// The status of the node-to-node encryption options for the specified domain.
+  final OptionStatus status;
+
+  NodeToNodeEncryptionOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory NodeToNodeEncryptionOptionsStatus.fromJson(
+      Map<String, dynamic> json) {
+    return NodeToNodeEncryptionOptionsStatus(
+      options: NodeToNodeEncryptionOptions.fromJson(
+          json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+enum OpenSearchPartitionInstanceType {
+  m3MediumSearch,
+  m3LargeSearch,
+  m3XlargeSearch,
+  m3_2xlargeSearch,
+  m4LargeSearch,
+  m4XlargeSearch,
+  m4_2xlargeSearch,
+  m4_4xlargeSearch,
+  m4_10xlargeSearch,
+  m5LargeSearch,
+  m5XlargeSearch,
+  m5_2xlargeSearch,
+  m5_4xlargeSearch,
+  m5_12xlargeSearch,
+  m5_24xlargeSearch,
+  r5LargeSearch,
+  r5XlargeSearch,
+  r5_2xlargeSearch,
+  r5_4xlargeSearch,
+  r5_12xlargeSearch,
+  r5_24xlargeSearch,
+  c5LargeSearch,
+  c5XlargeSearch,
+  c5_2xlargeSearch,
+  c5_4xlargeSearch,
+  c5_9xlargeSearch,
+  c5_18xlargeSearch,
+  t3NanoSearch,
+  t3MicroSearch,
+  t3SmallSearch,
+  t3MediumSearch,
+  t3LargeSearch,
+  t3XlargeSearch,
+  t3_2xlargeSearch,
+  ultrawarm1MediumSearch,
+  ultrawarm1LargeSearch,
+  ultrawarm1XlargeSearch,
+  t2MicroSearch,
+  t2SmallSearch,
+  t2MediumSearch,
+  r3LargeSearch,
+  r3XlargeSearch,
+  r3_2xlargeSearch,
+  r3_4xlargeSearch,
+  r3_8xlargeSearch,
+  i2XlargeSearch,
+  i2_2xlargeSearch,
+  d2XlargeSearch,
+  d2_2xlargeSearch,
+  d2_4xlargeSearch,
+  d2_8xlargeSearch,
+  c4LargeSearch,
+  c4XlargeSearch,
+  c4_2xlargeSearch,
+  c4_4xlargeSearch,
+  c4_8xlargeSearch,
+  r4LargeSearch,
+  r4XlargeSearch,
+  r4_2xlargeSearch,
+  r4_4xlargeSearch,
+  r4_8xlargeSearch,
+  r4_16xlargeSearch,
+  i3LargeSearch,
+  i3XlargeSearch,
+  i3_2xlargeSearch,
+  i3_4xlargeSearch,
+  i3_8xlargeSearch,
+  i3_16xlargeSearch,
+  r6gLargeSearch,
+  r6gXlargeSearch,
+  r6g_2xlargeSearch,
+  r6g_4xlargeSearch,
+  r6g_8xlargeSearch,
+  r6g_12xlargeSearch,
+  m6gLargeSearch,
+  m6gXlargeSearch,
+  m6g_2xlargeSearch,
+  m6g_4xlargeSearch,
+  m6g_8xlargeSearch,
+  m6g_12xlargeSearch,
+  c6gLargeSearch,
+  c6gXlargeSearch,
+  c6g_2xlargeSearch,
+  c6g_4xlargeSearch,
+  c6g_8xlargeSearch,
+  c6g_12xlargeSearch,
+  r6gdLargeSearch,
+  r6gdXlargeSearch,
+  r6gd_2xlargeSearch,
+  r6gd_4xlargeSearch,
+  r6gd_8xlargeSearch,
+  r6gd_12xlargeSearch,
+  r6gd_16xlargeSearch,
+  t4gSmallSearch,
+  t4gMediumSearch,
+}
+
+extension OpenSearchPartitionInstanceTypeValue
+    on OpenSearchPartitionInstanceType {
+  String toValue() {
+    switch (this) {
+      case OpenSearchPartitionInstanceType.m3MediumSearch:
+        return 'm3.medium.search';
+      case OpenSearchPartitionInstanceType.m3LargeSearch:
+        return 'm3.large.search';
+      case OpenSearchPartitionInstanceType.m3XlargeSearch:
+        return 'm3.xlarge.search';
+      case OpenSearchPartitionInstanceType.m3_2xlargeSearch:
+        return 'm3.2xlarge.search';
+      case OpenSearchPartitionInstanceType.m4LargeSearch:
+        return 'm4.large.search';
+      case OpenSearchPartitionInstanceType.m4XlargeSearch:
+        return 'm4.xlarge.search';
+      case OpenSearchPartitionInstanceType.m4_2xlargeSearch:
+        return 'm4.2xlarge.search';
+      case OpenSearchPartitionInstanceType.m4_4xlargeSearch:
+        return 'm4.4xlarge.search';
+      case OpenSearchPartitionInstanceType.m4_10xlargeSearch:
+        return 'm4.10xlarge.search';
+      case OpenSearchPartitionInstanceType.m5LargeSearch:
+        return 'm5.large.search';
+      case OpenSearchPartitionInstanceType.m5XlargeSearch:
+        return 'm5.xlarge.search';
+      case OpenSearchPartitionInstanceType.m5_2xlargeSearch:
+        return 'm5.2xlarge.search';
+      case OpenSearchPartitionInstanceType.m5_4xlargeSearch:
+        return 'm5.4xlarge.search';
+      case OpenSearchPartitionInstanceType.m5_12xlargeSearch:
+        return 'm5.12xlarge.search';
+      case OpenSearchPartitionInstanceType.m5_24xlargeSearch:
+        return 'm5.24xlarge.search';
+      case OpenSearchPartitionInstanceType.r5LargeSearch:
+        return 'r5.large.search';
+      case OpenSearchPartitionInstanceType.r5XlargeSearch:
+        return 'r5.xlarge.search';
+      case OpenSearchPartitionInstanceType.r5_2xlargeSearch:
+        return 'r5.2xlarge.search';
+      case OpenSearchPartitionInstanceType.r5_4xlargeSearch:
+        return 'r5.4xlarge.search';
+      case OpenSearchPartitionInstanceType.r5_12xlargeSearch:
+        return 'r5.12xlarge.search';
+      case OpenSearchPartitionInstanceType.r5_24xlargeSearch:
+        return 'r5.24xlarge.search';
+      case OpenSearchPartitionInstanceType.c5LargeSearch:
+        return 'c5.large.search';
+      case OpenSearchPartitionInstanceType.c5XlargeSearch:
+        return 'c5.xlarge.search';
+      case OpenSearchPartitionInstanceType.c5_2xlargeSearch:
+        return 'c5.2xlarge.search';
+      case OpenSearchPartitionInstanceType.c5_4xlargeSearch:
+        return 'c5.4xlarge.search';
+      case OpenSearchPartitionInstanceType.c5_9xlargeSearch:
+        return 'c5.9xlarge.search';
+      case OpenSearchPartitionInstanceType.c5_18xlargeSearch:
+        return 'c5.18xlarge.search';
+      case OpenSearchPartitionInstanceType.t3NanoSearch:
+        return 't3.nano.search';
+      case OpenSearchPartitionInstanceType.t3MicroSearch:
+        return 't3.micro.search';
+      case OpenSearchPartitionInstanceType.t3SmallSearch:
+        return 't3.small.search';
+      case OpenSearchPartitionInstanceType.t3MediumSearch:
+        return 't3.medium.search';
+      case OpenSearchPartitionInstanceType.t3LargeSearch:
+        return 't3.large.search';
+      case OpenSearchPartitionInstanceType.t3XlargeSearch:
+        return 't3.xlarge.search';
+      case OpenSearchPartitionInstanceType.t3_2xlargeSearch:
+        return 't3.2xlarge.search';
+      case OpenSearchPartitionInstanceType.ultrawarm1MediumSearch:
+        return 'ultrawarm1.medium.search';
+      case OpenSearchPartitionInstanceType.ultrawarm1LargeSearch:
+        return 'ultrawarm1.large.search';
+      case OpenSearchPartitionInstanceType.ultrawarm1XlargeSearch:
+        return 'ultrawarm1.xlarge.search';
+      case OpenSearchPartitionInstanceType.t2MicroSearch:
+        return 't2.micro.search';
+      case OpenSearchPartitionInstanceType.t2SmallSearch:
+        return 't2.small.search';
+      case OpenSearchPartitionInstanceType.t2MediumSearch:
+        return 't2.medium.search';
+      case OpenSearchPartitionInstanceType.r3LargeSearch:
+        return 'r3.large.search';
+      case OpenSearchPartitionInstanceType.r3XlargeSearch:
+        return 'r3.xlarge.search';
+      case OpenSearchPartitionInstanceType.r3_2xlargeSearch:
+        return 'r3.2xlarge.search';
+      case OpenSearchPartitionInstanceType.r3_4xlargeSearch:
+        return 'r3.4xlarge.search';
+      case OpenSearchPartitionInstanceType.r3_8xlargeSearch:
+        return 'r3.8xlarge.search';
+      case OpenSearchPartitionInstanceType.i2XlargeSearch:
+        return 'i2.xlarge.search';
+      case OpenSearchPartitionInstanceType.i2_2xlargeSearch:
+        return 'i2.2xlarge.search';
+      case OpenSearchPartitionInstanceType.d2XlargeSearch:
+        return 'd2.xlarge.search';
+      case OpenSearchPartitionInstanceType.d2_2xlargeSearch:
+        return 'd2.2xlarge.search';
+      case OpenSearchPartitionInstanceType.d2_4xlargeSearch:
+        return 'd2.4xlarge.search';
+      case OpenSearchPartitionInstanceType.d2_8xlargeSearch:
+        return 'd2.8xlarge.search';
+      case OpenSearchPartitionInstanceType.c4LargeSearch:
+        return 'c4.large.search';
+      case OpenSearchPartitionInstanceType.c4XlargeSearch:
+        return 'c4.xlarge.search';
+      case OpenSearchPartitionInstanceType.c4_2xlargeSearch:
+        return 'c4.2xlarge.search';
+      case OpenSearchPartitionInstanceType.c4_4xlargeSearch:
+        return 'c4.4xlarge.search';
+      case OpenSearchPartitionInstanceType.c4_8xlargeSearch:
+        return 'c4.8xlarge.search';
+      case OpenSearchPartitionInstanceType.r4LargeSearch:
+        return 'r4.large.search';
+      case OpenSearchPartitionInstanceType.r4XlargeSearch:
+        return 'r4.xlarge.search';
+      case OpenSearchPartitionInstanceType.r4_2xlargeSearch:
+        return 'r4.2xlarge.search';
+      case OpenSearchPartitionInstanceType.r4_4xlargeSearch:
+        return 'r4.4xlarge.search';
+      case OpenSearchPartitionInstanceType.r4_8xlargeSearch:
+        return 'r4.8xlarge.search';
+      case OpenSearchPartitionInstanceType.r4_16xlargeSearch:
+        return 'r4.16xlarge.search';
+      case OpenSearchPartitionInstanceType.i3LargeSearch:
+        return 'i3.large.search';
+      case OpenSearchPartitionInstanceType.i3XlargeSearch:
+        return 'i3.xlarge.search';
+      case OpenSearchPartitionInstanceType.i3_2xlargeSearch:
+        return 'i3.2xlarge.search';
+      case OpenSearchPartitionInstanceType.i3_4xlargeSearch:
+        return 'i3.4xlarge.search';
+      case OpenSearchPartitionInstanceType.i3_8xlargeSearch:
+        return 'i3.8xlarge.search';
+      case OpenSearchPartitionInstanceType.i3_16xlargeSearch:
+        return 'i3.16xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gLargeSearch:
+        return 'r6g.large.search';
+      case OpenSearchPartitionInstanceType.r6gXlargeSearch:
+        return 'r6g.xlarge.search';
+      case OpenSearchPartitionInstanceType.r6g_2xlargeSearch:
+        return 'r6g.2xlarge.search';
+      case OpenSearchPartitionInstanceType.r6g_4xlargeSearch:
+        return 'r6g.4xlarge.search';
+      case OpenSearchPartitionInstanceType.r6g_8xlargeSearch:
+        return 'r6g.8xlarge.search';
+      case OpenSearchPartitionInstanceType.r6g_12xlargeSearch:
+        return 'r6g.12xlarge.search';
+      case OpenSearchPartitionInstanceType.m6gLargeSearch:
+        return 'm6g.large.search';
+      case OpenSearchPartitionInstanceType.m6gXlargeSearch:
+        return 'm6g.xlarge.search';
+      case OpenSearchPartitionInstanceType.m6g_2xlargeSearch:
+        return 'm6g.2xlarge.search';
+      case OpenSearchPartitionInstanceType.m6g_4xlargeSearch:
+        return 'm6g.4xlarge.search';
+      case OpenSearchPartitionInstanceType.m6g_8xlargeSearch:
+        return 'm6g.8xlarge.search';
+      case OpenSearchPartitionInstanceType.m6g_12xlargeSearch:
+        return 'm6g.12xlarge.search';
+      case OpenSearchPartitionInstanceType.c6gLargeSearch:
+        return 'c6g.large.search';
+      case OpenSearchPartitionInstanceType.c6gXlargeSearch:
+        return 'c6g.xlarge.search';
+      case OpenSearchPartitionInstanceType.c6g_2xlargeSearch:
+        return 'c6g.2xlarge.search';
+      case OpenSearchPartitionInstanceType.c6g_4xlargeSearch:
+        return 'c6g.4xlarge.search';
+      case OpenSearchPartitionInstanceType.c6g_8xlargeSearch:
+        return 'c6g.8xlarge.search';
+      case OpenSearchPartitionInstanceType.c6g_12xlargeSearch:
+        return 'c6g.12xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gdLargeSearch:
+        return 'r6gd.large.search';
+      case OpenSearchPartitionInstanceType.r6gdXlargeSearch:
+        return 'r6gd.xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gd_2xlargeSearch:
+        return 'r6gd.2xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gd_4xlargeSearch:
+        return 'r6gd.4xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gd_8xlargeSearch:
+        return 'r6gd.8xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gd_12xlargeSearch:
+        return 'r6gd.12xlarge.search';
+      case OpenSearchPartitionInstanceType.r6gd_16xlargeSearch:
+        return 'r6gd.16xlarge.search';
+      case OpenSearchPartitionInstanceType.t4gSmallSearch:
+        return 't4g.small.search';
+      case OpenSearchPartitionInstanceType.t4gMediumSearch:
+        return 't4g.medium.search';
+    }
+  }
+}
+
+extension OpenSearchPartitionInstanceTypeFromString on String {
+  OpenSearchPartitionInstanceType toOpenSearchPartitionInstanceType() {
+    switch (this) {
+      case 'm3.medium.search':
+        return OpenSearchPartitionInstanceType.m3MediumSearch;
+      case 'm3.large.search':
+        return OpenSearchPartitionInstanceType.m3LargeSearch;
+      case 'm3.xlarge.search':
+        return OpenSearchPartitionInstanceType.m3XlargeSearch;
+      case 'm3.2xlarge.search':
+        return OpenSearchPartitionInstanceType.m3_2xlargeSearch;
+      case 'm4.large.search':
+        return OpenSearchPartitionInstanceType.m4LargeSearch;
+      case 'm4.xlarge.search':
+        return OpenSearchPartitionInstanceType.m4XlargeSearch;
+      case 'm4.2xlarge.search':
+        return OpenSearchPartitionInstanceType.m4_2xlargeSearch;
+      case 'm4.4xlarge.search':
+        return OpenSearchPartitionInstanceType.m4_4xlargeSearch;
+      case 'm4.10xlarge.search':
+        return OpenSearchPartitionInstanceType.m4_10xlargeSearch;
+      case 'm5.large.search':
+        return OpenSearchPartitionInstanceType.m5LargeSearch;
+      case 'm5.xlarge.search':
+        return OpenSearchPartitionInstanceType.m5XlargeSearch;
+      case 'm5.2xlarge.search':
+        return OpenSearchPartitionInstanceType.m5_2xlargeSearch;
+      case 'm5.4xlarge.search':
+        return OpenSearchPartitionInstanceType.m5_4xlargeSearch;
+      case 'm5.12xlarge.search':
+        return OpenSearchPartitionInstanceType.m5_12xlargeSearch;
+      case 'm5.24xlarge.search':
+        return OpenSearchPartitionInstanceType.m5_24xlargeSearch;
+      case 'r5.large.search':
+        return OpenSearchPartitionInstanceType.r5LargeSearch;
+      case 'r5.xlarge.search':
+        return OpenSearchPartitionInstanceType.r5XlargeSearch;
+      case 'r5.2xlarge.search':
+        return OpenSearchPartitionInstanceType.r5_2xlargeSearch;
+      case 'r5.4xlarge.search':
+        return OpenSearchPartitionInstanceType.r5_4xlargeSearch;
+      case 'r5.12xlarge.search':
+        return OpenSearchPartitionInstanceType.r5_12xlargeSearch;
+      case 'r5.24xlarge.search':
+        return OpenSearchPartitionInstanceType.r5_24xlargeSearch;
+      case 'c5.large.search':
+        return OpenSearchPartitionInstanceType.c5LargeSearch;
+      case 'c5.xlarge.search':
+        return OpenSearchPartitionInstanceType.c5XlargeSearch;
+      case 'c5.2xlarge.search':
+        return OpenSearchPartitionInstanceType.c5_2xlargeSearch;
+      case 'c5.4xlarge.search':
+        return OpenSearchPartitionInstanceType.c5_4xlargeSearch;
+      case 'c5.9xlarge.search':
+        return OpenSearchPartitionInstanceType.c5_9xlargeSearch;
+      case 'c5.18xlarge.search':
+        return OpenSearchPartitionInstanceType.c5_18xlargeSearch;
+      case 't3.nano.search':
+        return OpenSearchPartitionInstanceType.t3NanoSearch;
+      case 't3.micro.search':
+        return OpenSearchPartitionInstanceType.t3MicroSearch;
+      case 't3.small.search':
+        return OpenSearchPartitionInstanceType.t3SmallSearch;
+      case 't3.medium.search':
+        return OpenSearchPartitionInstanceType.t3MediumSearch;
+      case 't3.large.search':
+        return OpenSearchPartitionInstanceType.t3LargeSearch;
+      case 't3.xlarge.search':
+        return OpenSearchPartitionInstanceType.t3XlargeSearch;
+      case 't3.2xlarge.search':
+        return OpenSearchPartitionInstanceType.t3_2xlargeSearch;
+      case 'ultrawarm1.medium.search':
+        return OpenSearchPartitionInstanceType.ultrawarm1MediumSearch;
+      case 'ultrawarm1.large.search':
+        return OpenSearchPartitionInstanceType.ultrawarm1LargeSearch;
+      case 'ultrawarm1.xlarge.search':
+        return OpenSearchPartitionInstanceType.ultrawarm1XlargeSearch;
+      case 't2.micro.search':
+        return OpenSearchPartitionInstanceType.t2MicroSearch;
+      case 't2.small.search':
+        return OpenSearchPartitionInstanceType.t2SmallSearch;
+      case 't2.medium.search':
+        return OpenSearchPartitionInstanceType.t2MediumSearch;
+      case 'r3.large.search':
+        return OpenSearchPartitionInstanceType.r3LargeSearch;
+      case 'r3.xlarge.search':
+        return OpenSearchPartitionInstanceType.r3XlargeSearch;
+      case 'r3.2xlarge.search':
+        return OpenSearchPartitionInstanceType.r3_2xlargeSearch;
+      case 'r3.4xlarge.search':
+        return OpenSearchPartitionInstanceType.r3_4xlargeSearch;
+      case 'r3.8xlarge.search':
+        return OpenSearchPartitionInstanceType.r3_8xlargeSearch;
+      case 'i2.xlarge.search':
+        return OpenSearchPartitionInstanceType.i2XlargeSearch;
+      case 'i2.2xlarge.search':
+        return OpenSearchPartitionInstanceType.i2_2xlargeSearch;
+      case 'd2.xlarge.search':
+        return OpenSearchPartitionInstanceType.d2XlargeSearch;
+      case 'd2.2xlarge.search':
+        return OpenSearchPartitionInstanceType.d2_2xlargeSearch;
+      case 'd2.4xlarge.search':
+        return OpenSearchPartitionInstanceType.d2_4xlargeSearch;
+      case 'd2.8xlarge.search':
+        return OpenSearchPartitionInstanceType.d2_8xlargeSearch;
+      case 'c4.large.search':
+        return OpenSearchPartitionInstanceType.c4LargeSearch;
+      case 'c4.xlarge.search':
+        return OpenSearchPartitionInstanceType.c4XlargeSearch;
+      case 'c4.2xlarge.search':
+        return OpenSearchPartitionInstanceType.c4_2xlargeSearch;
+      case 'c4.4xlarge.search':
+        return OpenSearchPartitionInstanceType.c4_4xlargeSearch;
+      case 'c4.8xlarge.search':
+        return OpenSearchPartitionInstanceType.c4_8xlargeSearch;
+      case 'r4.large.search':
+        return OpenSearchPartitionInstanceType.r4LargeSearch;
+      case 'r4.xlarge.search':
+        return OpenSearchPartitionInstanceType.r4XlargeSearch;
+      case 'r4.2xlarge.search':
+        return OpenSearchPartitionInstanceType.r4_2xlargeSearch;
+      case 'r4.4xlarge.search':
+        return OpenSearchPartitionInstanceType.r4_4xlargeSearch;
+      case 'r4.8xlarge.search':
+        return OpenSearchPartitionInstanceType.r4_8xlargeSearch;
+      case 'r4.16xlarge.search':
+        return OpenSearchPartitionInstanceType.r4_16xlargeSearch;
+      case 'i3.large.search':
+        return OpenSearchPartitionInstanceType.i3LargeSearch;
+      case 'i3.xlarge.search':
+        return OpenSearchPartitionInstanceType.i3XlargeSearch;
+      case 'i3.2xlarge.search':
+        return OpenSearchPartitionInstanceType.i3_2xlargeSearch;
+      case 'i3.4xlarge.search':
+        return OpenSearchPartitionInstanceType.i3_4xlargeSearch;
+      case 'i3.8xlarge.search':
+        return OpenSearchPartitionInstanceType.i3_8xlargeSearch;
+      case 'i3.16xlarge.search':
+        return OpenSearchPartitionInstanceType.i3_16xlargeSearch;
+      case 'r6g.large.search':
+        return OpenSearchPartitionInstanceType.r6gLargeSearch;
+      case 'r6g.xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gXlargeSearch;
+      case 'r6g.2xlarge.search':
+        return OpenSearchPartitionInstanceType.r6g_2xlargeSearch;
+      case 'r6g.4xlarge.search':
+        return OpenSearchPartitionInstanceType.r6g_4xlargeSearch;
+      case 'r6g.8xlarge.search':
+        return OpenSearchPartitionInstanceType.r6g_8xlargeSearch;
+      case 'r6g.12xlarge.search':
+        return OpenSearchPartitionInstanceType.r6g_12xlargeSearch;
+      case 'm6g.large.search':
+        return OpenSearchPartitionInstanceType.m6gLargeSearch;
+      case 'm6g.xlarge.search':
+        return OpenSearchPartitionInstanceType.m6gXlargeSearch;
+      case 'm6g.2xlarge.search':
+        return OpenSearchPartitionInstanceType.m6g_2xlargeSearch;
+      case 'm6g.4xlarge.search':
+        return OpenSearchPartitionInstanceType.m6g_4xlargeSearch;
+      case 'm6g.8xlarge.search':
+        return OpenSearchPartitionInstanceType.m6g_8xlargeSearch;
+      case 'm6g.12xlarge.search':
+        return OpenSearchPartitionInstanceType.m6g_12xlargeSearch;
+      case 'c6g.large.search':
+        return OpenSearchPartitionInstanceType.c6gLargeSearch;
+      case 'c6g.xlarge.search':
+        return OpenSearchPartitionInstanceType.c6gXlargeSearch;
+      case 'c6g.2xlarge.search':
+        return OpenSearchPartitionInstanceType.c6g_2xlargeSearch;
+      case 'c6g.4xlarge.search':
+        return OpenSearchPartitionInstanceType.c6g_4xlargeSearch;
+      case 'c6g.8xlarge.search':
+        return OpenSearchPartitionInstanceType.c6g_8xlargeSearch;
+      case 'c6g.12xlarge.search':
+        return OpenSearchPartitionInstanceType.c6g_12xlargeSearch;
+      case 'r6gd.large.search':
+        return OpenSearchPartitionInstanceType.r6gdLargeSearch;
+      case 'r6gd.xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gdXlargeSearch;
+      case 'r6gd.2xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gd_2xlargeSearch;
+      case 'r6gd.4xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gd_4xlargeSearch;
+      case 'r6gd.8xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gd_8xlargeSearch;
+      case 'r6gd.12xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gd_12xlargeSearch;
+      case 'r6gd.16xlarge.search':
+        return OpenSearchPartitionInstanceType.r6gd_16xlargeSearch;
+      case 't4g.small.search':
+        return OpenSearchPartitionInstanceType.t4gSmallSearch;
+      case 't4g.medium.search':
+        return OpenSearchPartitionInstanceType.t4gMediumSearch;
+    }
+    throw Exception(
+        '$this is not known in enum OpenSearchPartitionInstanceType');
+  }
+}
+
+enum OpenSearchWarmPartitionInstanceType {
+  ultrawarm1MediumSearch,
+  ultrawarm1LargeSearch,
+  ultrawarm1XlargeSearch,
+}
+
+extension OpenSearchWarmPartitionInstanceTypeValue
+    on OpenSearchWarmPartitionInstanceType {
+  String toValue() {
+    switch (this) {
+      case OpenSearchWarmPartitionInstanceType.ultrawarm1MediumSearch:
+        return 'ultrawarm1.medium.search';
+      case OpenSearchWarmPartitionInstanceType.ultrawarm1LargeSearch:
+        return 'ultrawarm1.large.search';
+      case OpenSearchWarmPartitionInstanceType.ultrawarm1XlargeSearch:
+        return 'ultrawarm1.xlarge.search';
+    }
+  }
+}
+
+extension OpenSearchWarmPartitionInstanceTypeFromString on String {
+  OpenSearchWarmPartitionInstanceType toOpenSearchWarmPartitionInstanceType() {
+    switch (this) {
+      case 'ultrawarm1.medium.search':
+        return OpenSearchWarmPartitionInstanceType.ultrawarm1MediumSearch;
+      case 'ultrawarm1.large.search':
+        return OpenSearchWarmPartitionInstanceType.ultrawarm1LargeSearch;
+      case 'ultrawarm1.xlarge.search':
+        return OpenSearchWarmPartitionInstanceType.ultrawarm1XlargeSearch;
+    }
+    throw Exception(
+        '$this is not known in enum OpenSearchWarmPartitionInstanceType');
+  }
+}
+
+/// The state of a requested change. One of the following:
+///
+/// <ul>
+/// <li>Processing: The request change is still in progress.</li>
+/// <li>Active: The request change is processed and deployed to the domain.</li>
+/// </ul>
+enum OptionState {
+  requiresIndexDocuments,
+  processing,
+  active,
+}
+
+extension OptionStateValue on OptionState {
+  String toValue() {
+    switch (this) {
+      case OptionState.requiresIndexDocuments:
+        return 'RequiresIndexDocuments';
+      case OptionState.processing:
+        return 'Processing';
+      case OptionState.active:
+        return 'Active';
+    }
+  }
+}
+
+extension OptionStateFromString on String {
+  OptionState toOptionState() {
+    switch (this) {
+      case 'RequiresIndexDocuments':
+        return OptionState.requiresIndexDocuments;
+      case 'Processing':
+        return OptionState.processing;
+      case 'Active':
+        return OptionState.active;
+    }
+    throw Exception('$this is not known in enum OptionState');
+  }
+}
+
+/// Provides the current status of the entity.
+class OptionStatus {
+  /// The timestamp of when the entity was created.
+  final DateTime creationDate;
+
+  /// Provides the <code>OptionState</code> for the domain.
+  final OptionState state;
+
+  /// The timestamp of the last time the entity was updated.
+  final DateTime updateDate;
+
+  /// Indicates whether the domain is being deleted.
+  final bool? pendingDeletion;
+
+  /// The latest version of the entity.
+  final int? updateVersion;
+
+  OptionStatus({
+    required this.creationDate,
+    required this.state,
+    required this.updateDate,
+    this.pendingDeletion,
+    this.updateVersion,
+  });
+  factory OptionStatus.fromJson(Map<String, dynamic> json) {
+    return OptionStatus(
+      creationDate:
+          nonNullableTimeStampFromJson(json['CreationDate'] as Object),
+      state: (json['State'] as String).toOptionState(),
+      updateDate: nonNullableTimeStampFromJson(json['UpdateDate'] as Object),
+      pendingDeletion: json['PendingDeletion'] as bool?,
+      updateVersion: json['UpdateVersion'] as int?,
+    );
+  }
+}
+
+/// Specifies details about an outbound connection.
+class OutboundConnection {
+  /// The connection alias for the outbound cross-cluster connection.
+  final String? connectionAlias;
+
+  /// The connection ID for the outbound cross-cluster connection.
+  final String? connectionId;
+
+  /// The <code> <a>OutboundConnectionStatus</a> </code> for the outbound
+  /// connection.
+  final OutboundConnectionStatus? connectionStatus;
+
+  /// The <code> <a>DomainInformation</a> </code> for the local OpenSearch domain.
+  final DomainInformationContainer? localDomainInfo;
+
+  /// The <code> <a>DomainInformation</a> </code> for the remote OpenSearch
+  /// domain.
+  final DomainInformationContainer? remoteDomainInfo;
+
+  OutboundConnection({
+    this.connectionAlias,
+    this.connectionId,
+    this.connectionStatus,
+    this.localDomainInfo,
+    this.remoteDomainInfo,
+  });
+  factory OutboundConnection.fromJson(Map<String, dynamic> json) {
+    return OutboundConnection(
+      connectionAlias: json['ConnectionAlias'] as String?,
+      connectionId: json['ConnectionId'] as String?,
+      connectionStatus: json['ConnectionStatus'] != null
+          ? OutboundConnectionStatus.fromJson(
+              json['ConnectionStatus'] as Map<String, dynamic>)
+          : null,
+      localDomainInfo: json['LocalDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['LocalDomainInfo'] as Map<String, dynamic>)
+          : null,
+      remoteDomainInfo: json['RemoteDomainInfo'] != null
+          ? DomainInformationContainer.fromJson(
+              json['RemoteDomainInfo'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// The connection status of an outbound cross-cluster connection.
+class OutboundConnectionStatus {
+  /// Verbose information for the outbound connection status.
+  final String? message;
+
+  /// The state code for the outbound connection. Can be one of the following:
+  ///
+  /// <ul>
+  /// <li>VALIDATING: The outbound connection request is being validated.</li>
+  /// <li>VALIDATION_FAILED: Validation failed for the connection request.</li>
+  /// <li>PENDING_ACCEPTANCE: Outbound connection request is validated and is not
+  /// yet accepted by the remote domain owner. </li>
+  /// <li>APPROVED: Outbound connection has been approved by the remote domain
+  /// owner for getting provisioned.</li>
+  /// <li>PROVISIONING: Outbound connection request is in process.</li>
+  /// <li>ACTIVE: Outbound connection is active and ready to use.</li>
+  /// <li>REJECTING: Outbound connection rejection by remote domain owner is in
+  /// progress.</li>
+  /// <li>REJECTED: Outbound connection request is rejected by remote domain
+  /// owner.</li>
+  /// <li>DELETING: Outbound connection deletion is in progress.</li>
+  /// <li>DELETED: Outbound connection is deleted and can no longer be used.</li>
+  /// </ul>
+  final OutboundConnectionStatusCode? statusCode;
+
+  OutboundConnectionStatus({
+    this.message,
+    this.statusCode,
+  });
+  factory OutboundConnectionStatus.fromJson(Map<String, dynamic> json) {
+    return OutboundConnectionStatus(
+      message: json['Message'] as String?,
+      statusCode:
+          (json['StatusCode'] as String?)?.toOutboundConnectionStatusCode(),
+    );
+  }
+}
+
+enum OutboundConnectionStatusCode {
+  validating,
+  validationFailed,
+  pendingAcceptance,
+  approved,
+  provisioning,
+  active,
+  rejecting,
+  rejected,
+  deleting,
+  deleted,
+}
+
+extension OutboundConnectionStatusCodeValue on OutboundConnectionStatusCode {
+  String toValue() {
+    switch (this) {
+      case OutboundConnectionStatusCode.validating:
+        return 'VALIDATING';
+      case OutboundConnectionStatusCode.validationFailed:
+        return 'VALIDATION_FAILED';
+      case OutboundConnectionStatusCode.pendingAcceptance:
+        return 'PENDING_ACCEPTANCE';
+      case OutboundConnectionStatusCode.approved:
+        return 'APPROVED';
+      case OutboundConnectionStatusCode.provisioning:
+        return 'PROVISIONING';
+      case OutboundConnectionStatusCode.active:
+        return 'ACTIVE';
+      case OutboundConnectionStatusCode.rejecting:
+        return 'REJECTING';
+      case OutboundConnectionStatusCode.rejected:
+        return 'REJECTED';
+      case OutboundConnectionStatusCode.deleting:
+        return 'DELETING';
+      case OutboundConnectionStatusCode.deleted:
+        return 'DELETED';
+    }
+  }
+}
+
+extension OutboundConnectionStatusCodeFromString on String {
+  OutboundConnectionStatusCode toOutboundConnectionStatusCode() {
+    switch (this) {
+      case 'VALIDATING':
+        return OutboundConnectionStatusCode.validating;
+      case 'VALIDATION_FAILED':
+        return OutboundConnectionStatusCode.validationFailed;
+      case 'PENDING_ACCEPTANCE':
+        return OutboundConnectionStatusCode.pendingAcceptance;
+      case 'APPROVED':
+        return OutboundConnectionStatusCode.approved;
+      case 'PROVISIONING':
+        return OutboundConnectionStatusCode.provisioning;
+      case 'ACTIVE':
+        return OutboundConnectionStatusCode.active;
+      case 'REJECTING':
+        return OutboundConnectionStatusCode.rejecting;
+      case 'REJECTED':
+        return OutboundConnectionStatusCode.rejected;
+      case 'DELETING':
+        return OutboundConnectionStatusCode.deleting;
+      case 'DELETED':
+        return OutboundConnectionStatusCode.deleted;
+    }
+    throw Exception('$this is not known in enum OutboundConnectionStatusCode');
+  }
+}
+
+/// The overall status value of the domain configuration change.
+enum OverallChangeStatus {
+  pending,
+  processing,
+  completed,
+  failed,
+}
+
+extension OverallChangeStatusValue on OverallChangeStatus {
+  String toValue() {
+    switch (this) {
+      case OverallChangeStatus.pending:
+        return 'PENDING';
+      case OverallChangeStatus.processing:
+        return 'PROCESSING';
+      case OverallChangeStatus.completed:
+        return 'COMPLETED';
+      case OverallChangeStatus.failed:
+        return 'FAILED';
+    }
+  }
+}
+
+extension OverallChangeStatusFromString on String {
+  OverallChangeStatus toOverallChangeStatus() {
+    switch (this) {
+      case 'PENDING':
+        return OverallChangeStatus.pending;
+      case 'PROCESSING':
+        return OverallChangeStatus.processing;
+      case 'COMPLETED':
+        return OverallChangeStatus.completed;
+      case 'FAILED':
+        return OverallChangeStatus.failed;
+    }
+    throw Exception('$this is not known in enum OverallChangeStatus');
+  }
+}
+
+/// Basic information about a package.
+class PackageDetails {
+  final String? availablePackageVersion;
+
+  /// The timestamp of when the package was created.
+  final DateTime? createdAt;
+
+  /// Additional information if the package is in an error state. Null otherwise.
+  final ErrorDetails? errorDetails;
+  final DateTime? lastUpdatedAt;
+
+  /// User-specified description of the package.
+  final String? packageDescription;
+
+  /// Internal ID of the package.
+  final String? packageID;
+
+  /// User-specified name of the package.
+  final String? packageName;
+
+  /// Current state of the package. Values are COPYING, COPY_FAILED, AVAILABLE,
+  /// DELETING, and DELETE_FAILED.
+  final PackageStatus? packageStatus;
+
+  /// Currently supports only TXT-DICTIONARY.
+  final PackageType? packageType;
+
+  PackageDetails({
+    this.availablePackageVersion,
+    this.createdAt,
+    this.errorDetails,
+    this.lastUpdatedAt,
+    this.packageDescription,
+    this.packageID,
+    this.packageName,
+    this.packageStatus,
+    this.packageType,
+  });
+  factory PackageDetails.fromJson(Map<String, dynamic> json) {
+    return PackageDetails(
+      availablePackageVersion: json['AvailablePackageVersion'] as String?,
+      createdAt: timeStampFromJson(json['CreatedAt']),
+      errorDetails: json['ErrorDetails'] != null
+          ? ErrorDetails.fromJson(json['ErrorDetails'] as Map<String, dynamic>)
+          : null,
+      lastUpdatedAt: timeStampFromJson(json['LastUpdatedAt']),
+      packageDescription: json['PackageDescription'] as String?,
+      packageID: json['PackageID'] as String?,
+      packageName: json['PackageName'] as String?,
+      packageStatus: (json['PackageStatus'] as String?)?.toPackageStatus(),
+      packageType: (json['PackageType'] as String?)?.toPackageType(),
+    );
+  }
+}
+
+/// The Amazon S3 location for importing the package specified as
+/// <code>S3BucketName</code> and <code>S3Key</code>
+class PackageSource {
+  /// The name of the Amazon S3 bucket containing the package.
+  final String? s3BucketName;
+
+  /// Key (file name) of the package.
+  final String? s3Key;
+
+  PackageSource({
+    this.s3BucketName,
+    this.s3Key,
+  });
+  Map<String, dynamic> toJson() {
+    final s3BucketName = this.s3BucketName;
+    final s3Key = this.s3Key;
+    return {
+      if (s3BucketName != null) 'S3BucketName': s3BucketName,
+      if (s3Key != null) 'S3Key': s3Key,
+    };
+  }
+}
+
+enum PackageStatus {
+  copying,
+  copyFailed,
+  validating,
+  validationFailed,
+  available,
+  deleting,
+  deleted,
+  deleteFailed,
+}
+
+extension PackageStatusValue on PackageStatus {
+  String toValue() {
+    switch (this) {
+      case PackageStatus.copying:
+        return 'COPYING';
+      case PackageStatus.copyFailed:
+        return 'COPY_FAILED';
+      case PackageStatus.validating:
+        return 'VALIDATING';
+      case PackageStatus.validationFailed:
+        return 'VALIDATION_FAILED';
+      case PackageStatus.available:
+        return 'AVAILABLE';
+      case PackageStatus.deleting:
+        return 'DELETING';
+      case PackageStatus.deleted:
+        return 'DELETED';
+      case PackageStatus.deleteFailed:
+        return 'DELETE_FAILED';
+    }
+  }
+}
+
+extension PackageStatusFromString on String {
+  PackageStatus toPackageStatus() {
+    switch (this) {
+      case 'COPYING':
+        return PackageStatus.copying;
+      case 'COPY_FAILED':
+        return PackageStatus.copyFailed;
+      case 'VALIDATING':
+        return PackageStatus.validating;
+      case 'VALIDATION_FAILED':
+        return PackageStatus.validationFailed;
+      case 'AVAILABLE':
+        return PackageStatus.available;
+      case 'DELETING':
+        return PackageStatus.deleting;
+      case 'DELETED':
+        return PackageStatus.deleted;
+      case 'DELETE_FAILED':
+        return PackageStatus.deleteFailed;
+    }
+    throw Exception('$this is not known in enum PackageStatus');
+  }
+}
+
+enum PackageType {
+  txtDictionary,
+}
+
+extension PackageTypeValue on PackageType {
+  String toValue() {
+    switch (this) {
+      case PackageType.txtDictionary:
+        return 'TXT-DICTIONARY';
+    }
+  }
+}
+
+extension PackageTypeFromString on String {
+  PackageType toPackageType() {
+    switch (this) {
+      case 'TXT-DICTIONARY':
+        return PackageType.txtDictionary;
+    }
+    throw Exception('$this is not known in enum PackageType');
+  }
+}
+
+/// Details of a package version.
+class PackageVersionHistory {
+  /// A message associated with the package version.
+  final String? commitMessage;
+
+  /// The timestamp of when the package was created.
+  final DateTime? createdAt;
+
+  /// The package version.
+  final String? packageVersion;
+
+  PackageVersionHistory({
+    this.commitMessage,
+    this.createdAt,
+    this.packageVersion,
+  });
+  factory PackageVersionHistory.fromJson(Map<String, dynamic> json) {
+    return PackageVersionHistory(
+      commitMessage: json['CommitMessage'] as String?,
+      createdAt: timeStampFromJson(json['CreatedAt']),
+      packageVersion: json['PackageVersion'] as String?,
+    );
+  }
+}
+
+/// Represents the output of a <code>PurchaseReservedInstanceOffering</code>
+/// operation.
+class PurchaseReservedInstanceOfferingResponse {
+  /// The customer-specified identifier used to track this reservation.
+  final String? reservationName;
+
+  /// Details of the reserved OpenSearch instance which was purchased.
+  final String? reservedInstanceId;
+
+  PurchaseReservedInstanceOfferingResponse({
+    this.reservationName,
+    this.reservedInstanceId,
+  });
+  factory PurchaseReservedInstanceOfferingResponse.fromJson(
+      Map<String, dynamic> json) {
+    return PurchaseReservedInstanceOfferingResponse(
+      reservationName: json['ReservationName'] as String?,
+      reservedInstanceId: json['ReservedInstanceId'] as String?,
+    );
+  }
+}
+
+/// Contains the specific price and frequency of a recurring charges for a
+/// reserved OpenSearch instance, or for a reserved OpenSearch instance
+/// offering.
+class RecurringCharge {
+  /// The monetary amount of the recurring charge.
+  final double? recurringChargeAmount;
+
+  /// The frequency of the recurring charge.
+  final String? recurringChargeFrequency;
+
+  RecurringCharge({
+    this.recurringChargeAmount,
+    this.recurringChargeFrequency,
+  });
+  factory RecurringCharge.fromJson(Map<String, dynamic> json) {
+    return RecurringCharge(
+      recurringChargeAmount: json['RecurringChargeAmount'] as double?,
+      recurringChargeFrequency: json['RecurringChargeFrequency'] as String?,
+    );
+  }
+}
+
+/// The result of a <code> <a>RejectInboundConnection</a> </code> operation.
+/// Contains details about the rejected inbound connection.
+class RejectInboundConnectionResponse {
+  /// The <code> <a>InboundConnection</a> </code> of the rejected inbound
+  /// connection.
+  final InboundConnection? connection;
+
+  RejectInboundConnectionResponse({
+    this.connection,
+  });
+  factory RejectInboundConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return RejectInboundConnectionResponse(
+      connection: json['Connection'] != null
+          ? InboundConnection.fromJson(
+              json['Connection'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Details of a reserved OpenSearch instance.
+class ReservedInstance {
+  final int? billingSubscriptionId;
+
+  /// The currency code for the reserved OpenSearch instance offering.
+  final String? currencyCode;
+
+  /// The duration, in seconds, for which the OpenSearch instance is reserved.
+  final int? duration;
+
+  /// The upfront fixed charge you will paid to purchase the specific reserved
+  /// OpenSearch instance offering.
+  final double? fixedPrice;
+
+  /// The number of OpenSearch instances that have been reserved.
+  final int? instanceCount;
+
+  /// The OpenSearch instance type offered by the reserved instance offering.
+  final OpenSearchPartitionInstanceType? instanceType;
+
+  /// The payment option as defined in the reserved OpenSearch instance offering.
+  final ReservedInstancePaymentOption? paymentOption;
+
+  /// The charge to your account regardless of whether you are creating any
+  /// domains using the instance offering.
+  final List<RecurringCharge>? recurringCharges;
+
+  /// The customer-specified identifier to track this reservation.
+  final String? reservationName;
+
+  /// The unique identifier for the reservation.
+  final String? reservedInstanceId;
+
+  /// The offering identifier.
+  final String? reservedInstanceOfferingId;
+
+  /// The time the reservation started.
+  final DateTime? startTime;
+
+  /// The state of the reserved OpenSearch instance.
+  final String? state;
+
+  /// The rate you are charged for each hour for the domain that is using this
+  /// reserved instance.
+  final double? usagePrice;
+
+  ReservedInstance({
+    this.billingSubscriptionId,
+    this.currencyCode,
+    this.duration,
+    this.fixedPrice,
+    this.instanceCount,
+    this.instanceType,
+    this.paymentOption,
+    this.recurringCharges,
+    this.reservationName,
+    this.reservedInstanceId,
+    this.reservedInstanceOfferingId,
+    this.startTime,
+    this.state,
+    this.usagePrice,
+  });
+  factory ReservedInstance.fromJson(Map<String, dynamic> json) {
+    return ReservedInstance(
+      billingSubscriptionId: json['BillingSubscriptionId'] as int?,
+      currencyCode: json['CurrencyCode'] as String?,
+      duration: json['Duration'] as int?,
+      fixedPrice: json['FixedPrice'] as double?,
+      instanceCount: json['InstanceCount'] as int?,
+      instanceType: (json['InstanceType'] as String?)
+          ?.toOpenSearchPartitionInstanceType(),
+      paymentOption:
+          (json['PaymentOption'] as String?)?.toReservedInstancePaymentOption(),
+      recurringCharges: (json['RecurringCharges'] as List?)
+          ?.whereNotNull()
+          .map((e) => RecurringCharge.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      reservationName: json['ReservationName'] as String?,
+      reservedInstanceId: json['ReservedInstanceId'] as String?,
+      reservedInstanceOfferingId: json['ReservedInstanceOfferingId'] as String?,
+      startTime: timeStampFromJson(json['StartTime']),
+      state: json['State'] as String?,
+      usagePrice: json['UsagePrice'] as double?,
+    );
+  }
+}
+
+/// Details of a reserved OpenSearch instance offering.
+class ReservedInstanceOffering {
+  /// The currency code for the reserved OpenSearch instance offering.
+  final String? currencyCode;
+
+  /// The duration, in seconds, for which the offering will reserve the OpenSearch
+  /// instance.
+  final int? duration;
+
+  /// The upfront fixed charge you will pay to purchase the specific reserved
+  /// OpenSearch instance offering.
+  final double? fixedPrice;
+
+  /// The OpenSearch instance type offered by the reserved instance offering.
+  final OpenSearchPartitionInstanceType? instanceType;
+
+  /// Payment option for the reserved OpenSearch instance offering
+  final ReservedInstancePaymentOption? paymentOption;
+
+  /// The charge to your account regardless of whether you are creating any
+  /// domains using the instance offering.
+  final List<RecurringCharge>? recurringCharges;
+
+  /// The OpenSearch reserved instance offering identifier.
+  final String? reservedInstanceOfferingId;
+
+  /// The rate you are charged for each hour the domain that is using the offering
+  /// is running.
+  final double? usagePrice;
+
+  ReservedInstanceOffering({
+    this.currencyCode,
+    this.duration,
+    this.fixedPrice,
+    this.instanceType,
+    this.paymentOption,
+    this.recurringCharges,
+    this.reservedInstanceOfferingId,
+    this.usagePrice,
+  });
+  factory ReservedInstanceOffering.fromJson(Map<String, dynamic> json) {
+    return ReservedInstanceOffering(
+      currencyCode: json['CurrencyCode'] as String?,
+      duration: json['Duration'] as int?,
+      fixedPrice: json['FixedPrice'] as double?,
+      instanceType: (json['InstanceType'] as String?)
+          ?.toOpenSearchPartitionInstanceType(),
+      paymentOption:
+          (json['PaymentOption'] as String?)?.toReservedInstancePaymentOption(),
+      recurringCharges: (json['RecurringCharges'] as List?)
+          ?.whereNotNull()
+          .map((e) => RecurringCharge.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      reservedInstanceOfferingId: json['ReservedInstanceOfferingId'] as String?,
+      usagePrice: json['UsagePrice'] as double?,
+    );
+  }
+}
+
+enum ReservedInstancePaymentOption {
+  allUpfront,
+  partialUpfront,
+  noUpfront,
+}
+
+extension ReservedInstancePaymentOptionValue on ReservedInstancePaymentOption {
+  String toValue() {
+    switch (this) {
+      case ReservedInstancePaymentOption.allUpfront:
+        return 'ALL_UPFRONT';
+      case ReservedInstancePaymentOption.partialUpfront:
+        return 'PARTIAL_UPFRONT';
+      case ReservedInstancePaymentOption.noUpfront:
+        return 'NO_UPFRONT';
+    }
+  }
+}
+
+extension ReservedInstancePaymentOptionFromString on String {
+  ReservedInstancePaymentOption toReservedInstancePaymentOption() {
+    switch (this) {
+      case 'ALL_UPFRONT':
+        return ReservedInstancePaymentOption.allUpfront;
+      case 'PARTIAL_UPFRONT':
+        return ReservedInstancePaymentOption.partialUpfront;
+      case 'NO_UPFRONT':
+        return ReservedInstancePaymentOption.noUpfront;
+    }
+    throw Exception('$this is not known in enum ReservedInstancePaymentOption');
+  }
+}
+
+/// The rollback state while disabling Auto-Tune for the domain. Valid values
+/// are NO_ROLLBACK and DEFAULT_ROLLBACK.
+enum RollbackOnDisable {
+  noRollback,
+  defaultRollback,
+}
+
+extension RollbackOnDisableValue on RollbackOnDisable {
+  String toValue() {
+    switch (this) {
+      case RollbackOnDisable.noRollback:
+        return 'NO_ROLLBACK';
+      case RollbackOnDisable.defaultRollback:
+        return 'DEFAULT_ROLLBACK';
+    }
+  }
+}
+
+extension RollbackOnDisableFromString on String {
+  RollbackOnDisable toRollbackOnDisable() {
+    switch (this) {
+      case 'NO_ROLLBACK':
+        return RollbackOnDisable.noRollback;
+      case 'DEFAULT_ROLLBACK':
+        return RollbackOnDisable.defaultRollback;
+    }
+    throw Exception('$this is not known in enum RollbackOnDisable');
+  }
+}
+
+/// The SAML identity povider's information.
+class SAMLIdp {
+  /// The unique entity ID of the application in SAML identity provider.
+  final String entityId;
+
+  /// The metadata of the SAML application in XML format.
+  final String metadataContent;
+
+  SAMLIdp({
+    required this.entityId,
+    required this.metadataContent,
+  });
+  factory SAMLIdp.fromJson(Map<String, dynamic> json) {
+    return SAMLIdp(
+      entityId: json['EntityId'] as String,
+      metadataContent: json['MetadataContent'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final entityId = this.entityId;
+    final metadataContent = this.metadataContent;
+    return {
+      'EntityId': entityId,
+      'MetadataContent': metadataContent,
+    };
+  }
+}
+
+/// The SAML application configuration for the domain.
+class SAMLOptionsInput {
+  /// True if SAML is enabled.
+  final bool? enabled;
+
+  /// The SAML Identity Provider's information.
+  final SAMLIdp? idp;
+
+  /// The backend role that the SAML master user is mapped to.
+  final String? masterBackendRole;
+
+  /// The SAML master username, which is stored in the Amazon OpenSearch Service
+  /// domain's internal database.
+  final String? masterUserName;
+
+  /// Element of the SAML assertion to use for backend roles. Default is roles.
+  final String? rolesKey;
+
+  /// The duration, in minutes, after which a user session becomes inactive.
+  /// Acceptable values are between 1 and 1440, and the default value is 60.
+  final int? sessionTimeoutMinutes;
+
+  /// Element of the SAML assertion to use for username. Default is NameID.
+  final String? subjectKey;
+
+  SAMLOptionsInput({
+    this.enabled,
+    this.idp,
+    this.masterBackendRole,
+    this.masterUserName,
+    this.rolesKey,
+    this.sessionTimeoutMinutes,
+    this.subjectKey,
+  });
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    final idp = this.idp;
+    final masterBackendRole = this.masterBackendRole;
+    final masterUserName = this.masterUserName;
+    final rolesKey = this.rolesKey;
+    final sessionTimeoutMinutes = this.sessionTimeoutMinutes;
+    final subjectKey = this.subjectKey;
+    return {
+      if (enabled != null) 'Enabled': enabled,
+      if (idp != null) 'Idp': idp,
+      if (masterBackendRole != null) 'MasterBackendRole': masterBackendRole,
+      if (masterUserName != null) 'MasterUserName': masterUserName,
+      if (rolesKey != null) 'RolesKey': rolesKey,
+      if (sessionTimeoutMinutes != null)
+        'SessionTimeoutMinutes': sessionTimeoutMinutes,
+      if (subjectKey != null) 'SubjectKey': subjectKey,
+    };
+  }
+}
+
+/// Describes the SAML application configured for the domain.
+class SAMLOptionsOutput {
+  /// True if SAML is enabled.
+  final bool? enabled;
+
+  /// Describes the SAML identity provider's information.
+  final SAMLIdp? idp;
+
+  /// The key used for matching the SAML roles attribute.
+  final String? rolesKey;
+
+  /// The duration, in minutes, after which a user session becomes inactive.
+  final int? sessionTimeoutMinutes;
+
+  /// The key used for matching the SAML subject attribute.
+  final String? subjectKey;
+
+  SAMLOptionsOutput({
+    this.enabled,
+    this.idp,
+    this.rolesKey,
+    this.sessionTimeoutMinutes,
+    this.subjectKey,
+  });
+  factory SAMLOptionsOutput.fromJson(Map<String, dynamic> json) {
+    return SAMLOptionsOutput(
+      enabled: json['Enabled'] as bool?,
+      idp: json['Idp'] != null
+          ? SAMLIdp.fromJson(json['Idp'] as Map<String, dynamic>)
+          : null,
+      rolesKey: json['RolesKey'] as String?,
+      sessionTimeoutMinutes: json['SessionTimeoutMinutes'] as int?,
+      subjectKey: json['SubjectKey'] as String?,
+    );
+  }
+}
+
+/// The Auto-Tune action type. Valid values are JVM_HEAP_SIZE_TUNING, and
+/// JVM_YOUNG_GEN_TUNING.
+enum ScheduledAutoTuneActionType {
+  jvmHeapSizeTuning,
+  jvmYoungGenTuning,
+}
+
+extension ScheduledAutoTuneActionTypeValue on ScheduledAutoTuneActionType {
+  String toValue() {
+    switch (this) {
+      case ScheduledAutoTuneActionType.jvmHeapSizeTuning:
+        return 'JVM_HEAP_SIZE_TUNING';
+      case ScheduledAutoTuneActionType.jvmYoungGenTuning:
+        return 'JVM_YOUNG_GEN_TUNING';
+    }
+  }
+}
+
+extension ScheduledAutoTuneActionTypeFromString on String {
+  ScheduledAutoTuneActionType toScheduledAutoTuneActionType() {
+    switch (this) {
+      case 'JVM_HEAP_SIZE_TUNING':
+        return ScheduledAutoTuneActionType.jvmHeapSizeTuning;
+      case 'JVM_YOUNG_GEN_TUNING':
+        return ScheduledAutoTuneActionType.jvmYoungGenTuning;
+    }
+    throw Exception('$this is not known in enum ScheduledAutoTuneActionType');
+  }
+}
+
+/// Specifies details about the scheduled Auto-Tune action. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+class ScheduledAutoTuneDetails {
+  /// The Auto-Tune action description.
+  final String? action;
+
+  /// The Auto-Tune action type. Valid values are JVM_HEAP_SIZE_TUNING and
+  /// JVM_YOUNG_GEN_TUNING.
+  final ScheduledAutoTuneActionType? actionType;
+
+  /// The timestamp of the Auto-Tune action scheduled for the domain.
+  final DateTime? date;
+
+  /// The Auto-Tune action severity. Valid values are LOW, MEDIUM, and HIGH.
+  final ScheduledAutoTuneSeverityType? severity;
+
+  ScheduledAutoTuneDetails({
+    this.action,
+    this.actionType,
+    this.date,
+    this.severity,
+  });
+  factory ScheduledAutoTuneDetails.fromJson(Map<String, dynamic> json) {
+    return ScheduledAutoTuneDetails(
+      action: json['Action'] as String?,
+      actionType:
+          (json['ActionType'] as String?)?.toScheduledAutoTuneActionType(),
+      date: timeStampFromJson(json['Date']),
+      severity:
+          (json['Severity'] as String?)?.toScheduledAutoTuneSeverityType(),
+    );
+  }
+}
+
+/// The Auto-Tune action severity. Valid values are LOW, MEDIUM, and HIGH.
+enum ScheduledAutoTuneSeverityType {
+  low,
+  medium,
+  high,
+}
+
+extension ScheduledAutoTuneSeverityTypeValue on ScheduledAutoTuneSeverityType {
+  String toValue() {
+    switch (this) {
+      case ScheduledAutoTuneSeverityType.low:
+        return 'LOW';
+      case ScheduledAutoTuneSeverityType.medium:
+        return 'MEDIUM';
+      case ScheduledAutoTuneSeverityType.high:
+        return 'HIGH';
+    }
+  }
+}
+
+extension ScheduledAutoTuneSeverityTypeFromString on String {
+  ScheduledAutoTuneSeverityType toScheduledAutoTuneSeverityType() {
+    switch (this) {
+      case 'LOW':
+        return ScheduledAutoTuneSeverityType.low;
+      case 'MEDIUM':
+        return ScheduledAutoTuneSeverityType.medium;
+      case 'HIGH':
+        return ScheduledAutoTuneSeverityType.high;
+    }
+    throw Exception('$this is not known in enum ScheduledAutoTuneSeverityType');
+  }
+}
+
+/// The current options of an domain service software options.
+class ServiceSoftwareOptions {
+  /// The timestamp, in Epoch time, until which you can manually request a service
+  /// software update. After this date, we automatically update your service
+  /// software.
+  final DateTime? automatedUpdateDate;
+
+  /// <code>True</code> if you're able to cancel your service software version
+  /// update. <code>False</code> if you can't cancel your service software update.
+  final bool? cancellable;
+
+  /// The current service software version present on the domain.
+  final String? currentVersion;
+
+  /// The description of the <code>UpdateStatus</code>.
+  final String? description;
+
+  /// The new service software version if one is available.
+  final String? newVersion;
+
+  /// <code>True</code> if a service software is never automatically updated.
+  /// <code>False</code> if a service software is automatically updated after
+  /// <code>AutomatedUpdateDate</code>.
+  final bool? optionalDeployment;
+
+  /// <code>True</code> if you're able to update your service software version.
+  /// <code>False</code> if you can't update your service software version.
+  final bool? updateAvailable;
+
+  /// The status of your service software update. This field can take the
+  /// following values: <code> ELIGIBLE</code>, <code>PENDING_UPDATE</code>,
+  /// <code>IN_PROGRESS</code>, <code>COMPLETED</code>, and <code>
+  /// NOT_ELIGIBLE</code>.
+  final DeploymentStatus? updateStatus;
+
+  ServiceSoftwareOptions({
+    this.automatedUpdateDate,
+    this.cancellable,
+    this.currentVersion,
+    this.description,
+    this.newVersion,
+    this.optionalDeployment,
+    this.updateAvailable,
+    this.updateStatus,
+  });
+  factory ServiceSoftwareOptions.fromJson(Map<String, dynamic> json) {
+    return ServiceSoftwareOptions(
+      automatedUpdateDate: timeStampFromJson(json['AutomatedUpdateDate']),
+      cancellable: json['Cancellable'] as bool?,
+      currentVersion: json['CurrentVersion'] as String?,
+      description: json['Description'] as String?,
+      newVersion: json['NewVersion'] as String?,
+      optionalDeployment: json['OptionalDeployment'] as bool?,
+      updateAvailable: json['UpdateAvailable'] as bool?,
+      updateStatus: (json['UpdateStatus'] as String?)?.toDeploymentStatus(),
+    );
+  }
+}
+
+/// The time, in UTC format, when the service takes a daily automated snapshot
+/// of the specified domain. Default is <code>0</code> hours.
+class SnapshotOptions {
+  /// The time, in UTC format, when the service takes a daily automated snapshot
+  /// of the specified domain. Default is <code>0</code> hours.
+  final int? automatedSnapshotStartHour;
+
+  SnapshotOptions({
+    this.automatedSnapshotStartHour,
+  });
+  factory SnapshotOptions.fromJson(Map<String, dynamic> json) {
+    return SnapshotOptions(
+      automatedSnapshotStartHour: json['AutomatedSnapshotStartHour'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final automatedSnapshotStartHour = this.automatedSnapshotStartHour;
+    return {
+      if (automatedSnapshotStartHour != null)
+        'AutomatedSnapshotStartHour': automatedSnapshotStartHour,
+    };
+  }
+}
+
+/// Status of a daily automated snapshot.
+class SnapshotOptionsStatus {
+  /// The daily snapshot options specified for the domain.
+  final SnapshotOptions options;
+
+  /// The status of a daily automated snapshot.
+  final OptionStatus status;
+
+  SnapshotOptionsStatus({
+    required this.options,
+    required this.status,
+  });
+  factory SnapshotOptionsStatus.fromJson(Map<String, dynamic> json) {
+    return SnapshotOptionsStatus(
+      options:
+          SnapshotOptions.fromJson(json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// The result of a <code>StartServiceSoftwareUpdate</code> operation. Contains
+/// the status of the update.
+class StartServiceSoftwareUpdateResponse {
+  /// The current status of the OpenSearch service software update.
+  final ServiceSoftwareOptions? serviceSoftwareOptions;
+
+  StartServiceSoftwareUpdateResponse({
+    this.serviceSoftwareOptions,
+  });
+  factory StartServiceSoftwareUpdateResponse.fromJson(
+      Map<String, dynamic> json) {
+    return StartServiceSoftwareUpdateResponse(
+      serviceSoftwareOptions: json['ServiceSoftwareOptions'] != null
+          ? ServiceSoftwareOptions.fromJson(
+              json['ServiceSoftwareOptions'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// StorageTypes represents the list of storage-related types and their
+/// attributes that are available for a given InstanceType.
+class StorageType {
+  final String? storageSubTypeName;
+
+  /// Limits that are applicable for the given storage type.
+  final List<StorageTypeLimit>? storageTypeLimits;
+  final String? storageTypeName;
+
+  StorageType({
+    this.storageSubTypeName,
+    this.storageTypeLimits,
+    this.storageTypeName,
+  });
+  factory StorageType.fromJson(Map<String, dynamic> json) {
+    return StorageType(
+      storageSubTypeName: json['StorageSubTypeName'] as String?,
+      storageTypeLimits: (json['StorageTypeLimits'] as List?)
+          ?.whereNotNull()
+          .map((e) => StorageTypeLimit.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      storageTypeName: json['StorageTypeName'] as String?,
+    );
+  }
+}
+
+/// Limits that are applicable for the given storage type.
+class StorageTypeLimit {
+  /// Name of storage limits that are applicable for the given storage type. If
+  /// <code> <a>StorageType</a> </code> is "ebs", the following storage options
+  /// are applicable: <ol>
+  /// <li>MinimumVolumeSize</li> Minimum amount of volume size that is applicable
+  /// for the given storage type. Can be empty if not applicable.
+  /// <li>MaximumVolumeSize</li> Maximum amount of volume size that is applicable
+  /// for the given storage type. Can be empty if not applicable.
+  /// <li>MaximumIops</li> Maximum amount of Iops that is applicable for given the
+  /// storage type. Can be empty if not applicable.
+  /// <li>MinimumIops</li> Minimum amount of Iops that is applicable for given the
+  /// storage type. Can be empty if not applicable. </ol>
+  final String? limitName;
+
+  /// Values for the <code> <a>StorageTypeLimit$LimitName</a> </code> .
+  final List<String>? limitValues;
+
+  StorageTypeLimit({
+    this.limitName,
+    this.limitValues,
+  });
+  factory StorageTypeLimit.fromJson(Map<String, dynamic> json) {
+    return StorageTypeLimit(
+      limitName: json['LimitName'] as String?,
+      limitValues: (json['LimitValues'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+    );
+  }
+}
+
+enum TLSSecurityPolicy {
+  policyMinTls_1_0_2019_07,
+  policyMinTls_1_2_2019_07,
+}
+
+extension TLSSecurityPolicyValue on TLSSecurityPolicy {
+  String toValue() {
+    switch (this) {
+      case TLSSecurityPolicy.policyMinTls_1_0_2019_07:
+        return 'Policy-Min-TLS-1-0-2019-07';
+      case TLSSecurityPolicy.policyMinTls_1_2_2019_07:
+        return 'Policy-Min-TLS-1-2-2019-07';
+    }
+  }
+}
+
+extension TLSSecurityPolicyFromString on String {
+  TLSSecurityPolicy toTLSSecurityPolicy() {
+    switch (this) {
+      case 'Policy-Min-TLS-1-0-2019-07':
+        return TLSSecurityPolicy.policyMinTls_1_0_2019_07;
+      case 'Policy-Min-TLS-1-2-2019-07':
+        return TLSSecurityPolicy.policyMinTls_1_2_2019_07;
+    }
+    throw Exception('$this is not known in enum TLSSecurityPolicy');
+  }
+}
+
+/// A key value pair for a resource tag.
+class Tag {
+  /// The <code>TagKey</code>, the name of the tag. Tag keys must be unique for
+  /// the domain to which they are attached.
+  final String key;
+
+  /// The <code>TagValue</code>, the value assigned to the corresponding tag key.
+  /// Tag values can be null and don't have to be unique in a tag set. For
+  /// example, you can have a key value pair in a tag set of <code>project :
+  /// Trinity</code> and <code>cost-center : Trinity</code>
+  final String value;
+
+  Tag({
+    required this.key,
+    required this.value,
+  });
+  factory Tag.fromJson(Map<String, dynamic> json) {
+    return Tag(
+      key: json['Key'] as String,
+      value: json['Value'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final key = this.key;
+    final value = this.value;
+    return {
+      'Key': key,
+      'Value': value,
+    };
+  }
+}
+
+/// The unit of a maintenance schedule duration. Valid value is HOUR. See <a
+/// href="https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html"
+/// target="_blank"> Auto-Tune for Amazon OpenSearch Service </a> for more
+/// information.
+enum TimeUnit {
+  hours,
+}
+
+extension TimeUnitValue on TimeUnit {
+  String toValue() {
+    switch (this) {
+      case TimeUnit.hours:
+        return 'HOURS';
+    }
+  }
+}
+
+extension TimeUnitFromString on String {
+  TimeUnit toTimeUnit() {
+    switch (this) {
+      case 'HOURS':
+        return TimeUnit.hours;
+    }
+    throw Exception('$this is not known in enum TimeUnit');
+  }
+}
+
+/// The result of an <code>UpdateDomain</code> request. Contains the status of
+/// the domain being updated.
+class UpdateDomainConfigResponse {
+  /// The status of the updated domain.
+  final DomainConfig domainConfig;
+
+  /// Contains result of DryRun.
+  final DryRunResults? dryRunResults;
+
+  UpdateDomainConfigResponse({
+    required this.domainConfig,
+    this.dryRunResults,
+  });
+  factory UpdateDomainConfigResponse.fromJson(Map<String, dynamic> json) {
+    return UpdateDomainConfigResponse(
+      domainConfig:
+          DomainConfig.fromJson(json['DomainConfig'] as Map<String, dynamic>),
+      dryRunResults: json['DryRunResults'] != null
+          ? DryRunResults.fromJson(
+              json['DryRunResults'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Container for the response returned by the <code> <a>UpdatePackage</a>
+/// </code> operation.
+class UpdatePackageResponse {
+  /// Information about the package.
+  final PackageDetails? packageDetails;
+
+  UpdatePackageResponse({
+    this.packageDetails,
+  });
+  factory UpdatePackageResponse.fromJson(Map<String, dynamic> json) {
+    return UpdatePackageResponse(
+      packageDetails: json['PackageDetails'] != null
+          ? PackageDetails.fromJson(
+              json['PackageDetails'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+}
+
+/// Container for response returned by <code> <a>UpgradeDomain</a> </code>
+/// operation.
+class UpgradeDomainResponse {
+  final Map<String, String>? advancedOptions;
+  final ChangeProgressDetails? changeProgressDetails;
+  final String? domainName;
+
+  /// When true, indicates that an upgrade eligibility check needs to be
+  /// performed. Does not actually perform the upgrade.
+  final bool? performCheckOnly;
+
+  /// The version of OpenSearch that you intend to upgrade the domain to.
+  final String? targetVersion;
+  final String? upgradeId;
+
+  UpgradeDomainResponse({
+    this.advancedOptions,
+    this.changeProgressDetails,
+    this.domainName,
+    this.performCheckOnly,
+    this.targetVersion,
+    this.upgradeId,
+  });
+  factory UpgradeDomainResponse.fromJson(Map<String, dynamic> json) {
+    return UpgradeDomainResponse(
+      advancedOptions: (json['AdvancedOptions'] as Map<String, dynamic>?)
+          ?.map((k, e) => MapEntry(k, e as String)),
+      changeProgressDetails: json['ChangeProgressDetails'] != null
+          ? ChangeProgressDetails.fromJson(
+              json['ChangeProgressDetails'] as Map<String, dynamic>)
+          : null,
+      domainName: json['DomainName'] as String?,
+      performCheckOnly: json['PerformCheckOnly'] as bool?,
+      targetVersion: json['TargetVersion'] as String?,
+      upgradeId: json['UpgradeId'] as String?,
+    );
+  }
+}
+
+/// History of the last 10 upgrades and upgrade eligibility checks.
+class UpgradeHistory {
+  /// UTC timestamp at which the upgrade API call was made in
+  /// "yyyy-MM-ddTHH:mm:ssZ" format.
+  final DateTime? startTimestamp;
+
+  /// A list of <code> <a>UpgradeStepItem</a> </code> s representing information
+  /// about each step performed as part of a specific upgrade or upgrade
+  /// eligibility check.
+  final List<UpgradeStepItem>? stepsList;
+
+  /// A string that briefly describes the upgrade.
+  final String? upgradeName;
+
+  /// The current status of the upgrade. The status can take one of the following
+  /// values:
+  /// <ul>
+  /// <li>In Progress</li>
+  /// <li>Succeeded</li>
+  /// <li>Succeeded with Issues</li>
+  /// <li>Failed</li>
+  /// </ul>
+  final UpgradeStatus? upgradeStatus;
+
+  UpgradeHistory({
+    this.startTimestamp,
+    this.stepsList,
+    this.upgradeName,
+    this.upgradeStatus,
+  });
+  factory UpgradeHistory.fromJson(Map<String, dynamic> json) {
+    return UpgradeHistory(
+      startTimestamp: timeStampFromJson(json['StartTimestamp']),
+      stepsList: (json['StepsList'] as List?)
+          ?.whereNotNull()
+          .map((e) => UpgradeStepItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      upgradeName: json['UpgradeName'] as String?,
+      upgradeStatus: (json['UpgradeStatus'] as String?)?.toUpgradeStatus(),
+    );
+  }
+}
+
+enum UpgradeStatus {
+  inProgress,
+  succeeded,
+  succeededWithIssues,
+  failed,
+}
+
+extension UpgradeStatusValue on UpgradeStatus {
+  String toValue() {
+    switch (this) {
+      case UpgradeStatus.inProgress:
+        return 'IN_PROGRESS';
+      case UpgradeStatus.succeeded:
+        return 'SUCCEEDED';
+      case UpgradeStatus.succeededWithIssues:
+        return 'SUCCEEDED_WITH_ISSUES';
+      case UpgradeStatus.failed:
+        return 'FAILED';
+    }
+  }
+}
+
+extension UpgradeStatusFromString on String {
+  UpgradeStatus toUpgradeStatus() {
+    switch (this) {
+      case 'IN_PROGRESS':
+        return UpgradeStatus.inProgress;
+      case 'SUCCEEDED':
+        return UpgradeStatus.succeeded;
+      case 'SUCCEEDED_WITH_ISSUES':
+        return UpgradeStatus.succeededWithIssues;
+      case 'FAILED':
+        return UpgradeStatus.failed;
+    }
+    throw Exception('$this is not known in enum UpgradeStatus');
+  }
+}
+
+enum UpgradeStep {
+  preUpgradeCheck,
+  snapshot,
+  upgrade,
+}
+
+extension UpgradeStepValue on UpgradeStep {
+  String toValue() {
+    switch (this) {
+      case UpgradeStep.preUpgradeCheck:
+        return 'PRE_UPGRADE_CHECK';
+      case UpgradeStep.snapshot:
+        return 'SNAPSHOT';
+      case UpgradeStep.upgrade:
+        return 'UPGRADE';
+    }
+  }
+}
+
+extension UpgradeStepFromString on String {
+  UpgradeStep toUpgradeStep() {
+    switch (this) {
+      case 'PRE_UPGRADE_CHECK':
+        return UpgradeStep.preUpgradeCheck;
+      case 'SNAPSHOT':
+        return UpgradeStep.snapshot;
+      case 'UPGRADE':
+        return UpgradeStep.upgrade;
+    }
+    throw Exception('$this is not known in enum UpgradeStep');
+  }
+}
+
+/// Represents a single step of the upgrade or upgrade eligibility check
+/// workflow.
+class UpgradeStepItem {
+  /// A list of strings containing detailed information about the errors
+  /// encountered in a particular step.
+  final List<String>? issues;
+
+  /// The floating point value representing the progress percentage of a
+  /// particular step.
+  final double? progressPercent;
+
+  /// One of three steps an upgrade or upgrade eligibility check goes through:
+  /// <ul>
+  /// <li>PreUpgradeCheck</li>
+  /// <li>Snapshot</li>
+  /// <li>Upgrade</li>
+  /// </ul>
+  final UpgradeStep? upgradeStep;
+
+  /// The current status of the upgrade. The status can take one of the following
+  /// values:
+  /// <ul>
+  /// <li>In Progress</li>
+  /// <li>Succeeded</li>
+  /// <li>Succeeded with Issues</li>
+  /// <li>Failed</li>
+  /// </ul>
+  final UpgradeStatus? upgradeStepStatus;
+
+  UpgradeStepItem({
+    this.issues,
+    this.progressPercent,
+    this.upgradeStep,
+    this.upgradeStepStatus,
+  });
+  factory UpgradeStepItem.fromJson(Map<String, dynamic> json) {
+    return UpgradeStepItem(
+      issues: (json['Issues'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      progressPercent: json['ProgressPercent'] as double?,
+      upgradeStep: (json['UpgradeStep'] as String?)?.toUpgradeStep(),
+      upgradeStepStatus:
+          (json['UpgradeStepStatus'] as String?)?.toUpgradeStatus(),
+    );
+  }
+}
+
+/// Options to specify the subnets and security groups for the VPC endpoint. For
+/// more information, see <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+/// target="_blank"> Launching your Amazon OpenSearch Service domains using a
+/// VPC</a>.
+class VPCDerivedInfo {
+  /// The Availability Zones for the domain. Exists only if the domain was created
+  /// with <code>VPCOptions</code>.
+  final List<String>? availabilityZones;
+
+  /// The security groups for the VPC endpoint.
+  final List<String>? securityGroupIds;
+
+  /// The subnets for the VPC endpoint.
+  final List<String>? subnetIds;
+
+  /// The VPC ID for the domain. Exists only if the domain was created with
+  /// <code>VPCOptions</code>.
+  final String? vPCId;
+
+  VPCDerivedInfo({
+    this.availabilityZones,
+    this.securityGroupIds,
+    this.subnetIds,
+    this.vPCId,
+  });
+  factory VPCDerivedInfo.fromJson(Map<String, dynamic> json) {
+    return VPCDerivedInfo(
+      availabilityZones: (json['AvailabilityZones'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      securityGroupIds: (json['SecurityGroupIds'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      subnetIds: (json['SubnetIds'] as List?)
+          ?.whereNotNull()
+          .map((e) => e as String)
+          .toList(),
+      vPCId: json['VPCId'] as String?,
+    );
+  }
+}
+
+/// Status of the VPC options for the specified domain.
+class VPCDerivedInfoStatus {
+  /// The VPC options for the specified domain.
+  final VPCDerivedInfo options;
+
+  /// The status of the VPC options for the specified domain.
+  final OptionStatus status;
+
+  VPCDerivedInfoStatus({
+    required this.options,
+    required this.status,
+  });
+  factory VPCDerivedInfoStatus.fromJson(Map<String, dynamic> json) {
+    return VPCDerivedInfoStatus(
+      options: VPCDerivedInfo.fromJson(json['Options'] as Map<String, dynamic>),
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// Options to specify the subnets and security groups for the VPC endpoint. For
+/// more information, see <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/vpc.html"
+/// target="_blank"> Launching your Amazon OpenSearch Service domains using a
+/// VPC</a>.
+class VPCOptions {
+  /// The security groups for the VPC endpoint.
+  final List<String>? securityGroupIds;
+
+  /// The subnets for the VPC endpoint.
+  final List<String>? subnetIds;
+
+  VPCOptions({
+    this.securityGroupIds,
+    this.subnetIds,
+  });
+  Map<String, dynamic> toJson() {
+    final securityGroupIds = this.securityGroupIds;
+    final subnetIds = this.subnetIds;
+    return {
+      if (securityGroupIds != null) 'SecurityGroupIds': securityGroupIds,
+      if (subnetIds != null) 'SubnetIds': subnetIds,
+    };
+  }
+}
+
+/// The status of the OpenSearch version options for the specified OpenSearch
+/// domain.
+class VersionStatus {
+  /// The OpenSearch version for the specified OpenSearch domain.
+  final String options;
+
+  /// The status of the OpenSearch version options for the specified OpenSearch
+  /// domain.
+  final OptionStatus status;
+
+  VersionStatus({
+    required this.options,
+    required this.status,
+  });
+  factory VersionStatus.fromJson(Map<String, dynamic> json) {
+    return VersionStatus(
+      options: json['Options'] as String,
+      status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
+    );
+  }
+}
+
+/// The type of EBS volume, standard, gp2, or io1. See <a
+/// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/opensearch-createupdatedomains.html#opensearch-createdomain-configure-ebs"
+/// target="_blank">Configuring EBS-based Storage</a> for more information.
+enum VolumeType {
+  standard,
+  gp2,
+  io1,
+}
+
+extension VolumeTypeValue on VolumeType {
+  String toValue() {
+    switch (this) {
+      case VolumeType.standard:
+        return 'standard';
+      case VolumeType.gp2:
+        return 'gp2';
+      case VolumeType.io1:
+        return 'io1';
+    }
+  }
+}
+
+extension VolumeTypeFromString on String {
+  VolumeType toVolumeType() {
+    switch (this) {
+      case 'standard':
+        return VolumeType.standard;
+      case 'gp2':
+        return VolumeType.gp2;
+      case 'io1':
+        return VolumeType.io1;
+    }
+    throw Exception('$this is not known in enum VolumeType');
+  }
+}
+
+/// The zone awareness configuration for the domain cluster, such as the number
+/// of availability zones.
+class ZoneAwarenessConfig {
+  /// An integer value to indicate the number of availability zones for a domain
+  /// when zone awareness is enabled. This should be equal to number of subnets if
+  /// VPC endpoints is enabled.
+  final int? availabilityZoneCount;
+
+  ZoneAwarenessConfig({
+    this.availabilityZoneCount,
+  });
+  factory ZoneAwarenessConfig.fromJson(Map<String, dynamic> json) {
+    return ZoneAwarenessConfig(
+      availabilityZoneCount: json['AvailabilityZoneCount'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    final availabilityZoneCount = this.availabilityZoneCount;
+    return {
+      if (availabilityZoneCount != null)
+        'AvailabilityZoneCount': availabilityZoneCount,
+    };
+  }
+}
+
+class AccessDeniedException extends _s.GenericAwsException {
+  AccessDeniedException({String? type, String? message})
+      : super(type: type, code: 'AccessDeniedException', message: message);
+}
+
+class BaseException extends _s.GenericAwsException {
+  BaseException({String? type, String? message})
+      : super(type: type, code: 'BaseException', message: message);
+}
+
+class ConflictException extends _s.GenericAwsException {
+  ConflictException({String? type, String? message})
+      : super(type: type, code: 'ConflictException', message: message);
+}
+
+class DisabledOperationException extends _s.GenericAwsException {
+  DisabledOperationException({String? type, String? message})
+      : super(type: type, code: 'DisabledOperationException', message: message);
+}
+
+class InternalException extends _s.GenericAwsException {
+  InternalException({String? type, String? message})
+      : super(type: type, code: 'InternalException', message: message);
+}
+
+class InvalidPaginationTokenException extends _s.GenericAwsException {
+  InvalidPaginationTokenException({String? type, String? message})
+      : super(
+            type: type,
+            code: 'InvalidPaginationTokenException',
+            message: message);
+}
+
+class InvalidTypeException extends _s.GenericAwsException {
+  InvalidTypeException({String? type, String? message})
+      : super(type: type, code: 'InvalidTypeException', message: message);
+}
+
+class LimitExceededException extends _s.GenericAwsException {
+  LimitExceededException({String? type, String? message})
+      : super(type: type, code: 'LimitExceededException', message: message);
+}
+
+class ResourceAlreadyExistsException extends _s.GenericAwsException {
+  ResourceAlreadyExistsException({String? type, String? message})
+      : super(
+            type: type,
+            code: 'ResourceAlreadyExistsException',
+            message: message);
+}
+
+class ResourceNotFoundException extends _s.GenericAwsException {
+  ResourceNotFoundException({String? type, String? message})
+      : super(type: type, code: 'ResourceNotFoundException', message: message);
+}
+
+class ValidationException extends _s.GenericAwsException {
+  ValidationException({String? type, String? message})
+      : super(type: type, code: 'ValidationException', message: message);
+}
+
+final _exceptionFns = <String, _s.AwsExceptionFn>{
+  'AccessDeniedException': (type, message) =>
+      AccessDeniedException(type: type, message: message),
+  'BaseException': (type, message) =>
+      BaseException(type: type, message: message),
+  'ConflictException': (type, message) =>
+      ConflictException(type: type, message: message),
+  'DisabledOperationException': (type, message) =>
+      DisabledOperationException(type: type, message: message),
+  'InternalException': (type, message) =>
+      InternalException(type: type, message: message),
+  'InvalidPaginationTokenException': (type, message) =>
+      InvalidPaginationTokenException(type: type, message: message),
+  'InvalidTypeException': (type, message) =>
+      InvalidTypeException(type: type, message: message),
+  'LimitExceededException': (type, message) =>
+      LimitExceededException(type: type, message: message),
+  'ResourceAlreadyExistsException': (type, message) =>
+      ResourceAlreadyExistsException(type: type, message: message),
+  'ResourceNotFoundException': (type, message) =>
+      ResourceNotFoundException(type: type, message: message),
+  'ValidationException': (type, message) =>
+      ValidationException(type: type, message: message),
+};

--- a/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
+++ b/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
@@ -2690,7 +2690,7 @@ enum ArchiveState {
   updateFailed,
 }
 
-extension on ArchiveState {
+extension ArchiveStateValue on ArchiveState {
   String toValue() {
     switch (this) {
       case ArchiveState.enabled:
@@ -2709,7 +2709,7 @@ extension on ArchiveState {
   }
 }
 
-extension on String {
+extension ArchiveStateFromString on String {
   ArchiveState toArchiveState() {
     switch (this) {
       case 'ENABLED':
@@ -2734,7 +2734,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension on AssignPublicIp {
+extension AssignPublicIpValue on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -2745,7 +2745,7 @@ extension on AssignPublicIp {
   }
 }
 
-extension on String {
+extension AssignPublicIpFromString on String {
   AssignPublicIp toAssignPublicIp() {
     switch (this) {
       case 'ENABLED':
@@ -3530,7 +3530,7 @@ enum EventSourceState {
   deleted,
 }
 
-extension on EventSourceState {
+extension EventSourceStateValue on EventSourceState {
   String toValue() {
     switch (this) {
       case EventSourceState.pending:
@@ -3543,7 +3543,7 @@ extension on EventSourceState {
   }
 }
 
-extension on String {
+extension EventSourceStateFromString on String {
   EventSourceState toEventSourceState() {
     switch (this) {
       case 'PENDING':
@@ -3722,7 +3722,7 @@ enum LaunchType {
   fargate,
 }
 
-extension on LaunchType {
+extension LaunchTypeValue on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -3733,7 +3733,7 @@ extension on LaunchType {
   }
 }
 
-extension on String {
+extension LaunchTypeFromString on String {
   LaunchType toLaunchType() {
     switch (this) {
       case 'EC2':
@@ -4528,7 +4528,7 @@ enum ReplayState {
   failed,
 }
 
-extension on ReplayState {
+extension ReplayStateValue on ReplayState {
   String toValue() {
     switch (this) {
       case ReplayState.starting:
@@ -4547,7 +4547,7 @@ extension on ReplayState {
   }
 }
 
-extension on String {
+extension ReplayStateFromString on String {
   ReplayState toReplayState() {
     switch (this) {
       case 'STARTING':
@@ -4667,7 +4667,7 @@ enum RuleState {
   disabled,
 }
 
-extension on RuleState {
+extension RuleStateValue on RuleState {
   String toValue() {
     switch (this) {
       case RuleState.enabled:
@@ -4678,7 +4678,7 @@ extension on RuleState {
   }
 }
 
-extension on String {
+extension RuleStateFromString on String {
   RuleState toRuleState() {
     switch (this) {
       case 'ENABLED':

--- a/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
+++ b/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
@@ -2690,7 +2690,7 @@ enum ArchiveState {
   updateFailed,
 }
 
-extension ArchiveStateValue on ArchiveState {
+extension ArchiveStateValueExtension on ArchiveState {
   String toValue() {
     switch (this) {
       case ArchiveState.enabled:
@@ -2734,7 +2734,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension AssignPublicIpValue on AssignPublicIp {
+extension AssignPublicIpValueExtension on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -3530,7 +3530,7 @@ enum EventSourceState {
   deleted,
 }
 
-extension EventSourceStateValue on EventSourceState {
+extension EventSourceStateValueExtension on EventSourceState {
   String toValue() {
     switch (this) {
       case EventSourceState.pending:
@@ -3722,7 +3722,7 @@ enum LaunchType {
   fargate,
 }
 
-extension LaunchTypeValue on LaunchType {
+extension LaunchTypeValueExtension on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -4528,7 +4528,7 @@ enum ReplayState {
   failed,
 }
 
-extension ReplayStateValue on ReplayState {
+extension ReplayStateValueExtension on ReplayState {
   String toValue() {
     switch (this) {
       case ReplayState.starting:
@@ -4667,7 +4667,7 @@ enum RuleState {
   disabled,
 }
 
-extension RuleStateValue on RuleState {
+extension RuleStateValueExtension on RuleState {
   String toValue() {
     switch (this) {
       case RuleState.enabled:

--- a/generated/aws_events_api/lib/events-2015-10-07.dart
+++ b/generated/aws_events_api/lib/events-2015-10-07.dart
@@ -2690,7 +2690,7 @@ enum ArchiveState {
   updateFailed,
 }
 
-extension on ArchiveState {
+extension ArchiveStateValue on ArchiveState {
   String toValue() {
     switch (this) {
       case ArchiveState.enabled:
@@ -2709,7 +2709,7 @@ extension on ArchiveState {
   }
 }
 
-extension on String {
+extension ArchiveStateFromString on String {
   ArchiveState toArchiveState() {
     switch (this) {
       case 'ENABLED':
@@ -2734,7 +2734,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension on AssignPublicIp {
+extension AssignPublicIpValue on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -2745,7 +2745,7 @@ extension on AssignPublicIp {
   }
 }
 
-extension on String {
+extension AssignPublicIpFromString on String {
   AssignPublicIp toAssignPublicIp() {
     switch (this) {
       case 'ENABLED':
@@ -3530,7 +3530,7 @@ enum EventSourceState {
   deleted,
 }
 
-extension on EventSourceState {
+extension EventSourceStateValue on EventSourceState {
   String toValue() {
     switch (this) {
       case EventSourceState.pending:
@@ -3543,7 +3543,7 @@ extension on EventSourceState {
   }
 }
 
-extension on String {
+extension EventSourceStateFromString on String {
   EventSourceState toEventSourceState() {
     switch (this) {
       case 'PENDING':
@@ -3722,7 +3722,7 @@ enum LaunchType {
   fargate,
 }
 
-extension on LaunchType {
+extension LaunchTypeValue on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -3733,7 +3733,7 @@ extension on LaunchType {
   }
 }
 
-extension on String {
+extension LaunchTypeFromString on String {
   LaunchType toLaunchType() {
     switch (this) {
       case 'EC2':
@@ -4528,7 +4528,7 @@ enum ReplayState {
   failed,
 }
 
-extension on ReplayState {
+extension ReplayStateValue on ReplayState {
   String toValue() {
     switch (this) {
       case ReplayState.starting:
@@ -4547,7 +4547,7 @@ extension on ReplayState {
   }
 }
 
-extension on String {
+extension ReplayStateFromString on String {
   ReplayState toReplayState() {
     switch (this) {
       case 'STARTING':
@@ -4667,7 +4667,7 @@ enum RuleState {
   disabled,
 }
 
-extension on RuleState {
+extension RuleStateValue on RuleState {
   String toValue() {
     switch (this) {
       case RuleState.enabled:
@@ -4678,7 +4678,7 @@ extension on RuleState {
   }
 }
 
-extension on String {
+extension RuleStateFromString on String {
   RuleState toRuleState() {
     switch (this) {
       case 'ENABLED':

--- a/generated/aws_events_api/lib/events-2015-10-07.dart
+++ b/generated/aws_events_api/lib/events-2015-10-07.dart
@@ -2690,7 +2690,7 @@ enum ArchiveState {
   updateFailed,
 }
 
-extension ArchiveStateValue on ArchiveState {
+extension ArchiveStateValueExtension on ArchiveState {
   String toValue() {
     switch (this) {
       case ArchiveState.enabled:
@@ -2734,7 +2734,7 @@ enum AssignPublicIp {
   disabled,
 }
 
-extension AssignPublicIpValue on AssignPublicIp {
+extension AssignPublicIpValueExtension on AssignPublicIp {
   String toValue() {
     switch (this) {
       case AssignPublicIp.enabled:
@@ -3530,7 +3530,7 @@ enum EventSourceState {
   deleted,
 }
 
-extension EventSourceStateValue on EventSourceState {
+extension EventSourceStateValueExtension on EventSourceState {
   String toValue() {
     switch (this) {
       case EventSourceState.pending:
@@ -3722,7 +3722,7 @@ enum LaunchType {
   fargate,
 }
 
-extension LaunchTypeValue on LaunchType {
+extension LaunchTypeValueExtension on LaunchType {
   String toValue() {
     switch (this) {
       case LaunchType.ec2:
@@ -4528,7 +4528,7 @@ enum ReplayState {
   failed,
 }
 
-extension ReplayStateValue on ReplayState {
+extension ReplayStateValueExtension on ReplayState {
   String toValue() {
     switch (this) {
       case ReplayState.starting:
@@ -4667,7 +4667,7 @@ enum RuleState {
   disabled,
 }
 
-extension RuleStateValue on RuleState {
+extension RuleStateValueExtension on RuleState {
   String toValue() {
     switch (this) {
       case RuleState.enabled:

--- a/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
+++ b/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
@@ -1228,7 +1228,7 @@ enum CompressionFormat {
   hadoopSnappy,
 }
 
-extension CompressionFormatValue on CompressionFormat {
+extension CompressionFormatValueExtension on CompressionFormat {
   String toValue() {
     switch (this) {
       case CompressionFormat.uncompressed:
@@ -1268,7 +1268,7 @@ enum ContentEncoding {
   gzip,
 }
 
-extension ContentEncodingValue on ContentEncoding {
+extension ContentEncodingValueExtension on ContentEncoding {
   String toValue() {
     switch (this) {
       case ContentEncoding.none:
@@ -1671,7 +1671,7 @@ enum DeliveryStreamEncryptionStatus {
   disablingFailed,
 }
 
-extension DeliveryStreamEncryptionStatusValue
+extension DeliveryStreamEncryptionStatusValueExtension
     on DeliveryStreamEncryptionStatus {
   String toValue() {
     switch (this) {
@@ -1730,7 +1730,7 @@ enum DeliveryStreamFailureType {
   unknownError,
 }
 
-extension DeliveryStreamFailureTypeValue on DeliveryStreamFailureType {
+extension DeliveryStreamFailureTypeValueExtension on DeliveryStreamFailureType {
   String toValue() {
     switch (this) {
       case DeliveryStreamFailureType.retireKmsGrantFailed:
@@ -1813,7 +1813,7 @@ enum DeliveryStreamStatus {
   active,
 }
 
-extension DeliveryStreamStatusValue on DeliveryStreamStatus {
+extension DeliveryStreamStatusValueExtension on DeliveryStreamStatus {
   String toValue() {
     switch (this) {
       case DeliveryStreamStatus.creating:
@@ -1853,7 +1853,7 @@ enum DeliveryStreamType {
   kinesisStreamAsSource,
 }
 
-extension DeliveryStreamTypeValue on DeliveryStreamType {
+extension DeliveryStreamTypeValueExtension on DeliveryStreamType {
   String toValue() {
     switch (this) {
       case DeliveryStreamType.directPut:
@@ -2402,7 +2402,7 @@ enum ElasticsearchIndexRotationPeriod {
   oneMonth,
 }
 
-extension ElasticsearchIndexRotationPeriodValue
+extension ElasticsearchIndexRotationPeriodValueExtension
     on ElasticsearchIndexRotationPeriod {
   String toValue() {
     switch (this) {
@@ -2471,7 +2471,7 @@ enum ElasticsearchS3BackupMode {
   allDocuments,
 }
 
-extension ElasticsearchS3BackupModeValue on ElasticsearchS3BackupMode {
+extension ElasticsearchS3BackupModeValueExtension on ElasticsearchS3BackupMode {
   String toValue() {
     switch (this) {
       case ElasticsearchS3BackupMode.failedDocumentsOnly:
@@ -2871,7 +2871,7 @@ enum HECEndpointType {
   event,
 }
 
-extension HECEndpointTypeValue on HECEndpointType {
+extension HECEndpointTypeValueExtension on HECEndpointType {
   String toValue() {
     switch (this) {
       case HECEndpointType.raw:
@@ -3361,7 +3361,7 @@ enum HttpEndpointS3BackupMode {
   allData,
 }
 
-extension HttpEndpointS3BackupModeValue on HttpEndpointS3BackupMode {
+extension HttpEndpointS3BackupModeValueExtension on HttpEndpointS3BackupMode {
   String toValue() {
     switch (this) {
       case HttpEndpointS3BackupMode.failedDataOnly:
@@ -3443,7 +3443,7 @@ enum KeyType {
   customerManagedCmk,
 }
 
-extension KeyTypeValue on KeyType {
+extension KeyTypeValueExtension on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.awsOwnedCmk:
@@ -3579,7 +3579,7 @@ enum NoEncryptionConfig {
   noEncryption,
 }
 
-extension NoEncryptionConfigValue on NoEncryptionConfig {
+extension NoEncryptionConfigValueExtension on NoEncryptionConfig {
   String toValue() {
     switch (this) {
       case NoEncryptionConfig.noEncryption:
@@ -3662,7 +3662,7 @@ enum OrcCompression {
   snappy,
 }
 
-extension OrcCompressionValue on OrcCompression {
+extension OrcCompressionValueExtension on OrcCompression {
   String toValue() {
     switch (this) {
       case OrcCompression.none:
@@ -3694,7 +3694,7 @@ enum OrcFormatVersion {
   v0_12,
 }
 
-extension OrcFormatVersionValue on OrcFormatVersion {
+extension OrcFormatVersionValueExtension on OrcFormatVersion {
   String toValue() {
     switch (this) {
       case OrcFormatVersion.v0_11:
@@ -3872,7 +3872,7 @@ enum ParquetCompression {
   snappy,
 }
 
-extension ParquetCompressionValue on ParquetCompression {
+extension ParquetCompressionValueExtension on ParquetCompression {
   String toValue() {
     switch (this) {
       case ParquetCompression.uncompressed:
@@ -3976,7 +3976,7 @@ enum ParquetWriterVersion {
   v2,
 }
 
-extension ParquetWriterVersionValue on ParquetWriterVersion {
+extension ParquetWriterVersionValueExtension on ParquetWriterVersion {
   String toValue() {
     switch (this) {
       case ParquetWriterVersion.v1:
@@ -4101,7 +4101,7 @@ enum ProcessorParameterName {
   bufferIntervalInSeconds,
 }
 
-extension ProcessorParameterNameValue on ProcessorParameterName {
+extension ProcessorParameterNameValueExtension on ProcessorParameterName {
   String toValue() {
     switch (this) {
       case ProcessorParameterName.lambdaArn:
@@ -4140,7 +4140,7 @@ enum ProcessorType {
   lambda,
 }
 
-extension ProcessorTypeValue on ProcessorType {
+extension ProcessorTypeValueExtension on ProcessorType {
   String toValue() {
     switch (this) {
       case ProcessorType.lambda:
@@ -4548,7 +4548,7 @@ enum RedshiftS3BackupMode {
   enabled,
 }
 
-extension RedshiftS3BackupModeValue on RedshiftS3BackupMode {
+extension RedshiftS3BackupModeValueExtension on RedshiftS3BackupMode {
   String toValue() {
     switch (this) {
       case RedshiftS3BackupMode.disabled:
@@ -4576,7 +4576,7 @@ enum S3BackupMode {
   enabled,
 }
 
-extension S3BackupModeValue on S3BackupMode {
+extension S3BackupModeValueExtension on S3BackupMode {
   String toValue() {
     switch (this) {
       case S3BackupMode.disabled:
@@ -5241,7 +5241,7 @@ enum SplunkS3BackupMode {
   allEvents,
 }
 
-extension SplunkS3BackupModeValue on SplunkS3BackupMode {
+extension SplunkS3BackupModeValueExtension on SplunkS3BackupMode {
   String toValue() {
     switch (this) {
       case SplunkS3BackupMode.failedEventsOnly:

--- a/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
+++ b/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
@@ -1228,7 +1228,7 @@ enum CompressionFormat {
   hadoopSnappy,
 }
 
-extension on CompressionFormat {
+extension CompressionFormatValue on CompressionFormat {
   String toValue() {
     switch (this) {
       case CompressionFormat.uncompressed:
@@ -1245,7 +1245,7 @@ extension on CompressionFormat {
   }
 }
 
-extension on String {
+extension CompressionFormatFromString on String {
   CompressionFormat toCompressionFormat() {
     switch (this) {
       case 'UNCOMPRESSED':
@@ -1268,7 +1268,7 @@ enum ContentEncoding {
   gzip,
 }
 
-extension on ContentEncoding {
+extension ContentEncodingValue on ContentEncoding {
   String toValue() {
     switch (this) {
       case ContentEncoding.none:
@@ -1279,7 +1279,7 @@ extension on ContentEncoding {
   }
 }
 
-extension on String {
+extension ContentEncodingFromString on String {
   ContentEncoding toContentEncoding() {
     switch (this) {
       case 'NONE':
@@ -1671,7 +1671,8 @@ enum DeliveryStreamEncryptionStatus {
   disablingFailed,
 }
 
-extension on DeliveryStreamEncryptionStatus {
+extension DeliveryStreamEncryptionStatusValue
+    on DeliveryStreamEncryptionStatus {
   String toValue() {
     switch (this) {
       case DeliveryStreamEncryptionStatus.enabled:
@@ -1690,7 +1691,7 @@ extension on DeliveryStreamEncryptionStatus {
   }
 }
 
-extension on String {
+extension DeliveryStreamEncryptionStatusFromString on String {
   DeliveryStreamEncryptionStatus toDeliveryStreamEncryptionStatus() {
     switch (this) {
       case 'ENABLED':
@@ -1729,7 +1730,7 @@ enum DeliveryStreamFailureType {
   unknownError,
 }
 
-extension on DeliveryStreamFailureType {
+extension DeliveryStreamFailureTypeValue on DeliveryStreamFailureType {
   String toValue() {
     switch (this) {
       case DeliveryStreamFailureType.retireKmsGrantFailed:
@@ -1766,7 +1767,7 @@ extension on DeliveryStreamFailureType {
   }
 }
 
-extension on String {
+extension DeliveryStreamFailureTypeFromString on String {
   DeliveryStreamFailureType toDeliveryStreamFailureType() {
     switch (this) {
       case 'RETIRE_KMS_GRANT_FAILED':
@@ -1812,7 +1813,7 @@ enum DeliveryStreamStatus {
   active,
 }
 
-extension on DeliveryStreamStatus {
+extension DeliveryStreamStatusValue on DeliveryStreamStatus {
   String toValue() {
     switch (this) {
       case DeliveryStreamStatus.creating:
@@ -1829,7 +1830,7 @@ extension on DeliveryStreamStatus {
   }
 }
 
-extension on String {
+extension DeliveryStreamStatusFromString on String {
   DeliveryStreamStatus toDeliveryStreamStatus() {
     switch (this) {
       case 'CREATING':
@@ -1852,7 +1853,7 @@ enum DeliveryStreamType {
   kinesisStreamAsSource,
 }
 
-extension on DeliveryStreamType {
+extension DeliveryStreamTypeValue on DeliveryStreamType {
   String toValue() {
     switch (this) {
       case DeliveryStreamType.directPut:
@@ -1863,7 +1864,7 @@ extension on DeliveryStreamType {
   }
 }
 
-extension on String {
+extension DeliveryStreamTypeFromString on String {
   DeliveryStreamType toDeliveryStreamType() {
     switch (this) {
       case 'DirectPut':
@@ -2401,7 +2402,8 @@ enum ElasticsearchIndexRotationPeriod {
   oneMonth,
 }
 
-extension on ElasticsearchIndexRotationPeriod {
+extension ElasticsearchIndexRotationPeriodValue
+    on ElasticsearchIndexRotationPeriod {
   String toValue() {
     switch (this) {
       case ElasticsearchIndexRotationPeriod.noRotation:
@@ -2418,7 +2420,7 @@ extension on ElasticsearchIndexRotationPeriod {
   }
 }
 
-extension on String {
+extension ElasticsearchIndexRotationPeriodFromString on String {
   ElasticsearchIndexRotationPeriod toElasticsearchIndexRotationPeriod() {
     switch (this) {
       case 'NoRotation':
@@ -2469,7 +2471,7 @@ enum ElasticsearchS3BackupMode {
   allDocuments,
 }
 
-extension on ElasticsearchS3BackupMode {
+extension ElasticsearchS3BackupModeValue on ElasticsearchS3BackupMode {
   String toValue() {
     switch (this) {
       case ElasticsearchS3BackupMode.failedDocumentsOnly:
@@ -2480,7 +2482,7 @@ extension on ElasticsearchS3BackupMode {
   }
 }
 
-extension on String {
+extension ElasticsearchS3BackupModeFromString on String {
   ElasticsearchS3BackupMode toElasticsearchS3BackupMode() {
     switch (this) {
       case 'FailedDocumentsOnly':
@@ -2869,7 +2871,7 @@ enum HECEndpointType {
   event,
 }
 
-extension on HECEndpointType {
+extension HECEndpointTypeValue on HECEndpointType {
   String toValue() {
     switch (this) {
       case HECEndpointType.raw:
@@ -2880,7 +2882,7 @@ extension on HECEndpointType {
   }
 }
 
-extension on String {
+extension HECEndpointTypeFromString on String {
   HECEndpointType toHECEndpointType() {
     switch (this) {
       case 'Raw':
@@ -3359,7 +3361,7 @@ enum HttpEndpointS3BackupMode {
   allData,
 }
 
-extension on HttpEndpointS3BackupMode {
+extension HttpEndpointS3BackupModeValue on HttpEndpointS3BackupMode {
   String toValue() {
     switch (this) {
       case HttpEndpointS3BackupMode.failedDataOnly:
@@ -3370,7 +3372,7 @@ extension on HttpEndpointS3BackupMode {
   }
 }
 
-extension on String {
+extension HttpEndpointS3BackupModeFromString on String {
   HttpEndpointS3BackupMode toHttpEndpointS3BackupMode() {
     switch (this) {
       case 'FailedDataOnly':
@@ -3441,7 +3443,7 @@ enum KeyType {
   customerManagedCmk,
 }
 
-extension on KeyType {
+extension KeyTypeValue on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.awsOwnedCmk:
@@ -3452,7 +3454,7 @@ extension on KeyType {
   }
 }
 
-extension on String {
+extension KeyTypeFromString on String {
   KeyType toKeyType() {
     switch (this) {
       case 'AWS_OWNED_CMK':
@@ -3577,7 +3579,7 @@ enum NoEncryptionConfig {
   noEncryption,
 }
 
-extension on NoEncryptionConfig {
+extension NoEncryptionConfigValue on NoEncryptionConfig {
   String toValue() {
     switch (this) {
       case NoEncryptionConfig.noEncryption:
@@ -3586,7 +3588,7 @@ extension on NoEncryptionConfig {
   }
 }
 
-extension on String {
+extension NoEncryptionConfigFromString on String {
   NoEncryptionConfig toNoEncryptionConfig() {
     switch (this) {
       case 'NoEncryption':
@@ -3660,7 +3662,7 @@ enum OrcCompression {
   snappy,
 }
 
-extension on OrcCompression {
+extension OrcCompressionValue on OrcCompression {
   String toValue() {
     switch (this) {
       case OrcCompression.none:
@@ -3673,7 +3675,7 @@ extension on OrcCompression {
   }
 }
 
-extension on String {
+extension OrcCompressionFromString on String {
   OrcCompression toOrcCompression() {
     switch (this) {
       case 'NONE':
@@ -3692,7 +3694,7 @@ enum OrcFormatVersion {
   v0_12,
 }
 
-extension on OrcFormatVersion {
+extension OrcFormatVersionValue on OrcFormatVersion {
   String toValue() {
     switch (this) {
       case OrcFormatVersion.v0_11:
@@ -3703,7 +3705,7 @@ extension on OrcFormatVersion {
   }
 }
 
-extension on String {
+extension OrcFormatVersionFromString on String {
   OrcFormatVersion toOrcFormatVersion() {
     switch (this) {
       case 'V0_11':
@@ -3870,7 +3872,7 @@ enum ParquetCompression {
   snappy,
 }
 
-extension on ParquetCompression {
+extension ParquetCompressionValue on ParquetCompression {
   String toValue() {
     switch (this) {
       case ParquetCompression.uncompressed:
@@ -3883,7 +3885,7 @@ extension on ParquetCompression {
   }
 }
 
-extension on String {
+extension ParquetCompressionFromString on String {
   ParquetCompression toParquetCompression() {
     switch (this) {
       case 'UNCOMPRESSED':
@@ -3974,7 +3976,7 @@ enum ParquetWriterVersion {
   v2,
 }
 
-extension on ParquetWriterVersion {
+extension ParquetWriterVersionValue on ParquetWriterVersion {
   String toValue() {
     switch (this) {
       case ParquetWriterVersion.v1:
@@ -3985,7 +3987,7 @@ extension on ParquetWriterVersion {
   }
 }
 
-extension on String {
+extension ParquetWriterVersionFromString on String {
   ParquetWriterVersion toParquetWriterVersion() {
     switch (this) {
       case 'V1':
@@ -4099,7 +4101,7 @@ enum ProcessorParameterName {
   bufferIntervalInSeconds,
 }
 
-extension on ProcessorParameterName {
+extension ProcessorParameterNameValue on ProcessorParameterName {
   String toValue() {
     switch (this) {
       case ProcessorParameterName.lambdaArn:
@@ -4116,7 +4118,7 @@ extension on ProcessorParameterName {
   }
 }
 
-extension on String {
+extension ProcessorParameterNameFromString on String {
   ProcessorParameterName toProcessorParameterName() {
     switch (this) {
       case 'LambdaArn':
@@ -4138,7 +4140,7 @@ enum ProcessorType {
   lambda,
 }
 
-extension on ProcessorType {
+extension ProcessorTypeValue on ProcessorType {
   String toValue() {
     switch (this) {
       case ProcessorType.lambda:
@@ -4147,7 +4149,7 @@ extension on ProcessorType {
   }
 }
 
-extension on String {
+extension ProcessorTypeFromString on String {
   ProcessorType toProcessorType() {
     switch (this) {
       case 'Lambda':
@@ -4546,7 +4548,7 @@ enum RedshiftS3BackupMode {
   enabled,
 }
 
-extension on RedshiftS3BackupMode {
+extension RedshiftS3BackupModeValue on RedshiftS3BackupMode {
   String toValue() {
     switch (this) {
       case RedshiftS3BackupMode.disabled:
@@ -4557,7 +4559,7 @@ extension on RedshiftS3BackupMode {
   }
 }
 
-extension on String {
+extension RedshiftS3BackupModeFromString on String {
   RedshiftS3BackupMode toRedshiftS3BackupMode() {
     switch (this) {
       case 'Disabled':
@@ -4574,7 +4576,7 @@ enum S3BackupMode {
   enabled,
 }
 
-extension on S3BackupMode {
+extension S3BackupModeValue on S3BackupMode {
   String toValue() {
     switch (this) {
       case S3BackupMode.disabled:
@@ -4585,7 +4587,7 @@ extension on S3BackupMode {
   }
 }
 
-extension on String {
+extension S3BackupModeFromString on String {
   S3BackupMode toS3BackupMode() {
     switch (this) {
       case 'Disabled':
@@ -5239,7 +5241,7 @@ enum SplunkS3BackupMode {
   allEvents,
 }
 
-extension on SplunkS3BackupMode {
+extension SplunkS3BackupModeValue on SplunkS3BackupMode {
   String toValue() {
     switch (this) {
       case SplunkS3BackupMode.failedEventsOnly:
@@ -5250,7 +5252,7 @@ extension on SplunkS3BackupMode {
   }
 }
 
-extension on String {
+extension SplunkS3BackupModeFromString on String {
   SplunkS3BackupMode toSplunkS3BackupMode() {
     switch (this) {
       case 'FailedEventsOnly':

--- a/generated/aws_fms_api/lib/fms-2018-01-01.dart
+++ b/generated/aws_fms_api/lib/fms-2018-01-01.dart
@@ -1378,7 +1378,7 @@ enum AccountRoleStatus {
   deleted,
 }
 
-extension AccountRoleStatusValue on AccountRoleStatus {
+extension AccountRoleStatusValueExtension on AccountRoleStatus {
   String toValue() {
     switch (this) {
       case AccountRoleStatus.ready:
@@ -1691,7 +1691,7 @@ enum CustomerPolicyScopeIdType {
   orgUnit,
 }
 
-extension CustomerPolicyScopeIdTypeValue on CustomerPolicyScopeIdType {
+extension CustomerPolicyScopeIdTypeValueExtension on CustomerPolicyScopeIdType {
   String toValue() {
     switch (this) {
       case CustomerPolicyScopeIdType.account:
@@ -1721,7 +1721,7 @@ enum DependentServiceName {
   awsvpc,
 }
 
-extension DependentServiceNameValue on DependentServiceName {
+extension DependentServiceNameValueExtension on DependentServiceName {
   String toValue() {
     switch (this) {
       case DependentServiceName.awsconfig:
@@ -2656,7 +2656,8 @@ enum PolicyComplianceStatusType {
   nonCompliant,
 }
 
-extension PolicyComplianceStatusTypeValue on PolicyComplianceStatusType {
+extension PolicyComplianceStatusTypeValueExtension
+    on PolicyComplianceStatusType {
   String toValue() {
     switch (this) {
       case PolicyComplianceStatusType.compliant:
@@ -2910,7 +2911,7 @@ enum RemediationActionType {
   modify,
 }
 
-extension RemediationActionTypeValue on RemediationActionType {
+extension RemediationActionTypeValueExtension on RemediationActionType {
   String toValue() {
     switch (this) {
       case RemediationActionType.remove:
@@ -3235,7 +3236,7 @@ enum SecurityServiceType {
   networkFirewall,
 }
 
-extension SecurityServiceTypeValue on SecurityServiceType {
+extension SecurityServiceTypeValueExtension on SecurityServiceType {
   String toValue() {
     switch (this) {
       case SecurityServiceType.waf:
@@ -3446,7 +3447,7 @@ enum ViolationReason {
   networkFirewallPolicyModified,
 }
 
-extension ViolationReasonValue on ViolationReason {
+extension ViolationReasonValueExtension on ViolationReason {
   String toValue() {
     switch (this) {
       case ViolationReason.webAclMissingRuleGroup:

--- a/generated/aws_fms_api/lib/fms-2018-01-01.dart
+++ b/generated/aws_fms_api/lib/fms-2018-01-01.dart
@@ -1378,7 +1378,7 @@ enum AccountRoleStatus {
   deleted,
 }
 
-extension on AccountRoleStatus {
+extension AccountRoleStatusValue on AccountRoleStatus {
   String toValue() {
     switch (this) {
       case AccountRoleStatus.ready:
@@ -1395,7 +1395,7 @@ extension on AccountRoleStatus {
   }
 }
 
-extension on String {
+extension AccountRoleStatusFromString on String {
   AccountRoleStatus toAccountRoleStatus() {
     switch (this) {
       case 'READY':
@@ -1691,7 +1691,7 @@ enum CustomerPolicyScopeIdType {
   orgUnit,
 }
 
-extension on CustomerPolicyScopeIdType {
+extension CustomerPolicyScopeIdTypeValue on CustomerPolicyScopeIdType {
   String toValue() {
     switch (this) {
       case CustomerPolicyScopeIdType.account:
@@ -1702,7 +1702,7 @@ extension on CustomerPolicyScopeIdType {
   }
 }
 
-extension on String {
+extension CustomerPolicyScopeIdTypeFromString on String {
   CustomerPolicyScopeIdType toCustomerPolicyScopeIdType() {
     switch (this) {
       case 'ACCOUNT':
@@ -1721,7 +1721,7 @@ enum DependentServiceName {
   awsvpc,
 }
 
-extension on DependentServiceName {
+extension DependentServiceNameValue on DependentServiceName {
   String toValue() {
     switch (this) {
       case DependentServiceName.awsconfig:
@@ -1736,7 +1736,7 @@ extension on DependentServiceName {
   }
 }
 
-extension on String {
+extension DependentServiceNameFromString on String {
   DependentServiceName toDependentServiceName() {
     switch (this) {
       case 'AWSCONFIG':
@@ -2656,7 +2656,7 @@ enum PolicyComplianceStatusType {
   nonCompliant,
 }
 
-extension on PolicyComplianceStatusType {
+extension PolicyComplianceStatusTypeValue on PolicyComplianceStatusType {
   String toValue() {
     switch (this) {
       case PolicyComplianceStatusType.compliant:
@@ -2667,7 +2667,7 @@ extension on PolicyComplianceStatusType {
   }
 }
 
-extension on String {
+extension PolicyComplianceStatusTypeFromString on String {
   PolicyComplianceStatusType toPolicyComplianceStatusType() {
     switch (this) {
       case 'COMPLIANT':
@@ -2910,7 +2910,7 @@ enum RemediationActionType {
   modify,
 }
 
-extension on RemediationActionType {
+extension RemediationActionTypeValue on RemediationActionType {
   String toValue() {
     switch (this) {
       case RemediationActionType.remove:
@@ -2921,7 +2921,7 @@ extension on RemediationActionType {
   }
 }
 
-extension on String {
+extension RemediationActionTypeFromString on String {
   RemediationActionType toRemediationActionType() {
     switch (this) {
       case 'REMOVE':
@@ -3235,7 +3235,7 @@ enum SecurityServiceType {
   networkFirewall,
 }
 
-extension on SecurityServiceType {
+extension SecurityServiceTypeValue on SecurityServiceType {
   String toValue() {
     switch (this) {
       case SecurityServiceType.waf:
@@ -3256,7 +3256,7 @@ extension on SecurityServiceType {
   }
 }
 
-extension on String {
+extension SecurityServiceTypeFromString on String {
   SecurityServiceType toSecurityServiceType() {
     switch (this) {
       case 'WAF':
@@ -3446,7 +3446,7 @@ enum ViolationReason {
   networkFirewallPolicyModified,
 }
 
-extension on ViolationReason {
+extension ViolationReasonValue on ViolationReason {
   String toValue() {
     switch (this) {
       case ViolationReason.webAclMissingRuleGroup:
@@ -3479,7 +3479,7 @@ extension on ViolationReason {
   }
 }
 
-extension on String {
+extension ViolationReasonFromString on String {
   ViolationReason toViolationReason() {
     switch (this) {
       case 'WEB_ACL_MISSING_RULE_GROUP':

--- a/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
+++ b/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
@@ -2707,7 +2707,7 @@ enum AttributeType {
   geolocation,
 }
 
-extension on AttributeType {
+extension AttributeTypeValue on AttributeType {
   String toValue() {
     switch (this) {
       case AttributeType.string:
@@ -2724,7 +2724,7 @@ extension on AttributeType {
   }
 }
 
-extension on String {
+extension AttributeTypeFromString on String {
   AttributeType toAttributeType() {
     switch (this) {
       case 'string':
@@ -3168,7 +3168,7 @@ enum DatasetType {
   itemMetadata,
 }
 
-extension on DatasetType {
+extension DatasetTypeValue on DatasetType {
   String toValue() {
     switch (this) {
       case DatasetType.targetTimeSeries:
@@ -3181,7 +3181,7 @@ extension on DatasetType {
   }
 }
 
-extension on String {
+extension DatasetTypeFromString on String {
   DatasetType toDatasetType() {
     switch (this) {
       case 'TARGET_TIME_SERIES':
@@ -3925,7 +3925,7 @@ enum Domain {
   metrics,
 }
 
-extension on Domain {
+extension DomainValue on Domain {
   String toValue() {
     switch (this) {
       case Domain.retail:
@@ -3946,7 +3946,7 @@ extension on Domain {
   }
 }
 
-extension on String {
+extension DomainFromString on String {
   Domain toDomain() {
     switch (this) {
       case 'RETAIL':
@@ -4105,7 +4105,7 @@ enum EvaluationType {
   computed,
 }
 
-extension on EvaluationType {
+extension EvaluationTypeValue on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.summary:
@@ -4116,7 +4116,7 @@ extension on EvaluationType {
   }
 }
 
-extension on String {
+extension EvaluationTypeFromString on String {
   EvaluationType toEvaluationType() {
     switch (this) {
       case 'SUMMARY':
@@ -4364,7 +4364,7 @@ enum FeaturizationMethodName {
   filling,
 }
 
-extension on FeaturizationMethodName {
+extension FeaturizationMethodNameValue on FeaturizationMethodName {
   String toValue() {
     switch (this) {
       case FeaturizationMethodName.filling:
@@ -4373,7 +4373,7 @@ extension on FeaturizationMethodName {
   }
 }
 
-extension on String {
+extension FeaturizationMethodNameFromString on String {
   FeaturizationMethodName toFeaturizationMethodName() {
     switch (this) {
       case 'filling':
@@ -4422,7 +4422,7 @@ enum FilterConditionString {
   isNot,
 }
 
-extension on FilterConditionString {
+extension FilterConditionStringValue on FilterConditionString {
   String toValue() {
     switch (this) {
       case FilterConditionString.$is:
@@ -4433,7 +4433,7 @@ extension on FilterConditionString {
   }
 }
 
-extension on String {
+extension FilterConditionStringFromString on String {
   FilterConditionString toFilterConditionString() {
     switch (this) {
       case 'IS':
@@ -5272,7 +5272,7 @@ enum ScalingType {
   reverseLogarithmic,
 }
 
-extension on ScalingType {
+extension ScalingTypeValue on ScalingType {
   String toValue() {
     switch (this) {
       case ScalingType.auto:
@@ -5287,7 +5287,7 @@ extension on ScalingType {
   }
 }
 
-extension on String {
+extension ScalingTypeFromString on String {
   ScalingType toScalingType() {
     switch (this) {
       case 'Auto':

--- a/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
+++ b/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
@@ -2707,7 +2707,7 @@ enum AttributeType {
   geolocation,
 }
 
-extension AttributeTypeValue on AttributeType {
+extension AttributeTypeValueExtension on AttributeType {
   String toValue() {
     switch (this) {
       case AttributeType.string:
@@ -3168,7 +3168,7 @@ enum DatasetType {
   itemMetadata,
 }
 
-extension DatasetTypeValue on DatasetType {
+extension DatasetTypeValueExtension on DatasetType {
   String toValue() {
     switch (this) {
       case DatasetType.targetTimeSeries:
@@ -3925,7 +3925,7 @@ enum Domain {
   metrics,
 }
 
-extension DomainValue on Domain {
+extension DomainValueExtension on Domain {
   String toValue() {
     switch (this) {
       case Domain.retail:
@@ -4105,7 +4105,7 @@ enum EvaluationType {
   computed,
 }
 
-extension EvaluationTypeValue on EvaluationType {
+extension EvaluationTypeValueExtension on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.summary:
@@ -4364,7 +4364,7 @@ enum FeaturizationMethodName {
   filling,
 }
 
-extension FeaturizationMethodNameValue on FeaturizationMethodName {
+extension FeaturizationMethodNameValueExtension on FeaturizationMethodName {
   String toValue() {
     switch (this) {
       case FeaturizationMethodName.filling:
@@ -4422,7 +4422,7 @@ enum FilterConditionString {
   isNot,
 }
 
-extension FilterConditionStringValue on FilterConditionString {
+extension FilterConditionStringValueExtension on FilterConditionString {
   String toValue() {
     switch (this) {
       case FilterConditionString.$is:
@@ -5272,7 +5272,7 @@ enum ScalingType {
   reverseLogarithmic,
 }
 
-extension ScalingTypeValue on ScalingType {
+extension ScalingTypeValueExtension on ScalingType {
   String toValue() {
     switch (this) {
       case ScalingType.auto:

--- a/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
+++ b/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
@@ -3263,7 +3263,7 @@ enum DataSource {
   externalModelScore,
 }
 
-extension DataSourceValue on DataSource {
+extension DataSourceValueExtension on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.event:
@@ -3297,7 +3297,7 @@ enum DataType {
   boolean,
 }
 
-extension DataTypeValue on DataType {
+extension DataTypeValueExtension on DataType {
   String toValue() {
     switch (this) {
       case DataType.string:
@@ -3540,7 +3540,7 @@ enum DetectorVersionStatus {
   inactive,
 }
 
-extension DetectorVersionStatusValue on DetectorVersionStatus {
+extension DetectorVersionStatusValueExtension on DetectorVersionStatus {
   String toValue() {
     switch (this) {
       case DetectorVersionStatus.draft:
@@ -4367,7 +4367,7 @@ enum Language {
   detectorpl,
 }
 
-extension LanguageValue on Language {
+extension LanguageValueExtension on Language {
   String toValue() {
     switch (this) {
       case Language.detectorpl:
@@ -4517,7 +4517,7 @@ enum ModelEndpointStatus {
   dissociated,
 }
 
-extension ModelEndpointStatusValue on ModelEndpointStatus {
+extension ModelEndpointStatusValueExtension on ModelEndpointStatus {
   String toValue() {
     switch (this) {
       case ModelEndpointStatus.associated:
@@ -4601,7 +4601,7 @@ enum ModelInputDataFormat {
   applicationJson,
 }
 
-extension ModelInputDataFormatValue on ModelInputDataFormat {
+extension ModelInputDataFormatValueExtension on ModelInputDataFormat {
   String toValue() {
     switch (this) {
       case ModelInputDataFormat.textCsv:
@@ -4673,7 +4673,7 @@ enum ModelOutputDataFormat {
   applicationJsonlines,
 }
 
-extension ModelOutputDataFormatValue on ModelOutputDataFormat {
+extension ModelOutputDataFormatValueExtension on ModelOutputDataFormat {
   String toValue() {
     switch (this) {
       case ModelOutputDataFormat.textCsv:
@@ -4723,7 +4723,7 @@ enum ModelSource {
   sagemaker,
 }
 
-extension ModelSourceValue on ModelSource {
+extension ModelSourceValueExtension on ModelSource {
   String toValue() {
     switch (this) {
       case ModelSource.sagemaker:
@@ -4746,7 +4746,7 @@ enum ModelTypeEnum {
   onlineFraudInsights,
 }
 
-extension ModelTypeEnumValue on ModelTypeEnum {
+extension ModelTypeEnumValueExtension on ModelTypeEnum {
   String toValue() {
     switch (this) {
       case ModelTypeEnum.onlineFraudInsights:
@@ -4888,7 +4888,7 @@ enum ModelVersionStatus {
   inactive,
 }
 
-extension ModelVersionStatusValue on ModelVersionStatus {
+extension ModelVersionStatusValueExtension on ModelVersionStatus {
   String toValue() {
     switch (this) {
       case ModelVersionStatus.active:
@@ -5099,7 +5099,7 @@ enum RuleExecutionMode {
   firstMatched,
 }
 
-extension RuleExecutionModeValue on RuleExecutionMode {
+extension RuleExecutionModeValueExtension on RuleExecutionMode {
   String toValue() {
     switch (this) {
       case RuleExecutionMode.allMatched:
@@ -5217,7 +5217,7 @@ enum TrainingDataSourceEnum {
   externalEvents,
 }
 
-extension TrainingDataSourceEnumValue on TrainingDataSourceEnum {
+extension TrainingDataSourceEnumValueExtension on TrainingDataSourceEnum {
   String toValue() {
     switch (this) {
       case TrainingDataSourceEnum.externalEvents:

--- a/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
+++ b/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
@@ -3263,7 +3263,7 @@ enum DataSource {
   externalModelScore,
 }
 
-extension on DataSource {
+extension DataSourceValue on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.event:
@@ -3276,7 +3276,7 @@ extension on DataSource {
   }
 }
 
-extension on String {
+extension DataSourceFromString on String {
   DataSource toDataSource() {
     switch (this) {
       case 'EVENT':
@@ -3297,7 +3297,7 @@ enum DataType {
   boolean,
 }
 
-extension on DataType {
+extension DataTypeValue on DataType {
   String toValue() {
     switch (this) {
       case DataType.string:
@@ -3312,7 +3312,7 @@ extension on DataType {
   }
 }
 
-extension on String {
+extension DataTypeFromString on String {
   DataType toDataType() {
     switch (this) {
       case 'STRING':
@@ -3540,7 +3540,7 @@ enum DetectorVersionStatus {
   inactive,
 }
 
-extension on DetectorVersionStatus {
+extension DetectorVersionStatusValue on DetectorVersionStatus {
   String toValue() {
     switch (this) {
       case DetectorVersionStatus.draft:
@@ -3553,7 +3553,7 @@ extension on DetectorVersionStatus {
   }
 }
 
-extension on String {
+extension DetectorVersionStatusFromString on String {
   DetectorVersionStatus toDetectorVersionStatus() {
     switch (this) {
       case 'DRAFT':
@@ -4367,7 +4367,7 @@ enum Language {
   detectorpl,
 }
 
-extension on Language {
+extension LanguageValue on Language {
   String toValue() {
     switch (this) {
       case Language.detectorpl:
@@ -4376,7 +4376,7 @@ extension on Language {
   }
 }
 
-extension on String {
+extension LanguageFromString on String {
   Language toLanguage() {
     switch (this) {
       case 'DETECTORPL':
@@ -4517,7 +4517,7 @@ enum ModelEndpointStatus {
   dissociated,
 }
 
-extension on ModelEndpointStatus {
+extension ModelEndpointStatusValue on ModelEndpointStatus {
   String toValue() {
     switch (this) {
       case ModelEndpointStatus.associated:
@@ -4528,7 +4528,7 @@ extension on ModelEndpointStatus {
   }
 }
 
-extension on String {
+extension ModelEndpointStatusFromString on String {
   ModelEndpointStatus toModelEndpointStatus() {
     switch (this) {
       case 'ASSOCIATED':
@@ -4601,7 +4601,7 @@ enum ModelInputDataFormat {
   applicationJson,
 }
 
-extension on ModelInputDataFormat {
+extension ModelInputDataFormatValue on ModelInputDataFormat {
   String toValue() {
     switch (this) {
       case ModelInputDataFormat.textCsv:
@@ -4612,7 +4612,7 @@ extension on ModelInputDataFormat {
   }
 }
 
-extension on String {
+extension ModelInputDataFormatFromString on String {
   ModelInputDataFormat toModelInputDataFormat() {
     switch (this) {
       case 'TEXT_CSV':
@@ -4673,7 +4673,7 @@ enum ModelOutputDataFormat {
   applicationJsonlines,
 }
 
-extension on ModelOutputDataFormat {
+extension ModelOutputDataFormatValue on ModelOutputDataFormat {
   String toValue() {
     switch (this) {
       case ModelOutputDataFormat.textCsv:
@@ -4684,7 +4684,7 @@ extension on ModelOutputDataFormat {
   }
 }
 
-extension on String {
+extension ModelOutputDataFormatFromString on String {
   ModelOutputDataFormat toModelOutputDataFormat() {
     switch (this) {
       case 'TEXT_CSV':
@@ -4723,7 +4723,7 @@ enum ModelSource {
   sagemaker,
 }
 
-extension on ModelSource {
+extension ModelSourceValue on ModelSource {
   String toValue() {
     switch (this) {
       case ModelSource.sagemaker:
@@ -4732,7 +4732,7 @@ extension on ModelSource {
   }
 }
 
-extension on String {
+extension ModelSourceFromString on String {
   ModelSource toModelSource() {
     switch (this) {
       case 'SAGEMAKER':
@@ -4746,7 +4746,7 @@ enum ModelTypeEnum {
   onlineFraudInsights,
 }
 
-extension on ModelTypeEnum {
+extension ModelTypeEnumValue on ModelTypeEnum {
   String toValue() {
     switch (this) {
       case ModelTypeEnum.onlineFraudInsights:
@@ -4755,7 +4755,7 @@ extension on ModelTypeEnum {
   }
 }
 
-extension on String {
+extension ModelTypeEnumFromString on String {
   ModelTypeEnum toModelTypeEnum() {
     switch (this) {
       case 'ONLINE_FRAUD_INSIGHTS':
@@ -4888,7 +4888,7 @@ enum ModelVersionStatus {
   inactive,
 }
 
-extension on ModelVersionStatus {
+extension ModelVersionStatusValue on ModelVersionStatus {
   String toValue() {
     switch (this) {
       case ModelVersionStatus.active:
@@ -4899,7 +4899,7 @@ extension on ModelVersionStatus {
   }
 }
 
-extension on String {
+extension ModelVersionStatusFromString on String {
   ModelVersionStatus toModelVersionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -5099,7 +5099,7 @@ enum RuleExecutionMode {
   firstMatched,
 }
 
-extension on RuleExecutionMode {
+extension RuleExecutionModeValue on RuleExecutionMode {
   String toValue() {
     switch (this) {
       case RuleExecutionMode.allMatched:
@@ -5110,7 +5110,7 @@ extension on RuleExecutionMode {
   }
 }
 
-extension on String {
+extension RuleExecutionModeFromString on String {
   RuleExecutionMode toRuleExecutionMode() {
     switch (this) {
       case 'ALL_MATCHED':
@@ -5217,7 +5217,7 @@ enum TrainingDataSourceEnum {
   externalEvents,
 }
 
-extension on TrainingDataSourceEnum {
+extension TrainingDataSourceEnumValue on TrainingDataSourceEnum {
   String toValue() {
     switch (this) {
       case TrainingDataSourceEnum.externalEvents:
@@ -5226,7 +5226,7 @@ extension on TrainingDataSourceEnum {
   }
 }
 
-extension on String {
+extension TrainingDataSourceEnumFromString on String {
   TrainingDataSourceEnum toTrainingDataSourceEnum() {
     switch (this) {
       case 'EXTERNAL_EVENTS':

--- a/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
+++ b/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
@@ -1807,7 +1807,7 @@ enum AdministrativeActionType {
   fileSystemAliasDisassociation,
 }
 
-extension AdministrativeActionTypeValue on AdministrativeActionType {
+extension AdministrativeActionTypeValueExtension on AdministrativeActionType {
   String toValue() {
     switch (this) {
       case AdministrativeActionType.fileSystemUpdate:
@@ -1914,7 +1914,7 @@ enum AliasLifecycle {
   deleteFailed,
 }
 
-extension AliasLifecycleValue on AliasLifecycle {
+extension AliasLifecycleValueExtension on AliasLifecycle {
   String toValue() {
     switch (this) {
       case AliasLifecycle.available:
@@ -1979,7 +1979,7 @@ enum AutoImportPolicyType {
   newChanged,
 }
 
-extension AutoImportPolicyTypeValue on AutoImportPolicyType {
+extension AutoImportPolicyTypeValueExtension on AutoImportPolicyType {
   String toValue() {
     switch (this) {
       case AutoImportPolicyType.none:
@@ -2170,7 +2170,7 @@ enum BackupLifecycle {
   pending,
 }
 
-extension BackupLifecycleValue on BackupLifecycle {
+extension BackupLifecycleValueExtension on BackupLifecycle {
   String toValue() {
     switch (this) {
       case BackupLifecycle.available:
@@ -2216,7 +2216,7 @@ enum BackupType {
   awsBackup,
 }
 
-extension BackupTypeValue on BackupType {
+extension BackupTypeValueExtension on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.automatic:
@@ -2894,7 +2894,7 @@ enum DataRepositoryLifecycle {
   deleting,
 }
 
-extension DataRepositoryLifecycleValue on DataRepositoryLifecycle {
+extension DataRepositoryLifecycleValueExtension on DataRepositoryLifecycle {
   String toValue() {
     switch (this) {
       case DataRepositoryLifecycle.creating:
@@ -3115,7 +3115,8 @@ enum DataRepositoryTaskFilterName {
   taskLifecycle,
 }
 
-extension DataRepositoryTaskFilterNameValue on DataRepositoryTaskFilterName {
+extension DataRepositoryTaskFilterNameValueExtension
+    on DataRepositoryTaskFilterName {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskFilterName.fileSystemId:
@@ -3147,7 +3148,8 @@ enum DataRepositoryTaskLifecycle {
   canceling,
 }
 
-extension DataRepositoryTaskLifecycleValue on DataRepositoryTaskLifecycle {
+extension DataRepositoryTaskLifecycleValueExtension
+    on DataRepositoryTaskLifecycle {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskLifecycle.pending:
@@ -3227,7 +3229,7 @@ enum DataRepositoryTaskType {
   exportToRepository,
 }
 
-extension DataRepositoryTaskTypeValue on DataRepositoryTaskType {
+extension DataRepositoryTaskTypeValueExtension on DataRepositoryTaskType {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskType.exportToRepository:
@@ -3529,7 +3531,7 @@ enum DriveCacheType {
   read,
 }
 
-extension DriveCacheTypeValue on DriveCacheType {
+extension DriveCacheTypeValueExtension on DriveCacheType {
   String toValue() {
     switch (this) {
       case DriveCacheType.none:
@@ -3760,7 +3762,7 @@ enum FileSystemLifecycle {
   updating,
 }
 
-extension FileSystemLifecycleValue on FileSystemLifecycle {
+extension FileSystemLifecycleValueExtension on FileSystemLifecycle {
   String toValue() {
     switch (this) {
       case FileSystemLifecycle.available:
@@ -3805,7 +3807,7 @@ enum FileSystemMaintenanceOperation {
   backingUp,
 }
 
-extension FileSystemMaintenanceOperationValue
+extension FileSystemMaintenanceOperationValueExtension
     on FileSystemMaintenanceOperation {
   String toValue() {
     switch (this) {
@@ -3836,7 +3838,7 @@ enum FileSystemType {
   lustre,
 }
 
-extension FileSystemTypeValue on FileSystemType {
+extension FileSystemTypeValueExtension on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.windows:
@@ -3891,7 +3893,7 @@ enum FilterName {
   fileSystemType,
 }
 
-extension FilterNameValue on FilterName {
+extension FilterNameValueExtension on FilterName {
   String toValue() {
     switch (this) {
       case FilterName.fileSystemId:
@@ -3949,7 +3951,7 @@ enum LustreDeploymentType {
   persistent_1,
 }
 
-extension LustreDeploymentTypeValue on LustreDeploymentType {
+extension LustreDeploymentTypeValueExtension on LustreDeploymentType {
   String toValue() {
     switch (this) {
       case LustreDeploymentType.scratch_1:
@@ -4076,7 +4078,7 @@ enum ReportFormat {
   reportCsv_20191124,
 }
 
-extension ReportFormatValue on ReportFormat {
+extension ReportFormatValueExtension on ReportFormat {
   String toValue() {
     switch (this) {
       case ReportFormat.reportCsv_20191124:
@@ -4099,7 +4101,7 @@ enum ReportScope {
   failedFilesOnly,
 }
 
-extension ReportScopeValue on ReportScope {
+extension ReportScopeValueExtension on ReportScope {
   String toValue() {
     switch (this) {
       case ReportScope.failedFilesOnly:
@@ -4297,7 +4299,7 @@ enum Status {
   updatedOptimizing,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.failed:
@@ -4338,7 +4340,7 @@ enum StorageType {
   hdd,
 }
 
-extension StorageTypeValue on StorageType {
+extension StorageTypeValueExtension on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.ssd:
@@ -4562,7 +4564,7 @@ enum WindowsDeploymentType {
   singleAz_2,
 }
 
-extension WindowsDeploymentTypeValue on WindowsDeploymentType {
+extension WindowsDeploymentTypeValueExtension on WindowsDeploymentType {
   String toValue() {
     switch (this) {
       case WindowsDeploymentType.multiAz_1:

--- a/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
+++ b/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
@@ -1807,7 +1807,7 @@ enum AdministrativeActionType {
   fileSystemAliasDisassociation,
 }
 
-extension on AdministrativeActionType {
+extension AdministrativeActionTypeValue on AdministrativeActionType {
   String toValue() {
     switch (this) {
       case AdministrativeActionType.fileSystemUpdate:
@@ -1822,7 +1822,7 @@ extension on AdministrativeActionType {
   }
 }
 
-extension on String {
+extension AdministrativeActionTypeFromString on String {
   AdministrativeActionType toAdministrativeActionType() {
     switch (this) {
       case 'FILE_SYSTEM_UPDATE':
@@ -1914,7 +1914,7 @@ enum AliasLifecycle {
   deleteFailed,
 }
 
-extension on AliasLifecycle {
+extension AliasLifecycleValue on AliasLifecycle {
   String toValue() {
     switch (this) {
       case AliasLifecycle.available:
@@ -1931,7 +1931,7 @@ extension on AliasLifecycle {
   }
 }
 
-extension on String {
+extension AliasLifecycleFromString on String {
   AliasLifecycle toAliasLifecycle() {
     switch (this) {
       case 'AVAILABLE':
@@ -1979,7 +1979,7 @@ enum AutoImportPolicyType {
   newChanged,
 }
 
-extension on AutoImportPolicyType {
+extension AutoImportPolicyTypeValue on AutoImportPolicyType {
   String toValue() {
     switch (this) {
       case AutoImportPolicyType.none:
@@ -1992,7 +1992,7 @@ extension on AutoImportPolicyType {
   }
 }
 
-extension on String {
+extension AutoImportPolicyTypeFromString on String {
   AutoImportPolicyType toAutoImportPolicyType() {
     switch (this) {
       case 'NONE':
@@ -2170,7 +2170,7 @@ enum BackupLifecycle {
   pending,
 }
 
-extension on BackupLifecycle {
+extension BackupLifecycleValue on BackupLifecycle {
   String toValue() {
     switch (this) {
       case BackupLifecycle.available:
@@ -2189,7 +2189,7 @@ extension on BackupLifecycle {
   }
 }
 
-extension on String {
+extension BackupLifecycleFromString on String {
   BackupLifecycle toBackupLifecycle() {
     switch (this) {
       case 'AVAILABLE':
@@ -2216,7 +2216,7 @@ enum BackupType {
   awsBackup,
 }
 
-extension on BackupType {
+extension BackupTypeValue on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.automatic:
@@ -2229,7 +2229,7 @@ extension on BackupType {
   }
 }
 
-extension on String {
+extension BackupTypeFromString on String {
   BackupType toBackupType() {
     switch (this) {
       case 'AUTOMATIC':
@@ -2894,7 +2894,7 @@ enum DataRepositoryLifecycle {
   deleting,
 }
 
-extension on DataRepositoryLifecycle {
+extension DataRepositoryLifecycleValue on DataRepositoryLifecycle {
   String toValue() {
     switch (this) {
       case DataRepositoryLifecycle.creating:
@@ -2911,7 +2911,7 @@ extension on DataRepositoryLifecycle {
   }
 }
 
-extension on String {
+extension DataRepositoryLifecycleFromString on String {
   DataRepositoryLifecycle toDataRepositoryLifecycle() {
     switch (this) {
       case 'CREATING':
@@ -3115,7 +3115,7 @@ enum DataRepositoryTaskFilterName {
   taskLifecycle,
 }
 
-extension on DataRepositoryTaskFilterName {
+extension DataRepositoryTaskFilterNameValue on DataRepositoryTaskFilterName {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskFilterName.fileSystemId:
@@ -3126,7 +3126,7 @@ extension on DataRepositoryTaskFilterName {
   }
 }
 
-extension on String {
+extension DataRepositoryTaskFilterNameFromString on String {
   DataRepositoryTaskFilterName toDataRepositoryTaskFilterName() {
     switch (this) {
       case 'file-system-id':
@@ -3147,7 +3147,7 @@ enum DataRepositoryTaskLifecycle {
   canceling,
 }
 
-extension on DataRepositoryTaskLifecycle {
+extension DataRepositoryTaskLifecycleValue on DataRepositoryTaskLifecycle {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskLifecycle.pending:
@@ -3166,7 +3166,7 @@ extension on DataRepositoryTaskLifecycle {
   }
 }
 
-extension on String {
+extension DataRepositoryTaskLifecycleFromString on String {
   DataRepositoryTaskLifecycle toDataRepositoryTaskLifecycle() {
     switch (this) {
       case 'PENDING':
@@ -3227,7 +3227,7 @@ enum DataRepositoryTaskType {
   exportToRepository,
 }
 
-extension on DataRepositoryTaskType {
+extension DataRepositoryTaskTypeValue on DataRepositoryTaskType {
   String toValue() {
     switch (this) {
       case DataRepositoryTaskType.exportToRepository:
@@ -3236,7 +3236,7 @@ extension on DataRepositoryTaskType {
   }
 }
 
-extension on String {
+extension DataRepositoryTaskTypeFromString on String {
   DataRepositoryTaskType toDataRepositoryTaskType() {
     switch (this) {
       case 'EXPORT_TO_REPOSITORY':
@@ -3529,7 +3529,7 @@ enum DriveCacheType {
   read,
 }
 
-extension on DriveCacheType {
+extension DriveCacheTypeValue on DriveCacheType {
   String toValue() {
     switch (this) {
       case DriveCacheType.none:
@@ -3540,7 +3540,7 @@ extension on DriveCacheType {
   }
 }
 
-extension on String {
+extension DriveCacheTypeFromString on String {
   DriveCacheType toDriveCacheType() {
     switch (this) {
       case 'NONE':
@@ -3760,7 +3760,7 @@ enum FileSystemLifecycle {
   updating,
 }
 
-extension on FileSystemLifecycle {
+extension FileSystemLifecycleValue on FileSystemLifecycle {
   String toValue() {
     switch (this) {
       case FileSystemLifecycle.available:
@@ -3779,7 +3779,7 @@ extension on FileSystemLifecycle {
   }
 }
 
-extension on String {
+extension FileSystemLifecycleFromString on String {
   FileSystemLifecycle toFileSystemLifecycle() {
     switch (this) {
       case 'AVAILABLE':
@@ -3805,7 +3805,8 @@ enum FileSystemMaintenanceOperation {
   backingUp,
 }
 
-extension on FileSystemMaintenanceOperation {
+extension FileSystemMaintenanceOperationValue
+    on FileSystemMaintenanceOperation {
   String toValue() {
     switch (this) {
       case FileSystemMaintenanceOperation.patching:
@@ -3816,7 +3817,7 @@ extension on FileSystemMaintenanceOperation {
   }
 }
 
-extension on String {
+extension FileSystemMaintenanceOperationFromString on String {
   FileSystemMaintenanceOperation toFileSystemMaintenanceOperation() {
     switch (this) {
       case 'PATCHING':
@@ -3835,7 +3836,7 @@ enum FileSystemType {
   lustre,
 }
 
-extension on FileSystemType {
+extension FileSystemTypeValue on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.windows:
@@ -3846,7 +3847,7 @@ extension on FileSystemType {
   }
 }
 
-extension on String {
+extension FileSystemTypeFromString on String {
   FileSystemType toFileSystemType() {
     switch (this) {
       case 'WINDOWS':
@@ -3890,7 +3891,7 @@ enum FilterName {
   fileSystemType,
 }
 
-extension on FilterName {
+extension FilterNameValue on FilterName {
   String toValue() {
     switch (this) {
       case FilterName.fileSystemId:
@@ -3903,7 +3904,7 @@ extension on FilterName {
   }
 }
 
-extension on String {
+extension FilterNameFromString on String {
   FilterName toFilterName() {
     switch (this) {
       case 'file-system-id':
@@ -3948,7 +3949,7 @@ enum LustreDeploymentType {
   persistent_1,
 }
 
-extension on LustreDeploymentType {
+extension LustreDeploymentTypeValue on LustreDeploymentType {
   String toValue() {
     switch (this) {
       case LustreDeploymentType.scratch_1:
@@ -3961,7 +3962,7 @@ extension on LustreDeploymentType {
   }
 }
 
-extension on String {
+extension LustreDeploymentTypeFromString on String {
   LustreDeploymentType toLustreDeploymentType() {
     switch (this) {
       case 'SCRATCH_1':
@@ -4075,7 +4076,7 @@ enum ReportFormat {
   reportCsv_20191124,
 }
 
-extension on ReportFormat {
+extension ReportFormatValue on ReportFormat {
   String toValue() {
     switch (this) {
       case ReportFormat.reportCsv_20191124:
@@ -4084,7 +4085,7 @@ extension on ReportFormat {
   }
 }
 
-extension on String {
+extension ReportFormatFromString on String {
   ReportFormat toReportFormat() {
     switch (this) {
       case 'REPORT_CSV_20191124':
@@ -4098,7 +4099,7 @@ enum ReportScope {
   failedFilesOnly,
 }
 
-extension on ReportScope {
+extension ReportScopeValue on ReportScope {
   String toValue() {
     switch (this) {
       case ReportScope.failedFilesOnly:
@@ -4107,7 +4108,7 @@ extension on ReportScope {
   }
 }
 
-extension on String {
+extension ReportScopeFromString on String {
   ReportScope toReportScope() {
     switch (this) {
       case 'FAILED_FILES_ONLY':
@@ -4296,7 +4297,7 @@ enum Status {
   updatedOptimizing,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.failed:
@@ -4313,7 +4314,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'FAILED':
@@ -4337,7 +4338,7 @@ enum StorageType {
   hdd,
 }
 
-extension on StorageType {
+extension StorageTypeValue on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.ssd:
@@ -4348,7 +4349,7 @@ extension on StorageType {
   }
 }
 
-extension on String {
+extension StorageTypeFromString on String {
   StorageType toStorageType() {
     switch (this) {
       case 'SSD':
@@ -4561,7 +4562,7 @@ enum WindowsDeploymentType {
   singleAz_2,
 }
 
-extension on WindowsDeploymentType {
+extension WindowsDeploymentTypeValue on WindowsDeploymentType {
   String toValue() {
     switch (this) {
       case WindowsDeploymentType.multiAz_1:
@@ -4574,7 +4575,7 @@ extension on WindowsDeploymentType {
   }
 }
 
-extension on String {
+extension WindowsDeploymentTypeFromString on String {
   WindowsDeploymentType toWindowsDeploymentType() {
     switch (this) {
       case 'MULTI_AZ_1':

--- a/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
+++ b/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
@@ -10464,7 +10464,7 @@ enum AcceptanceType {
   reject,
 }
 
-extension on AcceptanceType {
+extension AcceptanceTypeValue on AcceptanceType {
   String toValue() {
     switch (this) {
       case AcceptanceType.accept:
@@ -10475,7 +10475,7 @@ extension on AcceptanceType {
   }
 }
 
-extension on String {
+extension AcceptanceTypeFromString on String {
   AcceptanceType toAcceptanceType() {
     switch (this) {
       case 'ACCEPT':
@@ -10652,7 +10652,7 @@ enum BackfillMode {
   manual,
 }
 
-extension on BackfillMode {
+extension BackfillModeValue on BackfillMode {
   String toValue() {
     switch (this) {
       case BackfillMode.automatic:
@@ -10663,7 +10663,7 @@ extension on BackfillMode {
   }
 }
 
-extension on String {
+extension BackfillModeFromString on String {
   BackfillMode toBackfillMode() {
     switch (this) {
       case 'AUTOMATIC':
@@ -10681,7 +10681,7 @@ enum BalancingStrategy {
   onDemandOnly,
 }
 
-extension on BalancingStrategy {
+extension BalancingStrategyValue on BalancingStrategy {
   String toValue() {
     switch (this) {
       case BalancingStrategy.spotOnly:
@@ -10694,7 +10694,7 @@ extension on BalancingStrategy {
   }
 }
 
-extension on String {
+extension BalancingStrategyFromString on String {
   BalancingStrategy toBalancingStrategy() {
     switch (this) {
       case 'SPOT_ONLY':
@@ -10814,7 +10814,7 @@ enum BuildStatus {
   failed,
 }
 
-extension on BuildStatus {
+extension BuildStatusValue on BuildStatus {
   String toValue() {
     switch (this) {
       case BuildStatus.initialized:
@@ -10827,7 +10827,7 @@ extension on BuildStatus {
   }
 }
 
-extension on String {
+extension BuildStatusFromString on String {
   BuildStatus toBuildStatus() {
     switch (this) {
       case 'INITIALIZED':
@@ -10878,7 +10878,7 @@ enum CertificateType {
   generated,
 }
 
-extension on CertificateType {
+extension CertificateTypeValue on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.disabled:
@@ -10889,7 +10889,7 @@ extension on CertificateType {
   }
 }
 
-extension on String {
+extension CertificateTypeFromString on String {
   CertificateType toCertificateType() {
     switch (this) {
       case 'DISABLED':
@@ -10924,7 +10924,7 @@ enum ComparisonOperatorType {
   lessThanOrEqualToThreshold,
 }
 
-extension on ComparisonOperatorType {
+extension ComparisonOperatorTypeValue on ComparisonOperatorType {
   String toValue() {
     switch (this) {
       case ComparisonOperatorType.greaterThanOrEqualToThreshold:
@@ -10939,7 +10939,7 @@ extension on ComparisonOperatorType {
   }
 }
 
-extension on String {
+extension ComparisonOperatorTypeFromString on String {
   ComparisonOperatorType toComparisonOperatorType() {
     switch (this) {
       case 'GreaterThanOrEqualToThreshold':
@@ -12025,7 +12025,7 @@ enum EC2InstanceType {
   m5a_24xlarge,
 }
 
-extension on EC2InstanceType {
+extension EC2InstanceTypeValue on EC2InstanceType {
   String toValue() {
     switch (this) {
       case EC2InstanceType.t2Micro:
@@ -12196,7 +12196,7 @@ extension on EC2InstanceType {
   }
 }
 
-extension on String {
+extension EC2InstanceTypeFromString on String {
   EC2InstanceType toEC2InstanceType() {
     switch (this) {
       case 't2.micro':
@@ -12578,7 +12578,7 @@ enum EventCode {
   instanceInterrupted,
 }
 
-extension on EventCode {
+extension EventCodeValue on EventCode {
   String toValue() {
     switch (this) {
       case EventCode.genericEvent:
@@ -12651,7 +12651,7 @@ extension on EventCode {
   }
 }
 
-extension on String {
+extension EventCodeFromString on String {
   EventCode toEventCode() {
     switch (this) {
       case 'GENERIC_EVENT':
@@ -12729,7 +12729,7 @@ enum FleetAction {
   autoScaling,
 }
 
-extension on FleetAction {
+extension FleetActionValue on FleetAction {
   String toValue() {
     switch (this) {
       case FleetAction.autoScaling:
@@ -12738,7 +12738,7 @@ extension on FleetAction {
   }
 }
 
-extension on String {
+extension FleetActionFromString on String {
   FleetAction toFleetAction() {
     switch (this) {
       case 'AUTO_SCALING':
@@ -13061,7 +13061,7 @@ enum FleetStatus {
   terminated,
 }
 
-extension on FleetStatus {
+extension FleetStatusValue on FleetStatus {
   String toValue() {
     switch (this) {
       case FleetStatus.$new:
@@ -13086,7 +13086,7 @@ extension on FleetStatus {
   }
 }
 
-extension on String {
+extension FleetStatusFromString on String {
   FleetStatus toFleetStatus() {
     switch (this) {
       case 'NEW':
@@ -13117,7 +13117,7 @@ enum FleetType {
   spot,
 }
 
-extension on FleetType {
+extension FleetTypeValue on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.onDemand:
@@ -13128,7 +13128,7 @@ extension on FleetType {
   }
 }
 
-extension on String {
+extension FleetTypeFromString on String {
   FleetType toFleetType() {
     switch (this) {
       case 'ON_DEMAND':
@@ -13206,7 +13206,7 @@ enum FlexMatchMode {
   withQueue,
 }
 
-extension on FlexMatchMode {
+extension FlexMatchModeValue on FlexMatchMode {
   String toValue() {
     switch (this) {
       case FlexMatchMode.standalone:
@@ -13217,7 +13217,7 @@ extension on FlexMatchMode {
   }
 }
 
-extension on String {
+extension FlexMatchModeFromString on String {
   FlexMatchMode toFlexMatchMode() {
     switch (this) {
       case 'STANDALONE':
@@ -13403,7 +13403,7 @@ enum GameServerClaimStatus {
   claimed,
 }
 
-extension on GameServerClaimStatus {
+extension GameServerClaimStatusValue on GameServerClaimStatus {
   String toValue() {
     switch (this) {
       case GameServerClaimStatus.claimed:
@@ -13412,7 +13412,7 @@ extension on GameServerClaimStatus {
   }
 }
 
-extension on String {
+extension GameServerClaimStatusFromString on String {
   GameServerClaimStatus toGameServerClaimStatus() {
     switch (this) {
       case 'CLAIMED':
@@ -13619,7 +13619,7 @@ enum GameServerGroupAction {
   replaceInstanceTypes,
 }
 
-extension on GameServerGroupAction {
+extension GameServerGroupActionValue on GameServerGroupAction {
   String toValue() {
     switch (this) {
       case GameServerGroupAction.replaceInstanceTypes:
@@ -13628,7 +13628,7 @@ extension on GameServerGroupAction {
   }
 }
 
-extension on String {
+extension GameServerGroupActionFromString on String {
   GameServerGroupAction toGameServerGroupAction() {
     switch (this) {
       case 'REPLACE_INSTANCE_TYPES':
@@ -13683,7 +13683,7 @@ enum GameServerGroupDeleteOption {
   retain,
 }
 
-extension on GameServerGroupDeleteOption {
+extension GameServerGroupDeleteOptionValue on GameServerGroupDeleteOption {
   String toValue() {
     switch (this) {
       case GameServerGroupDeleteOption.safeDelete:
@@ -13696,7 +13696,7 @@ extension on GameServerGroupDeleteOption {
   }
 }
 
-extension on String {
+extension GameServerGroupDeleteOptionFromString on String {
   GameServerGroupDeleteOption toGameServerGroupDeleteOption() {
     switch (this) {
       case 'SAFE_DELETE':
@@ -13753,7 +13753,7 @@ enum GameServerGroupInstanceType {
   m5_24xlarge,
 }
 
-extension on GameServerGroupInstanceType {
+extension GameServerGroupInstanceTypeValue on GameServerGroupInstanceType {
   String toValue() {
     switch (this) {
       case GameServerGroupInstanceType.c4Large:
@@ -13840,7 +13840,7 @@ extension on GameServerGroupInstanceType {
   }
 }
 
-extension on String {
+extension GameServerGroupInstanceTypeFromString on String {
   GameServerGroupInstanceType toGameServerGroupInstanceType() {
     switch (this) {
       case 'c4.large':
@@ -13938,7 +13938,7 @@ enum GameServerGroupStatus {
   error,
 }
 
-extension on GameServerGroupStatus {
+extension GameServerGroupStatusValue on GameServerGroupStatus {
   String toValue() {
     switch (this) {
       case GameServerGroupStatus.$new:
@@ -13959,7 +13959,7 @@ extension on GameServerGroupStatus {
   }
 }
 
-extension on String {
+extension GameServerGroupStatusFromString on String {
   GameServerGroupStatus toGameServerGroupStatus() {
     switch (this) {
       case 'NEW':
@@ -13985,7 +13985,7 @@ enum GameServerHealthCheck {
   healthy,
 }
 
-extension on GameServerHealthCheck {
+extension GameServerHealthCheckValue on GameServerHealthCheck {
   String toValue() {
     switch (this) {
       case GameServerHealthCheck.healthy:
@@ -13994,7 +13994,7 @@ extension on GameServerHealthCheck {
   }
 }
 
-extension on String {
+extension GameServerHealthCheckFromString on String {
   GameServerHealthCheck toGameServerHealthCheck() {
     switch (this) {
       case 'HEALTHY':
@@ -14101,7 +14101,7 @@ enum GameServerInstanceStatus {
   spotTerminating,
 }
 
-extension on GameServerInstanceStatus {
+extension GameServerInstanceStatusValue on GameServerInstanceStatus {
   String toValue() {
     switch (this) {
       case GameServerInstanceStatus.active:
@@ -14114,7 +14114,7 @@ extension on GameServerInstanceStatus {
   }
 }
 
-extension on String {
+extension GameServerInstanceStatusFromString on String {
   GameServerInstanceStatus toGameServerInstanceStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -14133,7 +14133,7 @@ enum GameServerProtectionPolicy {
   fullProtection,
 }
 
-extension on GameServerProtectionPolicy {
+extension GameServerProtectionPolicyValue on GameServerProtectionPolicy {
   String toValue() {
     switch (this) {
       case GameServerProtectionPolicy.noProtection:
@@ -14144,7 +14144,7 @@ extension on GameServerProtectionPolicy {
   }
 }
 
-extension on String {
+extension GameServerProtectionPolicyFromString on String {
   GameServerProtectionPolicy toGameServerProtectionPolicy() {
     switch (this) {
       case 'NO_PROTECTION':
@@ -14161,7 +14161,7 @@ enum GameServerUtilizationStatus {
   utilized,
 }
 
-extension on GameServerUtilizationStatus {
+extension GameServerUtilizationStatusValue on GameServerUtilizationStatus {
   String toValue() {
     switch (this) {
       case GameServerUtilizationStatus.available:
@@ -14172,7 +14172,7 @@ extension on GameServerUtilizationStatus {
   }
 }
 
-extension on String {
+extension GameServerUtilizationStatusFromString on String {
   GameServerUtilizationStatus toGameServerUtilizationStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -14696,7 +14696,7 @@ enum GameSessionPlacementState {
   failed,
 }
 
-extension on GameSessionPlacementState {
+extension GameSessionPlacementStateValue on GameSessionPlacementState {
   String toValue() {
     switch (this) {
       case GameSessionPlacementState.pending:
@@ -14713,7 +14713,7 @@ extension on GameSessionPlacementState {
   }
 }
 
-extension on String {
+extension GameSessionPlacementStateFromString on String {
   GameSessionPlacementState toGameSessionPlacementState() {
     switch (this) {
       case 'PENDING':
@@ -14872,7 +14872,7 @@ enum GameSessionStatus {
   error,
 }
 
-extension on GameSessionStatus {
+extension GameSessionStatusValue on GameSessionStatus {
   String toValue() {
     switch (this) {
       case GameSessionStatus.active:
@@ -14889,7 +14889,7 @@ extension on GameSessionStatus {
   }
 }
 
-extension on String {
+extension GameSessionStatusFromString on String {
   GameSessionStatus toGameSessionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -14911,7 +14911,7 @@ enum GameSessionStatusReason {
   interrupted,
 }
 
-extension on GameSessionStatusReason {
+extension GameSessionStatusReasonValue on GameSessionStatusReason {
   String toValue() {
     switch (this) {
       case GameSessionStatusReason.interrupted:
@@ -14920,7 +14920,7 @@ extension on GameSessionStatusReason {
   }
 }
 
-extension on String {
+extension GameSessionStatusReasonFromString on String {
   GameSessionStatusReason toGameSessionStatusReason() {
     switch (this) {
       case 'INTERRUPTED':
@@ -15167,7 +15167,7 @@ enum InstanceStatus {
   terminating,
 }
 
-extension on InstanceStatus {
+extension InstanceStatusValue on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.pending:
@@ -15180,7 +15180,7 @@ extension on InstanceStatus {
   }
 }
 
-extension on String {
+extension InstanceStatusFromString on String {
   InstanceStatus toInstanceStatus() {
     switch (this) {
       case 'PENDING':
@@ -15252,7 +15252,7 @@ enum IpProtocol {
   udp,
 }
 
-extension on IpProtocol {
+extension IpProtocolValue on IpProtocol {
   String toValue() {
     switch (this) {
       case IpProtocol.tcp:
@@ -15263,7 +15263,7 @@ extension on IpProtocol {
   }
 }
 
-extension on String {
+extension IpProtocolFromString on String {
   IpProtocol toIpProtocol() {
     switch (this) {
       case 'TCP':
@@ -15684,7 +15684,8 @@ enum MatchmakingConfigurationStatus {
   timedOut,
 }
 
-extension on MatchmakingConfigurationStatus {
+extension MatchmakingConfigurationStatusValue
+    on MatchmakingConfigurationStatus {
   String toValue() {
     switch (this) {
       case MatchmakingConfigurationStatus.cancelled:
@@ -15707,7 +15708,7 @@ extension on MatchmakingConfigurationStatus {
   }
 }
 
-extension on String {
+extension MatchmakingConfigurationStatusFromString on String {
   MatchmakingConfigurationStatus toMatchmakingConfigurationStatus() {
     switch (this) {
       case 'CANCELLED':
@@ -15957,7 +15958,7 @@ enum MetricName {
   waitTime,
 }
 
-extension on MetricName {
+extension MetricNameValue on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.activatingGameSessions:
@@ -15986,7 +15987,7 @@ extension on MetricName {
   }
 }
 
-extension on String {
+extension MetricNameFromString on String {
   MetricName toMetricName() {
     switch (this) {
       case 'ActivatingGameSessions':
@@ -16022,7 +16023,7 @@ enum OperatingSystem {
   amazonLinux_2,
 }
 
-extension on OperatingSystem {
+extension OperatingSystemValue on OperatingSystem {
   String toValue() {
     switch (this) {
       case OperatingSystem.windows_2012:
@@ -16035,7 +16036,7 @@ extension on OperatingSystem {
   }
 }
 
-extension on String {
+extension OperatingSystemFromString on String {
   OperatingSystem toOperatingSystem() {
     switch (this) {
       case 'WINDOWS_2012':
@@ -16418,7 +16419,7 @@ enum PlayerSessionCreationPolicy {
   denyAll,
 }
 
-extension on PlayerSessionCreationPolicy {
+extension PlayerSessionCreationPolicyValue on PlayerSessionCreationPolicy {
   String toValue() {
     switch (this) {
       case PlayerSessionCreationPolicy.acceptAll:
@@ -16429,7 +16430,7 @@ extension on PlayerSessionCreationPolicy {
   }
 }
 
-extension on String {
+extension PlayerSessionCreationPolicyFromString on String {
   PlayerSessionCreationPolicy toPlayerSessionCreationPolicy() {
     switch (this) {
       case 'ACCEPT_ALL':
@@ -16448,7 +16449,7 @@ enum PlayerSessionStatus {
   timedout,
 }
 
-extension on PlayerSessionStatus {
+extension PlayerSessionStatusValue on PlayerSessionStatus {
   String toValue() {
     switch (this) {
       case PlayerSessionStatus.reserved:
@@ -16463,7 +16464,7 @@ extension on PlayerSessionStatus {
   }
 }
 
-extension on String {
+extension PlayerSessionStatusFromString on String {
   PlayerSessionStatus toPlayerSessionStatus() {
     switch (this) {
       case 'RESERVED':
@@ -16484,7 +16485,7 @@ enum PolicyType {
   targetBased,
 }
 
-extension on PolicyType {
+extension PolicyTypeValue on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.ruleBased:
@@ -16495,7 +16496,7 @@ extension on PolicyType {
   }
 }
 
-extension on String {
+extension PolicyTypeFromString on String {
   PolicyType toPolicyType() {
     switch (this) {
       case 'RuleBased':
@@ -16512,7 +16513,7 @@ enum ProtectionPolicy {
   fullProtection,
 }
 
-extension on ProtectionPolicy {
+extension ProtectionPolicyValue on ProtectionPolicy {
   String toValue() {
     switch (this) {
       case ProtectionPolicy.noProtection:
@@ -16523,7 +16524,7 @@ extension on ProtectionPolicy {
   }
 }
 
-extension on String {
+extension ProtectionPolicyFromString on String {
   ProtectionPolicy toProtectionPolicy() {
     switch (this) {
       case 'NoProtection':
@@ -16756,7 +16757,7 @@ enum RoutingStrategyType {
   terminal,
 }
 
-extension on RoutingStrategyType {
+extension RoutingStrategyTypeValue on RoutingStrategyType {
   String toValue() {
     switch (this) {
       case RoutingStrategyType.simple:
@@ -16767,7 +16768,7 @@ extension on RoutingStrategyType {
   }
 }
 
-extension on String {
+extension RoutingStrategyTypeFromString on String {
   RoutingStrategyType toRoutingStrategyType() {
     switch (this) {
       case 'SIMPLE':
@@ -16929,7 +16930,7 @@ enum ScalingAdjustmentType {
   percentChangeInCapacity,
 }
 
-extension on ScalingAdjustmentType {
+extension ScalingAdjustmentTypeValue on ScalingAdjustmentType {
   String toValue() {
     switch (this) {
       case ScalingAdjustmentType.changeInCapacity:
@@ -16942,7 +16943,7 @@ extension on ScalingAdjustmentType {
   }
 }
 
-extension on String {
+extension ScalingAdjustmentTypeFromString on String {
   ScalingAdjustmentType toScalingAdjustmentType() {
     switch (this) {
       case 'ChangeInCapacity':
@@ -17183,7 +17184,7 @@ enum ScalingStatusType {
   error,
 }
 
-extension on ScalingStatusType {
+extension ScalingStatusTypeValue on ScalingStatusType {
   String toValue() {
     switch (this) {
       case ScalingStatusType.active:
@@ -17204,7 +17205,7 @@ extension on ScalingStatusType {
   }
 }
 
-extension on String {
+extension ScalingStatusTypeFromString on String {
   ScalingStatusType toScalingStatusType() {
     switch (this) {
       case 'ACTIVE':
@@ -17389,7 +17390,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -17400,7 +17401,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASCENDING':

--- a/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
+++ b/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
@@ -10464,7 +10464,7 @@ enum AcceptanceType {
   reject,
 }
 
-extension AcceptanceTypeValue on AcceptanceType {
+extension AcceptanceTypeValueExtension on AcceptanceType {
   String toValue() {
     switch (this) {
       case AcceptanceType.accept:
@@ -10652,7 +10652,7 @@ enum BackfillMode {
   manual,
 }
 
-extension BackfillModeValue on BackfillMode {
+extension BackfillModeValueExtension on BackfillMode {
   String toValue() {
     switch (this) {
       case BackfillMode.automatic:
@@ -10681,7 +10681,7 @@ enum BalancingStrategy {
   onDemandOnly,
 }
 
-extension BalancingStrategyValue on BalancingStrategy {
+extension BalancingStrategyValueExtension on BalancingStrategy {
   String toValue() {
     switch (this) {
       case BalancingStrategy.spotOnly:
@@ -10814,7 +10814,7 @@ enum BuildStatus {
   failed,
 }
 
-extension BuildStatusValue on BuildStatus {
+extension BuildStatusValueExtension on BuildStatus {
   String toValue() {
     switch (this) {
       case BuildStatus.initialized:
@@ -10878,7 +10878,7 @@ enum CertificateType {
   generated,
 }
 
-extension CertificateTypeValue on CertificateType {
+extension CertificateTypeValueExtension on CertificateType {
   String toValue() {
     switch (this) {
       case CertificateType.disabled:
@@ -10924,7 +10924,7 @@ enum ComparisonOperatorType {
   lessThanOrEqualToThreshold,
 }
 
-extension ComparisonOperatorTypeValue on ComparisonOperatorType {
+extension ComparisonOperatorTypeValueExtension on ComparisonOperatorType {
   String toValue() {
     switch (this) {
       case ComparisonOperatorType.greaterThanOrEqualToThreshold:
@@ -12025,7 +12025,7 @@ enum EC2InstanceType {
   m5a_24xlarge,
 }
 
-extension EC2InstanceTypeValue on EC2InstanceType {
+extension EC2InstanceTypeValueExtension on EC2InstanceType {
   String toValue() {
     switch (this) {
       case EC2InstanceType.t2Micro:
@@ -12578,7 +12578,7 @@ enum EventCode {
   instanceInterrupted,
 }
 
-extension EventCodeValue on EventCode {
+extension EventCodeValueExtension on EventCode {
   String toValue() {
     switch (this) {
       case EventCode.genericEvent:
@@ -12729,7 +12729,7 @@ enum FleetAction {
   autoScaling,
 }
 
-extension FleetActionValue on FleetAction {
+extension FleetActionValueExtension on FleetAction {
   String toValue() {
     switch (this) {
       case FleetAction.autoScaling:
@@ -13061,7 +13061,7 @@ enum FleetStatus {
   terminated,
 }
 
-extension FleetStatusValue on FleetStatus {
+extension FleetStatusValueExtension on FleetStatus {
   String toValue() {
     switch (this) {
       case FleetStatus.$new:
@@ -13117,7 +13117,7 @@ enum FleetType {
   spot,
 }
 
-extension FleetTypeValue on FleetType {
+extension FleetTypeValueExtension on FleetType {
   String toValue() {
     switch (this) {
       case FleetType.onDemand:
@@ -13206,7 +13206,7 @@ enum FlexMatchMode {
   withQueue,
 }
 
-extension FlexMatchModeValue on FlexMatchMode {
+extension FlexMatchModeValueExtension on FlexMatchMode {
   String toValue() {
     switch (this) {
       case FlexMatchMode.standalone:
@@ -13403,7 +13403,7 @@ enum GameServerClaimStatus {
   claimed,
 }
 
-extension GameServerClaimStatusValue on GameServerClaimStatus {
+extension GameServerClaimStatusValueExtension on GameServerClaimStatus {
   String toValue() {
     switch (this) {
       case GameServerClaimStatus.claimed:
@@ -13619,7 +13619,7 @@ enum GameServerGroupAction {
   replaceInstanceTypes,
 }
 
-extension GameServerGroupActionValue on GameServerGroupAction {
+extension GameServerGroupActionValueExtension on GameServerGroupAction {
   String toValue() {
     switch (this) {
       case GameServerGroupAction.replaceInstanceTypes:
@@ -13683,7 +13683,8 @@ enum GameServerGroupDeleteOption {
   retain,
 }
 
-extension GameServerGroupDeleteOptionValue on GameServerGroupDeleteOption {
+extension GameServerGroupDeleteOptionValueExtension
+    on GameServerGroupDeleteOption {
   String toValue() {
     switch (this) {
       case GameServerGroupDeleteOption.safeDelete:
@@ -13753,7 +13754,8 @@ enum GameServerGroupInstanceType {
   m5_24xlarge,
 }
 
-extension GameServerGroupInstanceTypeValue on GameServerGroupInstanceType {
+extension GameServerGroupInstanceTypeValueExtension
+    on GameServerGroupInstanceType {
   String toValue() {
     switch (this) {
       case GameServerGroupInstanceType.c4Large:
@@ -13938,7 +13940,7 @@ enum GameServerGroupStatus {
   error,
 }
 
-extension GameServerGroupStatusValue on GameServerGroupStatus {
+extension GameServerGroupStatusValueExtension on GameServerGroupStatus {
   String toValue() {
     switch (this) {
       case GameServerGroupStatus.$new:
@@ -13985,7 +13987,7 @@ enum GameServerHealthCheck {
   healthy,
 }
 
-extension GameServerHealthCheckValue on GameServerHealthCheck {
+extension GameServerHealthCheckValueExtension on GameServerHealthCheck {
   String toValue() {
     switch (this) {
       case GameServerHealthCheck.healthy:
@@ -14101,7 +14103,7 @@ enum GameServerInstanceStatus {
   spotTerminating,
 }
 
-extension GameServerInstanceStatusValue on GameServerInstanceStatus {
+extension GameServerInstanceStatusValueExtension on GameServerInstanceStatus {
   String toValue() {
     switch (this) {
       case GameServerInstanceStatus.active:
@@ -14133,7 +14135,8 @@ enum GameServerProtectionPolicy {
   fullProtection,
 }
 
-extension GameServerProtectionPolicyValue on GameServerProtectionPolicy {
+extension GameServerProtectionPolicyValueExtension
+    on GameServerProtectionPolicy {
   String toValue() {
     switch (this) {
       case GameServerProtectionPolicy.noProtection:
@@ -14161,7 +14164,8 @@ enum GameServerUtilizationStatus {
   utilized,
 }
 
-extension GameServerUtilizationStatusValue on GameServerUtilizationStatus {
+extension GameServerUtilizationStatusValueExtension
+    on GameServerUtilizationStatus {
   String toValue() {
     switch (this) {
       case GameServerUtilizationStatus.available:
@@ -14696,7 +14700,7 @@ enum GameSessionPlacementState {
   failed,
 }
 
-extension GameSessionPlacementStateValue on GameSessionPlacementState {
+extension GameSessionPlacementStateValueExtension on GameSessionPlacementState {
   String toValue() {
     switch (this) {
       case GameSessionPlacementState.pending:
@@ -14872,7 +14876,7 @@ enum GameSessionStatus {
   error,
 }
 
-extension GameSessionStatusValue on GameSessionStatus {
+extension GameSessionStatusValueExtension on GameSessionStatus {
   String toValue() {
     switch (this) {
       case GameSessionStatus.active:
@@ -14911,7 +14915,7 @@ enum GameSessionStatusReason {
   interrupted,
 }
 
-extension GameSessionStatusReasonValue on GameSessionStatusReason {
+extension GameSessionStatusReasonValueExtension on GameSessionStatusReason {
   String toValue() {
     switch (this) {
       case GameSessionStatusReason.interrupted:
@@ -15167,7 +15171,7 @@ enum InstanceStatus {
   terminating,
 }
 
-extension InstanceStatusValue on InstanceStatus {
+extension InstanceStatusValueExtension on InstanceStatus {
   String toValue() {
     switch (this) {
       case InstanceStatus.pending:
@@ -15252,7 +15256,7 @@ enum IpProtocol {
   udp,
 }
 
-extension IpProtocolValue on IpProtocol {
+extension IpProtocolValueExtension on IpProtocol {
   String toValue() {
     switch (this) {
       case IpProtocol.tcp:
@@ -15684,7 +15688,7 @@ enum MatchmakingConfigurationStatus {
   timedOut,
 }
 
-extension MatchmakingConfigurationStatusValue
+extension MatchmakingConfigurationStatusValueExtension
     on MatchmakingConfigurationStatus {
   String toValue() {
     switch (this) {
@@ -15958,7 +15962,7 @@ enum MetricName {
   waitTime,
 }
 
-extension MetricNameValue on MetricName {
+extension MetricNameValueExtension on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.activatingGameSessions:
@@ -16023,7 +16027,7 @@ enum OperatingSystem {
   amazonLinux_2,
 }
 
-extension OperatingSystemValue on OperatingSystem {
+extension OperatingSystemValueExtension on OperatingSystem {
   String toValue() {
     switch (this) {
       case OperatingSystem.windows_2012:
@@ -16419,7 +16423,8 @@ enum PlayerSessionCreationPolicy {
   denyAll,
 }
 
-extension PlayerSessionCreationPolicyValue on PlayerSessionCreationPolicy {
+extension PlayerSessionCreationPolicyValueExtension
+    on PlayerSessionCreationPolicy {
   String toValue() {
     switch (this) {
       case PlayerSessionCreationPolicy.acceptAll:
@@ -16449,7 +16454,7 @@ enum PlayerSessionStatus {
   timedout,
 }
 
-extension PlayerSessionStatusValue on PlayerSessionStatus {
+extension PlayerSessionStatusValueExtension on PlayerSessionStatus {
   String toValue() {
     switch (this) {
       case PlayerSessionStatus.reserved:
@@ -16485,7 +16490,7 @@ enum PolicyType {
   targetBased,
 }
 
-extension PolicyTypeValue on PolicyType {
+extension PolicyTypeValueExtension on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.ruleBased:
@@ -16513,7 +16518,7 @@ enum ProtectionPolicy {
   fullProtection,
 }
 
-extension ProtectionPolicyValue on ProtectionPolicy {
+extension ProtectionPolicyValueExtension on ProtectionPolicy {
   String toValue() {
     switch (this) {
       case ProtectionPolicy.noProtection:
@@ -16757,7 +16762,7 @@ enum RoutingStrategyType {
   terminal,
 }
 
-extension RoutingStrategyTypeValue on RoutingStrategyType {
+extension RoutingStrategyTypeValueExtension on RoutingStrategyType {
   String toValue() {
     switch (this) {
       case RoutingStrategyType.simple:
@@ -16930,7 +16935,7 @@ enum ScalingAdjustmentType {
   percentChangeInCapacity,
 }
 
-extension ScalingAdjustmentTypeValue on ScalingAdjustmentType {
+extension ScalingAdjustmentTypeValueExtension on ScalingAdjustmentType {
   String toValue() {
     switch (this) {
       case ScalingAdjustmentType.changeInCapacity:
@@ -17184,7 +17189,7 @@ enum ScalingStatusType {
   error,
 }
 
-extension ScalingStatusTypeValue on ScalingStatusType {
+extension ScalingStatusTypeValueExtension on ScalingStatusType {
   String toValue() {
     switch (this) {
       case ScalingStatusType.active:
@@ -17390,7 +17395,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:

--- a/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
+++ b/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
@@ -2210,7 +2210,7 @@ enum ActionCode {
   select,
 }
 
-extension on ActionCode {
+extension ActionCodeValue on ActionCode {
   String toValue() {
     switch (this) {
       case ActionCode.archiveRetrieval:
@@ -2223,7 +2223,7 @@ extension on ActionCode {
   }
 }
 
-extension on String {
+extension ActionCodeFromString on String {
   ActionCode toActionCode() {
     switch (this) {
       case 'ArchiveRetrieval':
@@ -2389,7 +2389,7 @@ enum CannedACL {
   bucketOwnerFullControl,
 }
 
-extension on CannedACL {
+extension CannedACLValue on CannedACL {
   String toValue() {
     switch (this) {
       case CannedACL.private:
@@ -2410,7 +2410,7 @@ extension on CannedACL {
   }
 }
 
-extension on String {
+extension CannedACLFromString on String {
   CannedACL toCannedACL() {
     switch (this) {
       case 'private':
@@ -2599,7 +2599,7 @@ enum EncryptionType {
   aes256,
 }
 
-extension on EncryptionType {
+extension EncryptionTypeValue on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.awsKms:
@@ -2610,7 +2610,7 @@ extension on EncryptionType {
   }
 }
 
-extension on String {
+extension EncryptionTypeFromString on String {
   EncryptionType toEncryptionType() {
     switch (this) {
       case 'aws:kms':
@@ -2626,7 +2626,7 @@ enum ExpressionType {
   sql,
 }
 
-extension on ExpressionType {
+extension ExpressionTypeValue on ExpressionType {
   String toValue() {
     switch (this) {
       case ExpressionType.sql:
@@ -2635,7 +2635,7 @@ extension on ExpressionType {
   }
 }
 
-extension on String {
+extension ExpressionTypeFromString on String {
   ExpressionType toExpressionType() {
     switch (this) {
       case 'SQL':
@@ -2651,7 +2651,7 @@ enum FileHeaderInfo {
   none,
 }
 
-extension on FileHeaderInfo {
+extension FileHeaderInfoValue on FileHeaderInfo {
   String toValue() {
     switch (this) {
       case FileHeaderInfo.use:
@@ -2664,7 +2664,7 @@ extension on FileHeaderInfo {
   }
 }
 
-extension on String {
+extension FileHeaderInfoFromString on String {
   FileHeaderInfo toFileHeaderInfo() {
     switch (this) {
       case 'USE':
@@ -3569,7 +3569,7 @@ enum Permission {
   readAcp,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.fullControl:
@@ -3586,7 +3586,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'FULL_CONTROL':
@@ -3645,7 +3645,7 @@ enum QuoteFields {
   asneeded,
 }
 
-extension on QuoteFields {
+extension QuoteFieldsValue on QuoteFields {
   String toValue() {
     switch (this) {
       case QuoteFields.always:
@@ -3656,7 +3656,7 @@ extension on QuoteFields {
   }
 }
 
-extension on String {
+extension QuoteFieldsFromString on String {
   QuoteFields toQuoteFields() {
     switch (this) {
       case 'ALWAYS':
@@ -3804,7 +3804,7 @@ enum StatusCode {
   failed,
 }
 
-extension on StatusCode {
+extension StatusCodeValue on StatusCode {
   String toValue() {
     switch (this) {
       case StatusCode.inProgress:
@@ -3817,7 +3817,7 @@ extension on StatusCode {
   }
 }
 
-extension on String {
+extension StatusCodeFromString on String {
   StatusCode toStatusCode() {
     switch (this) {
       case 'InProgress':
@@ -3837,7 +3837,7 @@ enum StorageClass {
   standardIa,
 }
 
-extension on StorageClass {
+extension StorageClassValue on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.standard:
@@ -3850,7 +3850,7 @@ extension on StorageClass {
   }
 }
 
-extension on String {
+extension StorageClassFromString on String {
   StorageClass toStorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -3870,7 +3870,7 @@ enum Type {
   group,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.amazonCustomerByEmail:
@@ -3883,7 +3883,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'AmazonCustomerByEmail':

--- a/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
+++ b/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
@@ -2210,7 +2210,7 @@ enum ActionCode {
   select,
 }
 
-extension ActionCodeValue on ActionCode {
+extension ActionCodeValueExtension on ActionCode {
   String toValue() {
     switch (this) {
       case ActionCode.archiveRetrieval:
@@ -2389,7 +2389,7 @@ enum CannedACL {
   bucketOwnerFullControl,
 }
 
-extension CannedACLValue on CannedACL {
+extension CannedACLValueExtension on CannedACL {
   String toValue() {
     switch (this) {
       case CannedACL.private:
@@ -2599,7 +2599,7 @@ enum EncryptionType {
   aes256,
 }
 
-extension EncryptionTypeValue on EncryptionType {
+extension EncryptionTypeValueExtension on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.awsKms:
@@ -2626,7 +2626,7 @@ enum ExpressionType {
   sql,
 }
 
-extension ExpressionTypeValue on ExpressionType {
+extension ExpressionTypeValueExtension on ExpressionType {
   String toValue() {
     switch (this) {
       case ExpressionType.sql:
@@ -2651,7 +2651,7 @@ enum FileHeaderInfo {
   none,
 }
 
-extension FileHeaderInfoValue on FileHeaderInfo {
+extension FileHeaderInfoValueExtension on FileHeaderInfo {
   String toValue() {
     switch (this) {
       case FileHeaderInfo.use:
@@ -3569,7 +3569,7 @@ enum Permission {
   readAcp,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.fullControl:
@@ -3645,7 +3645,7 @@ enum QuoteFields {
   asneeded,
 }
 
-extension QuoteFieldsValue on QuoteFields {
+extension QuoteFieldsValueExtension on QuoteFields {
   String toValue() {
     switch (this) {
       case QuoteFields.always:
@@ -3804,7 +3804,7 @@ enum StatusCode {
   failed,
 }
 
-extension StatusCodeValue on StatusCode {
+extension StatusCodeValueExtension on StatusCode {
   String toValue() {
     switch (this) {
       case StatusCode.inProgress:
@@ -3837,7 +3837,7 @@ enum StorageClass {
   standardIa,
 }
 
-extension StorageClassValue on StorageClass {
+extension StorageClassValueExtension on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.standard:
@@ -3870,7 +3870,7 @@ enum Type {
   group,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.amazonCustomerByEmail:

--- a/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
+++ b/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
@@ -3142,7 +3142,7 @@ enum AcceleratorStatus {
   inProgress,
 }
 
-extension on AcceleratorStatus {
+extension AcceleratorStatusValue on AcceleratorStatus {
   String toValue() {
     switch (this) {
       case AcceleratorStatus.deployed:
@@ -3153,7 +3153,7 @@ extension on AcceleratorStatus {
   }
 }
 
-extension on String {
+extension AcceleratorStatusFromString on String {
   AcceleratorStatus toAcceleratorStatus() {
     switch (this) {
       case 'DEPLOYED':
@@ -3336,7 +3336,7 @@ enum ByoipCidrState {
   failedDeprovision,
 }
 
-extension on ByoipCidrState {
+extension ByoipCidrStateValue on ByoipCidrState {
   String toValue() {
     switch (this) {
       case ByoipCidrState.pendingProvisioning:
@@ -3365,7 +3365,7 @@ extension on ByoipCidrState {
   }
 }
 
-extension on String {
+extension ByoipCidrStateFromString on String {
   ByoipCidrState toByoipCidrState() {
     switch (this) {
       case 'PENDING_PROVISIONING':
@@ -3428,7 +3428,7 @@ enum ClientAffinity {
   sourceIp,
 }
 
-extension on ClientAffinity {
+extension ClientAffinityValue on ClientAffinity {
   String toValue() {
     switch (this) {
       case ClientAffinity.none:
@@ -3439,7 +3439,7 @@ extension on ClientAffinity {
   }
 }
 
-extension on String {
+extension ClientAffinityFromString on String {
   ClientAffinity toClientAffinity() {
     switch (this) {
       case 'NONE':
@@ -3679,7 +3679,8 @@ enum CustomRoutingAcceleratorStatus {
   inProgress,
 }
 
-extension on CustomRoutingAcceleratorStatus {
+extension CustomRoutingAcceleratorStatusValue
+    on CustomRoutingAcceleratorStatus {
   String toValue() {
     switch (this) {
       case CustomRoutingAcceleratorStatus.deployed:
@@ -3690,7 +3691,7 @@ extension on CustomRoutingAcceleratorStatus {
   }
 }
 
-extension on String {
+extension CustomRoutingAcceleratorStatusFromString on String {
   CustomRoutingAcceleratorStatus toCustomRoutingAcceleratorStatus() {
     switch (this) {
       case 'DEPLOYED':
@@ -3775,7 +3776,8 @@ enum CustomRoutingDestinationTrafficState {
   deny,
 }
 
-extension on CustomRoutingDestinationTrafficState {
+extension CustomRoutingDestinationTrafficStateValue
+    on CustomRoutingDestinationTrafficState {
   String toValue() {
     switch (this) {
       case CustomRoutingDestinationTrafficState.allow:
@@ -3786,7 +3788,7 @@ extension on CustomRoutingDestinationTrafficState {
   }
 }
 
-extension on String {
+extension CustomRoutingDestinationTrafficStateFromString on String {
   CustomRoutingDestinationTrafficState
       toCustomRoutingDestinationTrafficState() {
     switch (this) {
@@ -3910,7 +3912,7 @@ enum CustomRoutingProtocol {
   udp,
 }
 
-extension on CustomRoutingProtocol {
+extension CustomRoutingProtocolValue on CustomRoutingProtocol {
   String toValue() {
     switch (this) {
       case CustomRoutingProtocol.tcp:
@@ -3921,7 +3923,7 @@ extension on CustomRoutingProtocol {
   }
 }
 
-extension on String {
+extension CustomRoutingProtocolFromString on String {
   CustomRoutingProtocol toCustomRoutingProtocol() {
     switch (this) {
       case 'TCP':
@@ -4364,7 +4366,7 @@ enum HealthCheckProtocol {
   https,
 }
 
-extension on HealthCheckProtocol {
+extension HealthCheckProtocolValue on HealthCheckProtocol {
   String toValue() {
     switch (this) {
       case HealthCheckProtocol.tcp:
@@ -4377,7 +4379,7 @@ extension on HealthCheckProtocol {
   }
 }
 
-extension on String {
+extension HealthCheckProtocolFromString on String {
   HealthCheckProtocol toHealthCheckProtocol() {
     switch (this) {
       case 'TCP':
@@ -4397,7 +4399,7 @@ enum HealthState {
   unhealthy,
 }
 
-extension on HealthState {
+extension HealthStateValue on HealthState {
   String toValue() {
     switch (this) {
       case HealthState.initial:
@@ -4410,7 +4412,7 @@ extension on HealthState {
   }
 }
 
-extension on String {
+extension HealthStateFromString on String {
   HealthState toHealthState() {
     switch (this) {
       case 'INITIAL':
@@ -4428,7 +4430,7 @@ enum IpAddressType {
   ipv4,
 }
 
-extension on IpAddressType {
+extension IpAddressTypeValue on IpAddressType {
   String toValue() {
     switch (this) {
       case IpAddressType.ipv4:
@@ -4437,7 +4439,7 @@ extension on IpAddressType {
   }
 }
 
-extension on String {
+extension IpAddressTypeFromString on String {
   IpAddressType toIpAddressType() {
     switch (this) {
       case 'IPV4':
@@ -4885,7 +4887,7 @@ enum Protocol {
   udp,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.tcp:
@@ -4896,7 +4898,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'TCP':

--- a/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
+++ b/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
@@ -3142,7 +3142,7 @@ enum AcceleratorStatus {
   inProgress,
 }
 
-extension AcceleratorStatusValue on AcceleratorStatus {
+extension AcceleratorStatusValueExtension on AcceleratorStatus {
   String toValue() {
     switch (this) {
       case AcceleratorStatus.deployed:
@@ -3336,7 +3336,7 @@ enum ByoipCidrState {
   failedDeprovision,
 }
 
-extension ByoipCidrStateValue on ByoipCidrState {
+extension ByoipCidrStateValueExtension on ByoipCidrState {
   String toValue() {
     switch (this) {
       case ByoipCidrState.pendingProvisioning:
@@ -3428,7 +3428,7 @@ enum ClientAffinity {
   sourceIp,
 }
 
-extension ClientAffinityValue on ClientAffinity {
+extension ClientAffinityValueExtension on ClientAffinity {
   String toValue() {
     switch (this) {
       case ClientAffinity.none:
@@ -3679,7 +3679,7 @@ enum CustomRoutingAcceleratorStatus {
   inProgress,
 }
 
-extension CustomRoutingAcceleratorStatusValue
+extension CustomRoutingAcceleratorStatusValueExtension
     on CustomRoutingAcceleratorStatus {
   String toValue() {
     switch (this) {
@@ -3776,7 +3776,7 @@ enum CustomRoutingDestinationTrafficState {
   deny,
 }
 
-extension CustomRoutingDestinationTrafficStateValue
+extension CustomRoutingDestinationTrafficStateValueExtension
     on CustomRoutingDestinationTrafficState {
   String toValue() {
     switch (this) {
@@ -3912,7 +3912,7 @@ enum CustomRoutingProtocol {
   udp,
 }
 
-extension CustomRoutingProtocolValue on CustomRoutingProtocol {
+extension CustomRoutingProtocolValueExtension on CustomRoutingProtocol {
   String toValue() {
     switch (this) {
       case CustomRoutingProtocol.tcp:
@@ -4366,7 +4366,7 @@ enum HealthCheckProtocol {
   https,
 }
 
-extension HealthCheckProtocolValue on HealthCheckProtocol {
+extension HealthCheckProtocolValueExtension on HealthCheckProtocol {
   String toValue() {
     switch (this) {
       case HealthCheckProtocol.tcp:
@@ -4399,7 +4399,7 @@ enum HealthState {
   unhealthy,
 }
 
-extension HealthStateValue on HealthState {
+extension HealthStateValueExtension on HealthState {
   String toValue() {
     switch (this) {
       case HealthState.initial:
@@ -4430,7 +4430,7 @@ enum IpAddressType {
   ipv4,
 }
 
-extension IpAddressTypeValue on IpAddressType {
+extension IpAddressTypeValueExtension on IpAddressType {
   String toValue() {
     switch (this) {
       case IpAddressType.ipv4:
@@ -4887,7 +4887,7 @@ enum Protocol {
   udp,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.tcp:

--- a/generated/aws_glue_api/lib/glue-2017-03-31.dart
+++ b/generated/aws_glue_api/lib/glue-2017-03-31.dart
@@ -9936,7 +9936,7 @@ enum BackfillErrorCode {
   unsupportedPartitionCharacterError,
 }
 
-extension BackfillErrorCodeValue on BackfillErrorCode {
+extension BackfillErrorCodeValueExtension on BackfillErrorCode {
   String toValue() {
     switch (this) {
       case BackfillErrorCode.encryptedPartitionError:
@@ -10460,7 +10460,7 @@ enum CatalogEncryptionMode {
   sseKms,
 }
 
-extension CatalogEncryptionModeValue on CatalogEncryptionMode {
+extension CatalogEncryptionModeValueExtension on CatalogEncryptionMode {
   String toValue() {
     switch (this) {
       case CatalogEncryptionMode.disabled:
@@ -10672,7 +10672,7 @@ enum CloudWatchEncryptionMode {
   sseKms,
 }
 
-extension CloudWatchEncryptionModeValue on CloudWatchEncryptionMode {
+extension CloudWatchEncryptionModeValueExtension on CloudWatchEncryptionMode {
   String toValue() {
     switch (this) {
       case CloudWatchEncryptionMode.disabled:
@@ -11085,7 +11085,7 @@ enum ColumnStatisticsType {
   binary,
 }
 
-extension ColumnStatisticsTypeValue on ColumnStatisticsType {
+extension ColumnStatisticsTypeValueExtension on ColumnStatisticsType {
   String toValue() {
     switch (this) {
       case ColumnStatisticsType.boolean:
@@ -11136,7 +11136,7 @@ enum Comparator {
   lessThanEquals,
 }
 
-extension ComparatorValue on Comparator {
+extension ComparatorValueExtension on Comparator {
   String toValue() {
     switch (this) {
       case Comparator.equals:
@@ -11182,7 +11182,7 @@ enum Compatibility {
   fullAll,
 }
 
-extension CompatibilityValue on Compatibility {
+extension CompatibilityValueExtension on Compatibility {
   String toValue() {
     switch (this) {
       case Compatibility.none:
@@ -11667,7 +11667,7 @@ enum ConnectionPropertyKey {
   connectorClassName,
 }
 
-extension ConnectionPropertyKeyValue on ConnectionPropertyKey {
+extension ConnectionPropertyKeyValueExtension on ConnectionPropertyKey {
   String toValue() {
     switch (this) {
       case ConnectionPropertyKey.host:
@@ -11792,7 +11792,7 @@ enum ConnectionType {
   custom,
 }
 
-extension ConnectionTypeValue on ConnectionType {
+extension ConnectionTypeValueExtension on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.jdbc:
@@ -11908,7 +11908,7 @@ enum CrawlState {
   failed,
 }
 
-extension CrawlStateValue on CrawlState {
+extension CrawlStateValueExtension on CrawlState {
   String toValue() {
     switch (this) {
       case CrawlState.running:
@@ -12084,7 +12084,7 @@ enum CrawlerLineageSettings {
   disable,
 }
 
-extension CrawlerLineageSettingsValue on CrawlerLineageSettings {
+extension CrawlerLineageSettingsValueExtension on CrawlerLineageSettings {
   String toValue() {
     switch (this) {
       case CrawlerLineageSettings.enable:
@@ -12182,7 +12182,7 @@ enum CrawlerState {
   stopping,
 }
 
-extension CrawlerStateValue on CrawlerState {
+extension CrawlerStateValueExtension on CrawlerState {
   String toValue() {
     switch (this) {
       case CrawlerState.ready:
@@ -12898,7 +12898,7 @@ enum CsvHeaderOption {
   absent,
 }
 
-extension CsvHeaderOptionValue on CsvHeaderOption {
+extension CsvHeaderOptionValueExtension on CsvHeaderOption {
   String toValue() {
     switch (this) {
       case CsvHeaderOption.unknown:
@@ -12969,7 +12969,7 @@ enum DataFormat {
   avro,
 }
 
-extension DataFormatValue on DataFormat {
+extension DataFormatValueExtension on DataFormat {
   String toValue() {
     switch (this) {
       case DataFormat.avro:
@@ -13281,7 +13281,7 @@ enum DeleteBehavior {
   deprecateInDatabase,
 }
 
-extension DeleteBehaviorValue on DeleteBehavior {
+extension DeleteBehaviorValueExtension on DeleteBehavior {
   String toValue() {
     switch (this) {
       case DeleteBehavior.log:
@@ -13923,7 +13923,7 @@ enum EnableHybridValues {
   $false,
 }
 
-extension EnableHybridValuesValue on EnableHybridValues {
+extension EnableHybridValuesValueExtension on EnableHybridValues {
   String toValue() {
     switch (this) {
       case EnableHybridValues.$true:
@@ -14118,7 +14118,7 @@ enum ExistCondition {
   none,
 }
 
-extension ExistConditionValue on ExistCondition {
+extension ExistConditionValueExtension on ExistCondition {
   String toValue() {
     switch (this) {
       case ExistCondition.mustExist:
@@ -16186,7 +16186,8 @@ enum JobBookmarksEncryptionMode {
   cseKms,
 }
 
-extension JobBookmarksEncryptionModeValue on JobBookmarksEncryptionMode {
+extension JobBookmarksEncryptionModeValueExtension
+    on JobBookmarksEncryptionMode {
   String toValue() {
     switch (this) {
       case JobBookmarksEncryptionMode.disabled:
@@ -16493,7 +16494,7 @@ enum JobRunState {
   timeout,
 }
 
-extension JobRunStateValue on JobRunState {
+extension JobRunStateValueExtension on JobRunState {
   String toValue() {
     switch (this) {
       case JobRunState.starting:
@@ -16810,7 +16811,7 @@ enum Language {
   scala,
 }
 
-extension LanguageValue on Language {
+extension LanguageValueExtension on Language {
   String toValue() {
     switch (this) {
       case Language.python:
@@ -16879,7 +16880,7 @@ enum LastCrawlStatus {
   failed,
 }
 
-extension LastCrawlStatusValue on LastCrawlStatus {
+extension LastCrawlStatusValueExtension on LastCrawlStatus {
   String toValue() {
     switch (this) {
       case LastCrawlStatus.succeeded:
@@ -17185,7 +17186,7 @@ enum Logical {
   any,
 }
 
-extension LogicalValue on Logical {
+extension LogicalValueExtension on Logical {
   String toValue() {
     switch (this) {
       case Logical.and:
@@ -17212,7 +17213,7 @@ enum LogicalOperator {
   equals,
 }
 
-extension LogicalOperatorValue on LogicalOperator {
+extension LogicalOperatorValueExtension on LogicalOperator {
   String toValue() {
     switch (this) {
       case LogicalOperator.equals:
@@ -17549,7 +17550,7 @@ enum MLUserDataEncryptionModeString {
   sseKms,
 }
 
-extension MLUserDataEncryptionModeStringValue
+extension MLUserDataEncryptionModeStringValueExtension
     on MLUserDataEncryptionModeString {
   String toValue() {
     switch (this) {
@@ -17771,7 +17772,7 @@ enum NodeType {
   trigger,
 }
 
-extension NodeTypeValue on NodeType {
+extension NodeTypeValueExtension on NodeType {
   String toValue() {
     switch (this) {
       case NodeType.crawler:
@@ -18024,7 +18025,7 @@ enum PartitionIndexStatus {
   failed,
 }
 
-extension PartitionIndexStatusValue on PartitionIndexStatus {
+extension PartitionIndexStatusValueExtension on PartitionIndexStatus {
   String toValue() {
     switch (this) {
       case PartitionIndexStatus.creating:
@@ -18141,7 +18142,7 @@ enum Permission {
   dataLocationAccess,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.all:
@@ -18330,7 +18331,7 @@ enum PrincipalType {
   group,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -18497,7 +18498,7 @@ enum RecrawlBehavior {
   crawlNewFoldersOnly,
 }
 
-extension RecrawlBehaviorValue on RecrawlBehavior {
+extension RecrawlBehaviorValueExtension on RecrawlBehavior {
   String toValue() {
     switch (this) {
       case RecrawlBehavior.crawlEverything:
@@ -18649,7 +18650,7 @@ enum RegistryStatus {
   deleting,
 }
 
-extension RegistryStatusValue on RegistryStatus {
+extension RegistryStatusValueExtension on RegistryStatus {
   String toValue() {
     switch (this) {
       case RegistryStatus.available:
@@ -18744,7 +18745,7 @@ enum ResourceShareType {
   all,
 }
 
-extension ResourceShareTypeValue on ResourceShareType {
+extension ResourceShareTypeValueExtension on ResourceShareType {
   String toValue() {
     switch (this) {
       case ResourceShareType.foreign:
@@ -18773,7 +18774,7 @@ enum ResourceType {
   archive,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.jar:
@@ -18891,7 +18892,7 @@ enum S3EncryptionMode {
   sseS3,
 }
 
-extension S3EncryptionModeValue on S3EncryptionMode {
+extension S3EncryptionModeValueExtension on S3EncryptionMode {
   String toValue() {
     switch (this) {
       case S3EncryptionMode.disabled:
@@ -18991,7 +18992,7 @@ enum ScheduleState {
   transitioning,
 }
 
-extension ScheduleStateValue on ScheduleState {
+extension ScheduleStateValueExtension on ScheduleState {
   String toValue() {
     switch (this) {
       case ScheduleState.scheduled:
@@ -19082,7 +19083,7 @@ enum SchemaDiffType {
   syntaxDiff,
 }
 
-extension SchemaDiffTypeValue on SchemaDiffType {
+extension SchemaDiffTypeValueExtension on SchemaDiffType {
   String toValue() {
     switch (this) {
       case SchemaDiffType.syntaxDiff:
@@ -19231,7 +19232,7 @@ enum SchemaStatus {
   deleting,
 }
 
-extension SchemaStatusValue on SchemaStatus {
+extension SchemaStatusValueExtension on SchemaStatus {
   String toValue() {
     switch (this) {
       case SchemaStatus.available:
@@ -19345,7 +19346,7 @@ enum SchemaVersionStatus {
   deleting,
 }
 
-extension SchemaVersionStatusValue on SchemaVersionStatus {
+extension SchemaVersionStatusValueExtension on SchemaVersionStatus {
   String toValue() {
     switch (this) {
       case SchemaVersionStatus.available:
@@ -19543,7 +19544,7 @@ enum Sort {
   desc,
 }
 
-extension SortValue on Sort {
+extension SortValueExtension on Sort {
   String toValue() {
     switch (this) {
       case Sort.asc:
@@ -19593,7 +19594,7 @@ enum SortDirectionType {
   ascending,
 }
 
-extension SortDirectionTypeValue on SortDirectionType {
+extension SortDirectionTypeValueExtension on SortDirectionType {
   String toValue() {
     switch (this) {
       case SortDirectionType.descending:
@@ -20452,7 +20453,7 @@ enum TaskRunSortColumnType {
   started,
 }
 
-extension TaskRunSortColumnTypeValue on TaskRunSortColumnType {
+extension TaskRunSortColumnTypeValueExtension on TaskRunSortColumnType {
   String toValue() {
     switch (this) {
       case TaskRunSortColumnType.taskRunType:
@@ -20514,7 +20515,7 @@ enum TaskStatusType {
   timeout,
 }
 
-extension TaskStatusTypeValue on TaskStatusType {
+extension TaskStatusTypeValueExtension on TaskStatusType {
   String toValue() {
     switch (this) {
       case TaskStatusType.starting:
@@ -20565,7 +20566,7 @@ enum TaskType {
   findMatches,
 }
 
-extension TaskTypeValue on TaskType {
+extension TaskTypeValueExtension on TaskType {
   String toValue() {
     switch (this) {
       case TaskType.evaluation:
@@ -20769,7 +20770,7 @@ enum TransformSortColumnType {
   lastModified,
 }
 
-extension TransformSortColumnTypeValue on TransformSortColumnType {
+extension TransformSortColumnTypeValueExtension on TransformSortColumnType {
   String toValue() {
     switch (this) {
       case TransformSortColumnType.name:
@@ -20835,7 +20836,7 @@ enum TransformStatusType {
   deleting,
 }
 
-extension TransformStatusTypeValue on TransformStatusType {
+extension TransformStatusTypeValueExtension on TransformStatusType {
   String toValue() {
     switch (this) {
       case TransformStatusType.notReady:
@@ -20866,7 +20867,7 @@ enum TransformType {
   findMatches,
 }
 
-extension TransformTypeValue on TransformType {
+extension TransformTypeValueExtension on TransformType {
   String toValue() {
     switch (this) {
       case TransformType.findMatches:
@@ -20976,7 +20977,7 @@ enum TriggerState {
   updating,
 }
 
-extension TriggerStateValue on TriggerState {
+extension TriggerStateValueExtension on TriggerState {
   String toValue() {
     switch (this) {
       case TriggerState.creating:
@@ -21029,7 +21030,7 @@ enum TriggerType {
   onDemand,
 }
 
-extension TriggerTypeValue on TriggerType {
+extension TriggerTypeValueExtension on TriggerType {
   String toValue() {
     switch (this) {
       case TriggerType.scheduled:
@@ -21112,7 +21113,7 @@ enum UpdateBehavior {
   updateInDatabase,
 }
 
-extension UpdateBehaviorValue on UpdateBehavior {
+extension UpdateBehaviorValueExtension on UpdateBehavior {
   String toValue() {
     switch (this) {
       case UpdateBehavior.log:
@@ -21584,7 +21585,7 @@ enum WorkerType {
   g_2x,
 }
 
-extension WorkerTypeValue on WorkerType {
+extension WorkerTypeValueExtension on WorkerType {
   String toValue() {
     switch (this) {
       case WorkerType.standard:
@@ -21822,7 +21823,7 @@ enum WorkflowRunStatus {
   error,
 }
 
-extension WorkflowRunStatusValue on WorkflowRunStatus {
+extension WorkflowRunStatusValueExtension on WorkflowRunStatus {
   String toValue() {
     switch (this) {
       case WorkflowRunStatus.running:

--- a/generated/aws_glue_api/lib/glue-2017-03-31.dart
+++ b/generated/aws_glue_api/lib/glue-2017-03-31.dart
@@ -9936,7 +9936,7 @@ enum BackfillErrorCode {
   unsupportedPartitionCharacterError,
 }
 
-extension on BackfillErrorCode {
+extension BackfillErrorCodeValue on BackfillErrorCode {
   String toValue() {
     switch (this) {
       case BackfillErrorCode.encryptedPartitionError:
@@ -9953,7 +9953,7 @@ extension on BackfillErrorCode {
   }
 }
 
-extension on String {
+extension BackfillErrorCodeFromString on String {
   BackfillErrorCode toBackfillErrorCode() {
     switch (this) {
       case 'ENCRYPTED_PARTITION_ERROR':
@@ -10460,7 +10460,7 @@ enum CatalogEncryptionMode {
   sseKms,
 }
 
-extension on CatalogEncryptionMode {
+extension CatalogEncryptionModeValue on CatalogEncryptionMode {
   String toValue() {
     switch (this) {
       case CatalogEncryptionMode.disabled:
@@ -10471,7 +10471,7 @@ extension on CatalogEncryptionMode {
   }
 }
 
-extension on String {
+extension CatalogEncryptionModeFromString on String {
   CatalogEncryptionMode toCatalogEncryptionMode() {
     switch (this) {
       case 'DISABLED':
@@ -10672,7 +10672,7 @@ enum CloudWatchEncryptionMode {
   sseKms,
 }
 
-extension on CloudWatchEncryptionMode {
+extension CloudWatchEncryptionModeValue on CloudWatchEncryptionMode {
   String toValue() {
     switch (this) {
       case CloudWatchEncryptionMode.disabled:
@@ -10683,7 +10683,7 @@ extension on CloudWatchEncryptionMode {
   }
 }
 
-extension on String {
+extension CloudWatchEncryptionModeFromString on String {
   CloudWatchEncryptionMode toCloudWatchEncryptionMode() {
     switch (this) {
       case 'DISABLED':
@@ -11085,7 +11085,7 @@ enum ColumnStatisticsType {
   binary,
 }
 
-extension on ColumnStatisticsType {
+extension ColumnStatisticsTypeValue on ColumnStatisticsType {
   String toValue() {
     switch (this) {
       case ColumnStatisticsType.boolean:
@@ -11106,7 +11106,7 @@ extension on ColumnStatisticsType {
   }
 }
 
-extension on String {
+extension ColumnStatisticsTypeFromString on String {
   ColumnStatisticsType toColumnStatisticsType() {
     switch (this) {
       case 'BOOLEAN':
@@ -11136,7 +11136,7 @@ enum Comparator {
   lessThanEquals,
 }
 
-extension on Comparator {
+extension ComparatorValue on Comparator {
   String toValue() {
     switch (this) {
       case Comparator.equals:
@@ -11153,7 +11153,7 @@ extension on Comparator {
   }
 }
 
-extension on String {
+extension ComparatorFromString on String {
   Comparator toComparator() {
     switch (this) {
       case 'EQUALS':
@@ -11182,7 +11182,7 @@ enum Compatibility {
   fullAll,
 }
 
-extension on Compatibility {
+extension CompatibilityValue on Compatibility {
   String toValue() {
     switch (this) {
       case Compatibility.none:
@@ -11205,7 +11205,7 @@ extension on Compatibility {
   }
 }
 
-extension on String {
+extension CompatibilityFromString on String {
   Compatibility toCompatibility() {
     switch (this) {
       case 'NONE':
@@ -11667,7 +11667,7 @@ enum ConnectionPropertyKey {
   connectorClassName,
 }
 
-extension on ConnectionPropertyKey {
+extension ConnectionPropertyKeyValue on ConnectionPropertyKey {
   String toValue() {
     switch (this) {
       case ConnectionPropertyKey.host:
@@ -11724,7 +11724,7 @@ extension on ConnectionPropertyKey {
   }
 }
 
-extension on String {
+extension ConnectionPropertyKeyFromString on String {
   ConnectionPropertyKey toConnectionPropertyKey() {
     switch (this) {
       case 'HOST':
@@ -11792,7 +11792,7 @@ enum ConnectionType {
   custom,
 }
 
-extension on ConnectionType {
+extension ConnectionTypeValue on ConnectionType {
   String toValue() {
     switch (this) {
       case ConnectionType.jdbc:
@@ -11813,7 +11813,7 @@ extension on ConnectionType {
   }
 }
 
-extension on String {
+extension ConnectionTypeFromString on String {
   ConnectionType toConnectionType() {
     switch (this) {
       case 'JDBC':
@@ -11908,7 +11908,7 @@ enum CrawlState {
   failed,
 }
 
-extension on CrawlState {
+extension CrawlStateValue on CrawlState {
   String toValue() {
     switch (this) {
       case CrawlState.running:
@@ -11925,7 +11925,7 @@ extension on CrawlState {
   }
 }
 
-extension on String {
+extension CrawlStateFromString on String {
   CrawlState toCrawlState() {
     switch (this) {
       case 'RUNNING':
@@ -12084,7 +12084,7 @@ enum CrawlerLineageSettings {
   disable,
 }
 
-extension on CrawlerLineageSettings {
+extension CrawlerLineageSettingsValue on CrawlerLineageSettings {
   String toValue() {
     switch (this) {
       case CrawlerLineageSettings.enable:
@@ -12095,7 +12095,7 @@ extension on CrawlerLineageSettings {
   }
 }
 
-extension on String {
+extension CrawlerLineageSettingsFromString on String {
   CrawlerLineageSettings toCrawlerLineageSettings() {
     switch (this) {
       case 'ENABLE':
@@ -12182,7 +12182,7 @@ enum CrawlerState {
   stopping,
 }
 
-extension on CrawlerState {
+extension CrawlerStateValue on CrawlerState {
   String toValue() {
     switch (this) {
       case CrawlerState.ready:
@@ -12195,7 +12195,7 @@ extension on CrawlerState {
   }
 }
 
-extension on String {
+extension CrawlerStateFromString on String {
   CrawlerState toCrawlerState() {
     switch (this) {
       case 'READY':
@@ -12898,7 +12898,7 @@ enum CsvHeaderOption {
   absent,
 }
 
-extension on CsvHeaderOption {
+extension CsvHeaderOptionValue on CsvHeaderOption {
   String toValue() {
     switch (this) {
       case CsvHeaderOption.unknown:
@@ -12911,7 +12911,7 @@ extension on CsvHeaderOption {
   }
 }
 
-extension on String {
+extension CsvHeaderOptionFromString on String {
   CsvHeaderOption toCsvHeaderOption() {
     switch (this) {
       case 'UNKNOWN':
@@ -12969,7 +12969,7 @@ enum DataFormat {
   avro,
 }
 
-extension on DataFormat {
+extension DataFormatValue on DataFormat {
   String toValue() {
     switch (this) {
       case DataFormat.avro:
@@ -12978,7 +12978,7 @@ extension on DataFormat {
   }
 }
 
-extension on String {
+extension DataFormatFromString on String {
   DataFormat toDataFormat() {
     switch (this) {
       case 'AVRO':
@@ -13281,7 +13281,7 @@ enum DeleteBehavior {
   deprecateInDatabase,
 }
 
-extension on DeleteBehavior {
+extension DeleteBehaviorValue on DeleteBehavior {
   String toValue() {
     switch (this) {
       case DeleteBehavior.log:
@@ -13294,7 +13294,7 @@ extension on DeleteBehavior {
   }
 }
 
-extension on String {
+extension DeleteBehaviorFromString on String {
   DeleteBehavior toDeleteBehavior() {
     switch (this) {
       case 'LOG':
@@ -13923,7 +13923,7 @@ enum EnableHybridValues {
   $false,
 }
 
-extension on EnableHybridValues {
+extension EnableHybridValuesValue on EnableHybridValues {
   String toValue() {
     switch (this) {
       case EnableHybridValues.$true:
@@ -13934,7 +13934,7 @@ extension on EnableHybridValues {
   }
 }
 
-extension on String {
+extension EnableHybridValuesFromString on String {
   EnableHybridValues toEnableHybridValues() {
     switch (this) {
       case 'TRUE':
@@ -14118,7 +14118,7 @@ enum ExistCondition {
   none,
 }
 
-extension on ExistCondition {
+extension ExistConditionValue on ExistCondition {
   String toValue() {
     switch (this) {
       case ExistCondition.mustExist:
@@ -14131,7 +14131,7 @@ extension on ExistCondition {
   }
 }
 
-extension on String {
+extension ExistConditionFromString on String {
   ExistCondition toExistCondition() {
     switch (this) {
       case 'MUST_EXIST':
@@ -16186,7 +16186,7 @@ enum JobBookmarksEncryptionMode {
   cseKms,
 }
 
-extension on JobBookmarksEncryptionMode {
+extension JobBookmarksEncryptionModeValue on JobBookmarksEncryptionMode {
   String toValue() {
     switch (this) {
       case JobBookmarksEncryptionMode.disabled:
@@ -16197,7 +16197,7 @@ extension on JobBookmarksEncryptionMode {
   }
 }
 
-extension on String {
+extension JobBookmarksEncryptionModeFromString on String {
   JobBookmarksEncryptionMode toJobBookmarksEncryptionMode() {
     switch (this) {
       case 'DISABLED':
@@ -16493,7 +16493,7 @@ enum JobRunState {
   timeout,
 }
 
-extension on JobRunState {
+extension JobRunStateValue on JobRunState {
   String toValue() {
     switch (this) {
       case JobRunState.starting:
@@ -16514,7 +16514,7 @@ extension on JobRunState {
   }
 }
 
-extension on String {
+extension JobRunStateFromString on String {
   JobRunState toJobRunState() {
     switch (this) {
       case 'STARTING':
@@ -16810,7 +16810,7 @@ enum Language {
   scala,
 }
 
-extension on Language {
+extension LanguageValue on Language {
   String toValue() {
     switch (this) {
       case Language.python:
@@ -16821,7 +16821,7 @@ extension on Language {
   }
 }
 
-extension on String {
+extension LanguageFromString on String {
   Language toLanguage() {
     switch (this) {
       case 'PYTHON':
@@ -16879,7 +16879,7 @@ enum LastCrawlStatus {
   failed,
 }
 
-extension on LastCrawlStatus {
+extension LastCrawlStatusValue on LastCrawlStatus {
   String toValue() {
     switch (this) {
       case LastCrawlStatus.succeeded:
@@ -16892,7 +16892,7 @@ extension on LastCrawlStatus {
   }
 }
 
-extension on String {
+extension LastCrawlStatusFromString on String {
   LastCrawlStatus toLastCrawlStatus() {
     switch (this) {
       case 'SUCCEEDED':
@@ -17185,7 +17185,7 @@ enum Logical {
   any,
 }
 
-extension on Logical {
+extension LogicalValue on Logical {
   String toValue() {
     switch (this) {
       case Logical.and:
@@ -17196,7 +17196,7 @@ extension on Logical {
   }
 }
 
-extension on String {
+extension LogicalFromString on String {
   Logical toLogical() {
     switch (this) {
       case 'AND':
@@ -17212,7 +17212,7 @@ enum LogicalOperator {
   equals,
 }
 
-extension on LogicalOperator {
+extension LogicalOperatorValue on LogicalOperator {
   String toValue() {
     switch (this) {
       case LogicalOperator.equals:
@@ -17221,7 +17221,7 @@ extension on LogicalOperator {
   }
 }
 
-extension on String {
+extension LogicalOperatorFromString on String {
   LogicalOperator toLogicalOperator() {
     switch (this) {
       case 'EQUALS':
@@ -17549,7 +17549,8 @@ enum MLUserDataEncryptionModeString {
   sseKms,
 }
 
-extension on MLUserDataEncryptionModeString {
+extension MLUserDataEncryptionModeStringValue
+    on MLUserDataEncryptionModeString {
   String toValue() {
     switch (this) {
       case MLUserDataEncryptionModeString.disabled:
@@ -17560,7 +17561,7 @@ extension on MLUserDataEncryptionModeString {
   }
 }
 
-extension on String {
+extension MLUserDataEncryptionModeStringFromString on String {
   MLUserDataEncryptionModeString toMLUserDataEncryptionModeString() {
     switch (this) {
       case 'DISABLED':
@@ -17770,7 +17771,7 @@ enum NodeType {
   trigger,
 }
 
-extension on NodeType {
+extension NodeTypeValue on NodeType {
   String toValue() {
     switch (this) {
       case NodeType.crawler:
@@ -17783,7 +17784,7 @@ extension on NodeType {
   }
 }
 
-extension on String {
+extension NodeTypeFromString on String {
   NodeType toNodeType() {
     switch (this) {
       case 'CRAWLER':
@@ -18023,7 +18024,7 @@ enum PartitionIndexStatus {
   failed,
 }
 
-extension on PartitionIndexStatus {
+extension PartitionIndexStatusValue on PartitionIndexStatus {
   String toValue() {
     switch (this) {
       case PartitionIndexStatus.creating:
@@ -18038,7 +18039,7 @@ extension on PartitionIndexStatus {
   }
 }
 
-extension on String {
+extension PartitionIndexStatusFromString on String {
   PartitionIndexStatus toPartitionIndexStatus() {
     switch (this) {
       case 'CREATING':
@@ -18140,7 +18141,7 @@ enum Permission {
   dataLocationAccess,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.all:
@@ -18165,7 +18166,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'ALL':
@@ -18329,7 +18330,7 @@ enum PrincipalType {
   group,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -18342,7 +18343,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'USER':
@@ -18496,7 +18497,7 @@ enum RecrawlBehavior {
   crawlNewFoldersOnly,
 }
 
-extension on RecrawlBehavior {
+extension RecrawlBehaviorValue on RecrawlBehavior {
   String toValue() {
     switch (this) {
       case RecrawlBehavior.crawlEverything:
@@ -18507,7 +18508,7 @@ extension on RecrawlBehavior {
   }
 }
 
-extension on String {
+extension RecrawlBehaviorFromString on String {
   RecrawlBehavior toRecrawlBehavior() {
     switch (this) {
       case 'CRAWL_EVERYTHING':
@@ -18648,7 +18649,7 @@ enum RegistryStatus {
   deleting,
 }
 
-extension on RegistryStatus {
+extension RegistryStatusValue on RegistryStatus {
   String toValue() {
     switch (this) {
       case RegistryStatus.available:
@@ -18659,7 +18660,7 @@ extension on RegistryStatus {
   }
 }
 
-extension on String {
+extension RegistryStatusFromString on String {
   RegistryStatus toRegistryStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -18743,7 +18744,7 @@ enum ResourceShareType {
   all,
 }
 
-extension on ResourceShareType {
+extension ResourceShareTypeValue on ResourceShareType {
   String toValue() {
     switch (this) {
       case ResourceShareType.foreign:
@@ -18754,7 +18755,7 @@ extension on ResourceShareType {
   }
 }
 
-extension on String {
+extension ResourceShareTypeFromString on String {
   ResourceShareType toResourceShareType() {
     switch (this) {
       case 'FOREIGN':
@@ -18772,7 +18773,7 @@ enum ResourceType {
   archive,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.jar:
@@ -18785,7 +18786,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'JAR':
@@ -18890,7 +18891,7 @@ enum S3EncryptionMode {
   sseS3,
 }
 
-extension on S3EncryptionMode {
+extension S3EncryptionModeValue on S3EncryptionMode {
   String toValue() {
     switch (this) {
       case S3EncryptionMode.disabled:
@@ -18903,7 +18904,7 @@ extension on S3EncryptionMode {
   }
 }
 
-extension on String {
+extension S3EncryptionModeFromString on String {
   S3EncryptionMode toS3EncryptionMode() {
     switch (this) {
       case 'DISABLED':
@@ -18990,7 +18991,7 @@ enum ScheduleState {
   transitioning,
 }
 
-extension on ScheduleState {
+extension ScheduleStateValue on ScheduleState {
   String toValue() {
     switch (this) {
       case ScheduleState.scheduled:
@@ -19003,7 +19004,7 @@ extension on ScheduleState {
   }
 }
 
-extension on String {
+extension ScheduleStateFromString on String {
   ScheduleState toScheduleState() {
     switch (this) {
       case 'SCHEDULED':
@@ -19081,7 +19082,7 @@ enum SchemaDiffType {
   syntaxDiff,
 }
 
-extension on SchemaDiffType {
+extension SchemaDiffTypeValue on SchemaDiffType {
   String toValue() {
     switch (this) {
       case SchemaDiffType.syntaxDiff:
@@ -19090,7 +19091,7 @@ extension on SchemaDiffType {
   }
 }
 
-extension on String {
+extension SchemaDiffTypeFromString on String {
   SchemaDiffType toSchemaDiffType() {
     switch (this) {
       case 'SYNTAX_DIFF':
@@ -19230,7 +19231,7 @@ enum SchemaStatus {
   deleting,
 }
 
-extension on SchemaStatus {
+extension SchemaStatusValue on SchemaStatus {
   String toValue() {
     switch (this) {
       case SchemaStatus.available:
@@ -19243,7 +19244,7 @@ extension on SchemaStatus {
   }
 }
 
-extension on String {
+extension SchemaStatusFromString on String {
   SchemaStatus toSchemaStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -19344,7 +19345,7 @@ enum SchemaVersionStatus {
   deleting,
 }
 
-extension on SchemaVersionStatus {
+extension SchemaVersionStatusValue on SchemaVersionStatus {
   String toValue() {
     switch (this) {
       case SchemaVersionStatus.available:
@@ -19359,7 +19360,7 @@ extension on SchemaVersionStatus {
   }
 }
 
-extension on String {
+extension SchemaVersionStatusFromString on String {
   SchemaVersionStatus toSchemaVersionStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -19542,7 +19543,7 @@ enum Sort {
   desc,
 }
 
-extension on Sort {
+extension SortValue on Sort {
   String toValue() {
     switch (this) {
       case Sort.asc:
@@ -19553,7 +19554,7 @@ extension on Sort {
   }
 }
 
-extension on String {
+extension SortFromString on String {
   Sort toSort() {
     switch (this) {
       case 'ASC':
@@ -19592,7 +19593,7 @@ enum SortDirectionType {
   ascending,
 }
 
-extension on SortDirectionType {
+extension SortDirectionTypeValue on SortDirectionType {
   String toValue() {
     switch (this) {
       case SortDirectionType.descending:
@@ -19603,7 +19604,7 @@ extension on SortDirectionType {
   }
 }
 
-extension on String {
+extension SortDirectionTypeFromString on String {
   SortDirectionType toSortDirectionType() {
     switch (this) {
       case 'DESCENDING':
@@ -20451,7 +20452,7 @@ enum TaskRunSortColumnType {
   started,
 }
 
-extension on TaskRunSortColumnType {
+extension TaskRunSortColumnTypeValue on TaskRunSortColumnType {
   String toValue() {
     switch (this) {
       case TaskRunSortColumnType.taskRunType:
@@ -20464,7 +20465,7 @@ extension on TaskRunSortColumnType {
   }
 }
 
-extension on String {
+extension TaskRunSortColumnTypeFromString on String {
   TaskRunSortColumnType toTaskRunSortColumnType() {
     switch (this) {
       case 'TASK_RUN_TYPE':
@@ -20513,7 +20514,7 @@ enum TaskStatusType {
   timeout,
 }
 
-extension on TaskStatusType {
+extension TaskStatusTypeValue on TaskStatusType {
   String toValue() {
     switch (this) {
       case TaskStatusType.starting:
@@ -20534,7 +20535,7 @@ extension on TaskStatusType {
   }
 }
 
-extension on String {
+extension TaskStatusTypeFromString on String {
   TaskStatusType toTaskStatusType() {
     switch (this) {
       case 'STARTING':
@@ -20564,7 +20565,7 @@ enum TaskType {
   findMatches,
 }
 
-extension on TaskType {
+extension TaskTypeValue on TaskType {
   String toValue() {
     switch (this) {
       case TaskType.evaluation:
@@ -20581,7 +20582,7 @@ extension on TaskType {
   }
 }
 
-extension on String {
+extension TaskTypeFromString on String {
   TaskType toTaskType() {
     switch (this) {
       case 'EVALUATION':
@@ -20768,7 +20769,7 @@ enum TransformSortColumnType {
   lastModified,
 }
 
-extension on TransformSortColumnType {
+extension TransformSortColumnTypeValue on TransformSortColumnType {
   String toValue() {
     switch (this) {
       case TransformSortColumnType.name:
@@ -20785,7 +20786,7 @@ extension on TransformSortColumnType {
   }
 }
 
-extension on String {
+extension TransformSortColumnTypeFromString on String {
   TransformSortColumnType toTransformSortColumnType() {
     switch (this) {
       case 'NAME':
@@ -20834,7 +20835,7 @@ enum TransformStatusType {
   deleting,
 }
 
-extension on TransformStatusType {
+extension TransformStatusTypeValue on TransformStatusType {
   String toValue() {
     switch (this) {
       case TransformStatusType.notReady:
@@ -20847,7 +20848,7 @@ extension on TransformStatusType {
   }
 }
 
-extension on String {
+extension TransformStatusTypeFromString on String {
   TransformStatusType toTransformStatusType() {
     switch (this) {
       case 'NOT_READY':
@@ -20865,7 +20866,7 @@ enum TransformType {
   findMatches,
 }
 
-extension on TransformType {
+extension TransformTypeValue on TransformType {
   String toValue() {
     switch (this) {
       case TransformType.findMatches:
@@ -20874,7 +20875,7 @@ extension on TransformType {
   }
 }
 
-extension on String {
+extension TransformTypeFromString on String {
   TransformType toTransformType() {
     switch (this) {
       case 'FIND_MATCHES':
@@ -20975,7 +20976,7 @@ enum TriggerState {
   updating,
 }
 
-extension on TriggerState {
+extension TriggerStateValue on TriggerState {
   String toValue() {
     switch (this) {
       case TriggerState.creating:
@@ -20998,7 +20999,7 @@ extension on TriggerState {
   }
 }
 
-extension on String {
+extension TriggerStateFromString on String {
   TriggerState toTriggerState() {
     switch (this) {
       case 'CREATING':
@@ -21028,7 +21029,7 @@ enum TriggerType {
   onDemand,
 }
 
-extension on TriggerType {
+extension TriggerTypeValue on TriggerType {
   String toValue() {
     switch (this) {
       case TriggerType.scheduled:
@@ -21041,7 +21042,7 @@ extension on TriggerType {
   }
 }
 
-extension on String {
+extension TriggerTypeFromString on String {
   TriggerType toTriggerType() {
     switch (this) {
       case 'SCHEDULED':
@@ -21111,7 +21112,7 @@ enum UpdateBehavior {
   updateInDatabase,
 }
 
-extension on UpdateBehavior {
+extension UpdateBehaviorValue on UpdateBehavior {
   String toValue() {
     switch (this) {
       case UpdateBehavior.log:
@@ -21122,7 +21123,7 @@ extension on UpdateBehavior {
   }
 }
 
-extension on String {
+extension UpdateBehaviorFromString on String {
   UpdateBehavior toUpdateBehavior() {
     switch (this) {
       case 'LOG':
@@ -21583,7 +21584,7 @@ enum WorkerType {
   g_2x,
 }
 
-extension on WorkerType {
+extension WorkerTypeValue on WorkerType {
   String toValue() {
     switch (this) {
       case WorkerType.standard:
@@ -21596,7 +21597,7 @@ extension on WorkerType {
   }
 }
 
-extension on String {
+extension WorkerTypeFromString on String {
   WorkerType toWorkerType() {
     switch (this) {
       case 'Standard':
@@ -21821,7 +21822,7 @@ enum WorkflowRunStatus {
   error,
 }
 
-extension on WorkflowRunStatus {
+extension WorkflowRunStatusValue on WorkflowRunStatus {
   String toValue() {
     switch (this) {
       case WorkflowRunStatus.running:
@@ -21838,7 +21839,7 @@ extension on WorkflowRunStatus {
   }
 }
 
-extension on String {
+extension WorkflowRunStatusFromString on String {
   WorkflowRunStatus toWorkflowRunStatus() {
     switch (this) {
       case 'RUNNING':

--- a/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
+++ b/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
@@ -2985,7 +2985,7 @@ enum BulkDeploymentStatus {
   failed,
 }
 
-extension BulkDeploymentStatusValue on BulkDeploymentStatus {
+extension BulkDeploymentStatusValueExtension on BulkDeploymentStatus {
   String toValue() {
     switch (this) {
       case BulkDeploymentStatus.initializing:
@@ -3029,7 +3029,7 @@ enum ConfigurationSyncStatus {
   outOfSync,
 }
 
-extension ConfigurationSyncStatusValue on ConfigurationSyncStatus {
+extension ConfigurationSyncStatusValueExtension on ConfigurationSyncStatus {
   String toValue() {
     switch (this) {
       case ConfigurationSyncStatus.inSync:
@@ -4046,7 +4046,7 @@ enum DeploymentType {
   forceResetDeployment,
 }
 
-extension DeploymentTypeValue on DeploymentType {
+extension DeploymentTypeValueExtension on DeploymentType {
   String toValue() {
     switch (this) {
       case DeploymentType.newDeployment:
@@ -4184,7 +4184,7 @@ enum EncodingType {
   json,
 }
 
-extension EncodingTypeValue on EncodingType {
+extension EncodingTypeValueExtension on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.binary:
@@ -4529,7 +4529,7 @@ enum FunctionIsolationMode {
   noContainer,
 }
 
-extension FunctionIsolationModeValue on FunctionIsolationMode {
+extension FunctionIsolationModeValueExtension on FunctionIsolationMode {
   String toValue() {
     switch (this) {
       case FunctionIsolationMode.greengrassContainer:
@@ -6344,7 +6344,7 @@ enum LoggerComponent {
   lambda,
 }
 
-extension LoggerComponentValue on LoggerComponent {
+extension LoggerComponentValueExtension on LoggerComponent {
   String toValue() {
     switch (this) {
       case LoggerComponent.greengrassSystem:
@@ -6400,7 +6400,7 @@ enum LoggerLevel {
   fatal,
 }
 
-extension LoggerLevelValue on LoggerLevel {
+extension LoggerLevelValueExtension on LoggerLevel {
   String toValue() {
     switch (this) {
       case LoggerLevel.debug:
@@ -6440,7 +6440,7 @@ enum LoggerType {
   awsCloudWatch,
 }
 
-extension LoggerTypeValue on LoggerType {
+extension LoggerTypeValueExtension on LoggerType {
   String toValue() {
     switch (this) {
       case LoggerType.fileSystem:
@@ -6469,7 +6469,7 @@ enum Permission {
   rw,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.ro:
@@ -6870,7 +6870,7 @@ enum SoftwareToUpdate {
   otaAgent,
 }
 
-extension SoftwareToUpdateValue on SoftwareToUpdate {
+extension SoftwareToUpdateValueExtension on SoftwareToUpdate {
   String toValue() {
     switch (this) {
       case SoftwareToUpdate.core:
@@ -6998,7 +6998,7 @@ enum Telemetry {
   off,
 }
 
-extension TelemetryValue on Telemetry {
+extension TelemetryValueExtension on Telemetry {
   String toValue() {
     switch (this) {
       case Telemetry.on:
@@ -7072,7 +7072,7 @@ enum UpdateAgentLogLevel {
   fatal,
 }
 
-extension UpdateAgentLogLevelValue on UpdateAgentLogLevel {
+extension UpdateAgentLogLevelValueExtension on UpdateAgentLogLevel {
   String toValue() {
     switch (this) {
       case UpdateAgentLogLevel.none:
@@ -7232,7 +7232,7 @@ enum UpdateTargetsArchitecture {
   aarch64,
 }
 
-extension UpdateTargetsArchitectureValue on UpdateTargetsArchitecture {
+extension UpdateTargetsArchitectureValueExtension on UpdateTargetsArchitecture {
   String toValue() {
     switch (this) {
       case UpdateTargetsArchitecture.armv6l:
@@ -7271,7 +7271,8 @@ enum UpdateTargetsOperatingSystem {
   openwrt,
 }
 
-extension UpdateTargetsOperatingSystemValue on UpdateTargetsOperatingSystem {
+extension UpdateTargetsOperatingSystemValueExtension
+    on UpdateTargetsOperatingSystem {
   String toValue() {
     switch (this) {
       case UpdateTargetsOperatingSystem.ubuntu:

--- a/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
+++ b/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
@@ -2985,7 +2985,7 @@ enum BulkDeploymentStatus {
   failed,
 }
 
-extension on BulkDeploymentStatus {
+extension BulkDeploymentStatusValue on BulkDeploymentStatus {
   String toValue() {
     switch (this) {
       case BulkDeploymentStatus.initializing:
@@ -3004,7 +3004,7 @@ extension on BulkDeploymentStatus {
   }
 }
 
-extension on String {
+extension BulkDeploymentStatusFromString on String {
   BulkDeploymentStatus toBulkDeploymentStatus() {
     switch (this) {
       case 'Initializing':
@@ -3029,7 +3029,7 @@ enum ConfigurationSyncStatus {
   outOfSync,
 }
 
-extension on ConfigurationSyncStatus {
+extension ConfigurationSyncStatusValue on ConfigurationSyncStatus {
   String toValue() {
     switch (this) {
       case ConfigurationSyncStatus.inSync:
@@ -3040,7 +3040,7 @@ extension on ConfigurationSyncStatus {
   }
 }
 
-extension on String {
+extension ConfigurationSyncStatusFromString on String {
   ConfigurationSyncStatus toConfigurationSyncStatus() {
     switch (this) {
       case 'InSync':
@@ -4046,7 +4046,7 @@ enum DeploymentType {
   forceResetDeployment,
 }
 
-extension on DeploymentType {
+extension DeploymentTypeValue on DeploymentType {
   String toValue() {
     switch (this) {
       case DeploymentType.newDeployment:
@@ -4061,7 +4061,7 @@ extension on DeploymentType {
   }
 }
 
-extension on String {
+extension DeploymentTypeFromString on String {
   DeploymentType toDeploymentType() {
     switch (this) {
       case 'NewDeployment':
@@ -4184,7 +4184,7 @@ enum EncodingType {
   json,
 }
 
-extension on EncodingType {
+extension EncodingTypeValue on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.binary:
@@ -4195,7 +4195,7 @@ extension on EncodingType {
   }
 }
 
-extension on String {
+extension EncodingTypeFromString on String {
   EncodingType toEncodingType() {
     switch (this) {
       case 'binary':
@@ -4529,7 +4529,7 @@ enum FunctionIsolationMode {
   noContainer,
 }
 
-extension on FunctionIsolationMode {
+extension FunctionIsolationModeValue on FunctionIsolationMode {
   String toValue() {
     switch (this) {
       case FunctionIsolationMode.greengrassContainer:
@@ -4540,7 +4540,7 @@ extension on FunctionIsolationMode {
   }
 }
 
-extension on String {
+extension FunctionIsolationModeFromString on String {
   FunctionIsolationMode toFunctionIsolationMode() {
     switch (this) {
       case 'GreengrassContainer':
@@ -6344,7 +6344,7 @@ enum LoggerComponent {
   lambda,
 }
 
-extension on LoggerComponent {
+extension LoggerComponentValue on LoggerComponent {
   String toValue() {
     switch (this) {
       case LoggerComponent.greengrassSystem:
@@ -6355,7 +6355,7 @@ extension on LoggerComponent {
   }
 }
 
-extension on String {
+extension LoggerComponentFromString on String {
   LoggerComponent toLoggerComponent() {
     switch (this) {
       case 'GreengrassSystem':
@@ -6400,7 +6400,7 @@ enum LoggerLevel {
   fatal,
 }
 
-extension on LoggerLevel {
+extension LoggerLevelValue on LoggerLevel {
   String toValue() {
     switch (this) {
       case LoggerLevel.debug:
@@ -6417,7 +6417,7 @@ extension on LoggerLevel {
   }
 }
 
-extension on String {
+extension LoggerLevelFromString on String {
   LoggerLevel toLoggerLevel() {
     switch (this) {
       case 'DEBUG':
@@ -6440,7 +6440,7 @@ enum LoggerType {
   awsCloudWatch,
 }
 
-extension on LoggerType {
+extension LoggerTypeValue on LoggerType {
   String toValue() {
     switch (this) {
       case LoggerType.fileSystem:
@@ -6451,7 +6451,7 @@ extension on LoggerType {
   }
 }
 
-extension on String {
+extension LoggerTypeFromString on String {
   LoggerType toLoggerType() {
     switch (this) {
       case 'FileSystem':
@@ -6469,7 +6469,7 @@ enum Permission {
   rw,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.ro:
@@ -6480,7 +6480,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'ro':
@@ -6870,7 +6870,7 @@ enum SoftwareToUpdate {
   otaAgent,
 }
 
-extension on SoftwareToUpdate {
+extension SoftwareToUpdateValue on SoftwareToUpdate {
   String toValue() {
     switch (this) {
       case SoftwareToUpdate.core:
@@ -6881,7 +6881,7 @@ extension on SoftwareToUpdate {
   }
 }
 
-extension on String {
+extension SoftwareToUpdateFromString on String {
   SoftwareToUpdate toSoftwareToUpdate() {
     switch (this) {
       case 'core':
@@ -6998,7 +6998,7 @@ enum Telemetry {
   off,
 }
 
-extension on Telemetry {
+extension TelemetryValue on Telemetry {
   String toValue() {
     switch (this) {
       case Telemetry.on:
@@ -7009,7 +7009,7 @@ extension on Telemetry {
   }
 }
 
-extension on String {
+extension TelemetryFromString on String {
   Telemetry toTelemetry() {
     switch (this) {
       case 'On':
@@ -7072,7 +7072,7 @@ enum UpdateAgentLogLevel {
   fatal,
 }
 
-extension on UpdateAgentLogLevel {
+extension UpdateAgentLogLevelValue on UpdateAgentLogLevel {
   String toValue() {
     switch (this) {
       case UpdateAgentLogLevel.none:
@@ -7095,7 +7095,7 @@ extension on UpdateAgentLogLevel {
   }
 }
 
-extension on String {
+extension UpdateAgentLogLevelFromString on String {
   UpdateAgentLogLevel toUpdateAgentLogLevel() {
     switch (this) {
       case 'NONE':
@@ -7232,7 +7232,7 @@ enum UpdateTargetsArchitecture {
   aarch64,
 }
 
-extension on UpdateTargetsArchitecture {
+extension UpdateTargetsArchitectureValue on UpdateTargetsArchitecture {
   String toValue() {
     switch (this) {
       case UpdateTargetsArchitecture.armv6l:
@@ -7247,7 +7247,7 @@ extension on UpdateTargetsArchitecture {
   }
 }
 
-extension on String {
+extension UpdateTargetsArchitectureFromString on String {
   UpdateTargetsArchitecture toUpdateTargetsArchitecture() {
     switch (this) {
       case 'armv6l':
@@ -7271,7 +7271,7 @@ enum UpdateTargetsOperatingSystem {
   openwrt,
 }
 
-extension on UpdateTargetsOperatingSystem {
+extension UpdateTargetsOperatingSystemValue on UpdateTargetsOperatingSystem {
   String toValue() {
     switch (this) {
       case UpdateTargetsOperatingSystem.ubuntu:
@@ -7286,7 +7286,7 @@ extension on UpdateTargetsOperatingSystem {
   }
 }
 
-extension on String {
+extension UpdateTargetsOperatingSystemFromString on String {
   UpdateTargetsOperatingSystem toUpdateTargetsOperatingSystem() {
     switch (this) {
       case 'ubuntu':

--- a/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
+++ b/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
@@ -1003,7 +1003,7 @@ enum CloudComponentState {
   deprecated,
 }
 
-extension on CloudComponentState {
+extension CloudComponentStateValue on CloudComponentState {
   String toValue() {
     switch (this) {
       case CloudComponentState.requested:
@@ -1020,7 +1020,7 @@ extension on CloudComponentState {
   }
 }
 
-extension on String {
+extension CloudComponentStateFromString on String {
   CloudComponentState toCloudComponentState() {
     switch (this) {
       case 'REQUESTED':
@@ -1228,7 +1228,7 @@ enum ComponentDependencyType {
   soft,
 }
 
-extension on ComponentDependencyType {
+extension ComponentDependencyTypeValue on ComponentDependencyType {
   String toValue() {
     switch (this) {
       case ComponentDependencyType.hard:
@@ -1239,7 +1239,7 @@ extension on ComponentDependencyType {
   }
 }
 
-extension on String {
+extension ComponentDependencyTypeFromString on String {
   ComponentDependencyType toComponentDependencyType() {
     switch (this) {
       case 'HARD':
@@ -1456,7 +1456,7 @@ enum ComponentVisibilityScope {
   public,
 }
 
-extension on ComponentVisibilityScope {
+extension ComponentVisibilityScopeValue on ComponentVisibilityScope {
   String toValue() {
     switch (this) {
       case ComponentVisibilityScope.private:
@@ -1467,7 +1467,7 @@ extension on ComponentVisibilityScope {
   }
 }
 
-extension on String {
+extension ComponentVisibilityScopeFromString on String {
   ComponentVisibilityScope toComponentVisibilityScope() {
     switch (this) {
       case 'PRIVATE':
@@ -1523,7 +1523,7 @@ enum CoreDeviceStatus {
   unhealthy,
 }
 
-extension on CoreDeviceStatus {
+extension CoreDeviceStatusValue on CoreDeviceStatus {
   String toValue() {
     switch (this) {
       case CoreDeviceStatus.healthy:
@@ -1534,7 +1534,7 @@ extension on CoreDeviceStatus {
   }
 }
 
-extension on String {
+extension CoreDeviceStatusFromString on String {
   CoreDeviceStatus toCoreDeviceStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -1731,7 +1731,8 @@ enum DeploymentComponentUpdatePolicyAction {
   skipNotifyComponents,
 }
 
-extension on DeploymentComponentUpdatePolicyAction {
+extension DeploymentComponentUpdatePolicyActionValue
+    on DeploymentComponentUpdatePolicyAction {
   String toValue() {
     switch (this) {
       case DeploymentComponentUpdatePolicyAction.notifyComponents:
@@ -1742,7 +1743,7 @@ extension on DeploymentComponentUpdatePolicyAction {
   }
 }
 
-extension on String {
+extension DeploymentComponentUpdatePolicyActionFromString on String {
   DeploymentComponentUpdatePolicyAction
       toDeploymentComponentUpdatePolicyAction() {
     switch (this) {
@@ -1797,7 +1798,8 @@ enum DeploymentFailureHandlingPolicy {
   doNothing,
 }
 
-extension on DeploymentFailureHandlingPolicy {
+extension DeploymentFailureHandlingPolicyValue
+    on DeploymentFailureHandlingPolicy {
   String toValue() {
     switch (this) {
       case DeploymentFailureHandlingPolicy.rollback:
@@ -1808,7 +1810,7 @@ extension on DeploymentFailureHandlingPolicy {
   }
 }
 
-extension on String {
+extension DeploymentFailureHandlingPolicyFromString on String {
   DeploymentFailureHandlingPolicy toDeploymentFailureHandlingPolicy() {
     switch (this) {
       case 'ROLLBACK':
@@ -1826,7 +1828,7 @@ enum DeploymentHistoryFilter {
   latestOnly,
 }
 
-extension on DeploymentHistoryFilter {
+extension DeploymentHistoryFilterValue on DeploymentHistoryFilter {
   String toValue() {
     switch (this) {
       case DeploymentHistoryFilter.all:
@@ -1837,7 +1839,7 @@ extension on DeploymentHistoryFilter {
   }
 }
 
-extension on String {
+extension DeploymentHistoryFilterFromString on String {
   DeploymentHistoryFilter toDeploymentHistoryFilter() {
     switch (this) {
       case 'ALL':
@@ -1960,7 +1962,7 @@ enum DeploymentStatus {
   inactive,
 }
 
-extension on DeploymentStatus {
+extension DeploymentStatusValue on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.active:
@@ -1977,7 +1979,7 @@ extension on DeploymentStatus {
   }
 }
 
-extension on String {
+extension DeploymentStatusFromString on String {
   DeploymentStatus toDeploymentStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -2147,7 +2149,8 @@ enum EffectiveDeploymentExecutionStatus {
   rejected,
 }
 
-extension on EffectiveDeploymentExecutionStatus {
+extension EffectiveDeploymentExecutionStatusValue
+    on EffectiveDeploymentExecutionStatus {
   String toValue() {
     switch (this) {
       case EffectiveDeploymentExecutionStatus.inProgress:
@@ -2168,7 +2171,7 @@ extension on EffectiveDeploymentExecutionStatus {
   }
 }
 
-extension on String {
+extension EffectiveDeploymentExecutionStatusFromString on String {
   EffectiveDeploymentExecutionStatus toEffectiveDeploymentExecutionStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -2453,7 +2456,8 @@ enum InstalledComponentLifecycleState {
   finished,
 }
 
-extension on InstalledComponentLifecycleState {
+extension InstalledComponentLifecycleStateValue
+    on InstalledComponentLifecycleState {
   String toValue() {
     switch (this) {
       case InstalledComponentLifecycleState.$new:
@@ -2476,7 +2480,7 @@ extension on InstalledComponentLifecycleState {
   }
 }
 
-extension on String {
+extension InstalledComponentLifecycleStateFromString on String {
   InstalledComponentLifecycleState toInstalledComponentLifecycleState() {
     switch (this) {
       case 'NEW':
@@ -2505,7 +2509,7 @@ enum IoTJobAbortAction {
   cancel,
 }
 
-extension on IoTJobAbortAction {
+extension IoTJobAbortActionValue on IoTJobAbortAction {
   String toValue() {
     switch (this) {
       case IoTJobAbortAction.cancel:
@@ -2514,7 +2518,7 @@ extension on IoTJobAbortAction {
   }
 }
 
-extension on String {
+extension IoTJobAbortActionFromString on String {
   IoTJobAbortAction toIoTJobAbortAction() {
     switch (this) {
       case 'CANCEL':
@@ -2619,7 +2623,7 @@ enum IoTJobExecutionFailureType {
   all,
 }
 
-extension on IoTJobExecutionFailureType {
+extension IoTJobExecutionFailureTypeValue on IoTJobExecutionFailureType {
   String toValue() {
     switch (this) {
       case IoTJobExecutionFailureType.failed:
@@ -2634,7 +2638,7 @@ extension on IoTJobExecutionFailureType {
   }
 }
 
-extension on String {
+extension IoTJobExecutionFailureTypeFromString on String {
   IoTJobExecutionFailureType toIoTJobExecutionFailureType() {
     switch (this) {
       case 'FAILED':
@@ -2907,7 +2911,7 @@ enum LambdaEventSourceType {
   iotCore,
 }
 
-extension on LambdaEventSourceType {
+extension LambdaEventSourceTypeValue on LambdaEventSourceType {
   String toValue() {
     switch (this) {
       case LambdaEventSourceType.pubSub:
@@ -2918,7 +2922,7 @@ extension on LambdaEventSourceType {
   }
 }
 
-extension on String {
+extension LambdaEventSourceTypeFromString on String {
   LambdaEventSourceType toLambdaEventSourceType() {
     switch (this) {
       case 'PUB_SUB':
@@ -3041,7 +3045,7 @@ enum LambdaFilesystemPermission {
   rw,
 }
 
-extension on LambdaFilesystemPermission {
+extension LambdaFilesystemPermissionValue on LambdaFilesystemPermission {
   String toValue() {
     switch (this) {
       case LambdaFilesystemPermission.ro:
@@ -3052,7 +3056,7 @@ extension on LambdaFilesystemPermission {
   }
 }
 
-extension on String {
+extension LambdaFilesystemPermissionFromString on String {
   LambdaFilesystemPermission toLambdaFilesystemPermission() {
     switch (this) {
       case 'ro':
@@ -3128,7 +3132,8 @@ enum LambdaInputPayloadEncodingType {
   binary,
 }
 
-extension on LambdaInputPayloadEncodingType {
+extension LambdaInputPayloadEncodingTypeValue
+    on LambdaInputPayloadEncodingType {
   String toValue() {
     switch (this) {
       case LambdaInputPayloadEncodingType.json:
@@ -3139,7 +3144,7 @@ extension on LambdaInputPayloadEncodingType {
   }
 }
 
-extension on String {
+extension LambdaInputPayloadEncodingTypeFromString on String {
   LambdaInputPayloadEncodingType toLambdaInputPayloadEncodingType() {
     switch (this) {
       case 'json':
@@ -3157,7 +3162,7 @@ enum LambdaIsolationMode {
   noContainer,
 }
 
-extension on LambdaIsolationMode {
+extension LambdaIsolationModeValue on LambdaIsolationMode {
   String toValue() {
     switch (this) {
       case LambdaIsolationMode.greengrassContainer:
@@ -3168,7 +3173,7 @@ extension on LambdaIsolationMode {
   }
 }
 
-extension on String {
+extension LambdaIsolationModeFromString on String {
   LambdaIsolationMode toLambdaIsolationMode() {
     switch (this) {
       case 'GreengrassContainer':
@@ -3411,7 +3416,7 @@ enum RecipeOutputFormat {
   yaml,
 }
 
-extension on RecipeOutputFormat {
+extension RecipeOutputFormatValue on RecipeOutputFormat {
   String toValue() {
     switch (this) {
       case RecipeOutputFormat.json:
@@ -3422,7 +3427,7 @@ extension on RecipeOutputFormat {
   }
 }
 
-extension on String {
+extension RecipeOutputFormatFromString on String {
   RecipeOutputFormat toRecipeOutputFormat() {
     switch (this) {
       case 'JSON':

--- a/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
+++ b/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
@@ -1003,7 +1003,7 @@ enum CloudComponentState {
   deprecated,
 }
 
-extension CloudComponentStateValue on CloudComponentState {
+extension CloudComponentStateValueExtension on CloudComponentState {
   String toValue() {
     switch (this) {
       case CloudComponentState.requested:
@@ -1228,7 +1228,7 @@ enum ComponentDependencyType {
   soft,
 }
 
-extension ComponentDependencyTypeValue on ComponentDependencyType {
+extension ComponentDependencyTypeValueExtension on ComponentDependencyType {
   String toValue() {
     switch (this) {
       case ComponentDependencyType.hard:
@@ -1456,7 +1456,7 @@ enum ComponentVisibilityScope {
   public,
 }
 
-extension ComponentVisibilityScopeValue on ComponentVisibilityScope {
+extension ComponentVisibilityScopeValueExtension on ComponentVisibilityScope {
   String toValue() {
     switch (this) {
       case ComponentVisibilityScope.private:
@@ -1523,7 +1523,7 @@ enum CoreDeviceStatus {
   unhealthy,
 }
 
-extension CoreDeviceStatusValue on CoreDeviceStatus {
+extension CoreDeviceStatusValueExtension on CoreDeviceStatus {
   String toValue() {
     switch (this) {
       case CoreDeviceStatus.healthy:
@@ -1731,7 +1731,7 @@ enum DeploymentComponentUpdatePolicyAction {
   skipNotifyComponents,
 }
 
-extension DeploymentComponentUpdatePolicyActionValue
+extension DeploymentComponentUpdatePolicyActionValueExtension
     on DeploymentComponentUpdatePolicyAction {
   String toValue() {
     switch (this) {
@@ -1798,7 +1798,7 @@ enum DeploymentFailureHandlingPolicy {
   doNothing,
 }
 
-extension DeploymentFailureHandlingPolicyValue
+extension DeploymentFailureHandlingPolicyValueExtension
     on DeploymentFailureHandlingPolicy {
   String toValue() {
     switch (this) {
@@ -1828,7 +1828,7 @@ enum DeploymentHistoryFilter {
   latestOnly,
 }
 
-extension DeploymentHistoryFilterValue on DeploymentHistoryFilter {
+extension DeploymentHistoryFilterValueExtension on DeploymentHistoryFilter {
   String toValue() {
     switch (this) {
       case DeploymentHistoryFilter.all:
@@ -1962,7 +1962,7 @@ enum DeploymentStatus {
   inactive,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.active:
@@ -2149,7 +2149,7 @@ enum EffectiveDeploymentExecutionStatus {
   rejected,
 }
 
-extension EffectiveDeploymentExecutionStatusValue
+extension EffectiveDeploymentExecutionStatusValueExtension
     on EffectiveDeploymentExecutionStatus {
   String toValue() {
     switch (this) {
@@ -2456,7 +2456,7 @@ enum InstalledComponentLifecycleState {
   finished,
 }
 
-extension InstalledComponentLifecycleStateValue
+extension InstalledComponentLifecycleStateValueExtension
     on InstalledComponentLifecycleState {
   String toValue() {
     switch (this) {
@@ -2509,7 +2509,7 @@ enum IoTJobAbortAction {
   cancel,
 }
 
-extension IoTJobAbortActionValue on IoTJobAbortAction {
+extension IoTJobAbortActionValueExtension on IoTJobAbortAction {
   String toValue() {
     switch (this) {
       case IoTJobAbortAction.cancel:
@@ -2623,7 +2623,8 @@ enum IoTJobExecutionFailureType {
   all,
 }
 
-extension IoTJobExecutionFailureTypeValue on IoTJobExecutionFailureType {
+extension IoTJobExecutionFailureTypeValueExtension
+    on IoTJobExecutionFailureType {
   String toValue() {
     switch (this) {
       case IoTJobExecutionFailureType.failed:
@@ -2911,7 +2912,7 @@ enum LambdaEventSourceType {
   iotCore,
 }
 
-extension LambdaEventSourceTypeValue on LambdaEventSourceType {
+extension LambdaEventSourceTypeValueExtension on LambdaEventSourceType {
   String toValue() {
     switch (this) {
       case LambdaEventSourceType.pubSub:
@@ -3045,7 +3046,8 @@ enum LambdaFilesystemPermission {
   rw,
 }
 
-extension LambdaFilesystemPermissionValue on LambdaFilesystemPermission {
+extension LambdaFilesystemPermissionValueExtension
+    on LambdaFilesystemPermission {
   String toValue() {
     switch (this) {
       case LambdaFilesystemPermission.ro:
@@ -3132,7 +3134,7 @@ enum LambdaInputPayloadEncodingType {
   binary,
 }
 
-extension LambdaInputPayloadEncodingTypeValue
+extension LambdaInputPayloadEncodingTypeValueExtension
     on LambdaInputPayloadEncodingType {
   String toValue() {
     switch (this) {
@@ -3162,7 +3164,7 @@ enum LambdaIsolationMode {
   noContainer,
 }
 
-extension LambdaIsolationModeValue on LambdaIsolationMode {
+extension LambdaIsolationModeValueExtension on LambdaIsolationMode {
   String toValue() {
     switch (this) {
       case LambdaIsolationMode.greengrassContainer:
@@ -3416,7 +3418,7 @@ enum RecipeOutputFormat {
   yaml,
 }
 
-extension RecipeOutputFormatValue on RecipeOutputFormat {
+extension RecipeOutputFormatValueExtension on RecipeOutputFormat {
   String toValue() {
     switch (this) {
       case RecipeOutputFormat.json:

--- a/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
+++ b/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
@@ -968,7 +968,7 @@ enum AngleUnits {
   radian,
 }
 
-extension AngleUnitsValue on AngleUnits {
+extension AngleUnitsValueExtension on AngleUnits {
   String toValue() {
     switch (this) {
       case AngleUnits.degreeAngle:
@@ -1113,7 +1113,7 @@ enum BandwidthUnits {
   kHz,
 }
 
-extension BandwidthUnitsValue on BandwidthUnits {
+extension BandwidthUnitsValueExtension on BandwidthUnits {
   String toValue() {
     switch (this) {
       case BandwidthUnits.gHz:
@@ -1149,7 +1149,7 @@ enum ConfigCapabilityType {
   uplinkEcho,
 }
 
-extension ConfigCapabilityTypeValue on ConfigCapabilityType {
+extension ConfigCapabilityTypeValueExtension on ConfigCapabilityType {
   String toValue() {
     switch (this) {
       case ConfigCapabilityType.antennaDownlink:
@@ -1471,7 +1471,7 @@ enum ContactStatus {
   scheduling,
 }
 
-extension ContactStatusValue on ContactStatus {
+extension ContactStatusValueExtension on ContactStatus {
   String toValue() {
     switch (this) {
       case ContactStatus.available:
@@ -1544,7 +1544,7 @@ enum Criticality {
   required,
 }
 
-extension CriticalityValue on Criticality {
+extension CriticalityValueExtension on Criticality {
   String toValue() {
     switch (this) {
       case Criticality.preferred:
@@ -1906,7 +1906,7 @@ enum EirpUnits {
   dbw,
 }
 
-extension EirpUnitsValue on EirpUnits {
+extension EirpUnitsValueExtension on EirpUnits {
   String toValue() {
     switch (this) {
       case EirpUnits.dbw:
@@ -1987,7 +1987,7 @@ enum EndpointStatus {
   failed,
 }
 
-extension EndpointStatusValue on EndpointStatus {
+extension EndpointStatusValueExtension on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.created:
@@ -2103,7 +2103,7 @@ enum FrequencyUnits {
   kHz,
 }
 
-extension FrequencyUnitsValue on FrequencyUnits {
+extension FrequencyUnitsValueExtension on FrequencyUnits {
   String toValue() {
     switch (this) {
       case FrequencyUnits.gHz:
@@ -2593,7 +2593,7 @@ enum Polarization {
   rightHand,
 }
 
-extension PolarizationValue on Polarization {
+extension PolarizationValueExtension on Polarization {
   String toValue() {
     switch (this) {
       case Polarization.leftHand:

--- a/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
+++ b/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
@@ -968,7 +968,7 @@ enum AngleUnits {
   radian,
 }
 
-extension on AngleUnits {
+extension AngleUnitsValue on AngleUnits {
   String toValue() {
     switch (this) {
       case AngleUnits.degreeAngle:
@@ -979,7 +979,7 @@ extension on AngleUnits {
   }
 }
 
-extension on String {
+extension AngleUnitsFromString on String {
   AngleUnits toAngleUnits() {
     switch (this) {
       case 'DEGREE_ANGLE':
@@ -1113,7 +1113,7 @@ enum BandwidthUnits {
   kHz,
 }
 
-extension on BandwidthUnits {
+extension BandwidthUnitsValue on BandwidthUnits {
   String toValue() {
     switch (this) {
       case BandwidthUnits.gHz:
@@ -1126,7 +1126,7 @@ extension on BandwidthUnits {
   }
 }
 
-extension on String {
+extension BandwidthUnitsFromString on String {
   BandwidthUnits toBandwidthUnits() {
     switch (this) {
       case 'GHz':
@@ -1149,7 +1149,7 @@ enum ConfigCapabilityType {
   uplinkEcho,
 }
 
-extension on ConfigCapabilityType {
+extension ConfigCapabilityTypeValue on ConfigCapabilityType {
   String toValue() {
     switch (this) {
       case ConfigCapabilityType.antennaDownlink:
@@ -1168,7 +1168,7 @@ extension on ConfigCapabilityType {
   }
 }
 
-extension on String {
+extension ConfigCapabilityTypeFromString on String {
   ConfigCapabilityType toConfigCapabilityType() {
     switch (this) {
       case 'antenna-downlink':
@@ -1471,7 +1471,7 @@ enum ContactStatus {
   scheduling,
 }
 
-extension on ContactStatus {
+extension ContactStatusValue on ContactStatus {
   String toValue() {
     switch (this) {
       case ContactStatus.available:
@@ -1504,7 +1504,7 @@ extension on ContactStatus {
   }
 }
 
-extension on String {
+extension ContactStatusFromString on String {
   ContactStatus toContactStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -1544,7 +1544,7 @@ enum Criticality {
   required,
 }
 
-extension on Criticality {
+extension CriticalityValue on Criticality {
   String toValue() {
     switch (this) {
       case Criticality.preferred:
@@ -1557,7 +1557,7 @@ extension on Criticality {
   }
 }
 
-extension on String {
+extension CriticalityFromString on String {
   Criticality toCriticality() {
     switch (this) {
       case 'PREFERRED':
@@ -1906,7 +1906,7 @@ enum EirpUnits {
   dbw,
 }
 
-extension on EirpUnits {
+extension EirpUnitsValue on EirpUnits {
   String toValue() {
     switch (this) {
       case EirpUnits.dbw:
@@ -1915,7 +1915,7 @@ extension on EirpUnits {
   }
 }
 
-extension on String {
+extension EirpUnitsFromString on String {
   EirpUnits toEirpUnits() {
     switch (this) {
       case 'dBW':
@@ -1987,7 +1987,7 @@ enum EndpointStatus {
   failed,
 }
 
-extension on EndpointStatus {
+extension EndpointStatusValue on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.created:
@@ -2004,7 +2004,7 @@ extension on EndpointStatus {
   }
 }
 
-extension on String {
+extension EndpointStatusFromString on String {
   EndpointStatus toEndpointStatus() {
     switch (this) {
       case 'created':
@@ -2103,7 +2103,7 @@ enum FrequencyUnits {
   kHz,
 }
 
-extension on FrequencyUnits {
+extension FrequencyUnitsValue on FrequencyUnits {
   String toValue() {
     switch (this) {
       case FrequencyUnits.gHz:
@@ -2116,7 +2116,7 @@ extension on FrequencyUnits {
   }
 }
 
-extension on String {
+extension FrequencyUnitsFromString on String {
   FrequencyUnits toFrequencyUnits() {
     switch (this) {
       case 'GHz':
@@ -2593,7 +2593,7 @@ enum Polarization {
   rightHand,
 }
 
-extension on Polarization {
+extension PolarizationValue on Polarization {
   String toValue() {
     switch (this) {
       case Polarization.leftHand:
@@ -2606,7 +2606,7 @@ extension on Polarization {
   }
 }
 
-extension on String {
+extension PolarizationFromString on String {
   Polarization toPolarization() {
     switch (this) {
       case 'LEFT_HAND':

--- a/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
+++ b/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
@@ -3049,7 +3049,7 @@ enum AdminStatus {
   disableInProgress,
 }
 
-extension on AdminStatus {
+extension AdminStatusValue on AdminStatus {
   String toValue() {
     switch (this) {
       case AdminStatus.enabled:
@@ -3060,7 +3060,7 @@ extension on AdminStatus {
   }
 }
 
-extension on String {
+extension AdminStatusFromString on String {
   AdminStatus toAdminStatus() {
     switch (this) {
       case 'ENABLED':
@@ -3511,7 +3511,7 @@ enum DataSource {
   s3Logs,
 }
 
-extension on DataSource {
+extension DataSourceValue on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.flowLogs:
@@ -3526,7 +3526,7 @@ extension on DataSource {
   }
 }
 
-extension on String {
+extension DataSourceFromString on String {
   DataSource toDataSource() {
     switch (this) {
       case 'FLOW_LOGS':
@@ -3601,7 +3601,7 @@ enum DataSourceStatus {
   disabled,
 }
 
-extension on DataSourceStatus {
+extension DataSourceStatusValue on DataSourceStatus {
   String toValue() {
     switch (this) {
       case DataSourceStatus.enabled:
@@ -3612,7 +3612,7 @@ extension on DataSourceStatus {
   }
 }
 
-extension on String {
+extension DataSourceStatusFromString on String {
   DataSourceStatus toDataSourceStatus() {
     switch (this) {
       case 'ENABLED':
@@ -3869,7 +3869,7 @@ enum DestinationType {
   s3,
 }
 
-extension on DestinationType {
+extension DestinationTypeValue on DestinationType {
   String toValue() {
     switch (this) {
       case DestinationType.s3:
@@ -3878,7 +3878,7 @@ extension on DestinationType {
   }
 }
 
-extension on String {
+extension DestinationTypeFromString on String {
   DestinationType toDestinationType() {
     switch (this) {
       case 'S3':
@@ -3893,7 +3893,7 @@ enum DetectorStatus {
   disabled,
 }
 
-extension on DetectorStatus {
+extension DetectorStatusValue on DetectorStatus {
   String toValue() {
     switch (this) {
       case DetectorStatus.enabled:
@@ -3904,7 +3904,7 @@ extension on DetectorStatus {
   }
 }
 
-extension on String {
+extension DetectorStatusFromString on String {
   DetectorStatus toDetectorStatus() {
     switch (this) {
       case 'ENABLED':
@@ -4012,7 +4012,7 @@ enum Feedback {
   notUseful,
 }
 
-extension on Feedback {
+extension FeedbackValue on Feedback {
   String toValue() {
     switch (this) {
       case Feedback.useful:
@@ -4023,7 +4023,7 @@ extension on Feedback {
   }
 }
 
-extension on String {
+extension FeedbackFromString on String {
   Feedback toFeedback() {
     switch (this) {
       case 'USEFUL':
@@ -4040,7 +4040,7 @@ enum FilterAction {
   archive,
 }
 
-extension on FilterAction {
+extension FilterActionValue on FilterAction {
   String toValue() {
     switch (this) {
       case FilterAction.noop:
@@ -4051,7 +4051,7 @@ extension on FilterAction {
   }
 }
 
-extension on String {
+extension FilterActionFromString on String {
   FilterAction toFilterAction() {
     switch (this) {
       case 'NOOP':
@@ -4177,7 +4177,7 @@ enum FindingPublishingFrequency {
   sixHours,
 }
 
-extension on FindingPublishingFrequency {
+extension FindingPublishingFrequencyValue on FindingPublishingFrequency {
   String toValue() {
     switch (this) {
       case FindingPublishingFrequency.fifteenMinutes:
@@ -4190,7 +4190,7 @@ extension on FindingPublishingFrequency {
   }
 }
 
-extension on String {
+extension FindingPublishingFrequencyFromString on String {
   FindingPublishingFrequency toFindingPublishingFrequency() {
     switch (this) {
       case 'FIFTEEN_MINUTES':
@@ -4208,7 +4208,7 @@ enum FindingStatisticType {
   countBySeverity,
 }
 
-extension on FindingStatisticType {
+extension FindingStatisticTypeValue on FindingStatisticType {
   String toValue() {
     switch (this) {
       case FindingStatisticType.countBySeverity:
@@ -4217,7 +4217,7 @@ extension on FindingStatisticType {
   }
 }
 
-extension on String {
+extension FindingStatisticTypeFromString on String {
   FindingStatisticType toFindingStatisticType() {
     switch (this) {
       case 'COUNT_BY_SEVERITY':
@@ -4749,7 +4749,7 @@ enum IpSetFormat {
   fireEye,
 }
 
-extension on IpSetFormat {
+extension IpSetFormatValue on IpSetFormat {
   String toValue() {
     switch (this) {
       case IpSetFormat.txt:
@@ -4768,7 +4768,7 @@ extension on IpSetFormat {
   }
 }
 
-extension on String {
+extension IpSetFormatFromString on String {
   IpSetFormat toIpSetFormat() {
     switch (this) {
       case 'TXT':
@@ -4798,7 +4798,7 @@ enum IpSetStatus {
   deleted,
 }
 
-extension on IpSetStatus {
+extension IpSetStatusValue on IpSetStatus {
   String toValue() {
     switch (this) {
       case IpSetStatus.inactive:
@@ -4819,7 +4819,7 @@ extension on IpSetStatus {
   }
 }
 
-extension on String {
+extension IpSetStatusFromString on String {
   IpSetStatus toIpSetStatus() {
     switch (this) {
       case 'INACTIVE':
@@ -5334,7 +5334,7 @@ enum OrderBy {
   desc,
 }
 
-extension on OrderBy {
+extension OrderByValue on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.asc:
@@ -5345,7 +5345,7 @@ extension on OrderBy {
   }
 }
 
-extension on String {
+extension OrderByFromString on String {
   OrderBy toOrderBy() {
     switch (this) {
       case 'ASC':
@@ -5633,7 +5633,7 @@ enum PublishingStatus {
   stopped,
 }
 
-extension on PublishingStatus {
+extension PublishingStatusValue on PublishingStatus {
   String toValue() {
     switch (this) {
       case PublishingStatus.pendingVerification:
@@ -5648,7 +5648,7 @@ extension on PublishingStatus {
   }
 }
 
-extension on String {
+extension PublishingStatusFromString on String {
   PublishingStatus toPublishingStatus() {
     switch (this) {
       case 'PENDING_VERIFICATION':
@@ -6044,7 +6044,7 @@ enum ThreatIntelSetFormat {
   fireEye,
 }
 
-extension on ThreatIntelSetFormat {
+extension ThreatIntelSetFormatValue on ThreatIntelSetFormat {
   String toValue() {
     switch (this) {
       case ThreatIntelSetFormat.txt:
@@ -6063,7 +6063,7 @@ extension on ThreatIntelSetFormat {
   }
 }
 
-extension on String {
+extension ThreatIntelSetFormatFromString on String {
   ThreatIntelSetFormat toThreatIntelSetFormat() {
     switch (this) {
       case 'TXT':
@@ -6093,7 +6093,7 @@ enum ThreatIntelSetStatus {
   deleted,
 }
 
-extension on ThreatIntelSetStatus {
+extension ThreatIntelSetStatusValue on ThreatIntelSetStatus {
   String toValue() {
     switch (this) {
       case ThreatIntelSetStatus.inactive:
@@ -6114,7 +6114,7 @@ extension on ThreatIntelSetStatus {
   }
 }
 
-extension on String {
+extension ThreatIntelSetStatusFromString on String {
   ThreatIntelSetStatus toThreatIntelSetStatus() {
     switch (this) {
       case 'INACTIVE':
@@ -6393,7 +6393,7 @@ enum UsageStatisticType {
   topResources,
 }
 
-extension on UsageStatisticType {
+extension UsageStatisticTypeValue on UsageStatisticType {
   String toValue() {
     switch (this) {
       case UsageStatisticType.sumByAccount:
@@ -6408,7 +6408,7 @@ extension on UsageStatisticType {
   }
 }
 
-extension on String {
+extension UsageStatisticTypeFromString on String {
   UsageStatisticType toUsageStatisticType() {
     switch (this) {
       case 'SUM_BY_ACCOUNT':

--- a/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
+++ b/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
@@ -3049,7 +3049,7 @@ enum AdminStatus {
   disableInProgress,
 }
 
-extension AdminStatusValue on AdminStatus {
+extension AdminStatusValueExtension on AdminStatus {
   String toValue() {
     switch (this) {
       case AdminStatus.enabled:
@@ -3511,7 +3511,7 @@ enum DataSource {
   s3Logs,
 }
 
-extension DataSourceValue on DataSource {
+extension DataSourceValueExtension on DataSource {
   String toValue() {
     switch (this) {
       case DataSource.flowLogs:
@@ -3601,7 +3601,7 @@ enum DataSourceStatus {
   disabled,
 }
 
-extension DataSourceStatusValue on DataSourceStatus {
+extension DataSourceStatusValueExtension on DataSourceStatus {
   String toValue() {
     switch (this) {
       case DataSourceStatus.enabled:
@@ -3869,7 +3869,7 @@ enum DestinationType {
   s3,
 }
 
-extension DestinationTypeValue on DestinationType {
+extension DestinationTypeValueExtension on DestinationType {
   String toValue() {
     switch (this) {
       case DestinationType.s3:
@@ -3893,7 +3893,7 @@ enum DetectorStatus {
   disabled,
 }
 
-extension DetectorStatusValue on DetectorStatus {
+extension DetectorStatusValueExtension on DetectorStatus {
   String toValue() {
     switch (this) {
       case DetectorStatus.enabled:
@@ -4012,7 +4012,7 @@ enum Feedback {
   notUseful,
 }
 
-extension FeedbackValue on Feedback {
+extension FeedbackValueExtension on Feedback {
   String toValue() {
     switch (this) {
       case Feedback.useful:
@@ -4040,7 +4040,7 @@ enum FilterAction {
   archive,
 }
 
-extension FilterActionValue on FilterAction {
+extension FilterActionValueExtension on FilterAction {
   String toValue() {
     switch (this) {
       case FilterAction.noop:
@@ -4177,7 +4177,8 @@ enum FindingPublishingFrequency {
   sixHours,
 }
 
-extension FindingPublishingFrequencyValue on FindingPublishingFrequency {
+extension FindingPublishingFrequencyValueExtension
+    on FindingPublishingFrequency {
   String toValue() {
     switch (this) {
       case FindingPublishingFrequency.fifteenMinutes:
@@ -4208,7 +4209,7 @@ enum FindingStatisticType {
   countBySeverity,
 }
 
-extension FindingStatisticTypeValue on FindingStatisticType {
+extension FindingStatisticTypeValueExtension on FindingStatisticType {
   String toValue() {
     switch (this) {
       case FindingStatisticType.countBySeverity:
@@ -4749,7 +4750,7 @@ enum IpSetFormat {
   fireEye,
 }
 
-extension IpSetFormatValue on IpSetFormat {
+extension IpSetFormatValueExtension on IpSetFormat {
   String toValue() {
     switch (this) {
       case IpSetFormat.txt:
@@ -4798,7 +4799,7 @@ enum IpSetStatus {
   deleted,
 }
 
-extension IpSetStatusValue on IpSetStatus {
+extension IpSetStatusValueExtension on IpSetStatus {
   String toValue() {
     switch (this) {
       case IpSetStatus.inactive:
@@ -5334,7 +5335,7 @@ enum OrderBy {
   desc,
 }
 
-extension OrderByValue on OrderBy {
+extension OrderByValueExtension on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.asc:
@@ -5633,7 +5634,7 @@ enum PublishingStatus {
   stopped,
 }
 
-extension PublishingStatusValue on PublishingStatus {
+extension PublishingStatusValueExtension on PublishingStatus {
   String toValue() {
     switch (this) {
       case PublishingStatus.pendingVerification:
@@ -6044,7 +6045,7 @@ enum ThreatIntelSetFormat {
   fireEye,
 }
 
-extension ThreatIntelSetFormatValue on ThreatIntelSetFormat {
+extension ThreatIntelSetFormatValueExtension on ThreatIntelSetFormat {
   String toValue() {
     switch (this) {
       case ThreatIntelSetFormat.txt:
@@ -6093,7 +6094,7 @@ enum ThreatIntelSetStatus {
   deleted,
 }
 
-extension ThreatIntelSetStatusValue on ThreatIntelSetStatus {
+extension ThreatIntelSetStatusValueExtension on ThreatIntelSetStatus {
   String toValue() {
     switch (this) {
       case ThreatIntelSetStatus.inactive:
@@ -6393,7 +6394,7 @@ enum UsageStatisticType {
   topResources,
 }
 
-extension UsageStatisticTypeValue on UsageStatisticType {
+extension UsageStatisticTypeValueExtension on UsageStatisticType {
   String toValue() {
     switch (this) {
       case UsageStatisticType.sumByAccount:

--- a/generated/aws_health_api/lib/health-2016-08-04.dart
+++ b/generated/aws_health_api/lib/health-2016-08-04.dart
@@ -2103,7 +2103,7 @@ enum EntityStatusCode {
   unknown,
 }
 
-extension on EntityStatusCode {
+extension EntityStatusCodeValue on EntityStatusCode {
   String toValue() {
     switch (this) {
       case EntityStatusCode.impaired:
@@ -2116,7 +2116,7 @@ extension on EntityStatusCode {
   }
 }
 
-extension on String {
+extension EntityStatusCodeFromString on String {
   EntityStatusCode toEntityStatusCode() {
     switch (this) {
       case 'IMPAIRED':
@@ -2134,7 +2134,7 @@ enum EventAggregateField {
   eventTypeCategory,
 }
 
-extension on EventAggregateField {
+extension EventAggregateFieldValue on EventAggregateField {
   String toValue() {
     switch (this) {
       case EventAggregateField.eventTypeCategory:
@@ -2143,7 +2143,7 @@ extension on EventAggregateField {
   }
 }
 
-extension on String {
+extension EventAggregateFieldFromString on String {
   EventAggregateField toEventAggregateField() {
     switch (this) {
       case 'eventTypeCategory':
@@ -2159,7 +2159,7 @@ enum EventScopeCode {
   none,
 }
 
-extension on EventScopeCode {
+extension EventScopeCodeValue on EventScopeCode {
   String toValue() {
     switch (this) {
       case EventScopeCode.public:
@@ -2172,7 +2172,7 @@ extension on EventScopeCode {
   }
 }
 
-extension on String {
+extension EventScopeCodeFromString on String {
   EventScopeCode toEventScopeCode() {
     switch (this) {
       case 'PUBLIC':
@@ -2192,7 +2192,7 @@ enum EventStatusCode {
   upcoming,
 }
 
-extension on EventStatusCode {
+extension EventStatusCodeValue on EventStatusCode {
   String toValue() {
     switch (this) {
       case EventStatusCode.open:
@@ -2205,7 +2205,7 @@ extension on EventStatusCode {
   }
 }
 
-extension on String {
+extension EventStatusCodeFromString on String {
   EventStatusCode toEventStatusCode() {
     switch (this) {
       case 'open':
@@ -2226,7 +2226,7 @@ enum EventTypeCategory {
   investigation,
 }
 
-extension on EventTypeCategory {
+extension EventTypeCategoryValue on EventTypeCategory {
   String toValue() {
     switch (this) {
       case EventTypeCategory.issue:
@@ -2241,7 +2241,7 @@ extension on EventTypeCategory {
   }
 }
 
-extension on String {
+extension EventTypeCategoryFromString on String {
   EventTypeCategory toEventTypeCategory() {
     switch (this) {
       case 'issue':

--- a/generated/aws_health_api/lib/health-2016-08-04.dart
+++ b/generated/aws_health_api/lib/health-2016-08-04.dart
@@ -2103,7 +2103,7 @@ enum EntityStatusCode {
   unknown,
 }
 
-extension EntityStatusCodeValue on EntityStatusCode {
+extension EntityStatusCodeValueExtension on EntityStatusCode {
   String toValue() {
     switch (this) {
       case EntityStatusCode.impaired:
@@ -2134,7 +2134,7 @@ enum EventAggregateField {
   eventTypeCategory,
 }
 
-extension EventAggregateFieldValue on EventAggregateField {
+extension EventAggregateFieldValueExtension on EventAggregateField {
   String toValue() {
     switch (this) {
       case EventAggregateField.eventTypeCategory:
@@ -2159,7 +2159,7 @@ enum EventScopeCode {
   none,
 }
 
-extension EventScopeCodeValue on EventScopeCode {
+extension EventScopeCodeValueExtension on EventScopeCode {
   String toValue() {
     switch (this) {
       case EventScopeCode.public:
@@ -2192,7 +2192,7 @@ enum EventStatusCode {
   upcoming,
 }
 
-extension EventStatusCodeValue on EventStatusCode {
+extension EventStatusCodeValueExtension on EventStatusCode {
   String toValue() {
     switch (this) {
       case EventStatusCode.open:
@@ -2226,7 +2226,7 @@ enum EventTypeCategory {
   investigation,
 }
 
-extension EventTypeCategoryValue on EventTypeCategory {
+extension EventTypeCategoryValueExtension on EventTypeCategory {
   String toValue() {
     switch (this) {
       case EventTypeCategory.issue:

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -10959,7 +10959,7 @@ enum AccessAdvisorUsageGranularityType {
   actionLevel,
 }
 
-extension AccessAdvisorUsageGranularityTypeValue
+extension AccessAdvisorUsageGranularityTypeValueExtension
     on AccessAdvisorUsageGranularityType {
   String toValue() {
     switch (this) {
@@ -11332,7 +11332,7 @@ enum ContextKeyTypeEnum {
   dateList,
 }
 
-extension ContextKeyTypeEnumValue on ContextKeyTypeEnum {
+extension ContextKeyTypeEnumValueExtension on ContextKeyTypeEnum {
   String toValue() {
     switch (this) {
       case ContextKeyTypeEnum.string:
@@ -11660,7 +11660,7 @@ enum DeletionTaskStatusType {
   notStarted,
 }
 
-extension DeletionTaskStatusTypeValue on DeletionTaskStatusType {
+extension DeletionTaskStatusTypeValueExtension on DeletionTaskStatusType {
   String toValue() {
     switch (this) {
       case DeletionTaskStatusType.succeeded:
@@ -11770,7 +11770,7 @@ enum EntityType {
   awsManagedPolicy,
 }
 
-extension EntityTypeValue on EntityType {
+extension EntityTypeValueExtension on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.user:
@@ -14275,7 +14275,7 @@ enum PermissionsBoundaryAttachmentType {
   permissionsBoundaryPolicy,
 }
 
-extension PermissionsBoundaryAttachmentTypeValue
+extension PermissionsBoundaryAttachmentTypeValueExtension
     on PermissionsBoundaryAttachmentType {
   String toValue() {
     switch (this) {
@@ -14447,7 +14447,8 @@ enum PolicyEvaluationDecisionType {
   implicitDeny,
 }
 
-extension PolicyEvaluationDecisionTypeValue on PolicyEvaluationDecisionType {
+extension PolicyEvaluationDecisionTypeValueExtension
+    on PolicyEvaluationDecisionType {
   String toValue() {
     switch (this) {
       case PolicyEvaluationDecisionType.allowed:
@@ -14597,7 +14598,7 @@ enum PolicySourceType {
   none,
 }
 
-extension PolicySourceTypeValue on PolicySourceType {
+extension PolicySourceTypeValueExtension on PolicySourceType {
   String toValue() {
     switch (this) {
       case PolicySourceType.user:
@@ -14651,7 +14652,7 @@ enum PolicyUsageType {
   permissionsBoundary,
 }
 
-extension PolicyUsageTypeValue on PolicyUsageType {
+extension PolicyUsageTypeValueExtension on PolicyUsageType {
   String toValue() {
     switch (this) {
       case PolicyUsageType.permissionsPolicy:
@@ -14788,7 +14789,7 @@ enum ReportFormatType {
   textCsv,
 }
 
-extension ReportFormatTypeValue on ReportFormatType {
+extension ReportFormatTypeValueExtension on ReportFormatType {
   String toValue() {
     switch (this) {
       case ReportFormatType.textCsv:
@@ -14813,7 +14814,7 @@ enum ReportStateType {
   complete,
 }
 
-extension ReportStateTypeValue on ReportStateType {
+extension ReportStateTypeValueExtension on ReportStateType {
   String toValue() {
     switch (this) {
       case ReportStateType.started:
@@ -16149,7 +16150,7 @@ enum AssignmentStatusType {
   any,
 }
 
-extension AssignmentStatusTypeValue on AssignmentStatusType {
+extension AssignmentStatusTypeValueExtension on AssignmentStatusType {
   String toValue() {
     switch (this) {
       case AssignmentStatusType.assigned:
@@ -16181,7 +16182,7 @@ enum EncodingType {
   pem,
 }
 
-extension EncodingTypeValue on EncodingType {
+extension EncodingTypeValueExtension on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.ssh:
@@ -16209,7 +16210,8 @@ enum GlobalEndpointTokenVersion {
   v2Token,
 }
 
-extension GlobalEndpointTokenVersionValue on GlobalEndpointTokenVersion {
+extension GlobalEndpointTokenVersionValueExtension
+    on GlobalEndpointTokenVersion {
   String toValue() {
     switch (this) {
       case GlobalEndpointTokenVersion.v1Token:
@@ -16238,7 +16240,7 @@ enum JobStatusType {
   failed,
 }
 
-extension JobStatusTypeValue on JobStatusType {
+extension JobStatusTypeValueExtension on JobStatusType {
   String toValue() {
     switch (this) {
       case JobStatusType.inProgress:
@@ -16271,7 +16273,7 @@ enum PolicyOwnerEntityType {
   group,
 }
 
-extension PolicyOwnerEntityTypeValue on PolicyOwnerEntityType {
+extension PolicyOwnerEntityTypeValueExtension on PolicyOwnerEntityType {
   String toValue() {
     switch (this) {
       case PolicyOwnerEntityType.user:
@@ -16304,7 +16306,7 @@ enum PolicyScopeType {
   local,
 }
 
-extension PolicyScopeTypeValue on PolicyScopeType {
+extension PolicyScopeTypeValueExtension on PolicyScopeType {
   String toValue() {
     switch (this) {
       case PolicyScopeType.all:
@@ -16336,7 +16338,7 @@ enum PolicyType {
   managed,
 }
 
-extension PolicyTypeValue on PolicyType {
+extension PolicyTypeValueExtension on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.inline:
@@ -16366,7 +16368,7 @@ enum SortKeyType {
   lastAuthenticatedTimeDescending,
 }
 
-extension SortKeyTypeValue on SortKeyType {
+extension SortKeyTypeValueExtension on SortKeyType {
   String toValue() {
     switch (this) {
       case SortKeyType.serviceNamespaceAscending:
@@ -16402,7 +16404,7 @@ enum StatusType {
   inactive,
 }
 
-extension StatusTypeValue on StatusType {
+extension StatusTypeValueExtension on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.active:
@@ -16454,7 +16456,7 @@ enum SummaryKeyType {
   globalEndpointTokenVersion,
 }
 
-extension SummaryKeyTypeValue on SummaryKeyType {
+extension SummaryKeyTypeValueExtension on SummaryKeyType {
   String toValue() {
     switch (this) {
       case SummaryKeyType.users:

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -10959,7 +10959,8 @@ enum AccessAdvisorUsageGranularityType {
   actionLevel,
 }
 
-extension on AccessAdvisorUsageGranularityType {
+extension AccessAdvisorUsageGranularityTypeValue
+    on AccessAdvisorUsageGranularityType {
   String toValue() {
     switch (this) {
       case AccessAdvisorUsageGranularityType.serviceLevel:
@@ -10970,7 +10971,7 @@ extension on AccessAdvisorUsageGranularityType {
   }
 }
 
-extension on String {
+extension AccessAdvisorUsageGranularityTypeFromString on String {
   AccessAdvisorUsageGranularityType toAccessAdvisorUsageGranularityType() {
     switch (this) {
       case 'SERVICE_LEVEL':
@@ -11331,7 +11332,7 @@ enum ContextKeyTypeEnum {
   dateList,
 }
 
-extension on ContextKeyTypeEnum {
+extension ContextKeyTypeEnumValue on ContextKeyTypeEnum {
   String toValue() {
     switch (this) {
       case ContextKeyTypeEnum.string:
@@ -11362,7 +11363,7 @@ extension on ContextKeyTypeEnum {
   }
 }
 
-extension on String {
+extension ContextKeyTypeEnumFromString on String {
   ContextKeyTypeEnum toContextKeyTypeEnum() {
     switch (this) {
       case 'string':
@@ -11659,7 +11660,7 @@ enum DeletionTaskStatusType {
   notStarted,
 }
 
-extension on DeletionTaskStatusType {
+extension DeletionTaskStatusTypeValue on DeletionTaskStatusType {
   String toValue() {
     switch (this) {
       case DeletionTaskStatusType.succeeded:
@@ -11674,7 +11675,7 @@ extension on DeletionTaskStatusType {
   }
 }
 
-extension on String {
+extension DeletionTaskStatusTypeFromString on String {
   DeletionTaskStatusType toDeletionTaskStatusType() {
     switch (this) {
       case 'SUCCEEDED':
@@ -11769,7 +11770,7 @@ enum EntityType {
   awsManagedPolicy,
 }
 
-extension on EntityType {
+extension EntityTypeValue on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.user:
@@ -11786,7 +11787,7 @@ extension on EntityType {
   }
 }
 
-extension on String {
+extension EntityTypeFromString on String {
   EntityType toEntityType() {
     switch (this) {
       case 'User':
@@ -14274,7 +14275,8 @@ enum PermissionsBoundaryAttachmentType {
   permissionsBoundaryPolicy,
 }
 
-extension on PermissionsBoundaryAttachmentType {
+extension PermissionsBoundaryAttachmentTypeValue
+    on PermissionsBoundaryAttachmentType {
   String toValue() {
     switch (this) {
       case PermissionsBoundaryAttachmentType.permissionsBoundaryPolicy:
@@ -14283,7 +14285,7 @@ extension on PermissionsBoundaryAttachmentType {
   }
 }
 
-extension on String {
+extension PermissionsBoundaryAttachmentTypeFromString on String {
   PermissionsBoundaryAttachmentType toPermissionsBoundaryAttachmentType() {
     switch (this) {
       case 'PermissionsBoundaryPolicy':
@@ -14445,7 +14447,7 @@ enum PolicyEvaluationDecisionType {
   implicitDeny,
 }
 
-extension on PolicyEvaluationDecisionType {
+extension PolicyEvaluationDecisionTypeValue on PolicyEvaluationDecisionType {
   String toValue() {
     switch (this) {
       case PolicyEvaluationDecisionType.allowed:
@@ -14458,7 +14460,7 @@ extension on PolicyEvaluationDecisionType {
   }
 }
 
-extension on String {
+extension PolicyEvaluationDecisionTypeFromString on String {
   PolicyEvaluationDecisionType toPolicyEvaluationDecisionType() {
     switch (this) {
       case 'allowed':
@@ -14595,7 +14597,7 @@ enum PolicySourceType {
   none,
 }
 
-extension on PolicySourceType {
+extension PolicySourceTypeValue on PolicySourceType {
   String toValue() {
     switch (this) {
       case PolicySourceType.user:
@@ -14616,7 +14618,7 @@ extension on PolicySourceType {
   }
 }
 
-extension on String {
+extension PolicySourceTypeFromString on String {
   PolicySourceType toPolicySourceType() {
     switch (this) {
       case 'user':
@@ -14649,7 +14651,7 @@ enum PolicyUsageType {
   permissionsBoundary,
 }
 
-extension on PolicyUsageType {
+extension PolicyUsageTypeValue on PolicyUsageType {
   String toValue() {
     switch (this) {
       case PolicyUsageType.permissionsPolicy:
@@ -14660,7 +14662,7 @@ extension on PolicyUsageType {
   }
 }
 
-extension on String {
+extension PolicyUsageTypeFromString on String {
   PolicyUsageType toPolicyUsageType() {
     switch (this) {
       case 'PermissionsPolicy':
@@ -14786,7 +14788,7 @@ enum ReportFormatType {
   textCsv,
 }
 
-extension on ReportFormatType {
+extension ReportFormatTypeValue on ReportFormatType {
   String toValue() {
     switch (this) {
       case ReportFormatType.textCsv:
@@ -14795,7 +14797,7 @@ extension on ReportFormatType {
   }
 }
 
-extension on String {
+extension ReportFormatTypeFromString on String {
   ReportFormatType toReportFormatType() {
     switch (this) {
       case 'text/csv':
@@ -14811,7 +14813,7 @@ enum ReportStateType {
   complete,
 }
 
-extension on ReportStateType {
+extension ReportStateTypeValue on ReportStateType {
   String toValue() {
     switch (this) {
       case ReportStateType.started:
@@ -14824,7 +14826,7 @@ extension on ReportStateType {
   }
 }
 
-extension on String {
+extension ReportStateTypeFromString on String {
   ReportStateType toReportStateType() {
     switch (this) {
       case 'STARTED':
@@ -16147,7 +16149,7 @@ enum AssignmentStatusType {
   any,
 }
 
-extension on AssignmentStatusType {
+extension AssignmentStatusTypeValue on AssignmentStatusType {
   String toValue() {
     switch (this) {
       case AssignmentStatusType.assigned:
@@ -16160,7 +16162,7 @@ extension on AssignmentStatusType {
   }
 }
 
-extension on String {
+extension AssignmentStatusTypeFromString on String {
   AssignmentStatusType toAssignmentStatusType() {
     switch (this) {
       case 'Assigned':
@@ -16179,7 +16181,7 @@ enum EncodingType {
   pem,
 }
 
-extension on EncodingType {
+extension EncodingTypeValue on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.ssh:
@@ -16190,7 +16192,7 @@ extension on EncodingType {
   }
 }
 
-extension on String {
+extension EncodingTypeFromString on String {
   EncodingType toEncodingType() {
     switch (this) {
       case 'SSH':
@@ -16207,7 +16209,7 @@ enum GlobalEndpointTokenVersion {
   v2Token,
 }
 
-extension on GlobalEndpointTokenVersion {
+extension GlobalEndpointTokenVersionValue on GlobalEndpointTokenVersion {
   String toValue() {
     switch (this) {
       case GlobalEndpointTokenVersion.v1Token:
@@ -16218,7 +16220,7 @@ extension on GlobalEndpointTokenVersion {
   }
 }
 
-extension on String {
+extension GlobalEndpointTokenVersionFromString on String {
   GlobalEndpointTokenVersion toGlobalEndpointTokenVersion() {
     switch (this) {
       case 'v1Token':
@@ -16236,7 +16238,7 @@ enum JobStatusType {
   failed,
 }
 
-extension on JobStatusType {
+extension JobStatusTypeValue on JobStatusType {
   String toValue() {
     switch (this) {
       case JobStatusType.inProgress:
@@ -16249,7 +16251,7 @@ extension on JobStatusType {
   }
 }
 
-extension on String {
+extension JobStatusTypeFromString on String {
   JobStatusType toJobStatusType() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -16269,7 +16271,7 @@ enum PolicyOwnerEntityType {
   group,
 }
 
-extension on PolicyOwnerEntityType {
+extension PolicyOwnerEntityTypeValue on PolicyOwnerEntityType {
   String toValue() {
     switch (this) {
       case PolicyOwnerEntityType.user:
@@ -16282,7 +16284,7 @@ extension on PolicyOwnerEntityType {
   }
 }
 
-extension on String {
+extension PolicyOwnerEntityTypeFromString on String {
   PolicyOwnerEntityType toPolicyOwnerEntityType() {
     switch (this) {
       case 'USER':
@@ -16302,7 +16304,7 @@ enum PolicyScopeType {
   local,
 }
 
-extension on PolicyScopeType {
+extension PolicyScopeTypeValue on PolicyScopeType {
   String toValue() {
     switch (this) {
       case PolicyScopeType.all:
@@ -16315,7 +16317,7 @@ extension on PolicyScopeType {
   }
 }
 
-extension on String {
+extension PolicyScopeTypeFromString on String {
   PolicyScopeType toPolicyScopeType() {
     switch (this) {
       case 'All':
@@ -16334,7 +16336,7 @@ enum PolicyType {
   managed,
 }
 
-extension on PolicyType {
+extension PolicyTypeValue on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.inline:
@@ -16345,7 +16347,7 @@ extension on PolicyType {
   }
 }
 
-extension on String {
+extension PolicyTypeFromString on String {
   PolicyType toPolicyType() {
     switch (this) {
       case 'INLINE':
@@ -16364,7 +16366,7 @@ enum SortKeyType {
   lastAuthenticatedTimeDescending,
 }
 
-extension on SortKeyType {
+extension SortKeyTypeValue on SortKeyType {
   String toValue() {
     switch (this) {
       case SortKeyType.serviceNamespaceAscending:
@@ -16379,7 +16381,7 @@ extension on SortKeyType {
   }
 }
 
-extension on String {
+extension SortKeyTypeFromString on String {
   SortKeyType toSortKeyType() {
     switch (this) {
       case 'SERVICE_NAMESPACE_ASCENDING':
@@ -16400,7 +16402,7 @@ enum StatusType {
   inactive,
 }
 
-extension on StatusType {
+extension StatusTypeValue on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.active:
@@ -16411,7 +16413,7 @@ extension on StatusType {
   }
 }
 
-extension on String {
+extension StatusTypeFromString on String {
   StatusType toStatusType() {
     switch (this) {
       case 'Active':
@@ -16452,7 +16454,7 @@ enum SummaryKeyType {
   globalEndpointTokenVersion,
 }
 
-extension on SummaryKeyType {
+extension SummaryKeyTypeValue on SummaryKeyType {
   String toValue() {
     switch (this) {
       case SummaryKeyType.users:
@@ -16511,7 +16513,7 @@ extension on SummaryKeyType {
   }
 }
 
-extension on String {
+extension SummaryKeyTypeFromString on String {
   SummaryKeyType toSummaryKeyType() {
     switch (this) {
       case 'Users':

--- a/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
+++ b/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
@@ -2987,7 +2987,7 @@ enum ComponentFormat {
   shell,
 }
 
-extension ComponentFormatValue on ComponentFormat {
+extension ComponentFormatValueExtension on ComponentFormat {
   String toValue() {
     switch (this) {
       case ComponentFormat.shell:
@@ -3083,7 +3083,7 @@ enum ComponentType {
   test,
 }
 
-extension ComponentTypeValue on ComponentType {
+extension ComponentTypeValueExtension on ComponentType {
   String toValue() {
     switch (this) {
       case ComponentType.build:
@@ -3392,7 +3392,8 @@ enum ContainerRepositoryService {
   ecr,
 }
 
-extension ContainerRepositoryServiceValue on ContainerRepositoryService {
+extension ContainerRepositoryServiceValueExtension
+    on ContainerRepositoryService {
   String toValue() {
     switch (this) {
       case ContainerRepositoryService.ecr:
@@ -3415,7 +3416,7 @@ enum ContainerType {
   docker,
 }
 
-extension ContainerTypeValue on ContainerType {
+extension ContainerTypeValueExtension on ContainerType {
   String toValue() {
     switch (this) {
       case ContainerType.docker:
@@ -3992,7 +3993,7 @@ enum EbsVolumeType {
   st1,
 }
 
-extension EbsVolumeTypeValue on EbsVolumeType {
+extension EbsVolumeTypeValueExtension on EbsVolumeType {
   String toValue() {
     switch (this) {
       case EbsVolumeType.standard:
@@ -4687,7 +4688,7 @@ enum ImageStatus {
   deleted,
 }
 
-extension ImageStatusValue on ImageStatus {
+extension ImageStatusValueExtension on ImageStatus {
   String toValue() {
     switch (this) {
       case ImageStatus.pending:
@@ -4852,7 +4853,7 @@ enum ImageType {
   docker,
 }
 
-extension ImageTypeValue on ImageType {
+extension ImageTypeValueExtension on ImageType {
   String toValue() {
     switch (this) {
       case ImageType.ami:
@@ -5557,7 +5558,7 @@ enum Ownership {
   amazon,
 }
 
-extension OwnershipValue on Ownership {
+extension OwnershipValueExtension on Ownership {
   String toValue() {
     switch (this) {
       case Ownership.self:
@@ -5589,7 +5590,7 @@ enum PipelineExecutionStartCondition {
   expressionMatchAndDependencyUpdatesAvailable,
 }
 
-extension PipelineExecutionStartConditionValue
+extension PipelineExecutionStartConditionValueExtension
     on PipelineExecutionStartCondition {
   String toValue() {
     switch (this) {
@@ -5621,7 +5622,7 @@ enum PipelineStatus {
   enabled,
 }
 
-extension PipelineStatusValue on PipelineStatus {
+extension PipelineStatusValueExtension on PipelineStatus {
   String toValue() {
     switch (this) {
       case PipelineStatus.disabled:
@@ -5649,7 +5650,7 @@ enum Platform {
   linux,
 }
 
-extension PlatformValue on Platform {
+extension PlatformValueExtension on Platform {
   String toValue() {
     switch (this) {
       case Platform.windows:

--- a/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
+++ b/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
@@ -2987,7 +2987,7 @@ enum ComponentFormat {
   shell,
 }
 
-extension on ComponentFormat {
+extension ComponentFormatValue on ComponentFormat {
   String toValue() {
     switch (this) {
       case ComponentFormat.shell:
@@ -2996,7 +2996,7 @@ extension on ComponentFormat {
   }
 }
 
-extension on String {
+extension ComponentFormatFromString on String {
   ComponentFormat toComponentFormat() {
     switch (this) {
       case 'SHELL':
@@ -3083,7 +3083,7 @@ enum ComponentType {
   test,
 }
 
-extension on ComponentType {
+extension ComponentTypeValue on ComponentType {
   String toValue() {
     switch (this) {
       case ComponentType.build:
@@ -3094,7 +3094,7 @@ extension on ComponentType {
   }
 }
 
-extension on String {
+extension ComponentTypeFromString on String {
   ComponentType toComponentType() {
     switch (this) {
       case 'BUILD':
@@ -3392,7 +3392,7 @@ enum ContainerRepositoryService {
   ecr,
 }
 
-extension on ContainerRepositoryService {
+extension ContainerRepositoryServiceValue on ContainerRepositoryService {
   String toValue() {
     switch (this) {
       case ContainerRepositoryService.ecr:
@@ -3401,7 +3401,7 @@ extension on ContainerRepositoryService {
   }
 }
 
-extension on String {
+extension ContainerRepositoryServiceFromString on String {
   ContainerRepositoryService toContainerRepositoryService() {
     switch (this) {
       case 'ECR':
@@ -3415,7 +3415,7 @@ enum ContainerType {
   docker,
 }
 
-extension on ContainerType {
+extension ContainerTypeValue on ContainerType {
   String toValue() {
     switch (this) {
       case ContainerType.docker:
@@ -3424,7 +3424,7 @@ extension on ContainerType {
   }
 }
 
-extension on String {
+extension ContainerTypeFromString on String {
   ContainerType toContainerType() {
     switch (this) {
       case 'DOCKER':
@@ -3992,7 +3992,7 @@ enum EbsVolumeType {
   st1,
 }
 
-extension on EbsVolumeType {
+extension EbsVolumeTypeValue on EbsVolumeType {
   String toValue() {
     switch (this) {
       case EbsVolumeType.standard:
@@ -4011,7 +4011,7 @@ extension on EbsVolumeType {
   }
 }
 
-extension on String {
+extension EbsVolumeTypeFromString on String {
   EbsVolumeType toEbsVolumeType() {
     switch (this) {
       case 'standard':
@@ -4687,7 +4687,7 @@ enum ImageStatus {
   deleted,
 }
 
-extension on ImageStatus {
+extension ImageStatusValue on ImageStatus {
   String toValue() {
     switch (this) {
       case ImageStatus.pending:
@@ -4716,7 +4716,7 @@ extension on ImageStatus {
   }
 }
 
-extension on String {
+extension ImageStatusFromString on String {
   ImageStatus toImageStatus() {
     switch (this) {
       case 'PENDING':
@@ -4852,7 +4852,7 @@ enum ImageType {
   docker,
 }
 
-extension on ImageType {
+extension ImageTypeValue on ImageType {
   String toValue() {
     switch (this) {
       case ImageType.ami:
@@ -4863,7 +4863,7 @@ extension on ImageType {
   }
 }
 
-extension on String {
+extension ImageTypeFromString on String {
   ImageType toImageType() {
     switch (this) {
       case 'AMI':
@@ -5557,7 +5557,7 @@ enum Ownership {
   amazon,
 }
 
-extension on Ownership {
+extension OwnershipValue on Ownership {
   String toValue() {
     switch (this) {
       case Ownership.self:
@@ -5570,7 +5570,7 @@ extension on Ownership {
   }
 }
 
-extension on String {
+extension OwnershipFromString on String {
   Ownership toOwnership() {
     switch (this) {
       case 'Self':
@@ -5589,7 +5589,8 @@ enum PipelineExecutionStartCondition {
   expressionMatchAndDependencyUpdatesAvailable,
 }
 
-extension on PipelineExecutionStartCondition {
+extension PipelineExecutionStartConditionValue
+    on PipelineExecutionStartCondition {
   String toValue() {
     switch (this) {
       case PipelineExecutionStartCondition.expressionMatchOnly:
@@ -5601,7 +5602,7 @@ extension on PipelineExecutionStartCondition {
   }
 }
 
-extension on String {
+extension PipelineExecutionStartConditionFromString on String {
   PipelineExecutionStartCondition toPipelineExecutionStartCondition() {
     switch (this) {
       case 'EXPRESSION_MATCH_ONLY':
@@ -5620,7 +5621,7 @@ enum PipelineStatus {
   enabled,
 }
 
-extension on PipelineStatus {
+extension PipelineStatusValue on PipelineStatus {
   String toValue() {
     switch (this) {
       case PipelineStatus.disabled:
@@ -5631,7 +5632,7 @@ extension on PipelineStatus {
   }
 }
 
-extension on String {
+extension PipelineStatusFromString on String {
   PipelineStatus toPipelineStatus() {
     switch (this) {
       case 'DISABLED':
@@ -5648,7 +5649,7 @@ enum Platform {
   linux,
 }
 
-extension on Platform {
+extension PlatformValue on Platform {
   String toValue() {
     switch (this) {
       case Platform.windows:
@@ -5659,7 +5660,7 @@ extension on Platform {
   }
 }
 
-extension on String {
+extension PlatformFromString on String {
   Platform toPlatform() {
     switch (this) {
       case 'Windows':

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -654,7 +654,7 @@ enum JobType {
   export,
 }
 
-extension on JobType {
+extension JobTypeValue on JobType {
   String toValue() {
     switch (this) {
       case JobType.import:
@@ -665,7 +665,7 @@ extension on JobType {
   }
 }
 
-extension on String {
+extension JobTypeFromString on String {
   JobType toJobType() {
     switch (this) {
       case 'Import':

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -654,7 +654,7 @@ enum JobType {
   export,
 }
 
-extension JobTypeValue on JobType {
+extension JobTypeValueExtension on JobType {
   String toValue() {
     switch (this) {
       case JobType.import:

--- a/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
+++ b/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
@@ -1912,7 +1912,7 @@ enum AgentHealth {
   unknown,
 }
 
-extension AgentHealthValue on AgentHealth {
+extension AgentHealthValueExtension on AgentHealth {
   String toValue() {
     switch (this) {
       case AgentHealth.healthy:
@@ -1948,7 +1948,7 @@ enum AgentHealthCode {
   unknown,
 }
 
-extension AgentHealthCodeValue on AgentHealthCode {
+extension AgentHealthCodeValueExtension on AgentHealthCode {
   String toValue() {
     switch (this) {
       case AgentHealthCode.idle:
@@ -2321,7 +2321,7 @@ enum AssessmentRunNotificationSnsStatusCode {
   internalError,
 }
 
-extension AssessmentRunNotificationSnsStatusCodeValue
+extension AssessmentRunNotificationSnsStatusCodeValueExtension
     on AssessmentRunNotificationSnsStatusCode {
   String toValue() {
     switch (this) {
@@ -2371,7 +2371,7 @@ enum AssessmentRunState {
   canceled,
 }
 
-extension AssessmentRunStateValue on AssessmentRunState {
+extension AssessmentRunStateValueExtension on AssessmentRunState {
   String toValue() {
     switch (this) {
       case AssessmentRunState.created:
@@ -2690,7 +2690,7 @@ enum AssetType {
   ec2Instance,
 }
 
-extension AssetTypeValue on AssetType {
+extension AssetTypeValueExtension on AssetType {
   String toValue() {
     switch (this) {
       case AssetType.ec2Instance:
@@ -3156,7 +3156,7 @@ enum FailedItemErrorCode {
   internalError,
 }
 
-extension FailedItemErrorCodeValue on FailedItemErrorCode {
+extension FailedItemErrorCodeValueExtension on FailedItemErrorCode {
   String toValue() {
     switch (this) {
       case FailedItemErrorCode.invalidArn:
@@ -3458,7 +3458,7 @@ enum InspectorEvent {
   other,
 }
 
-extension InspectorEventValue on InspectorEvent {
+extension InspectorEventValueExtension on InspectorEvent {
   String toValue() {
     switch (this) {
       case InspectorEvent.assessmentRunStarted:
@@ -3742,7 +3742,7 @@ enum Locale {
   enUs,
 }
 
-extension LocaleValue on Locale {
+extension LocaleValueExtension on Locale {
   String toValue() {
     switch (this) {
       case Locale.enUs:
@@ -3864,7 +3864,7 @@ enum PreviewStatus {
   completed,
 }
 
-extension PreviewStatusValue on PreviewStatus {
+extension PreviewStatusValueExtension on PreviewStatus {
   String toValue() {
     switch (this) {
       case PreviewStatus.workInProgress:
@@ -3931,7 +3931,7 @@ enum ReportFileFormat {
   pdf,
 }
 
-extension ReportFileFormatValue on ReportFileFormat {
+extension ReportFileFormatValueExtension on ReportFileFormat {
   String toValue() {
     switch (this) {
       case ReportFileFormat.html:
@@ -3960,7 +3960,7 @@ enum ReportStatus {
   completed,
 }
 
-extension ReportStatusValue on ReportStatus {
+extension ReportStatusValueExtension on ReportStatus {
   String toValue() {
     switch (this) {
       case ReportStatus.workInProgress:
@@ -3992,7 +3992,7 @@ enum ReportType {
   full,
 }
 
-extension ReportTypeValue on ReportType {
+extension ReportTypeValueExtension on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.finding:
@@ -4139,7 +4139,7 @@ enum ScopeType {
   rulesPackageArn,
 }
 
-extension ScopeTypeValue on ScopeType {
+extension ScopeTypeValueExtension on ScopeType {
   String toValue() {
     switch (this) {
       case ScopeType.instanceId:
@@ -4192,7 +4192,7 @@ enum Severity {
   undefined,
 }
 
-extension SeverityValue on Severity {
+extension SeverityValueExtension on Severity {
   String toValue() {
     switch (this) {
       case Severity.low:
@@ -4246,7 +4246,7 @@ enum StopAction {
   skipEvaluation,
 }
 
-extension StopActionValue on StopAction {
+extension StopActionValueExtension on StopAction {
   String toValue() {
     switch (this) {
       case StopAction.startEvaluation:

--- a/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
+++ b/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
@@ -1912,7 +1912,7 @@ enum AgentHealth {
   unknown,
 }
 
-extension on AgentHealth {
+extension AgentHealthValue on AgentHealth {
   String toValue() {
     switch (this) {
       case AgentHealth.healthy:
@@ -1925,7 +1925,7 @@ extension on AgentHealth {
   }
 }
 
-extension on String {
+extension AgentHealthFromString on String {
   AgentHealth toAgentHealth() {
     switch (this) {
       case 'HEALTHY':
@@ -1948,7 +1948,7 @@ enum AgentHealthCode {
   unknown,
 }
 
-extension on AgentHealthCode {
+extension AgentHealthCodeValue on AgentHealthCode {
   String toValue() {
     switch (this) {
       case AgentHealthCode.idle:
@@ -1967,7 +1967,7 @@ extension on AgentHealthCode {
   }
 }
 
-extension on String {
+extension AgentHealthCodeFromString on String {
   AgentHealthCode toAgentHealthCode() {
     switch (this) {
       case 'IDLE':
@@ -2321,7 +2321,8 @@ enum AssessmentRunNotificationSnsStatusCode {
   internalError,
 }
 
-extension on AssessmentRunNotificationSnsStatusCode {
+extension AssessmentRunNotificationSnsStatusCodeValue
+    on AssessmentRunNotificationSnsStatusCode {
   String toValue() {
     switch (this) {
       case AssessmentRunNotificationSnsStatusCode.success:
@@ -2336,7 +2337,7 @@ extension on AssessmentRunNotificationSnsStatusCode {
   }
 }
 
-extension on String {
+extension AssessmentRunNotificationSnsStatusCodeFromString on String {
   AssessmentRunNotificationSnsStatusCode
       toAssessmentRunNotificationSnsStatusCode() {
     switch (this) {
@@ -2370,7 +2371,7 @@ enum AssessmentRunState {
   canceled,
 }
 
-extension on AssessmentRunState {
+extension AssessmentRunStateValue on AssessmentRunState {
   String toValue() {
     switch (this) {
       case AssessmentRunState.created:
@@ -2403,7 +2404,7 @@ extension on AssessmentRunState {
   }
 }
 
-extension on String {
+extension AssessmentRunStateFromString on String {
   AssessmentRunState toAssessmentRunState() {
     switch (this) {
       case 'CREATED':
@@ -2689,7 +2690,7 @@ enum AssetType {
   ec2Instance,
 }
 
-extension on AssetType {
+extension AssetTypeValue on AssetType {
   String toValue() {
     switch (this) {
       case AssetType.ec2Instance:
@@ -2698,7 +2699,7 @@ extension on AssetType {
   }
 }
 
-extension on String {
+extension AssetTypeFromString on String {
   AssetType toAssetType() {
     switch (this) {
       case 'ec2-instance':
@@ -3155,7 +3156,7 @@ enum FailedItemErrorCode {
   internalError,
 }
 
-extension on FailedItemErrorCode {
+extension FailedItemErrorCodeValue on FailedItemErrorCode {
   String toValue() {
     switch (this) {
       case FailedItemErrorCode.invalidArn:
@@ -3174,7 +3175,7 @@ extension on FailedItemErrorCode {
   }
 }
 
-extension on String {
+extension FailedItemErrorCodeFromString on String {
   FailedItemErrorCode toFailedItemErrorCode() {
     switch (this) {
       case 'INVALID_ARN':
@@ -3457,7 +3458,7 @@ enum InspectorEvent {
   other,
 }
 
-extension on InspectorEvent {
+extension InspectorEventValue on InspectorEvent {
   String toValue() {
     switch (this) {
       case InspectorEvent.assessmentRunStarted:
@@ -3474,7 +3475,7 @@ extension on InspectorEvent {
   }
 }
 
-extension on String {
+extension InspectorEventFromString on String {
   InspectorEvent toInspectorEvent() {
     switch (this) {
       case 'ASSESSMENT_RUN_STARTED':
@@ -3741,7 +3742,7 @@ enum Locale {
   enUs,
 }
 
-extension on Locale {
+extension LocaleValue on Locale {
   String toValue() {
     switch (this) {
       case Locale.enUs:
@@ -3750,7 +3751,7 @@ extension on Locale {
   }
 }
 
-extension on String {
+extension LocaleFromString on String {
   Locale toLocale() {
     switch (this) {
       case 'EN_US':
@@ -3863,7 +3864,7 @@ enum PreviewStatus {
   completed,
 }
 
-extension on PreviewStatus {
+extension PreviewStatusValue on PreviewStatus {
   String toValue() {
     switch (this) {
       case PreviewStatus.workInProgress:
@@ -3874,7 +3875,7 @@ extension on PreviewStatus {
   }
 }
 
-extension on String {
+extension PreviewStatusFromString on String {
   PreviewStatus toPreviewStatus() {
     switch (this) {
       case 'WORK_IN_PROGRESS':
@@ -3930,7 +3931,7 @@ enum ReportFileFormat {
   pdf,
 }
 
-extension on ReportFileFormat {
+extension ReportFileFormatValue on ReportFileFormat {
   String toValue() {
     switch (this) {
       case ReportFileFormat.html:
@@ -3941,7 +3942,7 @@ extension on ReportFileFormat {
   }
 }
 
-extension on String {
+extension ReportFileFormatFromString on String {
   ReportFileFormat toReportFileFormat() {
     switch (this) {
       case 'HTML':
@@ -3959,7 +3960,7 @@ enum ReportStatus {
   completed,
 }
 
-extension on ReportStatus {
+extension ReportStatusValue on ReportStatus {
   String toValue() {
     switch (this) {
       case ReportStatus.workInProgress:
@@ -3972,7 +3973,7 @@ extension on ReportStatus {
   }
 }
 
-extension on String {
+extension ReportStatusFromString on String {
   ReportStatus toReportStatus() {
     switch (this) {
       case 'WORK_IN_PROGRESS':
@@ -3991,7 +3992,7 @@ enum ReportType {
   full,
 }
 
-extension on ReportType {
+extension ReportTypeValue on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.finding:
@@ -4002,7 +4003,7 @@ extension on ReportType {
   }
 }
 
-extension on String {
+extension ReportTypeFromString on String {
   ReportType toReportType() {
     switch (this) {
       case 'FINDING':
@@ -4138,7 +4139,7 @@ enum ScopeType {
   rulesPackageArn,
 }
 
-extension on ScopeType {
+extension ScopeTypeValue on ScopeType {
   String toValue() {
     switch (this) {
       case ScopeType.instanceId:
@@ -4149,7 +4150,7 @@ extension on ScopeType {
   }
 }
 
-extension on String {
+extension ScopeTypeFromString on String {
   ScopeType toScopeType() {
     switch (this) {
       case 'INSTANCE_ID':
@@ -4191,7 +4192,7 @@ enum Severity {
   undefined,
 }
 
-extension on Severity {
+extension SeverityValue on Severity {
   String toValue() {
     switch (this) {
       case Severity.low:
@@ -4208,7 +4209,7 @@ extension on Severity {
   }
 }
 
-extension on String {
+extension SeverityFromString on String {
   Severity toSeverity() {
     switch (this) {
       case 'Low':
@@ -4245,7 +4246,7 @@ enum StopAction {
   skipEvaluation,
 }
 
-extension on StopAction {
+extension StopActionValue on StopAction {
   String toValue() {
     switch (this) {
       case StopAction.startEvaluation:
@@ -4256,7 +4257,7 @@ extension on StopAction {
   }
 }
 
-extension on String {
+extension StopActionFromString on String {
   StopAction toStopAction() {
     switch (this) {
       case 'START_EVALUATION':

--- a/generated/aws_iot_api/lib/iot-2015-05-28.dart
+++ b/generated/aws_iot_api/lib/iot-2015-05-28.dart
@@ -10941,7 +10941,7 @@ enum AbortAction {
   cancel,
 }
 
-extension on AbortAction {
+extension AbortActionValue on AbortAction {
   String toValue() {
     switch (this) {
       case AbortAction.cancel:
@@ -10950,7 +10950,7 @@ extension on AbortAction {
   }
 }
 
-extension on String {
+extension AbortActionFromString on String {
   AbortAction toAbortAction() {
     switch (this) {
       case 'CANCEL':
@@ -11261,7 +11261,7 @@ enum ActionType {
   connect,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.publish:
@@ -11276,7 +11276,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'PUBLISH':
@@ -11439,7 +11439,7 @@ enum AlertTargetType {
   sns,
 }
 
-extension on AlertTargetType {
+extension AlertTargetTypeValue on AlertTargetType {
   String toValue() {
     switch (this) {
       case AlertTargetType.sns:
@@ -11448,7 +11448,7 @@ extension on AlertTargetType {
   }
 }
 
-extension on String {
+extension AlertTargetTypeFromString on String {
   AlertTargetType toAlertTargetType() {
     switch (this) {
       case 'SNS':
@@ -11758,7 +11758,7 @@ enum AuditCheckRunStatus {
   failed,
 }
 
-extension on AuditCheckRunStatus {
+extension AuditCheckRunStatusValue on AuditCheckRunStatus {
   String toValue() {
     switch (this) {
       case AuditCheckRunStatus.inProgress:
@@ -11777,7 +11777,7 @@ extension on AuditCheckRunStatus {
   }
 }
 
-extension on String {
+extension AuditCheckRunStatusFromString on String {
   AuditCheckRunStatus toAuditCheckRunStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -11876,7 +11876,7 @@ enum AuditFindingSeverity {
   low,
 }
 
-extension on AuditFindingSeverity {
+extension AuditFindingSeverityValue on AuditFindingSeverity {
   String toValue() {
     switch (this) {
       case AuditFindingSeverity.critical:
@@ -11891,7 +11891,7 @@ extension on AuditFindingSeverity {
   }
 }
 
-extension on String {
+extension AuditFindingSeverityFromString on String {
   AuditFindingSeverity toAuditFindingSeverity() {
     switch (this) {
       case 'CRITICAL':
@@ -11914,7 +11914,7 @@ enum AuditFrequency {
   monthly,
 }
 
-extension on AuditFrequency {
+extension AuditFrequencyValue on AuditFrequency {
   String toValue() {
     switch (this) {
       case AuditFrequency.daily:
@@ -11929,7 +11929,7 @@ extension on AuditFrequency {
   }
 }
 
-extension on String {
+extension AuditFrequencyFromString on String {
   AuditFrequency toAuditFrequency() {
     switch (this) {
       case 'DAILY':
@@ -12014,7 +12014,8 @@ enum AuditMitigationActionsExecutionStatus {
   pending,
 }
 
-extension on AuditMitigationActionsExecutionStatus {
+extension AuditMitigationActionsExecutionStatusValue
+    on AuditMitigationActionsExecutionStatus {
   String toValue() {
     switch (this) {
       case AuditMitigationActionsExecutionStatus.inProgress:
@@ -12033,7 +12034,7 @@ extension on AuditMitigationActionsExecutionStatus {
   }
 }
 
-extension on String {
+extension AuditMitigationActionsExecutionStatusFromString on String {
   AuditMitigationActionsExecutionStatus
       toAuditMitigationActionsExecutionStatus() {
     switch (this) {
@@ -12090,7 +12091,8 @@ enum AuditMitigationActionsTaskStatus {
   canceled,
 }
 
-extension on AuditMitigationActionsTaskStatus {
+extension AuditMitigationActionsTaskStatusValue
+    on AuditMitigationActionsTaskStatus {
   String toValue() {
     switch (this) {
       case AuditMitigationActionsTaskStatus.inProgress:
@@ -12105,7 +12107,7 @@ extension on AuditMitigationActionsTaskStatus {
   }
 }
 
-extension on String {
+extension AuditMitigationActionsTaskStatusFromString on String {
   AuditMitigationActionsTaskStatus toAuditMitigationActionsTaskStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -12212,7 +12214,7 @@ enum AuditNotificationType {
   sns,
 }
 
-extension on AuditNotificationType {
+extension AuditNotificationTypeValue on AuditNotificationType {
   String toValue() {
     switch (this) {
       case AuditNotificationType.sns:
@@ -12221,7 +12223,7 @@ extension on AuditNotificationType {
   }
 }
 
-extension on String {
+extension AuditNotificationTypeFromString on String {
   AuditNotificationType toAuditNotificationType() {
     switch (this) {
       case 'SNS':
@@ -12299,7 +12301,7 @@ enum AuditTaskStatus {
   canceled,
 }
 
-extension on AuditTaskStatus {
+extension AuditTaskStatusValue on AuditTaskStatus {
   String toValue() {
     switch (this) {
       case AuditTaskStatus.inProgress:
@@ -12314,7 +12316,7 @@ extension on AuditTaskStatus {
   }
 }
 
-extension on String {
+extension AuditTaskStatusFromString on String {
   AuditTaskStatus toAuditTaskStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -12335,7 +12337,7 @@ enum AuditTaskType {
   scheduledAuditTask,
 }
 
-extension on AuditTaskType {
+extension AuditTaskTypeValue on AuditTaskType {
   String toValue() {
     switch (this) {
       case AuditTaskType.onDemandAuditTask:
@@ -12346,7 +12348,7 @@ extension on AuditTaskType {
   }
 }
 
-extension on String {
+extension AuditTaskTypeFromString on String {
   AuditTaskType toAuditTaskType() {
     switch (this) {
       case 'ON_DEMAND_AUDIT_TASK':
@@ -12364,7 +12366,7 @@ enum AuthDecision {
   implicitDeny,
 }
 
-extension on AuthDecision {
+extension AuthDecisionValue on AuthDecision {
   String toValue() {
     switch (this) {
       case AuthDecision.allowed:
@@ -12377,7 +12379,7 @@ extension on AuthDecision {
   }
 }
 
-extension on String {
+extension AuthDecisionFromString on String {
   AuthDecision toAuthDecision() {
     switch (this) {
       case 'ALLOWED':
@@ -12566,7 +12568,7 @@ enum AuthorizerStatus {
   inactive,
 }
 
-extension on AuthorizerStatus {
+extension AuthorizerStatusValue on AuthorizerStatus {
   String toValue() {
     switch (this) {
       case AuthorizerStatus.active:
@@ -12577,7 +12579,7 @@ extension on AuthorizerStatus {
   }
 }
 
-extension on String {
+extension AuthorizerStatusFromString on String {
   AuthorizerStatus toAuthorizerStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -12614,7 +12616,7 @@ enum AutoRegistrationStatus {
   disable,
 }
 
-extension on AutoRegistrationStatus {
+extension AutoRegistrationStatusValue on AutoRegistrationStatus {
   String toValue() {
     switch (this) {
       case AutoRegistrationStatus.enable:
@@ -12625,7 +12627,7 @@ extension on AutoRegistrationStatus {
   }
 }
 
-extension on String {
+extension AutoRegistrationStatusFromString on String {
   AutoRegistrationStatus toAutoRegistrationStatus() {
     switch (this) {
       case 'ENABLE':
@@ -12696,7 +12698,8 @@ enum AwsJobAbortCriteriaAbortAction {
   cancel,
 }
 
-extension on AwsJobAbortCriteriaAbortAction {
+extension AwsJobAbortCriteriaAbortActionValue
+    on AwsJobAbortCriteriaAbortAction {
   String toValue() {
     switch (this) {
       case AwsJobAbortCriteriaAbortAction.cancel:
@@ -12705,7 +12708,7 @@ extension on AwsJobAbortCriteriaAbortAction {
   }
 }
 
-extension on String {
+extension AwsJobAbortCriteriaAbortActionFromString on String {
   AwsJobAbortCriteriaAbortAction toAwsJobAbortCriteriaAbortAction() {
     switch (this) {
       case 'CANCEL':
@@ -12723,7 +12726,8 @@ enum AwsJobAbortCriteriaFailureType {
   all,
 }
 
-extension on AwsJobAbortCriteriaFailureType {
+extension AwsJobAbortCriteriaFailureTypeValue
+    on AwsJobAbortCriteriaFailureType {
   String toValue() {
     switch (this) {
       case AwsJobAbortCriteriaFailureType.failed:
@@ -12738,7 +12742,7 @@ extension on AwsJobAbortCriteriaFailureType {
   }
 }
 
-extension on String {
+extension AwsJobAbortCriteriaFailureTypeFromString on String {
   AwsJobAbortCriteriaFailureType toAwsJobAbortCriteriaFailureType() {
     switch (this) {
       case 'FAILED':
@@ -13092,7 +13096,7 @@ enum BehaviorCriteriaType {
   machineLearning,
 }
 
-extension on BehaviorCriteriaType {
+extension BehaviorCriteriaTypeValue on BehaviorCriteriaType {
   String toValue() {
     switch (this) {
       case BehaviorCriteriaType.static:
@@ -13105,7 +13109,7 @@ extension on BehaviorCriteriaType {
   }
 }
 
-extension on String {
+extension BehaviorCriteriaTypeFromString on String {
   BehaviorCriteriaType toBehaviorCriteriaType() {
     switch (this) {
       case 'STATIC':
@@ -13306,7 +13310,7 @@ enum CACertificateStatus {
   inactive,
 }
 
-extension on CACertificateStatus {
+extension CACertificateStatusValue on CACertificateStatus {
   String toValue() {
     switch (this) {
       case CACertificateStatus.active:
@@ -13317,7 +13321,7 @@ extension on CACertificateStatus {
   }
 }
 
-extension on String {
+extension CACertificateStatusFromString on String {
   CACertificateStatus toCACertificateStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -13333,7 +13337,7 @@ enum CACertificateUpdateAction {
   deactivate,
 }
 
-extension on CACertificateUpdateAction {
+extension CACertificateUpdateActionValue on CACertificateUpdateAction {
   String toValue() {
     switch (this) {
       case CACertificateUpdateAction.deactivate:
@@ -13342,7 +13346,7 @@ extension on CACertificateUpdateAction {
   }
 }
 
-extension on String {
+extension CACertificateUpdateActionFromString on String {
   CACertificateUpdateAction toCACertificateUpdateAction() {
     switch (this) {
       case 'DEACTIVATE':
@@ -13410,7 +13414,7 @@ enum CannedAccessControlList {
   logDeliveryWrite,
 }
 
-extension on CannedAccessControlList {
+extension CannedAccessControlListValue on CannedAccessControlList {
   String toValue() {
     switch (this) {
       case CannedAccessControlList.private:
@@ -13433,7 +13437,7 @@ extension on CannedAccessControlList {
   }
 }
 
-extension on String {
+extension CannedAccessControlListFromString on String {
   CannedAccessControlList toCannedAccessControlList() {
     switch (this) {
       case 'private':
@@ -13587,7 +13591,7 @@ enum CertificateMode {
   sniOnly,
 }
 
-extension on CertificateMode {
+extension CertificateModeValue on CertificateMode {
   String toValue() {
     switch (this) {
       case CertificateMode.$default:
@@ -13598,7 +13602,7 @@ extension on CertificateMode {
   }
 }
 
-extension on String {
+extension CertificateModeFromString on String {
   CertificateMode toCertificateMode() {
     switch (this) {
       case 'DEFAULT':
@@ -13619,7 +13623,7 @@ enum CertificateStatus {
   pendingActivation,
 }
 
-extension on CertificateStatus {
+extension CertificateStatusValue on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.active:
@@ -13638,7 +13642,7 @@ extension on CertificateStatus {
   }
 }
 
-extension on String {
+extension CertificateStatusFromString on String {
   CertificateStatus toCertificateStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -13929,7 +13933,7 @@ enum ComparisonOperator {
   notInSet,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.lessThan:
@@ -13956,7 +13960,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'less-than':
@@ -13990,7 +13994,7 @@ enum ConfidenceLevel {
   high,
 }
 
-extension on ConfidenceLevel {
+extension ConfidenceLevelValue on ConfidenceLevel {
   String toValue() {
     switch (this) {
       case ConfidenceLevel.low:
@@ -14003,7 +14007,7 @@ extension on ConfidenceLevel {
   }
 }
 
-extension on String {
+extension ConfidenceLevelFromString on String {
   ConfidenceLevel toConfidenceLevel() {
     switch (this) {
       case 'LOW':
@@ -14709,7 +14713,7 @@ enum CustomMetricType {
   number,
 }
 
-extension on CustomMetricType {
+extension CustomMetricTypeValue on CustomMetricType {
   String toValue() {
     switch (this) {
       case CustomMetricType.stringList:
@@ -14724,7 +14728,7 @@ extension on CustomMetricType {
   }
 }
 
-extension on String {
+extension CustomMetricTypeFromString on String {
   CustomMetricType toCustomMetricType() {
     switch (this) {
       case 'string-list':
@@ -14750,7 +14754,7 @@ enum DayOfWeek {
   sat,
 }
 
-extension on DayOfWeek {
+extension DayOfWeekValue on DayOfWeek {
   String toValue() {
     switch (this) {
       case DayOfWeek.sun:
@@ -14771,7 +14775,7 @@ extension on DayOfWeek {
   }
 }
 
-extension on String {
+extension DayOfWeekFromString on String {
   DayOfWeek toDayOfWeek() {
     switch (this) {
       case 'SUN':
@@ -16260,7 +16264,8 @@ enum DetectMitigationActionExecutionStatus {
   skipped,
 }
 
-extension on DetectMitigationActionExecutionStatus {
+extension DetectMitigationActionExecutionStatusValue
+    on DetectMitigationActionExecutionStatus {
   String toValue() {
     switch (this) {
       case DetectMitigationActionExecutionStatus.inProgress:
@@ -16275,7 +16280,7 @@ extension on DetectMitigationActionExecutionStatus {
   }
 }
 
-extension on String {
+extension DetectMitigationActionExecutionStatusFromString on String {
   DetectMitigationActionExecutionStatus
       toDetectMitigationActionExecutionStatus() {
     switch (this) {
@@ -16326,7 +16331,8 @@ enum DetectMitigationActionsTaskStatus {
   canceled,
 }
 
-extension on DetectMitigationActionsTaskStatus {
+extension DetectMitigationActionsTaskStatusValue
+    on DetectMitigationActionsTaskStatus {
   String toValue() {
     switch (this) {
       case DetectMitigationActionsTaskStatus.inProgress:
@@ -16341,7 +16347,7 @@ extension on DetectMitigationActionsTaskStatus {
   }
 }
 
-extension on String {
+extension DetectMitigationActionsTaskStatusFromString on String {
   DetectMitigationActionsTaskStatus toDetectMitigationActionsTaskStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -16480,7 +16486,7 @@ enum DeviceCertificateUpdateAction {
   deactivate,
 }
 
-extension on DeviceCertificateUpdateAction {
+extension DeviceCertificateUpdateActionValue on DeviceCertificateUpdateAction {
   String toValue() {
     switch (this) {
       case DeviceCertificateUpdateAction.deactivate:
@@ -16489,7 +16495,7 @@ extension on DeviceCertificateUpdateAction {
   }
 }
 
-extension on String {
+extension DeviceCertificateUpdateActionFromString on String {
   DeviceCertificateUpdateAction toDeviceCertificateUpdateAction() {
     switch (this) {
       case 'DEACTIVATE':
@@ -16503,7 +16509,7 @@ enum DimensionType {
   topicFilter,
 }
 
-extension on DimensionType {
+extension DimensionTypeValue on DimensionType {
   String toValue() {
     switch (this) {
       case DimensionType.topicFilter:
@@ -16512,7 +16518,7 @@ extension on DimensionType {
   }
 }
 
-extension on String {
+extension DimensionTypeFromString on String {
   DimensionType toDimensionType() {
     switch (this) {
       case 'TOPIC_FILTER':
@@ -16527,7 +16533,7 @@ enum DimensionValueOperator {
   notIn,
 }
 
-extension on DimensionValueOperator {
+extension DimensionValueOperatorValue on DimensionValueOperator {
   String toValue() {
     switch (this) {
       case DimensionValueOperator.$in:
@@ -16538,7 +16544,7 @@ extension on DimensionValueOperator {
   }
 }
 
-extension on String {
+extension DimensionValueOperatorFromString on String {
   DimensionValueOperator toDimensionValueOperator() {
     switch (this) {
       case 'IN':
@@ -16555,7 +16561,7 @@ enum DomainConfigurationStatus {
   disabled,
 }
 
-extension on DomainConfigurationStatus {
+extension DomainConfigurationStatusValue on DomainConfigurationStatus {
   String toValue() {
     switch (this) {
       case DomainConfigurationStatus.enabled:
@@ -16566,7 +16572,7 @@ extension on DomainConfigurationStatus {
   }
 }
 
-extension on String {
+extension DomainConfigurationStatusFromString on String {
   DomainConfigurationStatus toDomainConfigurationStatus() {
     switch (this) {
       case 'ENABLED':
@@ -16628,7 +16634,7 @@ enum DomainType {
   customerManaged,
 }
 
-extension on DomainType {
+extension DomainTypeValue on DomainType {
   String toValue() {
     switch (this) {
       case DomainType.endpoint:
@@ -16641,7 +16647,7 @@ extension on DomainType {
   }
 }
 
-extension on String {
+extension DomainTypeFromString on String {
   DomainType toDomainType() {
     switch (this) {
       case 'ENDPOINT':
@@ -16661,7 +16667,7 @@ enum DynamicGroupStatus {
   rebuilding,
 }
 
-extension on DynamicGroupStatus {
+extension DynamicGroupStatusValue on DynamicGroupStatus {
   String toValue() {
     switch (this) {
       case DynamicGroupStatus.active:
@@ -16674,7 +16680,7 @@ extension on DynamicGroupStatus {
   }
 }
 
-extension on String {
+extension DynamicGroupStatusFromString on String {
   DynamicGroupStatus toDynamicGroupStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -16838,7 +16844,7 @@ enum DynamoKeyType {
   number,
 }
 
-extension on DynamoKeyType {
+extension DynamoKeyTypeValue on DynamoKeyType {
   String toValue() {
     switch (this) {
       case DynamoKeyType.string:
@@ -16849,7 +16855,7 @@ extension on DynamoKeyType {
   }
 }
 
-extension on String {
+extension DynamoKeyTypeFromString on String {
   DynamoKeyType toDynamoKeyType() {
     switch (this) {
       case 'STRING':
@@ -17001,7 +17007,7 @@ enum EventType {
   caCertificate,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.thing:
@@ -17030,7 +17036,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'THING':
@@ -17155,7 +17161,7 @@ enum FieldType {
   boolean,
 }
 
-extension on FieldType {
+extension FieldTypeValue on FieldType {
   String toValue() {
     switch (this) {
       case FieldType.number:
@@ -17168,7 +17174,7 @@ extension on FieldType {
   }
 }
 
-extension on String {
+extension FieldTypeFromString on String {
   FieldType toFieldType() {
     switch (this) {
       case 'Number':
@@ -17838,7 +17844,7 @@ enum IndexStatus {
   rebuilding,
 }
 
-extension on IndexStatus {
+extension IndexStatusValue on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.active:
@@ -17851,7 +17857,7 @@ extension on IndexStatus {
   }
 }
 
-extension on String {
+extension IndexStatusFromString on String {
   IndexStatus toIndexStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -18247,7 +18253,7 @@ enum JobExecutionFailureType {
   all,
 }
 
-extension on JobExecutionFailureType {
+extension JobExecutionFailureTypeValue on JobExecutionFailureType {
   String toValue() {
     switch (this) {
       case JobExecutionFailureType.failed:
@@ -18262,7 +18268,7 @@ extension on JobExecutionFailureType {
   }
 }
 
-extension on String {
+extension JobExecutionFailureTypeFromString on String {
   JobExecutionFailureType toJobExecutionFailureType() {
     switch (this) {
       case 'FAILED':
@@ -18289,7 +18295,7 @@ enum JobExecutionStatus {
   canceled,
 }
 
-extension on JobExecutionStatus {
+extension JobExecutionStatusValue on JobExecutionStatus {
   String toValue() {
     switch (this) {
       case JobExecutionStatus.queued:
@@ -18312,7 +18318,7 @@ extension on JobExecutionStatus {
   }
 }
 
-extension on String {
+extension JobExecutionStatusFromString on String {
   JobExecutionStatus toJobExecutionStatus() {
     switch (this) {
       case 'QUEUED':
@@ -18539,7 +18545,7 @@ enum JobStatus {
   deletionInProgress,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.inProgress:
@@ -18554,7 +18560,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -19993,7 +19999,7 @@ enum LogLevel {
   disabled,
 }
 
-extension on LogLevel {
+extension LogLevelValue on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.debug:
@@ -20010,7 +20016,7 @@ extension on LogLevel {
   }
 }
 
-extension on String {
+extension LogLevelFromString on String {
   LogLevel toLogLevel() {
     switch (this) {
       case 'DEBUG':
@@ -20084,7 +20090,7 @@ enum LogTargetType {
   thingGroup,
 }
 
-extension on LogTargetType {
+extension LogTargetTypeValue on LogTargetType {
   String toValue() {
     switch (this) {
       case LogTargetType.$default:
@@ -20095,7 +20101,7 @@ extension on LogTargetType {
   }
 }
 
-extension on String {
+extension LogTargetTypeFromString on String {
   LogTargetType toLogTargetType() {
     switch (this) {
       case 'DEFAULT':
@@ -20157,7 +20163,7 @@ enum MessageFormat {
   json,
 }
 
-extension on MessageFormat {
+extension MessageFormatValue on MessageFormat {
   String toValue() {
     switch (this) {
       case MessageFormat.raw:
@@ -20168,7 +20174,7 @@ extension on MessageFormat {
   }
 }
 
-extension on String {
+extension MessageFormatFromString on String {
   MessageFormat toMessageFormat() {
     switch (this) {
       case 'RAW':
@@ -20483,7 +20489,7 @@ enum MitigationActionType {
   publishFindingToSns,
 }
 
-extension on MitigationActionType {
+extension MitigationActionTypeValue on MitigationActionType {
   String toValue() {
     switch (this) {
       case MitigationActionType.updateDeviceCertificate:
@@ -20502,7 +20508,7 @@ extension on MitigationActionType {
   }
 }
 
-extension on String {
+extension MitigationActionTypeFromString on String {
   MitigationActionType toMitigationActionType() {
     switch (this) {
       case 'UPDATE_DEVICE_CERTIFICATE':
@@ -20528,7 +20534,7 @@ enum ModelStatus {
   expired,
 }
 
-extension on ModelStatus {
+extension ModelStatusValue on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.pendingBuild:
@@ -20541,7 +20547,7 @@ extension on ModelStatus {
   }
 }
 
-extension on String {
+extension ModelStatusFromString on String {
   ModelStatus toModelStatus() {
     switch (this) {
       case 'PENDING_BUILD':
@@ -20802,7 +20808,7 @@ enum OTAUpdateStatus {
   createFailed,
 }
 
-extension on OTAUpdateStatus {
+extension OTAUpdateStatusValue on OTAUpdateStatus {
   String toValue() {
     switch (this) {
       case OTAUpdateStatus.createPending:
@@ -20817,7 +20823,7 @@ extension on OTAUpdateStatus {
   }
 }
 
-extension on String {
+extension OTAUpdateStatusFromString on String {
   OTAUpdateStatus toOTAUpdateStatus() {
     switch (this) {
       case 'CREATE_PENDING':
@@ -20942,7 +20948,7 @@ enum PolicyTemplateName {
   blankPolicy,
 }
 
-extension on PolicyTemplateName {
+extension PolicyTemplateNameValue on PolicyTemplateName {
   String toValue() {
     switch (this) {
       case PolicyTemplateName.blankPolicy:
@@ -20951,7 +20957,7 @@ extension on PolicyTemplateName {
   }
 }
 
-extension on String {
+extension PolicyTemplateNameFromString on String {
   PolicyTemplateName toPolicyTemplateName() {
     switch (this) {
       case 'BLANK_POLICY':
@@ -21053,7 +21059,7 @@ enum Protocol {
   http,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.mqtt:
@@ -21064,7 +21070,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'MQTT':
@@ -21503,7 +21509,7 @@ enum ReportType {
   results,
 }
 
-extension on ReportType {
+extension ReportTypeValue on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.errors:
@@ -21514,7 +21520,7 @@ extension on ReportType {
   }
 }
 
-extension on String {
+extension ReportTypeFromString on String {
   ReportType toReportType() {
     switch (this) {
       case 'ERRORS':
@@ -21651,7 +21657,7 @@ enum ResourceType {
   iamRole,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.deviceCertificate:
@@ -21674,7 +21680,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'DEVICE_CERTIFICATE':
@@ -22028,7 +22034,7 @@ enum ServerCertificateStatus {
   valid,
 }
 
-extension on ServerCertificateStatus {
+extension ServerCertificateStatusValue on ServerCertificateStatus {
   String toValue() {
     switch (this) {
       case ServerCertificateStatus.invalid:
@@ -22039,7 +22045,7 @@ extension on ServerCertificateStatus {
   }
 }
 
-extension on String {
+extension ServerCertificateStatusFromString on String {
   ServerCertificateStatus toServerCertificateStatus() {
     switch (this) {
       case 'INVALID':
@@ -22084,7 +22090,7 @@ enum ServiceType {
   jobs,
 }
 
-extension on ServiceType {
+extension ServiceTypeValue on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.data:
@@ -22097,7 +22103,7 @@ extension on ServiceType {
   }
 }
 
-extension on String {
+extension ServiceTypeFromString on String {
   ServiceType toServiceType() {
     switch (this) {
       case 'DATA':
@@ -22475,7 +22481,7 @@ enum Status {
   cancelling,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.inProgress:
@@ -22492,7 +22498,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'InProgress':
@@ -22742,7 +22748,7 @@ enum TargetSelection {
   snapshot,
 }
 
-extension on TargetSelection {
+extension TargetSelectionValue on TargetSelection {
   String toValue() {
     switch (this) {
       case TargetSelection.continuous:
@@ -22753,7 +22759,7 @@ extension on TargetSelection {
   }
 }
 
-extension on String {
+extension TargetSelectionFromString on String {
   TargetSelection toTargetSelection() {
     switch (this) {
       case 'CONTINUOUS':
@@ -22971,7 +22977,7 @@ enum ThingConnectivityIndexingMode {
   status,
 }
 
-extension on ThingConnectivityIndexingMode {
+extension ThingConnectivityIndexingModeValue on ThingConnectivityIndexingMode {
   String toValue() {
     switch (this) {
       case ThingConnectivityIndexingMode.off:
@@ -22982,7 +22988,7 @@ extension on ThingConnectivityIndexingMode {
   }
 }
 
-extension on String {
+extension ThingConnectivityIndexingModeFromString on String {
   ThingConnectivityIndexingMode toThingConnectivityIndexingMode() {
     switch (this) {
       case 'OFF':
@@ -23138,7 +23144,7 @@ enum ThingGroupIndexingMode {
   on,
 }
 
-extension on ThingGroupIndexingMode {
+extension ThingGroupIndexingModeValue on ThingGroupIndexingMode {
   String toValue() {
     switch (this) {
       case ThingGroupIndexingMode.off:
@@ -23149,7 +23155,7 @@ extension on ThingGroupIndexingMode {
   }
 }
 
-extension on String {
+extension ThingGroupIndexingModeFromString on String {
   ThingGroupIndexingMode toThingGroupIndexingMode() {
     switch (this) {
       case 'OFF':
@@ -23307,7 +23313,7 @@ enum ThingIndexingMode {
   registryAndShadow,
 }
 
-extension on ThingIndexingMode {
+extension ThingIndexingModeValue on ThingIndexingMode {
   String toValue() {
     switch (this) {
       case ThingIndexingMode.off:
@@ -23320,7 +23326,7 @@ extension on ThingIndexingMode {
   }
 }
 
-extension on String {
+extension ThingIndexingModeFromString on String {
   ThingIndexingMode toThingIndexingMode() {
     switch (this) {
       case 'OFF':
@@ -23786,7 +23792,7 @@ enum TopicRuleDestinationStatus {
   deleting,
 }
 
-extension on TopicRuleDestinationStatus {
+extension TopicRuleDestinationStatusValue on TopicRuleDestinationStatus {
   String toValue() {
     switch (this) {
       case TopicRuleDestinationStatus.enabled:
@@ -23803,7 +23809,7 @@ extension on TopicRuleDestinationStatus {
   }
 }
 
-extension on String {
+extension TopicRuleDestinationStatusFromString on String {
   TopicRuleDestinationStatus toTopicRuleDestinationStatus() {
     switch (this) {
       case 'ENABLED':
@@ -24618,7 +24624,7 @@ enum ViolationEventType {
   alarmInvalidated,
 }
 
-extension on ViolationEventType {
+extension ViolationEventTypeValue on ViolationEventType {
   String toValue() {
     switch (this) {
       case ViolationEventType.inAlarm:
@@ -24631,7 +24637,7 @@ extension on ViolationEventType {
   }
 }
 
-extension on String {
+extension ViolationEventTypeFromString on String {
   ViolationEventType toViolationEventType() {
     switch (this) {
       case 'in-alarm':

--- a/generated/aws_iot_api/lib/iot-2015-05-28.dart
+++ b/generated/aws_iot_api/lib/iot-2015-05-28.dart
@@ -10941,7 +10941,7 @@ enum AbortAction {
   cancel,
 }
 
-extension AbortActionValue on AbortAction {
+extension AbortActionValueExtension on AbortAction {
   String toValue() {
     switch (this) {
       case AbortAction.cancel:
@@ -11261,7 +11261,7 @@ enum ActionType {
   connect,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.publish:
@@ -11439,7 +11439,7 @@ enum AlertTargetType {
   sns,
 }
 
-extension AlertTargetTypeValue on AlertTargetType {
+extension AlertTargetTypeValueExtension on AlertTargetType {
   String toValue() {
     switch (this) {
       case AlertTargetType.sns:
@@ -11758,7 +11758,7 @@ enum AuditCheckRunStatus {
   failed,
 }
 
-extension AuditCheckRunStatusValue on AuditCheckRunStatus {
+extension AuditCheckRunStatusValueExtension on AuditCheckRunStatus {
   String toValue() {
     switch (this) {
       case AuditCheckRunStatus.inProgress:
@@ -11876,7 +11876,7 @@ enum AuditFindingSeverity {
   low,
 }
 
-extension AuditFindingSeverityValue on AuditFindingSeverity {
+extension AuditFindingSeverityValueExtension on AuditFindingSeverity {
   String toValue() {
     switch (this) {
       case AuditFindingSeverity.critical:
@@ -11914,7 +11914,7 @@ enum AuditFrequency {
   monthly,
 }
 
-extension AuditFrequencyValue on AuditFrequency {
+extension AuditFrequencyValueExtension on AuditFrequency {
   String toValue() {
     switch (this) {
       case AuditFrequency.daily:
@@ -12014,7 +12014,7 @@ enum AuditMitigationActionsExecutionStatus {
   pending,
 }
 
-extension AuditMitigationActionsExecutionStatusValue
+extension AuditMitigationActionsExecutionStatusValueExtension
     on AuditMitigationActionsExecutionStatus {
   String toValue() {
     switch (this) {
@@ -12091,7 +12091,7 @@ enum AuditMitigationActionsTaskStatus {
   canceled,
 }
 
-extension AuditMitigationActionsTaskStatusValue
+extension AuditMitigationActionsTaskStatusValueExtension
     on AuditMitigationActionsTaskStatus {
   String toValue() {
     switch (this) {
@@ -12214,7 +12214,7 @@ enum AuditNotificationType {
   sns,
 }
 
-extension AuditNotificationTypeValue on AuditNotificationType {
+extension AuditNotificationTypeValueExtension on AuditNotificationType {
   String toValue() {
     switch (this) {
       case AuditNotificationType.sns:
@@ -12301,7 +12301,7 @@ enum AuditTaskStatus {
   canceled,
 }
 
-extension AuditTaskStatusValue on AuditTaskStatus {
+extension AuditTaskStatusValueExtension on AuditTaskStatus {
   String toValue() {
     switch (this) {
       case AuditTaskStatus.inProgress:
@@ -12337,7 +12337,7 @@ enum AuditTaskType {
   scheduledAuditTask,
 }
 
-extension AuditTaskTypeValue on AuditTaskType {
+extension AuditTaskTypeValueExtension on AuditTaskType {
   String toValue() {
     switch (this) {
       case AuditTaskType.onDemandAuditTask:
@@ -12366,7 +12366,7 @@ enum AuthDecision {
   implicitDeny,
 }
 
-extension AuthDecisionValue on AuthDecision {
+extension AuthDecisionValueExtension on AuthDecision {
   String toValue() {
     switch (this) {
       case AuthDecision.allowed:
@@ -12568,7 +12568,7 @@ enum AuthorizerStatus {
   inactive,
 }
 
-extension AuthorizerStatusValue on AuthorizerStatus {
+extension AuthorizerStatusValueExtension on AuthorizerStatus {
   String toValue() {
     switch (this) {
       case AuthorizerStatus.active:
@@ -12616,7 +12616,7 @@ enum AutoRegistrationStatus {
   disable,
 }
 
-extension AutoRegistrationStatusValue on AutoRegistrationStatus {
+extension AutoRegistrationStatusValueExtension on AutoRegistrationStatus {
   String toValue() {
     switch (this) {
       case AutoRegistrationStatus.enable:
@@ -12698,7 +12698,7 @@ enum AwsJobAbortCriteriaAbortAction {
   cancel,
 }
 
-extension AwsJobAbortCriteriaAbortActionValue
+extension AwsJobAbortCriteriaAbortActionValueExtension
     on AwsJobAbortCriteriaAbortAction {
   String toValue() {
     switch (this) {
@@ -12726,7 +12726,7 @@ enum AwsJobAbortCriteriaFailureType {
   all,
 }
 
-extension AwsJobAbortCriteriaFailureTypeValue
+extension AwsJobAbortCriteriaFailureTypeValueExtension
     on AwsJobAbortCriteriaFailureType {
   String toValue() {
     switch (this) {
@@ -13096,7 +13096,7 @@ enum BehaviorCriteriaType {
   machineLearning,
 }
 
-extension BehaviorCriteriaTypeValue on BehaviorCriteriaType {
+extension BehaviorCriteriaTypeValueExtension on BehaviorCriteriaType {
   String toValue() {
     switch (this) {
       case BehaviorCriteriaType.static:
@@ -13310,7 +13310,7 @@ enum CACertificateStatus {
   inactive,
 }
 
-extension CACertificateStatusValue on CACertificateStatus {
+extension CACertificateStatusValueExtension on CACertificateStatus {
   String toValue() {
     switch (this) {
       case CACertificateStatus.active:
@@ -13337,7 +13337,7 @@ enum CACertificateUpdateAction {
   deactivate,
 }
 
-extension CACertificateUpdateActionValue on CACertificateUpdateAction {
+extension CACertificateUpdateActionValueExtension on CACertificateUpdateAction {
   String toValue() {
     switch (this) {
       case CACertificateUpdateAction.deactivate:
@@ -13414,7 +13414,7 @@ enum CannedAccessControlList {
   logDeliveryWrite,
 }
 
-extension CannedAccessControlListValue on CannedAccessControlList {
+extension CannedAccessControlListValueExtension on CannedAccessControlList {
   String toValue() {
     switch (this) {
       case CannedAccessControlList.private:
@@ -13591,7 +13591,7 @@ enum CertificateMode {
   sniOnly,
 }
 
-extension CertificateModeValue on CertificateMode {
+extension CertificateModeValueExtension on CertificateMode {
   String toValue() {
     switch (this) {
       case CertificateMode.$default:
@@ -13623,7 +13623,7 @@ enum CertificateStatus {
   pendingActivation,
 }
 
-extension CertificateStatusValue on CertificateStatus {
+extension CertificateStatusValueExtension on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.active:
@@ -13933,7 +13933,7 @@ enum ComparisonOperator {
   notInSet,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.lessThan:
@@ -13994,7 +13994,7 @@ enum ConfidenceLevel {
   high,
 }
 
-extension ConfidenceLevelValue on ConfidenceLevel {
+extension ConfidenceLevelValueExtension on ConfidenceLevel {
   String toValue() {
     switch (this) {
       case ConfidenceLevel.low:
@@ -14713,7 +14713,7 @@ enum CustomMetricType {
   number,
 }
 
-extension CustomMetricTypeValue on CustomMetricType {
+extension CustomMetricTypeValueExtension on CustomMetricType {
   String toValue() {
     switch (this) {
       case CustomMetricType.stringList:
@@ -14754,7 +14754,7 @@ enum DayOfWeek {
   sat,
 }
 
-extension DayOfWeekValue on DayOfWeek {
+extension DayOfWeekValueExtension on DayOfWeek {
   String toValue() {
     switch (this) {
       case DayOfWeek.sun:
@@ -16264,7 +16264,7 @@ enum DetectMitigationActionExecutionStatus {
   skipped,
 }
 
-extension DetectMitigationActionExecutionStatusValue
+extension DetectMitigationActionExecutionStatusValueExtension
     on DetectMitigationActionExecutionStatus {
   String toValue() {
     switch (this) {
@@ -16331,7 +16331,7 @@ enum DetectMitigationActionsTaskStatus {
   canceled,
 }
 
-extension DetectMitigationActionsTaskStatusValue
+extension DetectMitigationActionsTaskStatusValueExtension
     on DetectMitigationActionsTaskStatus {
   String toValue() {
     switch (this) {
@@ -16486,7 +16486,8 @@ enum DeviceCertificateUpdateAction {
   deactivate,
 }
 
-extension DeviceCertificateUpdateActionValue on DeviceCertificateUpdateAction {
+extension DeviceCertificateUpdateActionValueExtension
+    on DeviceCertificateUpdateAction {
   String toValue() {
     switch (this) {
       case DeviceCertificateUpdateAction.deactivate:
@@ -16509,7 +16510,7 @@ enum DimensionType {
   topicFilter,
 }
 
-extension DimensionTypeValue on DimensionType {
+extension DimensionTypeValueExtension on DimensionType {
   String toValue() {
     switch (this) {
       case DimensionType.topicFilter:
@@ -16533,7 +16534,7 @@ enum DimensionValueOperator {
   notIn,
 }
 
-extension DimensionValueOperatorValue on DimensionValueOperator {
+extension DimensionValueOperatorValueExtension on DimensionValueOperator {
   String toValue() {
     switch (this) {
       case DimensionValueOperator.$in:
@@ -16561,7 +16562,7 @@ enum DomainConfigurationStatus {
   disabled,
 }
 
-extension DomainConfigurationStatusValue on DomainConfigurationStatus {
+extension DomainConfigurationStatusValueExtension on DomainConfigurationStatus {
   String toValue() {
     switch (this) {
       case DomainConfigurationStatus.enabled:
@@ -16634,7 +16635,7 @@ enum DomainType {
   customerManaged,
 }
 
-extension DomainTypeValue on DomainType {
+extension DomainTypeValueExtension on DomainType {
   String toValue() {
     switch (this) {
       case DomainType.endpoint:
@@ -16667,7 +16668,7 @@ enum DynamicGroupStatus {
   rebuilding,
 }
 
-extension DynamicGroupStatusValue on DynamicGroupStatus {
+extension DynamicGroupStatusValueExtension on DynamicGroupStatus {
   String toValue() {
     switch (this) {
       case DynamicGroupStatus.active:
@@ -16844,7 +16845,7 @@ enum DynamoKeyType {
   number,
 }
 
-extension DynamoKeyTypeValue on DynamoKeyType {
+extension DynamoKeyTypeValueExtension on DynamoKeyType {
   String toValue() {
     switch (this) {
       case DynamoKeyType.string:
@@ -17007,7 +17008,7 @@ enum EventType {
   caCertificate,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.thing:
@@ -17161,7 +17162,7 @@ enum FieldType {
   boolean,
 }
 
-extension FieldTypeValue on FieldType {
+extension FieldTypeValueExtension on FieldType {
   String toValue() {
     switch (this) {
       case FieldType.number:
@@ -17844,7 +17845,7 @@ enum IndexStatus {
   rebuilding,
 }
 
-extension IndexStatusValue on IndexStatus {
+extension IndexStatusValueExtension on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.active:
@@ -18253,7 +18254,7 @@ enum JobExecutionFailureType {
   all,
 }
 
-extension JobExecutionFailureTypeValue on JobExecutionFailureType {
+extension JobExecutionFailureTypeValueExtension on JobExecutionFailureType {
   String toValue() {
     switch (this) {
       case JobExecutionFailureType.failed:
@@ -18295,7 +18296,7 @@ enum JobExecutionStatus {
   canceled,
 }
 
-extension JobExecutionStatusValue on JobExecutionStatus {
+extension JobExecutionStatusValueExtension on JobExecutionStatus {
   String toValue() {
     switch (this) {
       case JobExecutionStatus.queued:
@@ -18545,7 +18546,7 @@ enum JobStatus {
   deletionInProgress,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.inProgress:
@@ -19999,7 +20000,7 @@ enum LogLevel {
   disabled,
 }
 
-extension LogLevelValue on LogLevel {
+extension LogLevelValueExtension on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.debug:
@@ -20090,7 +20091,7 @@ enum LogTargetType {
   thingGroup,
 }
 
-extension LogTargetTypeValue on LogTargetType {
+extension LogTargetTypeValueExtension on LogTargetType {
   String toValue() {
     switch (this) {
       case LogTargetType.$default:
@@ -20163,7 +20164,7 @@ enum MessageFormat {
   json,
 }
 
-extension MessageFormatValue on MessageFormat {
+extension MessageFormatValueExtension on MessageFormat {
   String toValue() {
     switch (this) {
       case MessageFormat.raw:
@@ -20489,7 +20490,7 @@ enum MitigationActionType {
   publishFindingToSns,
 }
 
-extension MitigationActionTypeValue on MitigationActionType {
+extension MitigationActionTypeValueExtension on MitigationActionType {
   String toValue() {
     switch (this) {
       case MitigationActionType.updateDeviceCertificate:
@@ -20534,7 +20535,7 @@ enum ModelStatus {
   expired,
 }
 
-extension ModelStatusValue on ModelStatus {
+extension ModelStatusValueExtension on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.pendingBuild:
@@ -20808,7 +20809,7 @@ enum OTAUpdateStatus {
   createFailed,
 }
 
-extension OTAUpdateStatusValue on OTAUpdateStatus {
+extension OTAUpdateStatusValueExtension on OTAUpdateStatus {
   String toValue() {
     switch (this) {
       case OTAUpdateStatus.createPending:
@@ -20948,7 +20949,7 @@ enum PolicyTemplateName {
   blankPolicy,
 }
 
-extension PolicyTemplateNameValue on PolicyTemplateName {
+extension PolicyTemplateNameValueExtension on PolicyTemplateName {
   String toValue() {
     switch (this) {
       case PolicyTemplateName.blankPolicy:
@@ -21059,7 +21060,7 @@ enum Protocol {
   http,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.mqtt:
@@ -21509,7 +21510,7 @@ enum ReportType {
   results,
 }
 
-extension ReportTypeValue on ReportType {
+extension ReportTypeValueExtension on ReportType {
   String toValue() {
     switch (this) {
       case ReportType.errors:
@@ -21657,7 +21658,7 @@ enum ResourceType {
   iamRole,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.deviceCertificate:
@@ -22034,7 +22035,7 @@ enum ServerCertificateStatus {
   valid,
 }
 
-extension ServerCertificateStatusValue on ServerCertificateStatus {
+extension ServerCertificateStatusValueExtension on ServerCertificateStatus {
   String toValue() {
     switch (this) {
       case ServerCertificateStatus.invalid:
@@ -22090,7 +22091,7 @@ enum ServiceType {
   jobs,
 }
 
-extension ServiceTypeValue on ServiceType {
+extension ServiceTypeValueExtension on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.data:
@@ -22481,7 +22482,7 @@ enum Status {
   cancelling,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.inProgress:
@@ -22748,7 +22749,7 @@ enum TargetSelection {
   snapshot,
 }
 
-extension TargetSelectionValue on TargetSelection {
+extension TargetSelectionValueExtension on TargetSelection {
   String toValue() {
     switch (this) {
       case TargetSelection.continuous:
@@ -22977,7 +22978,8 @@ enum ThingConnectivityIndexingMode {
   status,
 }
 
-extension ThingConnectivityIndexingModeValue on ThingConnectivityIndexingMode {
+extension ThingConnectivityIndexingModeValueExtension
+    on ThingConnectivityIndexingMode {
   String toValue() {
     switch (this) {
       case ThingConnectivityIndexingMode.off:
@@ -23144,7 +23146,7 @@ enum ThingGroupIndexingMode {
   on,
 }
 
-extension ThingGroupIndexingModeValue on ThingGroupIndexingMode {
+extension ThingGroupIndexingModeValueExtension on ThingGroupIndexingMode {
   String toValue() {
     switch (this) {
       case ThingGroupIndexingMode.off:
@@ -23313,7 +23315,7 @@ enum ThingIndexingMode {
   registryAndShadow,
 }
 
-extension ThingIndexingModeValue on ThingIndexingMode {
+extension ThingIndexingModeValueExtension on ThingIndexingMode {
   String toValue() {
     switch (this) {
       case ThingIndexingMode.off:
@@ -23792,7 +23794,8 @@ enum TopicRuleDestinationStatus {
   deleting,
 }
 
-extension TopicRuleDestinationStatusValue on TopicRuleDestinationStatus {
+extension TopicRuleDestinationStatusValueExtension
+    on TopicRuleDestinationStatus {
   String toValue() {
     switch (this) {
       case TopicRuleDestinationStatus.enabled:
@@ -24624,7 +24627,7 @@ enum ViolationEventType {
   alarmInvalidated,
 }
 
-extension ViolationEventTypeValue on ViolationEventType {
+extension ViolationEventTypeValueExtension on ViolationEventType {
   String toValue() {
     switch (this) {
       case ViolationEventType.inAlarm:

--- a/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
+++ b/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
@@ -463,7 +463,7 @@ enum JobExecutionStatus {
   canceled,
 }
 
-extension JobExecutionStatusValue on JobExecutionStatus {
+extension JobExecutionStatusValueExtension on JobExecutionStatus {
   String toValue() {
     switch (this) {
       case JobExecutionStatus.queued:

--- a/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
+++ b/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
@@ -463,7 +463,7 @@ enum JobExecutionStatus {
   canceled,
 }
 
-extension on JobExecutionStatus {
+extension JobExecutionStatusValue on JobExecutionStatus {
   String toValue() {
     switch (this) {
       case JobExecutionStatus.queued:
@@ -486,7 +486,7 @@ extension on JobExecutionStatus {
   }
 }
 
-extension on String {
+extension JobExecutionStatusFromString on String {
   JobExecutionStatus toJobExecutionStatus() {
     switch (this) {
       case 'QUEUED':

--- a/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
+++ b/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
@@ -1863,7 +1863,7 @@ enum ChannelStatus {
   deleting,
 }
 
-extension on ChannelStatus {
+extension ChannelStatusValue on ChannelStatus {
   String toValue() {
     switch (this) {
       case ChannelStatus.creating:
@@ -1876,7 +1876,7 @@ extension on ChannelStatus {
   }
 }
 
-extension on String {
+extension ChannelStatusFromString on String {
   ChannelStatus toChannelStatus() {
     switch (this) {
       case 'CREATING':
@@ -2046,7 +2046,7 @@ enum ComputeType {
   acu_2,
 }
 
-extension on ComputeType {
+extension ComputeTypeValue on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.acu_1:
@@ -2057,7 +2057,7 @@ extension on ComputeType {
   }
 }
 
-extension on String {
+extension ComputeTypeFromString on String {
   ComputeType toComputeType() {
     switch (this) {
       case 'ACU_1':
@@ -2559,7 +2559,7 @@ enum DatasetActionType {
   container,
 }
 
-extension on DatasetActionType {
+extension DatasetActionTypeValue on DatasetActionType {
   String toValue() {
     switch (this) {
       case DatasetActionType.query:
@@ -2570,7 +2570,7 @@ extension on DatasetActionType {
   }
 }
 
-extension on String {
+extension DatasetActionTypeFromString on String {
   DatasetActionType toDatasetActionType() {
     switch (this) {
       case 'QUERY':
@@ -2661,7 +2661,7 @@ enum DatasetContentState {
   failed,
 }
 
-extension on DatasetContentState {
+extension DatasetContentStateValue on DatasetContentState {
   String toValue() {
     switch (this) {
       case DatasetContentState.creating:
@@ -2674,7 +2674,7 @@ extension on DatasetContentState {
   }
 }
 
-extension on String {
+extension DatasetContentStateFromString on String {
   DatasetContentState toDatasetContentState() {
     switch (this) {
       case 'CREATING':
@@ -2797,7 +2797,7 @@ enum DatasetStatus {
   deleting,
 }
 
-extension on DatasetStatus {
+extension DatasetStatusValue on DatasetStatus {
   String toValue() {
     switch (this) {
       case DatasetStatus.creating:
@@ -2810,7 +2810,7 @@ extension on DatasetStatus {
   }
 }
 
-extension on String {
+extension DatasetStatusFromString on String {
   DatasetStatus toDatasetStatus() {
     switch (this) {
       case 'CREATING':
@@ -3048,7 +3048,7 @@ enum DatastoreStatus {
   deleting,
 }
 
-extension on DatastoreStatus {
+extension DatastoreStatusValue on DatastoreStatus {
   String toValue() {
     switch (this) {
       case DatastoreStatus.creating:
@@ -3061,7 +3061,7 @@ extension on DatastoreStatus {
   }
 }
 
-extension on String {
+extension DatastoreStatusFromString on String {
   DatastoreStatus toDatastoreStatus() {
     switch (this) {
       case 'CREATING':
@@ -3548,7 +3548,7 @@ enum FileFormatType {
   parquet,
 }
 
-extension on FileFormatType {
+extension FileFormatTypeValue on FileFormatType {
   String toValue() {
     switch (this) {
       case FileFormatType.json:
@@ -3559,7 +3559,7 @@ extension on FileFormatType {
   }
 }
 
-extension on String {
+extension FileFormatTypeFromString on String {
   FileFormatType toFileFormatType() {
     switch (this) {
       case 'JSON':
@@ -3960,7 +3960,7 @@ enum LoggingLevel {
   error,
 }
 
-extension on LoggingLevel {
+extension LoggingLevelValue on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -3969,7 +3969,7 @@ extension on LoggingLevel {
   }
 }
 
-extension on String {
+extension LoggingLevelFromString on String {
   LoggingLevel toLoggingLevel() {
     switch (this) {
       case 'ERROR':
@@ -4399,7 +4399,7 @@ enum ReprocessingStatus {
   failed,
 }
 
-extension on ReprocessingStatus {
+extension ReprocessingStatusValue on ReprocessingStatus {
   String toValue() {
     switch (this) {
       case ReprocessingStatus.running:
@@ -4414,7 +4414,7 @@ extension on ReprocessingStatus {
   }
 }
 
-extension on String {
+extension ReprocessingStatusFromString on String {
   ReprocessingStatus toReprocessingStatus() {
     switch (this) {
       case 'RUNNING':

--- a/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
+++ b/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
@@ -1863,7 +1863,7 @@ enum ChannelStatus {
   deleting,
 }
 
-extension ChannelStatusValue on ChannelStatus {
+extension ChannelStatusValueExtension on ChannelStatus {
   String toValue() {
     switch (this) {
       case ChannelStatus.creating:
@@ -2046,7 +2046,7 @@ enum ComputeType {
   acu_2,
 }
 
-extension ComputeTypeValue on ComputeType {
+extension ComputeTypeValueExtension on ComputeType {
   String toValue() {
     switch (this) {
       case ComputeType.acu_1:
@@ -2559,7 +2559,7 @@ enum DatasetActionType {
   container,
 }
 
-extension DatasetActionTypeValue on DatasetActionType {
+extension DatasetActionTypeValueExtension on DatasetActionType {
   String toValue() {
     switch (this) {
       case DatasetActionType.query:
@@ -2661,7 +2661,7 @@ enum DatasetContentState {
   failed,
 }
 
-extension DatasetContentStateValue on DatasetContentState {
+extension DatasetContentStateValueExtension on DatasetContentState {
   String toValue() {
     switch (this) {
       case DatasetContentState.creating:
@@ -2797,7 +2797,7 @@ enum DatasetStatus {
   deleting,
 }
 
-extension DatasetStatusValue on DatasetStatus {
+extension DatasetStatusValueExtension on DatasetStatus {
   String toValue() {
     switch (this) {
       case DatasetStatus.creating:
@@ -3048,7 +3048,7 @@ enum DatastoreStatus {
   deleting,
 }
 
-extension DatastoreStatusValue on DatastoreStatus {
+extension DatastoreStatusValueExtension on DatastoreStatus {
   String toValue() {
     switch (this) {
       case DatastoreStatus.creating:
@@ -3548,7 +3548,7 @@ enum FileFormatType {
   parquet,
 }
 
-extension FileFormatTypeValue on FileFormatType {
+extension FileFormatTypeValueExtension on FileFormatType {
   String toValue() {
     switch (this) {
       case FileFormatType.json:
@@ -3960,7 +3960,7 @@ enum LoggingLevel {
   error,
 }
 
-extension LoggingLevelValue on LoggingLevel {
+extension LoggingLevelValueExtension on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -4399,7 +4399,7 @@ enum ReprocessingStatus {
   failed,
 }
 
-extension ReprocessingStatusValue on ReprocessingStatus {
+extension ReprocessingStatusValueExtension on ReprocessingStatus {
   String toValue() {
     switch (this) {
       case ReprocessingStatus.running:

--- a/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
+++ b/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
@@ -1451,7 +1451,8 @@ enum DetectorModelVersionStatus {
   failed,
 }
 
-extension DetectorModelVersionStatusValue on DetectorModelVersionStatus {
+extension DetectorModelVersionStatusValueExtension
+    on DetectorModelVersionStatus {
   String toValue() {
     switch (this) {
       case DetectorModelVersionStatus.active:
@@ -1755,7 +1756,7 @@ enum EvaluationMethod {
   serial,
 }
 
-extension EvaluationMethodValue on EvaluationMethod {
+extension EvaluationMethodValueExtension on EvaluationMethod {
   String toValue() {
     switch (this) {
       case EvaluationMethod.batch:
@@ -1969,7 +1970,7 @@ enum InputStatus {
   deleting,
 }
 
-extension InputStatusValue on InputStatus {
+extension InputStatusValueExtension on InputStatus {
   String toValue() {
     switch (this) {
       case InputStatus.creating:
@@ -2315,7 +2316,7 @@ enum LoggingLevel {
   debug,
 }
 
-extension LoggingLevelValue on LoggingLevel {
+extension LoggingLevelValueExtension on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -2529,7 +2530,7 @@ enum PayloadType {
   json,
 }
 
-extension PayloadTypeValue on PayloadType {
+extension PayloadTypeValueExtension on PayloadType {
   String toValue() {
     switch (this) {
       case PayloadType.string:

--- a/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
+++ b/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
@@ -1451,7 +1451,7 @@ enum DetectorModelVersionStatus {
   failed,
 }
 
-extension on DetectorModelVersionStatus {
+extension DetectorModelVersionStatusValue on DetectorModelVersionStatus {
   String toValue() {
     switch (this) {
       case DetectorModelVersionStatus.active:
@@ -1472,7 +1472,7 @@ extension on DetectorModelVersionStatus {
   }
 }
 
-extension on String {
+extension DetectorModelVersionStatusFromString on String {
   DetectorModelVersionStatus toDetectorModelVersionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -1755,7 +1755,7 @@ enum EvaluationMethod {
   serial,
 }
 
-extension on EvaluationMethod {
+extension EvaluationMethodValue on EvaluationMethod {
   String toValue() {
     switch (this) {
       case EvaluationMethod.batch:
@@ -1766,7 +1766,7 @@ extension on EvaluationMethod {
   }
 }
 
-extension on String {
+extension EvaluationMethodFromString on String {
   EvaluationMethod toEvaluationMethod() {
     switch (this) {
       case 'BATCH':
@@ -1969,7 +1969,7 @@ enum InputStatus {
   deleting,
 }
 
-extension on InputStatus {
+extension InputStatusValue on InputStatus {
   String toValue() {
     switch (this) {
       case InputStatus.creating:
@@ -1984,7 +1984,7 @@ extension on InputStatus {
   }
 }
 
-extension on String {
+extension InputStatusFromString on String {
   InputStatus toInputStatus() {
     switch (this) {
       case 'CREATING':
@@ -2315,7 +2315,7 @@ enum LoggingLevel {
   debug,
 }
 
-extension on LoggingLevel {
+extension LoggingLevelValue on LoggingLevel {
   String toValue() {
     switch (this) {
       case LoggingLevel.error:
@@ -2328,7 +2328,7 @@ extension on LoggingLevel {
   }
 }
 
-extension on String {
+extension LoggingLevelFromString on String {
   LoggingLevel toLoggingLevel() {
     switch (this) {
       case 'ERROR':
@@ -2529,7 +2529,7 @@ enum PayloadType {
   json,
 }
 
-extension on PayloadType {
+extension PayloadTypeValue on PayloadType {
   String toValue() {
     switch (this) {
       case PayloadType.string:
@@ -2540,7 +2540,7 @@ extension on PayloadType {
   }
 }
 
-extension on String {
+extension PayloadTypeFromString on String {
   PayloadType toPayloadType() {
     switch (this) {
       case 'STRING':

--- a/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
+++ b/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
@@ -499,7 +499,7 @@ enum ErrorCode {
   throttlingException,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.resourceNotFoundException:
@@ -516,7 +516,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'ResourceNotFoundException':

--- a/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
+++ b/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
@@ -499,7 +499,7 @@ enum ErrorCode {
   throttlingException,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.resourceNotFoundException:

--- a/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
+++ b/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
@@ -350,7 +350,7 @@ enum ConnectionStatus {
   disconnected,
 }
 
-extension ConnectionStatusValue on ConnectionStatus {
+extension ConnectionStatusValueExtension on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.connected:
@@ -646,7 +646,7 @@ enum TunnelStatus {
   closed,
 }
 
-extension TunnelStatusValue on TunnelStatus {
+extension TunnelStatusValueExtension on TunnelStatus {
   String toValue() {
     switch (this) {
       case TunnelStatus.open:

--- a/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
+++ b/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
@@ -350,7 +350,7 @@ enum ConnectionStatus {
   disconnected,
 }
 
-extension on ConnectionStatus {
+extension ConnectionStatusValue on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.connected:
@@ -361,7 +361,7 @@ extension on ConnectionStatus {
   }
 }
 
-extension on String {
+extension ConnectionStatusFromString on String {
   ConnectionStatus toConnectionStatus() {
     switch (this) {
       case 'CONNECTED':
@@ -646,7 +646,7 @@ enum TunnelStatus {
   closed,
 }
 
-extension on TunnelStatus {
+extension TunnelStatusValue on TunnelStatus {
   String toValue() {
     switch (this) {
       case TunnelStatus.open:
@@ -657,7 +657,7 @@ extension on TunnelStatus {
   }
 }
 
-extension on String {
+extension TunnelStatusFromString on String {
   TunnelStatus toTunnelStatus() {
     switch (this) {
       case 'OPEN':

--- a/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
+++ b/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
@@ -1943,7 +1943,7 @@ enum DefinitionLanguage {
   graphql,
 }
 
-extension on DefinitionLanguage {
+extension DefinitionLanguageValue on DefinitionLanguage {
   String toValue() {
     switch (this) {
       case DefinitionLanguage.graphql:
@@ -1952,7 +1952,7 @@ extension on DefinitionLanguage {
   }
 }
 
-extension on String {
+extension DefinitionLanguageFromString on String {
   DefinitionLanguage toDefinitionLanguage() {
     switch (this) {
       case 'GRAPHQL':
@@ -2049,7 +2049,7 @@ enum DeploymentTarget {
   cloud,
 }
 
-extension on DeploymentTarget {
+extension DeploymentTargetValue on DeploymentTarget {
   String toValue() {
     switch (this) {
       case DeploymentTarget.greengrass:
@@ -2060,7 +2060,7 @@ extension on DeploymentTarget {
   }
 }
 
-extension on String {
+extension DeploymentTargetFromString on String {
   DeploymentTarget toDeploymentTarget() {
     switch (this) {
       case 'GREENGRASS':
@@ -2203,7 +2203,7 @@ enum EntityFilterName {
   referencedEntityId,
 }
 
-extension on EntityFilterName {
+extension EntityFilterNameValue on EntityFilterName {
   String toValue() {
     switch (this) {
       case EntityFilterName.name:
@@ -2218,7 +2218,7 @@ extension on EntityFilterName {
   }
 }
 
-extension on String {
+extension EntityFilterNameFromString on String {
   EntityFilterName toEntityFilterName() {
     switch (this) {
       case 'NAME':
@@ -2247,7 +2247,7 @@ enum EntityType {
   $enum,
 }
 
-extension on EntityType {
+extension EntityTypeValue on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.device:
@@ -2274,7 +2274,7 @@ extension on EntityType {
   }
 }
 
-extension on String {
+extension EntityTypeFromString on String {
   EntityType toEntityType() {
     switch (this) {
       case 'DEVICE':
@@ -2322,7 +2322,7 @@ enum FlowExecutionEventType {
   acknowledgeTaskMessage,
 }
 
-extension on FlowExecutionEventType {
+extension FlowExecutionEventTypeValue on FlowExecutionEventType {
   String toValue() {
     switch (this) {
       case FlowExecutionEventType.executionStarted:
@@ -2363,7 +2363,7 @@ extension on FlowExecutionEventType {
   }
 }
 
-extension on String {
+extension FlowExecutionEventTypeFromString on String {
   FlowExecutionEventType toFlowExecutionEventType() {
     switch (this) {
       case 'EXECUTION_STARTED':
@@ -2442,7 +2442,7 @@ enum FlowExecutionStatus {
   failed,
 }
 
-extension on FlowExecutionStatus {
+extension FlowExecutionStatusValue on FlowExecutionStatus {
   String toValue() {
     switch (this) {
       case FlowExecutionStatus.running:
@@ -2457,7 +2457,7 @@ extension on FlowExecutionStatus {
   }
 }
 
-extension on String {
+extension FlowExecutionStatusFromString on String {
   FlowExecutionStatus toFlowExecutionStatus() {
     switch (this) {
       case 'RUNNING':
@@ -2572,7 +2572,7 @@ enum FlowTemplateFilterName {
   deviceModelId,
 }
 
-extension on FlowTemplateFilterName {
+extension FlowTemplateFilterNameValue on FlowTemplateFilterName {
   String toValue() {
     switch (this) {
       case FlowTemplateFilterName.deviceModelId:
@@ -2581,7 +2581,7 @@ extension on FlowTemplateFilterName {
   }
 }
 
-extension on String {
+extension FlowTemplateFilterNameFromString on String {
   FlowTemplateFilterName toFlowTemplateFilterName() {
     switch (this) {
       case 'DEVICE_MODEL_ID':
@@ -2905,7 +2905,7 @@ enum NamespaceDeletionStatus {
   failed,
 }
 
-extension on NamespaceDeletionStatus {
+extension NamespaceDeletionStatusValue on NamespaceDeletionStatus {
   String toValue() {
     switch (this) {
       case NamespaceDeletionStatus.inProgress:
@@ -2918,7 +2918,7 @@ extension on NamespaceDeletionStatus {
   }
 }
 
-extension on String {
+extension NamespaceDeletionStatusFromString on String {
   NamespaceDeletionStatus toNamespaceDeletionStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -2936,7 +2936,8 @@ enum NamespaceDeletionStatusErrorCodes {
   validationFailed,
 }
 
-extension on NamespaceDeletionStatusErrorCodes {
+extension NamespaceDeletionStatusErrorCodesValue
+    on NamespaceDeletionStatusErrorCodes {
   String toValue() {
     switch (this) {
       case NamespaceDeletionStatusErrorCodes.validationFailed:
@@ -2945,7 +2946,7 @@ extension on NamespaceDeletionStatusErrorCodes {
   }
 }
 
-extension on String {
+extension NamespaceDeletionStatusErrorCodesFromString on String {
   NamespaceDeletionStatusErrorCodes toNamespaceDeletionStatusErrorCodes() {
     switch (this) {
       case 'VALIDATION_FAILED':
@@ -3109,7 +3110,8 @@ enum SystemInstanceDeploymentStatus {
   deletedInTarget,
 }
 
-extension on SystemInstanceDeploymentStatus {
+extension SystemInstanceDeploymentStatusValue
+    on SystemInstanceDeploymentStatus {
   String toValue() {
     switch (this) {
       case SystemInstanceDeploymentStatus.notDeployed:
@@ -3132,7 +3134,7 @@ extension on SystemInstanceDeploymentStatus {
   }
 }
 
-extension on String {
+extension SystemInstanceDeploymentStatusFromString on String {
   SystemInstanceDeploymentStatus toSystemInstanceDeploymentStatus() {
     switch (this) {
       case 'NOT_DEPLOYED':
@@ -3251,7 +3253,7 @@ enum SystemInstanceFilterName {
   greengrassGroupName,
 }
 
-extension on SystemInstanceFilterName {
+extension SystemInstanceFilterNameValue on SystemInstanceFilterName {
   String toValue() {
     switch (this) {
       case SystemInstanceFilterName.systemTemplateId:
@@ -3264,7 +3266,7 @@ extension on SystemInstanceFilterName {
   }
 }
 
-extension on String {
+extension SystemInstanceFilterNameFromString on String {
   SystemInstanceFilterName toSystemInstanceFilterName() {
     switch (this) {
       case 'SYSTEM_TEMPLATE_ID':
@@ -3393,7 +3395,7 @@ enum SystemTemplateFilterName {
   flowTemplateId,
 }
 
-extension on SystemTemplateFilterName {
+extension SystemTemplateFilterNameValue on SystemTemplateFilterName {
   String toValue() {
     switch (this) {
       case SystemTemplateFilterName.flowTemplateId:
@@ -3402,7 +3404,7 @@ extension on SystemTemplateFilterName {
   }
 }
 
-extension on String {
+extension SystemTemplateFilterNameFromString on String {
   SystemTemplateFilterName toSystemTemplateFilterName() {
     switch (this) {
       case 'FLOW_TEMPLATE_ID':
@@ -3581,7 +3583,7 @@ enum UploadStatus {
   failed,
 }
 
-extension on UploadStatus {
+extension UploadStatusValue on UploadStatus {
   String toValue() {
     switch (this) {
       case UploadStatus.inProgress:
@@ -3594,7 +3596,7 @@ extension on UploadStatus {
   }
 }
 
-extension on String {
+extension UploadStatusFromString on String {
   UploadStatus toUploadStatus() {
     switch (this) {
       case 'IN_PROGRESS':

--- a/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
+++ b/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
@@ -1943,7 +1943,7 @@ enum DefinitionLanguage {
   graphql,
 }
 
-extension DefinitionLanguageValue on DefinitionLanguage {
+extension DefinitionLanguageValueExtension on DefinitionLanguage {
   String toValue() {
     switch (this) {
       case DefinitionLanguage.graphql:
@@ -2049,7 +2049,7 @@ enum DeploymentTarget {
   cloud,
 }
 
-extension DeploymentTargetValue on DeploymentTarget {
+extension DeploymentTargetValueExtension on DeploymentTarget {
   String toValue() {
     switch (this) {
       case DeploymentTarget.greengrass:
@@ -2203,7 +2203,7 @@ enum EntityFilterName {
   referencedEntityId,
 }
 
-extension EntityFilterNameValue on EntityFilterName {
+extension EntityFilterNameValueExtension on EntityFilterName {
   String toValue() {
     switch (this) {
       case EntityFilterName.name:
@@ -2247,7 +2247,7 @@ enum EntityType {
   $enum,
 }
 
-extension EntityTypeValue on EntityType {
+extension EntityTypeValueExtension on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.device:
@@ -2322,7 +2322,7 @@ enum FlowExecutionEventType {
   acknowledgeTaskMessage,
 }
 
-extension FlowExecutionEventTypeValue on FlowExecutionEventType {
+extension FlowExecutionEventTypeValueExtension on FlowExecutionEventType {
   String toValue() {
     switch (this) {
       case FlowExecutionEventType.executionStarted:
@@ -2442,7 +2442,7 @@ enum FlowExecutionStatus {
   failed,
 }
 
-extension FlowExecutionStatusValue on FlowExecutionStatus {
+extension FlowExecutionStatusValueExtension on FlowExecutionStatus {
   String toValue() {
     switch (this) {
       case FlowExecutionStatus.running:
@@ -2572,7 +2572,7 @@ enum FlowTemplateFilterName {
   deviceModelId,
 }
 
-extension FlowTemplateFilterNameValue on FlowTemplateFilterName {
+extension FlowTemplateFilterNameValueExtension on FlowTemplateFilterName {
   String toValue() {
     switch (this) {
       case FlowTemplateFilterName.deviceModelId:
@@ -2905,7 +2905,7 @@ enum NamespaceDeletionStatus {
   failed,
 }
 
-extension NamespaceDeletionStatusValue on NamespaceDeletionStatus {
+extension NamespaceDeletionStatusValueExtension on NamespaceDeletionStatus {
   String toValue() {
     switch (this) {
       case NamespaceDeletionStatus.inProgress:
@@ -2936,7 +2936,7 @@ enum NamespaceDeletionStatusErrorCodes {
   validationFailed,
 }
 
-extension NamespaceDeletionStatusErrorCodesValue
+extension NamespaceDeletionStatusErrorCodesValueExtension
     on NamespaceDeletionStatusErrorCodes {
   String toValue() {
     switch (this) {
@@ -3110,7 +3110,7 @@ enum SystemInstanceDeploymentStatus {
   deletedInTarget,
 }
 
-extension SystemInstanceDeploymentStatusValue
+extension SystemInstanceDeploymentStatusValueExtension
     on SystemInstanceDeploymentStatus {
   String toValue() {
     switch (this) {
@@ -3253,7 +3253,7 @@ enum SystemInstanceFilterName {
   greengrassGroupName,
 }
 
-extension SystemInstanceFilterNameValue on SystemInstanceFilterName {
+extension SystemInstanceFilterNameValueExtension on SystemInstanceFilterName {
   String toValue() {
     switch (this) {
       case SystemInstanceFilterName.systemTemplateId:
@@ -3395,7 +3395,7 @@ enum SystemTemplateFilterName {
   flowTemplateId,
 }
 
-extension SystemTemplateFilterNameValue on SystemTemplateFilterName {
+extension SystemTemplateFilterNameValueExtension on SystemTemplateFilterName {
   String toValue() {
     switch (this) {
       case SystemTemplateFilterName.flowTemplateId:
@@ -3583,7 +3583,7 @@ enum UploadStatus {
   failed,
 }
 
-extension UploadStatusValue on UploadStatus {
+extension UploadStatusValueExtension on UploadStatus {
   String toValue() {
     switch (this) {
       case UploadStatus.inProgress:

--- a/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
+++ b/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
@@ -1446,7 +1446,7 @@ enum BrokerAZDistribution {
   $default,
 }
 
-extension on BrokerAZDistribution {
+extension BrokerAZDistributionValue on BrokerAZDistribution {
   String toValue() {
     switch (this) {
       case BrokerAZDistribution.$default:
@@ -1455,7 +1455,7 @@ extension on BrokerAZDistribution {
   }
 }
 
-extension on String {
+extension BrokerAZDistributionFromString on String {
   BrokerAZDistribution toBrokerAZDistribution() {
     switch (this) {
       case 'DEFAULT':
@@ -1771,7 +1771,7 @@ enum ClientBroker {
   plaintext,
 }
 
-extension on ClientBroker {
+extension ClientBrokerValue on ClientBroker {
   String toValue() {
     switch (this) {
       case ClientBroker.tls:
@@ -1784,7 +1784,7 @@ extension on ClientBroker {
   }
 }
 
-extension on String {
+extension ClientBrokerFromString on String {
   ClientBroker toClientBroker() {
     switch (this) {
       case 'TLS':
@@ -2142,7 +2142,7 @@ enum ClusterState {
   updating,
 }
 
-extension on ClusterState {
+extension ClusterStateValue on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.active:
@@ -2165,7 +2165,7 @@ extension on ClusterState {
   }
 }
 
-extension on String {
+extension ClusterStateFromString on String {
   ClusterState toClusterState() {
     switch (this) {
       case 'ACTIVE':
@@ -2365,7 +2365,7 @@ enum ConfigurationState {
   deleteFailed,
 }
 
-extension on ConfigurationState {
+extension ConfigurationStateValue on ConfigurationState {
   String toValue() {
     switch (this) {
       case ConfigurationState.active:
@@ -2378,7 +2378,7 @@ extension on ConfigurationState {
   }
 }
 
-extension on String {
+extension ConfigurationStateFromString on String {
   ConfigurationState toConfigurationState() {
     switch (this) {
       case 'ACTIVE':
@@ -2869,7 +2869,7 @@ enum EnhancedMonitoring {
   perTopicPerPartition,
 }
 
-extension on EnhancedMonitoring {
+extension EnhancedMonitoringValue on EnhancedMonitoring {
   String toValue() {
     switch (this) {
       case EnhancedMonitoring.$default:
@@ -2884,7 +2884,7 @@ extension on EnhancedMonitoring {
   }
 }
 
-extension on String {
+extension EnhancedMonitoringFromString on String {
   EnhancedMonitoring toEnhancedMonitoring() {
     switch (this) {
       case 'DEFAULT':
@@ -3024,7 +3024,7 @@ enum KafkaVersionStatus {
   deprecated,
 }
 
-extension on KafkaVersionStatus {
+extension KafkaVersionStatusValue on KafkaVersionStatus {
   String toValue() {
     switch (this) {
       case KafkaVersionStatus.active:
@@ -3035,7 +3035,7 @@ extension on KafkaVersionStatus {
   }
 }
 
-extension on String {
+extension KafkaVersionStatusFromString on String {
   KafkaVersionStatus toKafkaVersionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -3690,7 +3690,7 @@ enum NodeType {
   broker,
 }
 
-extension on NodeType {
+extension NodeTypeValue on NodeType {
   String toValue() {
     switch (this) {
       case NodeType.broker:
@@ -3699,7 +3699,7 @@ extension on NodeType {
   }
 }
 
-extension on String {
+extension NodeTypeFromString on String {
   NodeType toNodeType() {
     switch (this) {
       case 'BROKER':

--- a/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
+++ b/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
@@ -1446,7 +1446,7 @@ enum BrokerAZDistribution {
   $default,
 }
 
-extension BrokerAZDistributionValue on BrokerAZDistribution {
+extension BrokerAZDistributionValueExtension on BrokerAZDistribution {
   String toValue() {
     switch (this) {
       case BrokerAZDistribution.$default:
@@ -1771,7 +1771,7 @@ enum ClientBroker {
   plaintext,
 }
 
-extension ClientBrokerValue on ClientBroker {
+extension ClientBrokerValueExtension on ClientBroker {
   String toValue() {
     switch (this) {
       case ClientBroker.tls:
@@ -2142,7 +2142,7 @@ enum ClusterState {
   updating,
 }
 
-extension ClusterStateValue on ClusterState {
+extension ClusterStateValueExtension on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.active:
@@ -2365,7 +2365,7 @@ enum ConfigurationState {
   deleteFailed,
 }
 
-extension ConfigurationStateValue on ConfigurationState {
+extension ConfigurationStateValueExtension on ConfigurationState {
   String toValue() {
     switch (this) {
       case ConfigurationState.active:
@@ -2869,7 +2869,7 @@ enum EnhancedMonitoring {
   perTopicPerPartition,
 }
 
-extension EnhancedMonitoringValue on EnhancedMonitoring {
+extension EnhancedMonitoringValueExtension on EnhancedMonitoring {
   String toValue() {
     switch (this) {
       case EnhancedMonitoring.$default:
@@ -3024,7 +3024,7 @@ enum KafkaVersionStatus {
   deprecated,
 }
 
-extension KafkaVersionStatusValue on KafkaVersionStatus {
+extension KafkaVersionStatusValueExtension on KafkaVersionStatus {
   String toValue() {
     switch (this) {
       case KafkaVersionStatus.active:
@@ -3690,7 +3690,7 @@ enum NodeType {
   broker,
 }
 
-extension NodeTypeValue on NodeType {
+extension NodeTypeValueExtension on NodeType {
   String toValue() {
     switch (this) {
       case NodeType.broker:

--- a/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
+++ b/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
@@ -2279,7 +2279,8 @@ enum AdditionalResultAttributeValueType {
   textWithHighlightsValue,
 }
 
-extension on AdditionalResultAttributeValueType {
+extension AdditionalResultAttributeValueTypeValue
+    on AdditionalResultAttributeValueType {
   String toValue() {
     switch (this) {
       case AdditionalResultAttributeValueType.textWithHighlightsValue:
@@ -2288,7 +2289,7 @@ extension on AdditionalResultAttributeValueType {
   }
 }
 
-extension on String {
+extension AdditionalResultAttributeValueTypeFromString on String {
   AdditionalResultAttributeValueType toAdditionalResultAttributeValueType() {
     switch (this) {
       case 'TEXT_WITH_HIGHLIGHTS_VALUE':
@@ -2668,7 +2669,7 @@ enum ConfluenceAttachmentFieldName {
   version,
 }
 
-extension on ConfluenceAttachmentFieldName {
+extension ConfluenceAttachmentFieldNameValue on ConfluenceAttachmentFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceAttachmentFieldName.author:
@@ -2697,7 +2698,7 @@ extension on ConfluenceAttachmentFieldName {
   }
 }
 
-extension on String {
+extension ConfluenceAttachmentFieldNameFromString on String {
   ConfluenceAttachmentFieldName toConfluenceAttachmentFieldName() {
     switch (this) {
       case 'AUTHOR':
@@ -2819,7 +2820,7 @@ enum ConfluenceBlogFieldName {
   version,
 }
 
-extension on ConfluenceBlogFieldName {
+extension ConfluenceBlogFieldNameValue on ConfluenceBlogFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceBlogFieldName.author:
@@ -2844,7 +2845,7 @@ extension on ConfluenceBlogFieldName {
   }
 }
 
-extension on String {
+extension ConfluenceBlogFieldNameFromString on String {
   ConfluenceBlogFieldName toConfluenceBlogFieldName() {
     switch (this) {
       case 'AUTHOR':
@@ -3096,7 +3097,7 @@ enum ConfluencePageFieldName {
   version,
 }
 
-extension on ConfluencePageFieldName {
+extension ConfluencePageFieldNameValue on ConfluencePageFieldName {
   String toValue() {
     switch (this) {
       case ConfluencePageFieldName.author:
@@ -3127,7 +3128,7 @@ extension on ConfluencePageFieldName {
   }
 }
 
-extension on String {
+extension ConfluencePageFieldNameFromString on String {
   ConfluencePageFieldName toConfluencePageFieldName() {
     switch (this) {
       case 'AUTHOR':
@@ -3291,7 +3292,7 @@ enum ConfluenceSpaceFieldName {
   url,
 }
 
-extension on ConfluenceSpaceFieldName {
+extension ConfluenceSpaceFieldNameValue on ConfluenceSpaceFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceSpaceFieldName.displayUrl:
@@ -3306,7 +3307,7 @@ extension on ConfluenceSpaceFieldName {
   }
 }
 
-extension on String {
+extension ConfluenceSpaceFieldNameFromString on String {
   ConfluenceSpaceFieldName toConfluenceSpaceFieldName() {
     switch (this) {
       case 'DISPLAY_URL':
@@ -3372,7 +3373,7 @@ enum ConfluenceVersion {
   server,
 }
 
-extension on ConfluenceVersion {
+extension ConfluenceVersionValue on ConfluenceVersion {
   String toValue() {
     switch (this) {
       case ConfluenceVersion.cloud:
@@ -3383,7 +3384,7 @@ extension on ConfluenceVersion {
   }
 }
 
-extension on String {
+extension ConfluenceVersionFromString on String {
   ConfluenceVersion toConfluenceVersion() {
     switch (this) {
       case 'CLOUD':
@@ -3461,7 +3462,7 @@ enum ContentType {
   ppt,
 }
 
-extension on ContentType {
+extension ContentTypeValue on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.pdf:
@@ -3478,7 +3479,7 @@ extension on ContentType {
   }
 }
 
-extension on String {
+extension ContentTypeFromString on String {
   ContentType toContentType() {
     switch (this) {
       case 'PDF':
@@ -3669,7 +3670,7 @@ enum DataSourceStatus {
   active,
 }
 
-extension on DataSourceStatus {
+extension DataSourceStatusValue on DataSourceStatus {
   String toValue() {
     switch (this) {
       case DataSourceStatus.creating:
@@ -3686,7 +3687,7 @@ extension on DataSourceStatus {
   }
 }
 
-extension on String {
+extension DataSourceStatusFromString on String {
   DataSourceStatus toDataSourceStatus() {
     switch (this) {
       case 'CREATING':
@@ -3884,7 +3885,7 @@ enum DataSourceSyncJobStatus {
   syncingIndexing,
 }
 
-extension on DataSourceSyncJobStatus {
+extension DataSourceSyncJobStatusValue on DataSourceSyncJobStatus {
   String toValue() {
     switch (this) {
       case DataSourceSyncJobStatus.failed:
@@ -3905,7 +3906,7 @@ extension on DataSourceSyncJobStatus {
   }
 }
 
-extension on String {
+extension DataSourceSyncJobStatusFromString on String {
   DataSourceSyncJobStatus toDataSourceSyncJobStatus() {
     switch (this) {
       case 'FAILED':
@@ -3976,7 +3977,7 @@ enum DataSourceType {
   googledrive,
 }
 
-extension on DataSourceType {
+extension DataSourceTypeValue on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.s3:
@@ -4001,7 +4002,7 @@ extension on DataSourceType {
   }
 }
 
-extension on String {
+extension DataSourceTypeFromString on String {
   DataSourceType toDataSourceType() {
     switch (this) {
       case 'S3':
@@ -4142,7 +4143,7 @@ enum DatabaseEngineType {
   rdsPostgresql,
 }
 
-extension on DatabaseEngineType {
+extension DatabaseEngineTypeValue on DatabaseEngineType {
   String toValue() {
     switch (this) {
       case DatabaseEngineType.rdsAuroraMysql:
@@ -4157,7 +4158,7 @@ extension on DatabaseEngineType {
   }
 }
 
-extension on String {
+extension DatabaseEngineTypeFromString on String {
   DatabaseEngineType toDatabaseEngineType() {
     switch (this) {
       case 'RDS_AURORA_MYSQL':
@@ -4688,7 +4689,7 @@ enum DocumentAttributeValueType {
   dateValue,
 }
 
-extension on DocumentAttributeValueType {
+extension DocumentAttributeValueTypeValue on DocumentAttributeValueType {
   String toValue() {
     switch (this) {
       case DocumentAttributeValueType.stringValue:
@@ -4703,7 +4704,7 @@ extension on DocumentAttributeValueType {
   }
 }
 
-extension on String {
+extension DocumentAttributeValueTypeFromString on String {
   DocumentAttributeValueType toDocumentAttributeValueType() {
     switch (this) {
       case 'STRING_VALUE':
@@ -4798,7 +4799,7 @@ enum ErrorCode {
   invalidRequest,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.internalError:
@@ -4809,7 +4810,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'InternalError':
@@ -4879,7 +4880,7 @@ enum FaqFileFormat {
   json,
 }
 
-extension on FaqFileFormat {
+extension FaqFileFormatValue on FaqFileFormat {
   String toValue() {
     switch (this) {
       case FaqFileFormat.csv:
@@ -4892,7 +4893,7 @@ extension on FaqFileFormat {
   }
 }
 
-extension on String {
+extension FaqFileFormatFromString on String {
   FaqFileFormat toFaqFileFormat() {
     switch (this) {
       case 'CSV':
@@ -4930,7 +4931,7 @@ enum FaqStatus {
   failed,
 }
 
-extension on FaqStatus {
+extension FaqStatusValue on FaqStatus {
   String toValue() {
     switch (this) {
       case FaqStatus.creating:
@@ -4947,7 +4948,7 @@ extension on FaqStatus {
   }
 }
 
-extension on String {
+extension FaqStatusFromString on String {
   FaqStatus toFaqStatus() {
     switch (this) {
       case 'CREATING':
@@ -5155,7 +5156,7 @@ enum HighlightType {
   thesaurusSynonym,
 }
 
-extension on HighlightType {
+extension HighlightTypeValue on HighlightType {
   String toValue() {
     switch (this) {
       case HighlightType.standard:
@@ -5166,7 +5167,7 @@ extension on HighlightType {
   }
 }
 
-extension on String {
+extension HighlightTypeFromString on String {
   HighlightType toHighlightType() {
     switch (this) {
       case 'STANDARD':
@@ -5228,7 +5229,7 @@ enum IndexEdition {
   enterpriseEdition,
 }
 
-extension on IndexEdition {
+extension IndexEditionValue on IndexEdition {
   String toValue() {
     switch (this) {
       case IndexEdition.developerEdition:
@@ -5239,7 +5240,7 @@ extension on IndexEdition {
   }
 }
 
-extension on String {
+extension IndexEditionFromString on String {
   IndexEdition toIndexEdition() {
     switch (this) {
       case 'DEVELOPER_EDITION':
@@ -5283,7 +5284,7 @@ enum IndexStatus {
   systemUpdating,
 }
 
-extension on IndexStatus {
+extension IndexStatusValue on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.creating:
@@ -5302,7 +5303,7 @@ extension on IndexStatus {
   }
 }
 
-extension on String {
+extension IndexStatusFromString on String {
   IndexStatus toIndexStatus() {
     switch (this) {
       case 'CREATING':
@@ -5422,7 +5423,7 @@ enum KeyLocation {
   secretManager,
 }
 
-extension on KeyLocation {
+extension KeyLocationValue on KeyLocation {
   String toValue() {
     switch (this) {
       case KeyLocation.url:
@@ -5433,7 +5434,7 @@ extension on KeyLocation {
   }
 }
 
-extension on String {
+extension KeyLocationFromString on String {
   KeyLocation toKeyLocation() {
     switch (this) {
       case 'URL':
@@ -5722,7 +5723,7 @@ enum Order {
   descending,
 }
 
-extension on Order {
+extension OrderValue on Order {
   String toValue() {
     switch (this) {
       case Order.ascending:
@@ -5733,7 +5734,7 @@ extension on Order {
   }
 }
 
-extension on String {
+extension OrderFromString on String {
   Order toOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -5778,7 +5779,7 @@ enum PrincipalType {
   group,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -5789,7 +5790,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'USER':
@@ -5806,7 +5807,8 @@ enum QueryIdentifiersEnclosingOption {
   none,
 }
 
-extension on QueryIdentifiersEnclosingOption {
+extension QueryIdentifiersEnclosingOptionValue
+    on QueryIdentifiersEnclosingOption {
   String toValue() {
     switch (this) {
       case QueryIdentifiersEnclosingOption.doubleQuotes:
@@ -5817,7 +5819,7 @@ extension on QueryIdentifiersEnclosingOption {
   }
 }
 
-extension on String {
+extension QueryIdentifiersEnclosingOptionFromString on String {
   QueryIdentifiersEnclosingOption toQueryIdentifiersEnclosingOption() {
     switch (this) {
       case 'DOUBLE_QUOTES':
@@ -5973,7 +5975,7 @@ enum QueryResultType {
   answer,
 }
 
-extension on QueryResultType {
+extension QueryResultTypeValue on QueryResultType {
   String toValue() {
     switch (this) {
       case QueryResultType.document:
@@ -5986,7 +5988,7 @@ extension on QueryResultType {
   }
 }
 
-extension on String {
+extension QueryResultTypeFromString on String {
   QueryResultType toQueryResultType() {
     switch (this) {
       case 'DOCUMENT':
@@ -6005,7 +6007,7 @@ enum ReadAccessType {
   deny,
 }
 
-extension on ReadAccessType {
+extension ReadAccessTypeValue on ReadAccessType {
   String toValue() {
     switch (this) {
       case ReadAccessType.allow:
@@ -6016,7 +6018,7 @@ extension on ReadAccessType {
   }
 }
 
-extension on String {
+extension ReadAccessTypeFromString on String {
   ReadAccessType toReadAccessType() {
     switch (this) {
       case 'ALLOW':
@@ -6144,7 +6146,7 @@ enum RelevanceType {
   notRelevant,
 }
 
-extension on RelevanceType {
+extension RelevanceTypeValue on RelevanceType {
   String toValue() {
     switch (this) {
       case RelevanceType.relevant:
@@ -6155,7 +6157,7 @@ extension on RelevanceType {
   }
 }
 
-extension on String {
+extension RelevanceTypeFromString on String {
   RelevanceType toRelevanceType() {
     switch (this) {
       case 'RELEVANT':
@@ -6353,7 +6355,8 @@ enum SalesforceChatterFeedIncludeFilterType {
   standardUser,
 }
 
-extension on SalesforceChatterFeedIncludeFilterType {
+extension SalesforceChatterFeedIncludeFilterTypeValue
+    on SalesforceChatterFeedIncludeFilterType {
   String toValue() {
     switch (this) {
       case SalesforceChatterFeedIncludeFilterType.activeUser:
@@ -6364,7 +6367,7 @@ extension on SalesforceChatterFeedIncludeFilterType {
   }
 }
 
-extension on String {
+extension SalesforceChatterFeedIncludeFilterTypeFromString on String {
   SalesforceChatterFeedIncludeFilterType
       toSalesforceChatterFeedIncludeFilterType() {
     switch (this) {
@@ -6657,7 +6660,8 @@ enum SalesforceKnowledgeArticleState {
   archived,
 }
 
-extension on SalesforceKnowledgeArticleState {
+extension SalesforceKnowledgeArticleStateValue
+    on SalesforceKnowledgeArticleState {
   String toValue() {
     switch (this) {
       case SalesforceKnowledgeArticleState.draft:
@@ -6670,7 +6674,7 @@ extension on SalesforceKnowledgeArticleState {
   }
 }
 
-extension on String {
+extension SalesforceKnowledgeArticleStateFromString on String {
   SalesforceKnowledgeArticleState toSalesforceKnowledgeArticleState() {
     switch (this) {
       case 'DRAFT':
@@ -6840,7 +6844,7 @@ enum SalesforceStandardObjectName {
   user,
 }
 
-extension on SalesforceStandardObjectName {
+extension SalesforceStandardObjectNameValue on SalesforceStandardObjectName {
   String toValue() {
     switch (this) {
       case SalesforceStandardObjectName.account:
@@ -6881,7 +6885,7 @@ extension on SalesforceStandardObjectName {
   }
 }
 
-extension on String {
+extension SalesforceStandardObjectNameFromString on String {
   SalesforceStandardObjectName toSalesforceStandardObjectName() {
     switch (this) {
       case 'ACCOUNT':
@@ -6948,7 +6952,7 @@ enum ScoreConfidence {
   low,
 }
 
-extension on ScoreConfidence {
+extension ScoreConfidenceValue on ScoreConfidence {
   String toValue() {
     switch (this) {
       case ScoreConfidence.veryHigh:
@@ -6963,7 +6967,7 @@ extension on ScoreConfidence {
   }
 }
 
-extension on String {
+extension ScoreConfidenceFromString on String {
   ScoreConfidence toScoreConfidence() {
     switch (this) {
       case 'VERY_HIGH':
@@ -7062,7 +7066,7 @@ enum ServiceNowBuildVersionType {
   others,
 }
 
-extension on ServiceNowBuildVersionType {
+extension ServiceNowBuildVersionTypeValue on ServiceNowBuildVersionType {
   String toValue() {
     switch (this) {
       case ServiceNowBuildVersionType.london:
@@ -7073,7 +7077,7 @@ extension on ServiceNowBuildVersionType {
   }
 }
 
-extension on String {
+extension ServiceNowBuildVersionTypeFromString on String {
   ServiceNowBuildVersionType toServiceNowBuildVersionType() {
     switch (this) {
       case 'LONDON':
@@ -7456,7 +7460,7 @@ enum SharePointVersion {
   sharepointOnline,
 }
 
-extension on SharePointVersion {
+extension SharePointVersionValue on SharePointVersion {
   String toValue() {
     switch (this) {
       case SharePointVersion.sharepointOnline:
@@ -7465,7 +7469,7 @@ extension on SharePointVersion {
   }
 }
 
-extension on String {
+extension SharePointVersionFromString on String {
   SharePointVersion toSharePointVersion() {
     switch (this) {
       case 'SHAREPOINT_ONLINE':
@@ -7480,7 +7484,7 @@ enum SortOrder {
   asc,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.desc:
@@ -7491,7 +7495,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'DESC':
@@ -7718,7 +7722,7 @@ enum ThesaurusStatus {
   failed,
 }
 
-extension on ThesaurusStatus {
+extension ThesaurusStatusValue on ThesaurusStatus {
   String toValue() {
     switch (this) {
       case ThesaurusStatus.creating:
@@ -7737,7 +7741,7 @@ extension on ThesaurusStatus {
   }
 }
 
-extension on String {
+extension ThesaurusStatusFromString on String {
   ThesaurusStatus toThesaurusStatus() {
     switch (this) {
       case 'CREATING':
@@ -7842,7 +7846,7 @@ enum UserContextPolicy {
   userToken,
 }
 
-extension on UserContextPolicy {
+extension UserContextPolicyValue on UserContextPolicy {
   String toValue() {
     switch (this) {
       case UserContextPolicy.attributeFilter:
@@ -7853,7 +7857,7 @@ extension on UserContextPolicy {
   }
 }
 
-extension on String {
+extension UserContextPolicyFromString on String {
   UserContextPolicy toUserContextPolicy() {
     switch (this) {
       case 'ATTRIBUTE_FILTER':

--- a/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
+++ b/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
@@ -2279,7 +2279,7 @@ enum AdditionalResultAttributeValueType {
   textWithHighlightsValue,
 }
 
-extension AdditionalResultAttributeValueTypeValue
+extension AdditionalResultAttributeValueTypeValueExtension
     on AdditionalResultAttributeValueType {
   String toValue() {
     switch (this) {
@@ -2669,7 +2669,8 @@ enum ConfluenceAttachmentFieldName {
   version,
 }
 
-extension ConfluenceAttachmentFieldNameValue on ConfluenceAttachmentFieldName {
+extension ConfluenceAttachmentFieldNameValueExtension
+    on ConfluenceAttachmentFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceAttachmentFieldName.author:
@@ -2820,7 +2821,7 @@ enum ConfluenceBlogFieldName {
   version,
 }
 
-extension ConfluenceBlogFieldNameValue on ConfluenceBlogFieldName {
+extension ConfluenceBlogFieldNameValueExtension on ConfluenceBlogFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceBlogFieldName.author:
@@ -3097,7 +3098,7 @@ enum ConfluencePageFieldName {
   version,
 }
 
-extension ConfluencePageFieldNameValue on ConfluencePageFieldName {
+extension ConfluencePageFieldNameValueExtension on ConfluencePageFieldName {
   String toValue() {
     switch (this) {
       case ConfluencePageFieldName.author:
@@ -3292,7 +3293,7 @@ enum ConfluenceSpaceFieldName {
   url,
 }
 
-extension ConfluenceSpaceFieldNameValue on ConfluenceSpaceFieldName {
+extension ConfluenceSpaceFieldNameValueExtension on ConfluenceSpaceFieldName {
   String toValue() {
     switch (this) {
       case ConfluenceSpaceFieldName.displayUrl:
@@ -3373,7 +3374,7 @@ enum ConfluenceVersion {
   server,
 }
 
-extension ConfluenceVersionValue on ConfluenceVersion {
+extension ConfluenceVersionValueExtension on ConfluenceVersion {
   String toValue() {
     switch (this) {
       case ConfluenceVersion.cloud:
@@ -3462,7 +3463,7 @@ enum ContentType {
   ppt,
 }
 
-extension ContentTypeValue on ContentType {
+extension ContentTypeValueExtension on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.pdf:
@@ -3670,7 +3671,7 @@ enum DataSourceStatus {
   active,
 }
 
-extension DataSourceStatusValue on DataSourceStatus {
+extension DataSourceStatusValueExtension on DataSourceStatus {
   String toValue() {
     switch (this) {
       case DataSourceStatus.creating:
@@ -3885,7 +3886,7 @@ enum DataSourceSyncJobStatus {
   syncingIndexing,
 }
 
-extension DataSourceSyncJobStatusValue on DataSourceSyncJobStatus {
+extension DataSourceSyncJobStatusValueExtension on DataSourceSyncJobStatus {
   String toValue() {
     switch (this) {
       case DataSourceSyncJobStatus.failed:
@@ -3977,7 +3978,7 @@ enum DataSourceType {
   googledrive,
 }
 
-extension DataSourceTypeValue on DataSourceType {
+extension DataSourceTypeValueExtension on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.s3:
@@ -4143,7 +4144,7 @@ enum DatabaseEngineType {
   rdsPostgresql,
 }
 
-extension DatabaseEngineTypeValue on DatabaseEngineType {
+extension DatabaseEngineTypeValueExtension on DatabaseEngineType {
   String toValue() {
     switch (this) {
       case DatabaseEngineType.rdsAuroraMysql:
@@ -4689,7 +4690,8 @@ enum DocumentAttributeValueType {
   dateValue,
 }
 
-extension DocumentAttributeValueTypeValue on DocumentAttributeValueType {
+extension DocumentAttributeValueTypeValueExtension
+    on DocumentAttributeValueType {
   String toValue() {
     switch (this) {
       case DocumentAttributeValueType.stringValue:
@@ -4799,7 +4801,7 @@ enum ErrorCode {
   invalidRequest,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.internalError:
@@ -4880,7 +4882,7 @@ enum FaqFileFormat {
   json,
 }
 
-extension FaqFileFormatValue on FaqFileFormat {
+extension FaqFileFormatValueExtension on FaqFileFormat {
   String toValue() {
     switch (this) {
       case FaqFileFormat.csv:
@@ -4931,7 +4933,7 @@ enum FaqStatus {
   failed,
 }
 
-extension FaqStatusValue on FaqStatus {
+extension FaqStatusValueExtension on FaqStatus {
   String toValue() {
     switch (this) {
       case FaqStatus.creating:
@@ -5156,7 +5158,7 @@ enum HighlightType {
   thesaurusSynonym,
 }
 
-extension HighlightTypeValue on HighlightType {
+extension HighlightTypeValueExtension on HighlightType {
   String toValue() {
     switch (this) {
       case HighlightType.standard:
@@ -5229,7 +5231,7 @@ enum IndexEdition {
   enterpriseEdition,
 }
 
-extension IndexEditionValue on IndexEdition {
+extension IndexEditionValueExtension on IndexEdition {
   String toValue() {
     switch (this) {
       case IndexEdition.developerEdition:
@@ -5284,7 +5286,7 @@ enum IndexStatus {
   systemUpdating,
 }
 
-extension IndexStatusValue on IndexStatus {
+extension IndexStatusValueExtension on IndexStatus {
   String toValue() {
     switch (this) {
       case IndexStatus.creating:
@@ -5423,7 +5425,7 @@ enum KeyLocation {
   secretManager,
 }
 
-extension KeyLocationValue on KeyLocation {
+extension KeyLocationValueExtension on KeyLocation {
   String toValue() {
     switch (this) {
       case KeyLocation.url:
@@ -5723,7 +5725,7 @@ enum Order {
   descending,
 }
 
-extension OrderValue on Order {
+extension OrderValueExtension on Order {
   String toValue() {
     switch (this) {
       case Order.ascending:
@@ -5779,7 +5781,7 @@ enum PrincipalType {
   group,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -5807,7 +5809,7 @@ enum QueryIdentifiersEnclosingOption {
   none,
 }
 
-extension QueryIdentifiersEnclosingOptionValue
+extension QueryIdentifiersEnclosingOptionValueExtension
     on QueryIdentifiersEnclosingOption {
   String toValue() {
     switch (this) {
@@ -5975,7 +5977,7 @@ enum QueryResultType {
   answer,
 }
 
-extension QueryResultTypeValue on QueryResultType {
+extension QueryResultTypeValueExtension on QueryResultType {
   String toValue() {
     switch (this) {
       case QueryResultType.document:
@@ -6007,7 +6009,7 @@ enum ReadAccessType {
   deny,
 }
 
-extension ReadAccessTypeValue on ReadAccessType {
+extension ReadAccessTypeValueExtension on ReadAccessType {
   String toValue() {
     switch (this) {
       case ReadAccessType.allow:
@@ -6146,7 +6148,7 @@ enum RelevanceType {
   notRelevant,
 }
 
-extension RelevanceTypeValue on RelevanceType {
+extension RelevanceTypeValueExtension on RelevanceType {
   String toValue() {
     switch (this) {
       case RelevanceType.relevant:
@@ -6355,7 +6357,7 @@ enum SalesforceChatterFeedIncludeFilterType {
   standardUser,
 }
 
-extension SalesforceChatterFeedIncludeFilterTypeValue
+extension SalesforceChatterFeedIncludeFilterTypeValueExtension
     on SalesforceChatterFeedIncludeFilterType {
   String toValue() {
     switch (this) {
@@ -6660,7 +6662,7 @@ enum SalesforceKnowledgeArticleState {
   archived,
 }
 
-extension SalesforceKnowledgeArticleStateValue
+extension SalesforceKnowledgeArticleStateValueExtension
     on SalesforceKnowledgeArticleState {
   String toValue() {
     switch (this) {
@@ -6844,7 +6846,8 @@ enum SalesforceStandardObjectName {
   user,
 }
 
-extension SalesforceStandardObjectNameValue on SalesforceStandardObjectName {
+extension SalesforceStandardObjectNameValueExtension
+    on SalesforceStandardObjectName {
   String toValue() {
     switch (this) {
       case SalesforceStandardObjectName.account:
@@ -6952,7 +6955,7 @@ enum ScoreConfidence {
   low,
 }
 
-extension ScoreConfidenceValue on ScoreConfidence {
+extension ScoreConfidenceValueExtension on ScoreConfidence {
   String toValue() {
     switch (this) {
       case ScoreConfidence.veryHigh:
@@ -7066,7 +7069,8 @@ enum ServiceNowBuildVersionType {
   others,
 }
 
-extension ServiceNowBuildVersionTypeValue on ServiceNowBuildVersionType {
+extension ServiceNowBuildVersionTypeValueExtension
+    on ServiceNowBuildVersionType {
   String toValue() {
     switch (this) {
       case ServiceNowBuildVersionType.london:
@@ -7460,7 +7464,7 @@ enum SharePointVersion {
   sharepointOnline,
 }
 
-extension SharePointVersionValue on SharePointVersion {
+extension SharePointVersionValueExtension on SharePointVersion {
   String toValue() {
     switch (this) {
       case SharePointVersion.sharepointOnline:
@@ -7484,7 +7488,7 @@ enum SortOrder {
   asc,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.desc:
@@ -7722,7 +7726,7 @@ enum ThesaurusStatus {
   failed,
 }
 
-extension ThesaurusStatusValue on ThesaurusStatus {
+extension ThesaurusStatusValueExtension on ThesaurusStatus {
   String toValue() {
     switch (this) {
       case ThesaurusStatus.creating:
@@ -7846,7 +7850,7 @@ enum UserContextPolicy {
   userToken,
 }
 
-extension UserContextPolicyValue on UserContextPolicy {
+extension UserContextPolicyValueExtension on UserContextPolicy {
   String toValue() {
     switch (this) {
       case UserContextPolicy.attributeFilter:

--- a/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
+++ b/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
@@ -2529,7 +2529,7 @@ enum ConsumerStatus {
   active,
 }
 
-extension ConsumerStatusValue on ConsumerStatus {
+extension ConsumerStatusValueExtension on ConsumerStatus {
   String toValue() {
     switch (this) {
       case ConsumerStatus.creating:
@@ -2628,7 +2628,7 @@ enum EncryptionType {
   kms,
 }
 
-extension EncryptionTypeValue on EncryptionType {
+extension EncryptionTypeValueExtension on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.none:
@@ -2953,7 +2953,7 @@ enum MetricsName {
   all,
 }
 
-extension MetricsNameValue on MetricsName {
+extension MetricsNameValueExtension on MetricsName {
   String toValue() {
     switch (this) {
       case MetricsName.incomingBytes:
@@ -3235,7 +3235,7 @@ enum ScalingType {
   uniformScaling,
 }
 
-extension ScalingTypeValue on ScalingType {
+extension ScalingTypeValueExtension on ScalingType {
   String toValue() {
     switch (this) {
       case ScalingType.uniformScaling:
@@ -3344,7 +3344,7 @@ enum ShardFilterType {
   fromTimestamp,
 }
 
-extension ShardFilterTypeValue on ShardFilterType {
+extension ShardFilterTypeValueExtension on ShardFilterType {
   String toValue() {
     switch (this) {
       case ShardFilterType.afterShardId:
@@ -3391,7 +3391,7 @@ enum ShardIteratorType {
   atTimestamp,
 }
 
-extension ShardIteratorTypeValue on ShardIteratorType {
+extension ShardIteratorTypeValueExtension on ShardIteratorType {
   String toValue() {
     switch (this) {
       case ShardIteratorType.atSequenceNumber:
@@ -3684,7 +3684,7 @@ enum StreamStatus {
   updating,
 }
 
-extension StreamStatusValue on StreamStatus {
+extension StreamStatusValueExtension on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.creating:

--- a/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
+++ b/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
@@ -2529,7 +2529,7 @@ enum ConsumerStatus {
   active,
 }
 
-extension on ConsumerStatus {
+extension ConsumerStatusValue on ConsumerStatus {
   String toValue() {
     switch (this) {
       case ConsumerStatus.creating:
@@ -2542,7 +2542,7 @@ extension on ConsumerStatus {
   }
 }
 
-extension on String {
+extension ConsumerStatusFromString on String {
   ConsumerStatus toConsumerStatus() {
     switch (this) {
       case 'CREATING':
@@ -2628,7 +2628,7 @@ enum EncryptionType {
   kms,
 }
 
-extension on EncryptionType {
+extension EncryptionTypeValue on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.none:
@@ -2639,7 +2639,7 @@ extension on EncryptionType {
   }
 }
 
-extension on String {
+extension EncryptionTypeFromString on String {
   EncryptionType toEncryptionType() {
     switch (this) {
       case 'NONE':
@@ -2953,7 +2953,7 @@ enum MetricsName {
   all,
 }
 
-extension on MetricsName {
+extension MetricsNameValue on MetricsName {
   String toValue() {
     switch (this) {
       case MetricsName.incomingBytes:
@@ -2976,7 +2976,7 @@ extension on MetricsName {
   }
 }
 
-extension on String {
+extension MetricsNameFromString on String {
   MetricsName toMetricsName() {
     switch (this) {
       case 'IncomingBytes':
@@ -3235,7 +3235,7 @@ enum ScalingType {
   uniformScaling,
 }
 
-extension on ScalingType {
+extension ScalingTypeValue on ScalingType {
   String toValue() {
     switch (this) {
       case ScalingType.uniformScaling:
@@ -3244,7 +3244,7 @@ extension on ScalingType {
   }
 }
 
-extension on String {
+extension ScalingTypeFromString on String {
   ScalingType toScalingType() {
     switch (this) {
       case 'UNIFORM_SCALING':
@@ -3344,7 +3344,7 @@ enum ShardFilterType {
   fromTimestamp,
 }
 
-extension on ShardFilterType {
+extension ShardFilterTypeValue on ShardFilterType {
   String toValue() {
     switch (this) {
       case ShardFilterType.afterShardId:
@@ -3363,7 +3363,7 @@ extension on ShardFilterType {
   }
 }
 
-extension on String {
+extension ShardFilterTypeFromString on String {
   ShardFilterType toShardFilterType() {
     switch (this) {
       case 'AFTER_SHARD_ID':
@@ -3391,7 +3391,7 @@ enum ShardIteratorType {
   atTimestamp,
 }
 
-extension on ShardIteratorType {
+extension ShardIteratorTypeValue on ShardIteratorType {
   String toValue() {
     switch (this) {
       case ShardIteratorType.atSequenceNumber:
@@ -3408,7 +3408,7 @@ extension on ShardIteratorType {
   }
 }
 
-extension on String {
+extension ShardIteratorTypeFromString on String {
   ShardIteratorType toShardIteratorType() {
     switch (this) {
       case 'AT_SEQUENCE_NUMBER':
@@ -3684,7 +3684,7 @@ enum StreamStatus {
   updating,
 }
 
-extension on StreamStatus {
+extension StreamStatusValue on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.creating:
@@ -3699,7 +3699,7 @@ extension on StreamStatus {
   }
 }
 
-extension on String {
+extension StreamStatusFromString on String {
   StreamStatus toStreamStatus() {
     switch (this) {
       case 'CREATING':

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -1246,7 +1246,7 @@ enum ClipFragmentSelectorType {
   serverTimestamp,
 }
 
-extension ClipFragmentSelectorTypeValue on ClipFragmentSelectorType {
+extension ClipFragmentSelectorTypeValueExtension on ClipFragmentSelectorType {
   String toValue() {
     switch (this) {
       case ClipFragmentSelectorType.producerTimestamp:
@@ -1318,7 +1318,7 @@ enum ContainerFormat {
   mpegTs,
 }
 
-extension ContainerFormatValue on ContainerFormat {
+extension ContainerFormatValueExtension on ContainerFormat {
   String toValue() {
     switch (this) {
       case ContainerFormat.fragmentedMp4:
@@ -1346,7 +1346,7 @@ enum DASHDisplayFragmentNumber {
   never,
 }
 
-extension DASHDisplayFragmentNumberValue on DASHDisplayFragmentNumber {
+extension DASHDisplayFragmentNumberValueExtension on DASHDisplayFragmentNumber {
   String toValue() {
     switch (this) {
       case DASHDisplayFragmentNumber.always:
@@ -1374,7 +1374,8 @@ enum DASHDisplayFragmentTimestamp {
   never,
 }
 
-extension DASHDisplayFragmentTimestampValue on DASHDisplayFragmentTimestamp {
+extension DASHDisplayFragmentTimestampValueExtension
+    on DASHDisplayFragmentTimestamp {
   String toValue() {
     switch (this) {
       case DASHDisplayFragmentTimestamp.always:
@@ -1460,7 +1461,7 @@ enum DASHFragmentSelectorType {
   serverTimestamp,
 }
 
-extension DASHFragmentSelectorTypeValue on DASHFragmentSelectorType {
+extension DASHFragmentSelectorTypeValueExtension on DASHFragmentSelectorType {
   String toValue() {
     switch (this) {
       case DASHFragmentSelectorType.producerTimestamp:
@@ -1489,7 +1490,7 @@ enum DASHPlaybackMode {
   onDemand,
 }
 
-extension DASHPlaybackModeValue on DASHPlaybackMode {
+extension DASHPlaybackModeValueExtension on DASHPlaybackMode {
   String toValue() {
     switch (this) {
       case DASHPlaybackMode.live:
@@ -1662,7 +1663,7 @@ enum FragmentSelectorType {
   serverTimestamp,
 }
 
-extension FragmentSelectorTypeValue on FragmentSelectorType {
+extension FragmentSelectorTypeValueExtension on FragmentSelectorType {
   String toValue() {
     switch (this) {
       case FragmentSelectorType.producerTimestamp:
@@ -1783,7 +1784,7 @@ enum HLSDiscontinuityMode {
   onDiscontinuity,
 }
 
-extension HLSDiscontinuityModeValue on HLSDiscontinuityMode {
+extension HLSDiscontinuityModeValueExtension on HLSDiscontinuityMode {
   String toValue() {
     switch (this) {
       case HLSDiscontinuityMode.always:
@@ -1815,7 +1816,8 @@ enum HLSDisplayFragmentTimestamp {
   never,
 }
 
-extension HLSDisplayFragmentTimestampValue on HLSDisplayFragmentTimestamp {
+extension HLSDisplayFragmentTimestampValueExtension
+    on HLSDisplayFragmentTimestamp {
   String toValue() {
     switch (this) {
       case HLSDisplayFragmentTimestamp.always:
@@ -1900,7 +1902,7 @@ enum HLSFragmentSelectorType {
   serverTimestamp,
 }
 
-extension HLSFragmentSelectorTypeValue on HLSFragmentSelectorType {
+extension HLSFragmentSelectorTypeValueExtension on HLSFragmentSelectorType {
   String toValue() {
     switch (this) {
       case HLSFragmentSelectorType.producerTimestamp:
@@ -1929,7 +1931,7 @@ enum HLSPlaybackMode {
   onDemand,
 }
 
-extension HLSPlaybackModeValue on HLSPlaybackMode {
+extension HLSPlaybackModeValueExtension on HLSPlaybackMode {
   String toValue() {
     switch (this) {
       case HLSPlaybackMode.live:

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -1246,7 +1246,7 @@ enum ClipFragmentSelectorType {
   serverTimestamp,
 }
 
-extension on ClipFragmentSelectorType {
+extension ClipFragmentSelectorTypeValue on ClipFragmentSelectorType {
   String toValue() {
     switch (this) {
       case ClipFragmentSelectorType.producerTimestamp:
@@ -1257,7 +1257,7 @@ extension on ClipFragmentSelectorType {
   }
 }
 
-extension on String {
+extension ClipFragmentSelectorTypeFromString on String {
   ClipFragmentSelectorType toClipFragmentSelectorType() {
     switch (this) {
       case 'PRODUCER_TIMESTAMP':
@@ -1318,7 +1318,7 @@ enum ContainerFormat {
   mpegTs,
 }
 
-extension on ContainerFormat {
+extension ContainerFormatValue on ContainerFormat {
   String toValue() {
     switch (this) {
       case ContainerFormat.fragmentedMp4:
@@ -1329,7 +1329,7 @@ extension on ContainerFormat {
   }
 }
 
-extension on String {
+extension ContainerFormatFromString on String {
   ContainerFormat toContainerFormat() {
     switch (this) {
       case 'FRAGMENTED_MP4':
@@ -1346,7 +1346,7 @@ enum DASHDisplayFragmentNumber {
   never,
 }
 
-extension on DASHDisplayFragmentNumber {
+extension DASHDisplayFragmentNumberValue on DASHDisplayFragmentNumber {
   String toValue() {
     switch (this) {
       case DASHDisplayFragmentNumber.always:
@@ -1357,7 +1357,7 @@ extension on DASHDisplayFragmentNumber {
   }
 }
 
-extension on String {
+extension DASHDisplayFragmentNumberFromString on String {
   DASHDisplayFragmentNumber toDASHDisplayFragmentNumber() {
     switch (this) {
       case 'ALWAYS':
@@ -1374,7 +1374,7 @@ enum DASHDisplayFragmentTimestamp {
   never,
 }
 
-extension on DASHDisplayFragmentTimestamp {
+extension DASHDisplayFragmentTimestampValue on DASHDisplayFragmentTimestamp {
   String toValue() {
     switch (this) {
       case DASHDisplayFragmentTimestamp.always:
@@ -1385,7 +1385,7 @@ extension on DASHDisplayFragmentTimestamp {
   }
 }
 
-extension on String {
+extension DASHDisplayFragmentTimestampFromString on String {
   DASHDisplayFragmentTimestamp toDASHDisplayFragmentTimestamp() {
     switch (this) {
       case 'ALWAYS':
@@ -1460,7 +1460,7 @@ enum DASHFragmentSelectorType {
   serverTimestamp,
 }
 
-extension on DASHFragmentSelectorType {
+extension DASHFragmentSelectorTypeValue on DASHFragmentSelectorType {
   String toValue() {
     switch (this) {
       case DASHFragmentSelectorType.producerTimestamp:
@@ -1471,7 +1471,7 @@ extension on DASHFragmentSelectorType {
   }
 }
 
-extension on String {
+extension DASHFragmentSelectorTypeFromString on String {
   DASHFragmentSelectorType toDASHFragmentSelectorType() {
     switch (this) {
       case 'PRODUCER_TIMESTAMP':
@@ -1489,7 +1489,7 @@ enum DASHPlaybackMode {
   onDemand,
 }
 
-extension on DASHPlaybackMode {
+extension DASHPlaybackModeValue on DASHPlaybackMode {
   String toValue() {
     switch (this) {
       case DASHPlaybackMode.live:
@@ -1502,7 +1502,7 @@ extension on DASHPlaybackMode {
   }
 }
 
-extension on String {
+extension DASHPlaybackModeFromString on String {
   DASHPlaybackMode toDASHPlaybackMode() {
     switch (this) {
       case 'LIVE':
@@ -1662,7 +1662,7 @@ enum FragmentSelectorType {
   serverTimestamp,
 }
 
-extension on FragmentSelectorType {
+extension FragmentSelectorTypeValue on FragmentSelectorType {
   String toValue() {
     switch (this) {
       case FragmentSelectorType.producerTimestamp:
@@ -1673,7 +1673,7 @@ extension on FragmentSelectorType {
   }
 }
 
-extension on String {
+extension FragmentSelectorTypeFromString on String {
   FragmentSelectorType toFragmentSelectorType() {
     switch (this) {
       case 'PRODUCER_TIMESTAMP':
@@ -1783,7 +1783,7 @@ enum HLSDiscontinuityMode {
   onDiscontinuity,
 }
 
-extension on HLSDiscontinuityMode {
+extension HLSDiscontinuityModeValue on HLSDiscontinuityMode {
   String toValue() {
     switch (this) {
       case HLSDiscontinuityMode.always:
@@ -1796,7 +1796,7 @@ extension on HLSDiscontinuityMode {
   }
 }
 
-extension on String {
+extension HLSDiscontinuityModeFromString on String {
   HLSDiscontinuityMode toHLSDiscontinuityMode() {
     switch (this) {
       case 'ALWAYS':
@@ -1815,7 +1815,7 @@ enum HLSDisplayFragmentTimestamp {
   never,
 }
 
-extension on HLSDisplayFragmentTimestamp {
+extension HLSDisplayFragmentTimestampValue on HLSDisplayFragmentTimestamp {
   String toValue() {
     switch (this) {
       case HLSDisplayFragmentTimestamp.always:
@@ -1826,7 +1826,7 @@ extension on HLSDisplayFragmentTimestamp {
   }
 }
 
-extension on String {
+extension HLSDisplayFragmentTimestampFromString on String {
   HLSDisplayFragmentTimestamp toHLSDisplayFragmentTimestamp() {
     switch (this) {
       case 'ALWAYS':
@@ -1900,7 +1900,7 @@ enum HLSFragmentSelectorType {
   serverTimestamp,
 }
 
-extension on HLSFragmentSelectorType {
+extension HLSFragmentSelectorTypeValue on HLSFragmentSelectorType {
   String toValue() {
     switch (this) {
       case HLSFragmentSelectorType.producerTimestamp:
@@ -1911,7 +1911,7 @@ extension on HLSFragmentSelectorType {
   }
 }
 
-extension on String {
+extension HLSFragmentSelectorTypeFromString on String {
   HLSFragmentSelectorType toHLSFragmentSelectorType() {
     switch (this) {
       case 'PRODUCER_TIMESTAMP':
@@ -1929,7 +1929,7 @@ enum HLSPlaybackMode {
   onDemand,
 }
 
-extension on HLSPlaybackMode {
+extension HLSPlaybackModeValue on HLSPlaybackMode {
   String toValue() {
     switch (this) {
       case HLSPlaybackMode.live:
@@ -1942,7 +1942,7 @@ extension on HLSPlaybackMode {
   }
 }
 
-extension on String {
+extension HLSPlaybackModeFromString on String {
   HLSPlaybackMode toHLSPlaybackMode() {
     switch (this) {
       case 'LIVE':

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -340,7 +340,7 @@ enum StartSelectorType {
   continuationToken,
 }
 
-extension StartSelectorTypeValue on StartSelectorType {
+extension StartSelectorTypeValueExtension on StartSelectorType {
   String toValue() {
     switch (this) {
       case StartSelectorType.fragmentNumber:

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -340,7 +340,7 @@ enum StartSelectorType {
   continuationToken,
 }
 
-extension on StartSelectorType {
+extension StartSelectorTypeValue on StartSelectorType {
   String toValue() {
     switch (this) {
       case StartSelectorType.fragmentNumber:
@@ -359,7 +359,7 @@ extension on StartSelectorType {
   }
 }
 
-extension on String {
+extension StartSelectorTypeFromString on String {
   StartSelectorType toStartSelectorType() {
     switch (this) {
       case 'FRAGMENT_NUMBER':

--- a/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
+++ b/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
@@ -269,7 +269,7 @@ enum Service {
   turn,
 }
 
-extension ServiceValue on Service {
+extension ServiceValueExtension on Service {
   String toValue() {
     switch (this) {
       case Service.turn:

--- a/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
+++ b/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
@@ -269,7 +269,7 @@ enum Service {
   turn,
 }
 
-extension on Service {
+extension ServiceValue on Service {
   String toValue() {
     switch (this) {
       case Service.turn:
@@ -278,7 +278,7 @@ extension on Service {
   }
 }
 
-extension on String {
+extension ServiceFromString on String {
   Service toService() {
     switch (this) {
       case 'TURN':

--- a/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
+++ b/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
@@ -1778,7 +1778,7 @@ enum ApplicationStatus {
   updating,
 }
 
-extension on ApplicationStatus {
+extension ApplicationStatusValue on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.deleting:
@@ -1797,7 +1797,7 @@ extension on ApplicationStatus {
   }
 }
 
-extension on String {
+extension ApplicationStatusFromString on String {
   ApplicationStatus toApplicationStatus() {
     switch (this) {
       case 'DELETING':
@@ -2606,7 +2606,7 @@ enum InputStartingPosition {
   lastStoppedPoint,
 }
 
-extension on InputStartingPosition {
+extension InputStartingPositionValue on InputStartingPosition {
   String toValue() {
     switch (this) {
       case InputStartingPosition.now:
@@ -2619,7 +2619,7 @@ extension on InputStartingPosition {
   }
 }
 
-extension on String {
+extension InputStartingPositionFromString on String {
   InputStartingPosition toInputStartingPosition() {
     switch (this) {
       case 'NOW':
@@ -3492,7 +3492,7 @@ enum RecordFormatType {
   csv,
 }
 
-extension on RecordFormatType {
+extension RecordFormatTypeValue on RecordFormatType {
   String toValue() {
     switch (this) {
       case RecordFormatType.json:
@@ -3503,7 +3503,7 @@ extension on RecordFormatType {
   }
 }
 
-extension on String {
+extension RecordFormatTypeFromString on String {
   RecordFormatType toRecordFormatType() {
     switch (this) {
       case 'JSON':

--- a/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
+++ b/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
@@ -1778,7 +1778,7 @@ enum ApplicationStatus {
   updating,
 }
 
-extension ApplicationStatusValue on ApplicationStatus {
+extension ApplicationStatusValueExtension on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.deleting:
@@ -2606,7 +2606,7 @@ enum InputStartingPosition {
   lastStoppedPoint,
 }
 
-extension InputStartingPositionValue on InputStartingPosition {
+extension InputStartingPositionValueExtension on InputStartingPosition {
   String toValue() {
     switch (this) {
       case InputStartingPosition.now:
@@ -3492,7 +3492,7 @@ enum RecordFormatType {
   csv,
 }
 
-extension RecordFormatTypeValue on RecordFormatType {
+extension RecordFormatTypeValueExtension on RecordFormatType {
   String toValue() {
     switch (this) {
       case RecordFormatType.json:

--- a/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
+++ b/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
@@ -2464,7 +2464,7 @@ enum ApplicationRestoreType {
   restoreFromCustomSnapshot,
 }
 
-extension on ApplicationRestoreType {
+extension ApplicationRestoreTypeValue on ApplicationRestoreType {
   String toValue() {
     switch (this) {
       case ApplicationRestoreType.skipRestoreFromSnapshot:
@@ -2477,7 +2477,7 @@ extension on ApplicationRestoreType {
   }
 }
 
-extension on String {
+extension ApplicationRestoreTypeFromString on String {
   ApplicationRestoreType toApplicationRestoreType() {
     switch (this) {
       case 'SKIP_RESTORE_FROM_SNAPSHOT':
@@ -2556,7 +2556,7 @@ enum ApplicationStatus {
   forceStopping,
 }
 
-extension on ApplicationStatus {
+extension ApplicationStatusValue on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.deleting:
@@ -2579,7 +2579,7 @@ extension on ApplicationStatus {
   }
 }
 
-extension on String {
+extension ApplicationStatusFromString on String {
   ApplicationStatus toApplicationStatus() {
     switch (this) {
       case 'DELETING':
@@ -3066,7 +3066,7 @@ enum CodeContentType {
   zipfile,
 }
 
-extension on CodeContentType {
+extension CodeContentTypeValue on CodeContentType {
   String toValue() {
     switch (this) {
       case CodeContentType.plaintext:
@@ -3077,7 +3077,7 @@ extension on CodeContentType {
   }
 }
 
-extension on String {
+extension CodeContentTypeFromString on String {
   CodeContentType toCodeContentType() {
     switch (this) {
       case 'PLAINTEXT':
@@ -3125,7 +3125,7 @@ enum ConfigurationType {
   custom,
 }
 
-extension on ConfigurationType {
+extension ConfigurationTypeValue on ConfigurationType {
   String toValue() {
     switch (this) {
       case ConfigurationType.$default:
@@ -3136,7 +3136,7 @@ extension on ConfigurationType {
   }
 }
 
-extension on String {
+extension ConfigurationTypeFromString on String {
   ConfigurationType toConfigurationType() {
     switch (this) {
       case 'DEFAULT':
@@ -4027,7 +4027,7 @@ enum InputStartingPosition {
   lastStoppedPoint,
 }
 
-extension on InputStartingPosition {
+extension InputStartingPositionValue on InputStartingPosition {
   String toValue() {
     switch (this) {
       case InputStartingPosition.now:
@@ -4040,7 +4040,7 @@ extension on InputStartingPosition {
   }
 }
 
-extension on String {
+extension InputStartingPositionFromString on String {
   InputStartingPosition toInputStartingPosition() {
     switch (this) {
       case 'NOW':
@@ -4595,7 +4595,7 @@ enum LogLevel {
   debug,
 }
 
-extension on LogLevel {
+extension LogLevelValue on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.info:
@@ -4610,7 +4610,7 @@ extension on LogLevel {
   }
 }
 
-extension on String {
+extension LogLevelFromString on String {
   LogLevel toLogLevel() {
     switch (this) {
       case 'INFO':
@@ -4675,7 +4675,7 @@ enum MetricsLevel {
   parallelism,
 }
 
-extension on MetricsLevel {
+extension MetricsLevelValue on MetricsLevel {
   String toValue() {
     switch (this) {
       case MetricsLevel.application:
@@ -4690,7 +4690,7 @@ extension on MetricsLevel {
   }
 }
 
-extension on String {
+extension MetricsLevelFromString on String {
   MetricsLevel toMetricsLevel() {
     switch (this) {
       case 'APPLICATION':
@@ -5256,7 +5256,7 @@ enum RecordFormatType {
   csv,
 }
 
-extension on RecordFormatType {
+extension RecordFormatTypeValue on RecordFormatType {
   String toValue() {
     switch (this) {
       case RecordFormatType.json:
@@ -5267,7 +5267,7 @@ extension on RecordFormatType {
   }
 }
 
-extension on String {
+extension RecordFormatTypeFromString on String {
   RecordFormatType toRecordFormatType() {
     switch (this) {
       case 'JSON':
@@ -5499,7 +5499,7 @@ enum RuntimeEnvironment {
   flink_1_11,
 }
 
-extension on RuntimeEnvironment {
+extension RuntimeEnvironmentValue on RuntimeEnvironment {
   String toValue() {
     switch (this) {
       case RuntimeEnvironment.sql_1_0:
@@ -5514,7 +5514,7 @@ extension on RuntimeEnvironment {
   }
 }
 
-extension on String {
+extension RuntimeEnvironmentFromString on String {
   RuntimeEnvironment toRuntimeEnvironment() {
     switch (this) {
       case 'SQL-1_0':
@@ -5766,7 +5766,7 @@ enum SnapshotStatus {
   failed,
 }
 
-extension on SnapshotStatus {
+extension SnapshotStatusValue on SnapshotStatus {
   String toValue() {
     switch (this) {
       case SnapshotStatus.creating:
@@ -5781,7 +5781,7 @@ extension on SnapshotStatus {
   }
 }
 
-extension on String {
+extension SnapshotStatusFromString on String {
   SnapshotStatus toSnapshotStatus() {
     switch (this) {
       case 'CREATING':
@@ -6055,7 +6055,7 @@ enum UrlType {
   flinkDashboardUrl,
 }
 
-extension on UrlType {
+extension UrlTypeValue on UrlType {
   String toValue() {
     switch (this) {
       case UrlType.flinkDashboardUrl:
@@ -6064,7 +6064,7 @@ extension on UrlType {
   }
 }
 
-extension on String {
+extension UrlTypeFromString on String {
   UrlType toUrlType() {
     switch (this) {
       case 'FLINK_DASHBOARD_URL':

--- a/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
+++ b/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
@@ -2464,7 +2464,7 @@ enum ApplicationRestoreType {
   restoreFromCustomSnapshot,
 }
 
-extension ApplicationRestoreTypeValue on ApplicationRestoreType {
+extension ApplicationRestoreTypeValueExtension on ApplicationRestoreType {
   String toValue() {
     switch (this) {
       case ApplicationRestoreType.skipRestoreFromSnapshot:
@@ -2556,7 +2556,7 @@ enum ApplicationStatus {
   forceStopping,
 }
 
-extension ApplicationStatusValue on ApplicationStatus {
+extension ApplicationStatusValueExtension on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.deleting:
@@ -3066,7 +3066,7 @@ enum CodeContentType {
   zipfile,
 }
 
-extension CodeContentTypeValue on CodeContentType {
+extension CodeContentTypeValueExtension on CodeContentType {
   String toValue() {
     switch (this) {
       case CodeContentType.plaintext:
@@ -3125,7 +3125,7 @@ enum ConfigurationType {
   custom,
 }
 
-extension ConfigurationTypeValue on ConfigurationType {
+extension ConfigurationTypeValueExtension on ConfigurationType {
   String toValue() {
     switch (this) {
       case ConfigurationType.$default:
@@ -4027,7 +4027,7 @@ enum InputStartingPosition {
   lastStoppedPoint,
 }
 
-extension InputStartingPositionValue on InputStartingPosition {
+extension InputStartingPositionValueExtension on InputStartingPosition {
   String toValue() {
     switch (this) {
       case InputStartingPosition.now:
@@ -4595,7 +4595,7 @@ enum LogLevel {
   debug,
 }
 
-extension LogLevelValue on LogLevel {
+extension LogLevelValueExtension on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.info:
@@ -4675,7 +4675,7 @@ enum MetricsLevel {
   parallelism,
 }
 
-extension MetricsLevelValue on MetricsLevel {
+extension MetricsLevelValueExtension on MetricsLevel {
   String toValue() {
     switch (this) {
       case MetricsLevel.application:
@@ -5256,7 +5256,7 @@ enum RecordFormatType {
   csv,
 }
 
-extension RecordFormatTypeValue on RecordFormatType {
+extension RecordFormatTypeValueExtension on RecordFormatType {
   String toValue() {
     switch (this) {
       case RecordFormatType.json:
@@ -5499,7 +5499,7 @@ enum RuntimeEnvironment {
   flink_1_11,
 }
 
-extension RuntimeEnvironmentValue on RuntimeEnvironment {
+extension RuntimeEnvironmentValueExtension on RuntimeEnvironment {
   String toValue() {
     switch (this) {
       case RuntimeEnvironment.sql_1_0:
@@ -5766,7 +5766,7 @@ enum SnapshotStatus {
   failed,
 }
 
-extension SnapshotStatusValue on SnapshotStatus {
+extension SnapshotStatusValueExtension on SnapshotStatus {
   String toValue() {
     switch (this) {
       case SnapshotStatus.creating:
@@ -6055,7 +6055,7 @@ enum UrlType {
   flinkDashboardUrl,
 }
 
-extension UrlTypeValue on UrlType {
+extension UrlTypeValueExtension on UrlType {
   String toValue() {
     switch (this) {
       case UrlType.flinkDashboardUrl:

--- a/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
+++ b/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
@@ -1254,7 +1254,7 @@ enum APIName {
   getClip,
 }
 
-extension APINameValue on APIName {
+extension APINameValueExtension on APIName {
   String toValue() {
     switch (this) {
       case APIName.putMedia:
@@ -1379,7 +1379,7 @@ enum ChannelProtocol {
   https,
 }
 
-extension ChannelProtocolValue on ChannelProtocol {
+extension ChannelProtocolValueExtension on ChannelProtocol {
   String toValue() {
     switch (this) {
       case ChannelProtocol.wss:
@@ -1407,7 +1407,7 @@ enum ChannelRole {
   viewer,
 }
 
-extension ChannelRoleValue on ChannelRole {
+extension ChannelRoleValueExtension on ChannelRole {
   String toValue() {
     switch (this) {
       case ChannelRole.master:
@@ -1434,7 +1434,7 @@ enum ChannelType {
   singleMaster,
 }
 
-extension ChannelTypeValue on ChannelType {
+extension ChannelTypeValueExtension on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.singleMaster:
@@ -1457,7 +1457,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.beginsWith:
@@ -1763,7 +1763,7 @@ enum Status {
   deleting,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.creating:
@@ -1936,7 +1936,8 @@ enum UpdateDataRetentionOperation {
   decreaseDataRetention,
 }
 
-extension UpdateDataRetentionOperationValue on UpdateDataRetentionOperation {
+extension UpdateDataRetentionOperationValueExtension
+    on UpdateDataRetentionOperation {
   String toValue() {
     switch (this) {
       case UpdateDataRetentionOperation.increaseDataRetention:

--- a/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
+++ b/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
@@ -1254,7 +1254,7 @@ enum APIName {
   getClip,
 }
 
-extension on APIName {
+extension APINameValue on APIName {
   String toValue() {
     switch (this) {
       case APIName.putMedia:
@@ -1275,7 +1275,7 @@ extension on APIName {
   }
 }
 
-extension on String {
+extension APINameFromString on String {
   APIName toAPIName() {
     switch (this) {
       case 'PUT_MEDIA':
@@ -1379,7 +1379,7 @@ enum ChannelProtocol {
   https,
 }
 
-extension on ChannelProtocol {
+extension ChannelProtocolValue on ChannelProtocol {
   String toValue() {
     switch (this) {
       case ChannelProtocol.wss:
@@ -1390,7 +1390,7 @@ extension on ChannelProtocol {
   }
 }
 
-extension on String {
+extension ChannelProtocolFromString on String {
   ChannelProtocol toChannelProtocol() {
     switch (this) {
       case 'WSS':
@@ -1407,7 +1407,7 @@ enum ChannelRole {
   viewer,
 }
 
-extension on ChannelRole {
+extension ChannelRoleValue on ChannelRole {
   String toValue() {
     switch (this) {
       case ChannelRole.master:
@@ -1418,7 +1418,7 @@ extension on ChannelRole {
   }
 }
 
-extension on String {
+extension ChannelRoleFromString on String {
   ChannelRole toChannelRole() {
     switch (this) {
       case 'MASTER':
@@ -1434,7 +1434,7 @@ enum ChannelType {
   singleMaster,
 }
 
-extension on ChannelType {
+extension ChannelTypeValue on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.singleMaster:
@@ -1443,7 +1443,7 @@ extension on ChannelType {
   }
 }
 
-extension on String {
+extension ChannelTypeFromString on String {
   ChannelType toChannelType() {
     switch (this) {
       case 'SINGLE_MASTER':
@@ -1457,7 +1457,7 @@ enum ComparisonOperator {
   beginsWith,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.beginsWith:
@@ -1466,7 +1466,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'BEGINS_WITH':
@@ -1763,7 +1763,7 @@ enum Status {
   deleting,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.creating:
@@ -1778,7 +1778,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'CREATING':
@@ -1936,7 +1936,7 @@ enum UpdateDataRetentionOperation {
   decreaseDataRetention,
 }
 
-extension on UpdateDataRetentionOperation {
+extension UpdateDataRetentionOperationValue on UpdateDataRetentionOperation {
   String toValue() {
     switch (this) {
       case UpdateDataRetentionOperation.increaseDataRetention:
@@ -1947,7 +1947,7 @@ extension on UpdateDataRetentionOperation {
   }
 }
 
-extension on String {
+extension UpdateDataRetentionOperationFromString on String {
   UpdateDataRetentionOperation toUpdateDataRetentionOperation() {
     switch (this) {
       case 'INCREASE_DATA_RETENTION':

--- a/generated/aws_kms_api/lib/kms-2014-11-01.dart
+++ b/generated/aws_kms_api/lib/kms-2014-11-01.dart
@@ -6546,7 +6546,7 @@ enum AlgorithmSpec {
   rsaesOaepSha_256,
 }
 
-extension on AlgorithmSpec {
+extension AlgorithmSpecValue on AlgorithmSpec {
   String toValue() {
     switch (this) {
       case AlgorithmSpec.rsaesPkcs1V1_5:
@@ -6559,7 +6559,7 @@ extension on AlgorithmSpec {
   }
 }
 
-extension on String {
+extension AlgorithmSpecFromString on String {
   AlgorithmSpec toAlgorithmSpec() {
     switch (this) {
       case 'RSAES_PKCS1_V1_5':
@@ -6646,7 +6646,7 @@ enum ConnectionErrorCodeType {
   subnetNotFound,
 }
 
-extension on ConnectionErrorCodeType {
+extension ConnectionErrorCodeTypeValue on ConnectionErrorCodeType {
   String toValue() {
     switch (this) {
       case ConnectionErrorCodeType.invalidCredentials:
@@ -6671,7 +6671,7 @@ extension on ConnectionErrorCodeType {
   }
 }
 
-extension on String {
+extension ConnectionErrorCodeTypeFromString on String {
   ConnectionErrorCodeType toConnectionErrorCodeType() {
     switch (this) {
       case 'INVALID_CREDENTIALS':
@@ -6705,7 +6705,7 @@ enum ConnectionStateType {
   disconnecting,
 }
 
-extension on ConnectionStateType {
+extension ConnectionStateTypeValue on ConnectionStateType {
   String toValue() {
     switch (this) {
       case ConnectionStateType.connected:
@@ -6722,7 +6722,7 @@ extension on ConnectionStateType {
   }
 }
 
-extension on String {
+extension ConnectionStateTypeFromString on String {
   ConnectionStateType toConnectionStateType() {
     switch (this) {
       case 'CONNECTED':
@@ -6952,7 +6952,7 @@ enum CustomerMasterKeySpec {
   symmetricDefault,
 }
 
-extension on CustomerMasterKeySpec {
+extension CustomerMasterKeySpecValue on CustomerMasterKeySpec {
   String toValue() {
     switch (this) {
       case CustomerMasterKeySpec.rsa_2048:
@@ -6975,7 +6975,7 @@ extension on CustomerMasterKeySpec {
   }
 }
 
-extension on String {
+extension CustomerMasterKeySpecFromString on String {
   CustomerMasterKeySpec toCustomerMasterKeySpec() {
     switch (this) {
       case 'RSA_2048':
@@ -7009,7 +7009,7 @@ enum DataKeyPairSpec {
   eccSecgP256k1,
 }
 
-extension on DataKeyPairSpec {
+extension DataKeyPairSpecValue on DataKeyPairSpec {
   String toValue() {
     switch (this) {
       case DataKeyPairSpec.rsa_2048:
@@ -7030,7 +7030,7 @@ extension on DataKeyPairSpec {
   }
 }
 
-extension on String {
+extension DataKeyPairSpecFromString on String {
   DataKeyPairSpec toDataKeyPairSpec() {
     switch (this) {
       case 'RSA_2048':
@@ -7057,7 +7057,7 @@ enum DataKeySpec {
   aes_128,
 }
 
-extension on DataKeySpec {
+extension DataKeySpecValue on DataKeySpec {
   String toValue() {
     switch (this) {
       case DataKeySpec.aes_256:
@@ -7068,7 +7068,7 @@ extension on DataKeySpec {
   }
 }
 
-extension on String {
+extension DataKeySpecFromString on String {
   DataKeySpec toDataKeySpec() {
     switch (this) {
       case 'AES_256':
@@ -7206,7 +7206,7 @@ enum EncryptionAlgorithmSpec {
   rsaesOaepSha_256,
 }
 
-extension on EncryptionAlgorithmSpec {
+extension EncryptionAlgorithmSpecValue on EncryptionAlgorithmSpec {
   String toValue() {
     switch (this) {
       case EncryptionAlgorithmSpec.symmetricDefault:
@@ -7219,7 +7219,7 @@ extension on EncryptionAlgorithmSpec {
   }
 }
 
-extension on String {
+extension EncryptionAlgorithmSpecFromString on String {
   EncryptionAlgorithmSpec toEncryptionAlgorithmSpec() {
     switch (this) {
       case 'SYMMETRIC_DEFAULT':
@@ -7238,7 +7238,7 @@ enum ExpirationModelType {
   keyMaterialDoesNotExpire,
 }
 
-extension on ExpirationModelType {
+extension ExpirationModelTypeValue on ExpirationModelType {
   String toValue() {
     switch (this) {
       case ExpirationModelType.keyMaterialExpires:
@@ -7249,7 +7249,7 @@ extension on ExpirationModelType {
   }
 }
 
-extension on String {
+extension ExpirationModelTypeFromString on String {
   ExpirationModelType toExpirationModelType() {
     switch (this) {
       case 'KEY_MATERIAL_EXPIRES':
@@ -7704,7 +7704,7 @@ enum GrantOperation {
   generateDataKeyPairWithoutPlaintext,
 }
 
-extension on GrantOperation {
+extension GrantOperationValue on GrantOperation {
   String toValue() {
     switch (this) {
       case GrantOperation.decrypt:
@@ -7739,7 +7739,7 @@ extension on GrantOperation {
   }
 }
 
-extension on String {
+extension GrantOperationFromString on String {
   GrantOperation toGrantOperation() {
     switch (this) {
       case 'Decrypt':
@@ -7807,7 +7807,7 @@ enum KeyManagerType {
   customer,
 }
 
-extension on KeyManagerType {
+extension KeyManagerTypeValue on KeyManagerType {
   String toValue() {
     switch (this) {
       case KeyManagerType.aws:
@@ -7818,7 +7818,7 @@ extension on KeyManagerType {
   }
 }
 
-extension on String {
+extension KeyManagerTypeFromString on String {
   KeyManagerType toKeyManagerType() {
     switch (this) {
       case 'AWS':
@@ -7991,7 +7991,7 @@ enum KeyState {
   unavailable,
 }
 
-extension on KeyState {
+extension KeyStateValue on KeyState {
   String toValue() {
     switch (this) {
       case KeyState.enabled:
@@ -8008,7 +8008,7 @@ extension on KeyState {
   }
 }
 
-extension on String {
+extension KeyStateFromString on String {
   KeyState toKeyState() {
     switch (this) {
       case 'Enabled':
@@ -8031,7 +8031,7 @@ enum KeyUsageType {
   encryptDecrypt,
 }
 
-extension on KeyUsageType {
+extension KeyUsageTypeValue on KeyUsageType {
   String toValue() {
     switch (this) {
       case KeyUsageType.signVerify:
@@ -8042,7 +8042,7 @@ extension on KeyUsageType {
   }
 }
 
-extension on String {
+extension KeyUsageTypeFromString on String {
   KeyUsageType toKeyUsageType() {
     switch (this) {
       case 'SIGN_VERIFY':
@@ -8221,7 +8221,7 @@ enum MessageType {
   digest,
 }
 
-extension on MessageType {
+extension MessageTypeValue on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.raw:
@@ -8232,7 +8232,7 @@ extension on MessageType {
   }
 }
 
-extension on String {
+extension MessageTypeFromString on String {
   MessageType toMessageType() {
     switch (this) {
       case 'RAW':
@@ -8250,7 +8250,7 @@ enum OriginType {
   awsCloudhsm,
 }
 
-extension on OriginType {
+extension OriginTypeValue on OriginType {
   String toValue() {
     switch (this) {
       case OriginType.awsKms:
@@ -8263,7 +8263,7 @@ extension on OriginType {
   }
 }
 
-extension on String {
+extension OriginTypeFromString on String {
   OriginType toOriginType() {
     switch (this) {
       case 'AWS_KMS':
@@ -8397,7 +8397,7 @@ enum SigningAlgorithmSpec {
   ecdsaSha_512,
 }
 
-extension on SigningAlgorithmSpec {
+extension SigningAlgorithmSpecValue on SigningAlgorithmSpec {
   String toValue() {
     switch (this) {
       case SigningAlgorithmSpec.rsassaPssSha_256:
@@ -8422,7 +8422,7 @@ extension on SigningAlgorithmSpec {
   }
 }
 
-extension on String {
+extension SigningAlgorithmSpecFromString on String {
   SigningAlgorithmSpec toSigningAlgorithmSpec() {
     switch (this) {
       case 'RSASSA_PSS_SHA_256':
@@ -8527,7 +8527,7 @@ enum WrappingKeySpec {
   rsa_2048,
 }
 
-extension on WrappingKeySpec {
+extension WrappingKeySpecValue on WrappingKeySpec {
   String toValue() {
     switch (this) {
       case WrappingKeySpec.rsa_2048:
@@ -8536,7 +8536,7 @@ extension on WrappingKeySpec {
   }
 }
 
-extension on String {
+extension WrappingKeySpecFromString on String {
   WrappingKeySpec toWrappingKeySpec() {
     switch (this) {
       case 'RSA_2048':

--- a/generated/aws_kms_api/lib/kms-2014-11-01.dart
+++ b/generated/aws_kms_api/lib/kms-2014-11-01.dart
@@ -6546,7 +6546,7 @@ enum AlgorithmSpec {
   rsaesOaepSha_256,
 }
 
-extension AlgorithmSpecValue on AlgorithmSpec {
+extension AlgorithmSpecValueExtension on AlgorithmSpec {
   String toValue() {
     switch (this) {
       case AlgorithmSpec.rsaesPkcs1V1_5:
@@ -6646,7 +6646,7 @@ enum ConnectionErrorCodeType {
   subnetNotFound,
 }
 
-extension ConnectionErrorCodeTypeValue on ConnectionErrorCodeType {
+extension ConnectionErrorCodeTypeValueExtension on ConnectionErrorCodeType {
   String toValue() {
     switch (this) {
       case ConnectionErrorCodeType.invalidCredentials:
@@ -6705,7 +6705,7 @@ enum ConnectionStateType {
   disconnecting,
 }
 
-extension ConnectionStateTypeValue on ConnectionStateType {
+extension ConnectionStateTypeValueExtension on ConnectionStateType {
   String toValue() {
     switch (this) {
       case ConnectionStateType.connected:
@@ -6952,7 +6952,7 @@ enum CustomerMasterKeySpec {
   symmetricDefault,
 }
 
-extension CustomerMasterKeySpecValue on CustomerMasterKeySpec {
+extension CustomerMasterKeySpecValueExtension on CustomerMasterKeySpec {
   String toValue() {
     switch (this) {
       case CustomerMasterKeySpec.rsa_2048:
@@ -7009,7 +7009,7 @@ enum DataKeyPairSpec {
   eccSecgP256k1,
 }
 
-extension DataKeyPairSpecValue on DataKeyPairSpec {
+extension DataKeyPairSpecValueExtension on DataKeyPairSpec {
   String toValue() {
     switch (this) {
       case DataKeyPairSpec.rsa_2048:
@@ -7057,7 +7057,7 @@ enum DataKeySpec {
   aes_128,
 }
 
-extension DataKeySpecValue on DataKeySpec {
+extension DataKeySpecValueExtension on DataKeySpec {
   String toValue() {
     switch (this) {
       case DataKeySpec.aes_256:
@@ -7206,7 +7206,7 @@ enum EncryptionAlgorithmSpec {
   rsaesOaepSha_256,
 }
 
-extension EncryptionAlgorithmSpecValue on EncryptionAlgorithmSpec {
+extension EncryptionAlgorithmSpecValueExtension on EncryptionAlgorithmSpec {
   String toValue() {
     switch (this) {
       case EncryptionAlgorithmSpec.symmetricDefault:
@@ -7238,7 +7238,7 @@ enum ExpirationModelType {
   keyMaterialDoesNotExpire,
 }
 
-extension ExpirationModelTypeValue on ExpirationModelType {
+extension ExpirationModelTypeValueExtension on ExpirationModelType {
   String toValue() {
     switch (this) {
       case ExpirationModelType.keyMaterialExpires:
@@ -7704,7 +7704,7 @@ enum GrantOperation {
   generateDataKeyPairWithoutPlaintext,
 }
 
-extension GrantOperationValue on GrantOperation {
+extension GrantOperationValueExtension on GrantOperation {
   String toValue() {
     switch (this) {
       case GrantOperation.decrypt:
@@ -7807,7 +7807,7 @@ enum KeyManagerType {
   customer,
 }
 
-extension KeyManagerTypeValue on KeyManagerType {
+extension KeyManagerTypeValueExtension on KeyManagerType {
   String toValue() {
     switch (this) {
       case KeyManagerType.aws:
@@ -7991,7 +7991,7 @@ enum KeyState {
   unavailable,
 }
 
-extension KeyStateValue on KeyState {
+extension KeyStateValueExtension on KeyState {
   String toValue() {
     switch (this) {
       case KeyState.enabled:
@@ -8031,7 +8031,7 @@ enum KeyUsageType {
   encryptDecrypt,
 }
 
-extension KeyUsageTypeValue on KeyUsageType {
+extension KeyUsageTypeValueExtension on KeyUsageType {
   String toValue() {
     switch (this) {
       case KeyUsageType.signVerify:
@@ -8221,7 +8221,7 @@ enum MessageType {
   digest,
 }
 
-extension MessageTypeValue on MessageType {
+extension MessageTypeValueExtension on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.raw:
@@ -8250,7 +8250,7 @@ enum OriginType {
   awsCloudhsm,
 }
 
-extension OriginTypeValue on OriginType {
+extension OriginTypeValueExtension on OriginType {
   String toValue() {
     switch (this) {
       case OriginType.awsKms:
@@ -8397,7 +8397,7 @@ enum SigningAlgorithmSpec {
   ecdsaSha_512,
 }
 
-extension SigningAlgorithmSpecValue on SigningAlgorithmSpec {
+extension SigningAlgorithmSpecValueExtension on SigningAlgorithmSpec {
   String toValue() {
     switch (this) {
       case SigningAlgorithmSpec.rsassaPssSha_256:
@@ -8527,7 +8527,7 @@ enum WrappingKeySpec {
   rsa_2048,
 }
 
-extension WrappingKeySpecValue on WrappingKeySpec {
+extension WrappingKeySpecValueExtension on WrappingKeySpec {
   String toValue() {
     switch (this) {
       case WrappingKeySpec.rsa_2048:

--- a/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
+++ b/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
@@ -914,7 +914,7 @@ enum ComparisonOperator {
   between,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -1005,7 +1005,7 @@ enum DataLakeResourceType {
   dataLocation,
 }
 
-extension DataLakeResourceTypeValue on DataLakeResourceType {
+extension DataLakeResourceTypeValueExtension on DataLakeResourceType {
   String toValue() {
     switch (this) {
       case DataLakeResourceType.catalog:
@@ -1242,7 +1242,7 @@ enum FieldNameString {
   lastModified,
 }
 
-extension FieldNameStringValue on FieldNameString {
+extension FieldNameStringValueExtension on FieldNameString {
   String toValue() {
     switch (this) {
       case FieldNameString.resourceArn:
@@ -1410,7 +1410,7 @@ enum Permission {
   dataLocationAccess,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.all:

--- a/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
+++ b/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
@@ -914,7 +914,7 @@ enum ComparisonOperator {
   between,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -943,7 +943,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -1005,7 +1005,7 @@ enum DataLakeResourceType {
   dataLocation,
 }
 
-extension on DataLakeResourceType {
+extension DataLakeResourceTypeValue on DataLakeResourceType {
   String toValue() {
     switch (this) {
       case DataLakeResourceType.catalog:
@@ -1020,7 +1020,7 @@ extension on DataLakeResourceType {
   }
 }
 
-extension on String {
+extension DataLakeResourceTypeFromString on String {
   DataLakeResourceType toDataLakeResourceType() {
     switch (this) {
       case 'CATALOG':
@@ -1242,7 +1242,7 @@ enum FieldNameString {
   lastModified,
 }
 
-extension on FieldNameString {
+extension FieldNameStringValue on FieldNameString {
   String toValue() {
     switch (this) {
       case FieldNameString.resourceArn:
@@ -1255,7 +1255,7 @@ extension on FieldNameString {
   }
 }
 
-extension on String {
+extension FieldNameStringFromString on String {
   FieldNameString toFieldNameString() {
     switch (this) {
       case 'RESOURCE_ARN':
@@ -1410,7 +1410,7 @@ enum Permission {
   dataLocationAccess,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.all:
@@ -1437,7 +1437,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'ALL':

--- a/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
+++ b/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
@@ -929,7 +929,7 @@ enum Mode {
   event,
 }
 
-extension on Mode {
+extension ModeValue on Mode {
   String toValue() {
     switch (this) {
       case Mode.event:
@@ -938,7 +938,7 @@ extension on Mode {
   }
 }
 
-extension on String {
+extension ModeFromString on String {
   Mode toMode() {
     switch (this) {
       case 'event':
@@ -969,7 +969,7 @@ enum Runtime {
   nodejs,
 }
 
-extension on Runtime {
+extension RuntimeValue on Runtime {
   String toValue() {
     switch (this) {
       case Runtime.nodejs:
@@ -978,7 +978,7 @@ extension on Runtime {
   }
 }
 
-extension on String {
+extension RuntimeFromString on String {
   Runtime toRuntime() {
     switch (this) {
       case 'nodejs':

--- a/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
+++ b/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
@@ -929,7 +929,7 @@ enum Mode {
   event,
 }
 
-extension ModeValue on Mode {
+extension ModeValueExtension on Mode {
   String toValue() {
     switch (this) {
       case Mode.event:
@@ -969,7 +969,7 @@ enum Runtime {
   nodejs,
 }
 
-extension RuntimeValue on Runtime {
+extension RuntimeValueExtension on Runtime {
   String toValue() {
     switch (this) {
       case Runtime.nodejs:

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -4834,7 +4834,7 @@ enum CodeSigningPolicy {
   enforce,
 }
 
-extension on CodeSigningPolicy {
+extension CodeSigningPolicyValue on CodeSigningPolicy {
   String toValue() {
     switch (this) {
       case CodeSigningPolicy.warn:
@@ -4845,7 +4845,7 @@ extension on CodeSigningPolicy {
   }
 }
 
-extension on String {
+extension CodeSigningPolicyFromString on String {
   CodeSigningPolicy toCodeSigningPolicy() {
     switch (this) {
       case 'Warn':
@@ -4959,7 +4959,7 @@ enum EndPointType {
   kafkaBootstrapServers,
 }
 
-extension on EndPointType {
+extension EndPointTypeValue on EndPointType {
   String toValue() {
     switch (this) {
       case EndPointType.kafkaBootstrapServers:
@@ -4968,7 +4968,7 @@ extension on EndPointType {
   }
 }
 
-extension on String {
+extension EndPointTypeFromString on String {
   EndPointType toEndPointType() {
     switch (this) {
       case 'KAFKA_BOOTSTRAP_SERVERS':
@@ -5207,7 +5207,7 @@ enum EventSourcePosition {
   atTimestamp,
 }
 
-extension on EventSourcePosition {
+extension EventSourcePositionValue on EventSourcePosition {
   String toValue() {
     switch (this) {
       case EventSourcePosition.trimHorizon:
@@ -5220,7 +5220,7 @@ extension on EventSourcePosition {
   }
 }
 
-extension on String {
+extension EventSourcePositionFromString on String {
   EventSourcePosition toEventSourcePosition() {
     switch (this) {
       case 'TRIM_HORIZON':
@@ -5598,7 +5598,7 @@ enum FunctionResponseType {
   reportBatchItemFailures,
 }
 
-extension on FunctionResponseType {
+extension FunctionResponseTypeValue on FunctionResponseType {
   String toValue() {
     switch (this) {
       case FunctionResponseType.reportBatchItemFailures:
@@ -5607,7 +5607,7 @@ extension on FunctionResponseType {
   }
 }
 
-extension on String {
+extension FunctionResponseTypeFromString on String {
   FunctionResponseType toFunctionResponseType() {
     switch (this) {
       case 'ReportBatchItemFailures':
@@ -5621,7 +5621,7 @@ enum FunctionVersion {
   all,
 }
 
-extension on FunctionVersion {
+extension FunctionVersionValue on FunctionVersion {
   String toValue() {
     switch (this) {
       case FunctionVersion.all:
@@ -5630,7 +5630,7 @@ extension on FunctionVersion {
   }
 }
 
-extension on String {
+extension FunctionVersionFromString on String {
   FunctionVersion toFunctionVersion() {
     switch (this) {
       case 'ALL':
@@ -6036,7 +6036,7 @@ enum InvocationType {
   dryRun,
 }
 
-extension on InvocationType {
+extension InvocationTypeValue on InvocationType {
   String toValue() {
     switch (this) {
       case InvocationType.event:
@@ -6049,7 +6049,7 @@ extension on InvocationType {
   }
 }
 
-extension on String {
+extension InvocationTypeFromString on String {
   InvocationType toInvocationType() {
     switch (this) {
       case 'Event':
@@ -6084,7 +6084,7 @@ enum LastUpdateStatus {
   inProgress,
 }
 
-extension on LastUpdateStatus {
+extension LastUpdateStatusValue on LastUpdateStatus {
   String toValue() {
     switch (this) {
       case LastUpdateStatus.successful:
@@ -6097,7 +6097,7 @@ extension on LastUpdateStatus {
   }
 }
 
-extension on String {
+extension LastUpdateStatusFromString on String {
   LastUpdateStatus toLastUpdateStatus() {
     switch (this) {
       case 'Successful':
@@ -6124,7 +6124,7 @@ enum LastUpdateStatusReasonCode {
   invalidImage,
 }
 
-extension on LastUpdateStatusReasonCode {
+extension LastUpdateStatusReasonCodeValue on LastUpdateStatusReasonCode {
   String toValue() {
     switch (this) {
       case LastUpdateStatusReasonCode.eniLimitExceeded:
@@ -6151,7 +6151,7 @@ extension on LastUpdateStatusReasonCode {
   }
 }
 
-extension on String {
+extension LastUpdateStatusReasonCodeFromString on String {
   LastUpdateStatusReasonCode toLastUpdateStatusReasonCode() {
     switch (this) {
       case 'EniLimitExceeded':
@@ -6612,7 +6612,7 @@ enum LogType {
   tail,
 }
 
-extension on LogType {
+extension LogTypeValue on LogType {
   String toValue() {
     switch (this) {
       case LogType.none:
@@ -6623,7 +6623,7 @@ extension on LogType {
   }
 }
 
-extension on String {
+extension LogTypeFromString on String {
   LogType toLogType() {
     switch (this) {
       case 'None':
@@ -6684,7 +6684,7 @@ enum PackageType {
   image,
 }
 
-extension on PackageType {
+extension PackageTypeValue on PackageType {
   String toValue() {
     switch (this) {
       case PackageType.zip:
@@ -6695,7 +6695,7 @@ extension on PackageType {
   }
 }
 
-extension on String {
+extension PackageTypeFromString on String {
   PackageType toPackageType() {
     switch (this) {
       case 'Zip':
@@ -6766,7 +6766,8 @@ enum ProvisionedConcurrencyStatusEnum {
   failed,
 }
 
-extension on ProvisionedConcurrencyStatusEnum {
+extension ProvisionedConcurrencyStatusEnumValue
+    on ProvisionedConcurrencyStatusEnum {
   String toValue() {
     switch (this) {
       case ProvisionedConcurrencyStatusEnum.inProgress:
@@ -6779,7 +6780,7 @@ extension on ProvisionedConcurrencyStatusEnum {
   }
 }
 
-extension on String {
+extension ProvisionedConcurrencyStatusEnumFromString on String {
   ProvisionedConcurrencyStatusEnum toProvisionedConcurrencyStatusEnum() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -6959,7 +6960,7 @@ enum Runtime {
   providedAl2,
 }
 
-extension on Runtime {
+extension RuntimeValue on Runtime {
   String toValue() {
     switch (this) {
       case Runtime.nodejs:
@@ -7012,7 +7013,7 @@ extension on Runtime {
   }
 }
 
-extension on String {
+extension RuntimeFromString on String {
   Runtime toRuntime() {
     switch (this) {
       case 'nodejs':
@@ -7157,7 +7158,7 @@ enum SourceAccessType {
   saslScram_256Auth,
 }
 
-extension on SourceAccessType {
+extension SourceAccessTypeValue on SourceAccessType {
   String toValue() {
     switch (this) {
       case SourceAccessType.basicAuth:
@@ -7174,7 +7175,7 @@ extension on SourceAccessType {
   }
 }
 
-extension on String {
+extension SourceAccessTypeFromString on String {
   SourceAccessType toSourceAccessType() {
     switch (this) {
       case 'BASIC_AUTH':
@@ -7199,7 +7200,7 @@ enum State {
   failed,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.pending:
@@ -7214,7 +7215,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'Pending':
@@ -7246,7 +7247,7 @@ enum StateReasonCode {
   invalidImage,
 }
 
-extension on StateReasonCode {
+extension StateReasonCodeValue on StateReasonCode {
   String toValue() {
     switch (this) {
       case StateReasonCode.idle:
@@ -7279,7 +7280,7 @@ extension on StateReasonCode {
   }
 }
 
-extension on String {
+extension StateReasonCodeFromString on String {
   StateReasonCode toStateReasonCode() {
     switch (this) {
       case 'Idle':
@@ -7350,7 +7351,7 @@ enum TracingMode {
   passThrough,
 }
 
-extension on TracingMode {
+extension TracingModeValue on TracingMode {
   String toValue() {
     switch (this) {
       case TracingMode.active:
@@ -7361,7 +7362,7 @@ extension on TracingMode {
   }
 }
 
-extension on String {
+extension TracingModeFromString on String {
   TracingMode toTracingMode() {
     switch (this) {
       case 'Active':

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -4834,7 +4834,7 @@ enum CodeSigningPolicy {
   enforce,
 }
 
-extension CodeSigningPolicyValue on CodeSigningPolicy {
+extension CodeSigningPolicyValueExtension on CodeSigningPolicy {
   String toValue() {
     switch (this) {
       case CodeSigningPolicy.warn:
@@ -4959,7 +4959,7 @@ enum EndPointType {
   kafkaBootstrapServers,
 }
 
-extension EndPointTypeValue on EndPointType {
+extension EndPointTypeValueExtension on EndPointType {
   String toValue() {
     switch (this) {
       case EndPointType.kafkaBootstrapServers:
@@ -5207,7 +5207,7 @@ enum EventSourcePosition {
   atTimestamp,
 }
 
-extension EventSourcePositionValue on EventSourcePosition {
+extension EventSourcePositionValueExtension on EventSourcePosition {
   String toValue() {
     switch (this) {
       case EventSourcePosition.trimHorizon:
@@ -5598,7 +5598,7 @@ enum FunctionResponseType {
   reportBatchItemFailures,
 }
 
-extension FunctionResponseTypeValue on FunctionResponseType {
+extension FunctionResponseTypeValueExtension on FunctionResponseType {
   String toValue() {
     switch (this) {
       case FunctionResponseType.reportBatchItemFailures:
@@ -5621,7 +5621,7 @@ enum FunctionVersion {
   all,
 }
 
-extension FunctionVersionValue on FunctionVersion {
+extension FunctionVersionValueExtension on FunctionVersion {
   String toValue() {
     switch (this) {
       case FunctionVersion.all:
@@ -6036,7 +6036,7 @@ enum InvocationType {
   dryRun,
 }
 
-extension InvocationTypeValue on InvocationType {
+extension InvocationTypeValueExtension on InvocationType {
   String toValue() {
     switch (this) {
       case InvocationType.event:
@@ -6084,7 +6084,7 @@ enum LastUpdateStatus {
   inProgress,
 }
 
-extension LastUpdateStatusValue on LastUpdateStatus {
+extension LastUpdateStatusValueExtension on LastUpdateStatus {
   String toValue() {
     switch (this) {
       case LastUpdateStatus.successful:
@@ -6124,7 +6124,8 @@ enum LastUpdateStatusReasonCode {
   invalidImage,
 }
 
-extension LastUpdateStatusReasonCodeValue on LastUpdateStatusReasonCode {
+extension LastUpdateStatusReasonCodeValueExtension
+    on LastUpdateStatusReasonCode {
   String toValue() {
     switch (this) {
       case LastUpdateStatusReasonCode.eniLimitExceeded:
@@ -6612,7 +6613,7 @@ enum LogType {
   tail,
 }
 
-extension LogTypeValue on LogType {
+extension LogTypeValueExtension on LogType {
   String toValue() {
     switch (this) {
       case LogType.none:
@@ -6684,7 +6685,7 @@ enum PackageType {
   image,
 }
 
-extension PackageTypeValue on PackageType {
+extension PackageTypeValueExtension on PackageType {
   String toValue() {
     switch (this) {
       case PackageType.zip:
@@ -6766,7 +6767,7 @@ enum ProvisionedConcurrencyStatusEnum {
   failed,
 }
 
-extension ProvisionedConcurrencyStatusEnumValue
+extension ProvisionedConcurrencyStatusEnumValueExtension
     on ProvisionedConcurrencyStatusEnum {
   String toValue() {
     switch (this) {
@@ -6960,7 +6961,7 @@ enum Runtime {
   providedAl2,
 }
 
-extension RuntimeValue on Runtime {
+extension RuntimeValueExtension on Runtime {
   String toValue() {
     switch (this) {
       case Runtime.nodejs:
@@ -7158,7 +7159,7 @@ enum SourceAccessType {
   saslScram_256Auth,
 }
 
-extension SourceAccessTypeValue on SourceAccessType {
+extension SourceAccessTypeValueExtension on SourceAccessType {
   String toValue() {
     switch (this) {
       case SourceAccessType.basicAuth:
@@ -7200,7 +7201,7 @@ enum State {
   failed,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.pending:
@@ -7247,7 +7248,7 @@ enum StateReasonCode {
   invalidImage,
 }
 
-extension StateReasonCodeValue on StateReasonCode {
+extension StateReasonCodeValueExtension on StateReasonCode {
   String toValue() {
     switch (this) {
       case StateReasonCode.idle:
@@ -7351,7 +7352,7 @@ enum TracingMode {
   passThrough,
 }
 
-extension TracingModeValue on TracingMode {
+extension TracingModeValueExtension on TracingMode {
   String toValue() {
     switch (this) {
       case TracingMode.active:

--- a/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
+++ b/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
@@ -3100,7 +3100,7 @@ enum ChannelStatus {
   failed,
 }
 
-extension on ChannelStatus {
+extension ChannelStatusValue on ChannelStatus {
   String toValue() {
     switch (this) {
       case ChannelStatus.inProgress:
@@ -3113,7 +3113,7 @@ extension on ChannelStatus {
   }
 }
 
-extension on String {
+extension ChannelStatusFromString on String {
   ChannelStatus toChannelStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3134,7 +3134,7 @@ enum ChannelType {
   kik,
 }
 
-extension on ChannelType {
+extension ChannelTypeValue on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.facebook:
@@ -3149,7 +3149,7 @@ extension on ChannelType {
   }
 }
 
-extension on String {
+extension ChannelTypeFromString on String {
   ChannelType toChannelType() {
     switch (this) {
       case 'Facebook':
@@ -3202,7 +3202,7 @@ enum ContentType {
   customPayload,
 }
 
-extension on ContentType {
+extension ContentTypeValue on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.plainText:
@@ -3215,7 +3215,7 @@ extension on ContentType {
   }
 }
 
-extension on String {
+extension ContentTypeFromString on String {
   ContentType toContentType() {
     switch (this) {
       case 'PlainText':
@@ -3635,7 +3635,7 @@ enum Destination {
   s3,
 }
 
-extension on Destination {
+extension DestinationValue on Destination {
   String toValue() {
     switch (this) {
       case Destination.cloudwatchLogs:
@@ -3646,7 +3646,7 @@ extension on Destination {
   }
 }
 
-extension on String {
+extension DestinationFromString on String {
   Destination toDestination() {
     switch (this) {
       case 'CLOUDWATCH_LOGS':
@@ -3713,7 +3713,7 @@ enum ExportStatus {
   failed,
 }
 
-extension on ExportStatus {
+extension ExportStatusValue on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -3726,7 +3726,7 @@ extension on ExportStatus {
   }
 }
 
-extension on String {
+extension ExportStatusFromString on String {
   ExportStatus toExportStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3745,7 +3745,7 @@ enum ExportType {
   lex,
 }
 
-extension on ExportType {
+extension ExportTypeValue on ExportType {
   String toValue() {
     switch (this) {
       case ExportType.alexaSkillsKit:
@@ -3756,7 +3756,7 @@ extension on ExportType {
   }
 }
 
-extension on String {
+extension ExportTypeFromString on String {
   ExportType toExportType() {
     switch (this) {
       case 'ALEXA_SKILLS_KIT':
@@ -3861,7 +3861,7 @@ enum FulfillmentActivityType {
   codeHook,
 }
 
-extension on FulfillmentActivityType {
+extension FulfillmentActivityTypeValue on FulfillmentActivityType {
   String toValue() {
     switch (this) {
       case FulfillmentActivityType.returnIntent:
@@ -3872,7 +3872,7 @@ extension on FulfillmentActivityType {
   }
 }
 
-extension on String {
+extension FulfillmentActivityTypeFromString on String {
   FulfillmentActivityType toFulfillmentActivityType() {
     switch (this) {
       case 'ReturnIntent':
@@ -4813,7 +4813,7 @@ enum ImportStatus {
   failed,
 }
 
-extension on ImportStatus {
+extension ImportStatusValue on ImportStatus {
   String toValue() {
     switch (this) {
       case ImportStatus.inProgress:
@@ -4826,7 +4826,7 @@ extension on ImportStatus {
   }
 }
 
-extension on String {
+extension ImportStatusFromString on String {
   ImportStatus toImportStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -5012,7 +5012,7 @@ enum Locale {
   itIt,
 }
 
-extension on Locale {
+extension LocaleValue on Locale {
   String toValue() {
     switch (this) {
       case Locale.deDe:
@@ -5039,7 +5039,7 @@ extension on Locale {
   }
 }
 
-extension on String {
+extension LocaleFromString on String {
   Locale toLocale() {
     switch (this) {
       case 'de-DE':
@@ -5151,7 +5151,7 @@ enum LogType {
   text,
 }
 
-extension on LogType {
+extension LogTypeValue on LogType {
   String toValue() {
     switch (this) {
       case LogType.audio:
@@ -5162,7 +5162,7 @@ extension on LogType {
   }
 }
 
-extension on String {
+extension LogTypeFromString on String {
   LogType toLogType() {
     switch (this) {
       case 'AUDIO':
@@ -5179,7 +5179,7 @@ enum MergeStrategy {
   failOnConflict,
 }
 
-extension on MergeStrategy {
+extension MergeStrategyValue on MergeStrategy {
   String toValue() {
     switch (this) {
       case MergeStrategy.overwriteLatest:
@@ -5190,7 +5190,7 @@ extension on MergeStrategy {
   }
 }
 
-extension on String {
+extension MergeStrategyFromString on String {
   MergeStrategy toMergeStrategy() {
     switch (this) {
       case 'OVERWRITE_LATEST':
@@ -5245,7 +5245,7 @@ enum ObfuscationSetting {
   defaultObfuscation,
 }
 
-extension on ObfuscationSetting {
+extension ObfuscationSettingValue on ObfuscationSetting {
   String toValue() {
     switch (this) {
       case ObfuscationSetting.none:
@@ -5256,7 +5256,7 @@ extension on ObfuscationSetting {
   }
 }
 
-extension on String {
+extension ObfuscationSettingFromString on String {
   ObfuscationSetting toObfuscationSetting() {
     switch (this) {
       case 'NONE':
@@ -5314,7 +5314,7 @@ enum ProcessBehavior {
   build,
 }
 
-extension on ProcessBehavior {
+extension ProcessBehaviorValue on ProcessBehavior {
   String toValue() {
     switch (this) {
       case ProcessBehavior.save:
@@ -5325,7 +5325,7 @@ extension on ProcessBehavior {
   }
 }
 
-extension on String {
+extension ProcessBehaviorFromString on String {
   ProcessBehavior toProcessBehavior() {
     switch (this) {
       case 'SAVE':
@@ -5868,7 +5868,7 @@ enum ResourceType {
   slotType,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.bot:
@@ -5881,7 +5881,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'BOT':
@@ -6022,7 +6022,7 @@ enum SlotConstraint {
   optional,
 }
 
-extension on SlotConstraint {
+extension SlotConstraintValue on SlotConstraint {
   String toValue() {
     switch (this) {
       case SlotConstraint.required:
@@ -6033,7 +6033,7 @@ extension on SlotConstraint {
   }
 }
 
-extension on String {
+extension SlotConstraintFromString on String {
   SlotConstraint toSlotConstraint() {
     switch (this) {
       case 'Required':
@@ -6230,7 +6230,7 @@ enum SlotValueSelectionStrategy {
   topResolution,
 }
 
-extension on SlotValueSelectionStrategy {
+extension SlotValueSelectionStrategyValue on SlotValueSelectionStrategy {
   String toValue() {
     switch (this) {
       case SlotValueSelectionStrategy.originalValue:
@@ -6241,7 +6241,7 @@ extension on SlotValueSelectionStrategy {
   }
 }
 
-extension on String {
+extension SlotValueSelectionStrategyFromString on String {
   SlotValueSelectionStrategy toSlotValueSelectionStrategy() {
     switch (this) {
       case 'ORIGINAL_VALUE':
@@ -6346,7 +6346,7 @@ enum Status {
   notBuilt,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.building:
@@ -6363,7 +6363,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'BUILDING':
@@ -6386,7 +6386,7 @@ enum StatusType {
   missed,
 }
 
-extension on StatusType {
+extension StatusTypeValue on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.detected:
@@ -6397,7 +6397,7 @@ extension on StatusType {
   }
 }
 
-extension on String {
+extension StatusTypeFromString on String {
   StatusType toStatusType() {
     switch (this) {
       case 'Detected':

--- a/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
+++ b/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
@@ -3100,7 +3100,7 @@ enum ChannelStatus {
   failed,
 }
 
-extension ChannelStatusValue on ChannelStatus {
+extension ChannelStatusValueExtension on ChannelStatus {
   String toValue() {
     switch (this) {
       case ChannelStatus.inProgress:
@@ -3134,7 +3134,7 @@ enum ChannelType {
   kik,
 }
 
-extension ChannelTypeValue on ChannelType {
+extension ChannelTypeValueExtension on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.facebook:
@@ -3202,7 +3202,7 @@ enum ContentType {
   customPayload,
 }
 
-extension ContentTypeValue on ContentType {
+extension ContentTypeValueExtension on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.plainText:
@@ -3635,7 +3635,7 @@ enum Destination {
   s3,
 }
 
-extension DestinationValue on Destination {
+extension DestinationValueExtension on Destination {
   String toValue() {
     switch (this) {
       case Destination.cloudwatchLogs:
@@ -3713,7 +3713,7 @@ enum ExportStatus {
   failed,
 }
 
-extension ExportStatusValue on ExportStatus {
+extension ExportStatusValueExtension on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -3745,7 +3745,7 @@ enum ExportType {
   lex,
 }
 
-extension ExportTypeValue on ExportType {
+extension ExportTypeValueExtension on ExportType {
   String toValue() {
     switch (this) {
       case ExportType.alexaSkillsKit:
@@ -3861,7 +3861,7 @@ enum FulfillmentActivityType {
   codeHook,
 }
 
-extension FulfillmentActivityTypeValue on FulfillmentActivityType {
+extension FulfillmentActivityTypeValueExtension on FulfillmentActivityType {
   String toValue() {
     switch (this) {
       case FulfillmentActivityType.returnIntent:
@@ -4813,7 +4813,7 @@ enum ImportStatus {
   failed,
 }
 
-extension ImportStatusValue on ImportStatus {
+extension ImportStatusValueExtension on ImportStatus {
   String toValue() {
     switch (this) {
       case ImportStatus.inProgress:
@@ -5012,7 +5012,7 @@ enum Locale {
   itIt,
 }
 
-extension LocaleValue on Locale {
+extension LocaleValueExtension on Locale {
   String toValue() {
     switch (this) {
       case Locale.deDe:
@@ -5151,7 +5151,7 @@ enum LogType {
   text,
 }
 
-extension LogTypeValue on LogType {
+extension LogTypeValueExtension on LogType {
   String toValue() {
     switch (this) {
       case LogType.audio:
@@ -5179,7 +5179,7 @@ enum MergeStrategy {
   failOnConflict,
 }
 
-extension MergeStrategyValue on MergeStrategy {
+extension MergeStrategyValueExtension on MergeStrategy {
   String toValue() {
     switch (this) {
       case MergeStrategy.overwriteLatest:
@@ -5245,7 +5245,7 @@ enum ObfuscationSetting {
   defaultObfuscation,
 }
 
-extension ObfuscationSettingValue on ObfuscationSetting {
+extension ObfuscationSettingValueExtension on ObfuscationSetting {
   String toValue() {
     switch (this) {
       case ObfuscationSetting.none:
@@ -5314,7 +5314,7 @@ enum ProcessBehavior {
   build,
 }
 
-extension ProcessBehaviorValue on ProcessBehavior {
+extension ProcessBehaviorValueExtension on ProcessBehavior {
   String toValue() {
     switch (this) {
       case ProcessBehavior.save:
@@ -5868,7 +5868,7 @@ enum ResourceType {
   slotType,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.bot:
@@ -6022,7 +6022,7 @@ enum SlotConstraint {
   optional,
 }
 
-extension SlotConstraintValue on SlotConstraint {
+extension SlotConstraintValueExtension on SlotConstraint {
   String toValue() {
     switch (this) {
       case SlotConstraint.required:
@@ -6230,7 +6230,8 @@ enum SlotValueSelectionStrategy {
   topResolution,
 }
 
-extension SlotValueSelectionStrategyValue on SlotValueSelectionStrategy {
+extension SlotValueSelectionStrategyValueExtension
+    on SlotValueSelectionStrategy {
   String toValue() {
     switch (this) {
       case SlotValueSelectionStrategy.originalValue:
@@ -6346,7 +6347,7 @@ enum Status {
   notBuilt,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.building:
@@ -6386,7 +6387,7 @@ enum StatusType {
   missed,
 }
 
-extension StatusTypeValue on StatusType {
+extension StatusTypeValueExtension on StatusType {
   String toValue() {
     switch (this) {
       case StatusType.detected:

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -977,7 +977,7 @@ enum ConfirmationStatus {
   denied,
 }
 
-extension ConfirmationStatusValue on ConfirmationStatus {
+extension ConfirmationStatusValueExtension on ConfirmationStatus {
   String toValue() {
     switch (this) {
       case ConfirmationStatus.none:
@@ -1008,7 +1008,7 @@ enum ContentType {
   applicationVndAmazonawsCardGeneric,
 }
 
-extension ContentTypeValue on ContentType {
+extension ContentTypeValueExtension on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.applicationVndAmazonawsCardGeneric:
@@ -1193,7 +1193,7 @@ enum DialogActionType {
   delegate,
 }
 
-extension DialogActionTypeValue on DialogActionType {
+extension DialogActionTypeValueExtension on DialogActionType {
   String toValue() {
     switch (this) {
       case DialogActionType.elicitIntent:
@@ -1237,7 +1237,7 @@ enum DialogState {
   failed,
 }
 
-extension DialogStateValue on DialogState {
+extension DialogStateValueExtension on DialogState {
   String toValue() {
     switch (this) {
       case DialogState.elicitIntent:
@@ -1282,7 +1282,7 @@ enum FulfillmentState {
   readyForFulfillment,
 }
 
-extension FulfillmentStateValue on FulfillmentState {
+extension FulfillmentStateValueExtension on FulfillmentState {
   String toValue() {
     switch (this) {
       case FulfillmentState.fulfilled:
@@ -1564,7 +1564,7 @@ enum MessageFormatType {
   composite,
 }
 
-extension MessageFormatTypeValue on MessageFormatType {
+extension MessageFormatTypeValueExtension on MessageFormatType {
   String toValue() {
     switch (this) {
       case MessageFormatType.plainText:

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -977,7 +977,7 @@ enum ConfirmationStatus {
   denied,
 }
 
-extension on ConfirmationStatus {
+extension ConfirmationStatusValue on ConfirmationStatus {
   String toValue() {
     switch (this) {
       case ConfirmationStatus.none:
@@ -990,7 +990,7 @@ extension on ConfirmationStatus {
   }
 }
 
-extension on String {
+extension ConfirmationStatusFromString on String {
   ConfirmationStatus toConfirmationStatus() {
     switch (this) {
       case 'None':
@@ -1008,7 +1008,7 @@ enum ContentType {
   applicationVndAmazonawsCardGeneric,
 }
 
-extension on ContentType {
+extension ContentTypeValue on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.applicationVndAmazonawsCardGeneric:
@@ -1017,7 +1017,7 @@ extension on ContentType {
   }
 }
 
-extension on String {
+extension ContentTypeFromString on String {
   ContentType toContentType() {
     switch (this) {
       case 'application/vnd.amazonaws.card.generic':
@@ -1193,7 +1193,7 @@ enum DialogActionType {
   delegate,
 }
 
-extension on DialogActionType {
+extension DialogActionTypeValue on DialogActionType {
   String toValue() {
     switch (this) {
       case DialogActionType.elicitIntent:
@@ -1210,7 +1210,7 @@ extension on DialogActionType {
   }
 }
 
-extension on String {
+extension DialogActionTypeFromString on String {
   DialogActionType toDialogActionType() {
     switch (this) {
       case 'ElicitIntent':
@@ -1237,7 +1237,7 @@ enum DialogState {
   failed,
 }
 
-extension on DialogState {
+extension DialogStateValue on DialogState {
   String toValue() {
     switch (this) {
       case DialogState.elicitIntent:
@@ -1256,7 +1256,7 @@ extension on DialogState {
   }
 }
 
-extension on String {
+extension DialogStateFromString on String {
   DialogState toDialogState() {
     switch (this) {
       case 'ElicitIntent':
@@ -1282,7 +1282,7 @@ enum FulfillmentState {
   readyForFulfillment,
 }
 
-extension on FulfillmentState {
+extension FulfillmentStateValue on FulfillmentState {
   String toValue() {
     switch (this) {
       case FulfillmentState.fulfilled:
@@ -1295,7 +1295,7 @@ extension on FulfillmentState {
   }
 }
 
-extension on String {
+extension FulfillmentStateFromString on String {
   FulfillmentState toFulfillmentState() {
     switch (this) {
       case 'Fulfilled':
@@ -1564,7 +1564,7 @@ enum MessageFormatType {
   composite,
 }
 
-extension on MessageFormatType {
+extension MessageFormatTypeValue on MessageFormatType {
   String toValue() {
     switch (this) {
       case MessageFormatType.plainText:
@@ -1579,7 +1579,7 @@ extension on MessageFormatType {
   }
 }
 
-extension on String {
+extension MessageFormatTypeFromString on String {
   MessageFormatType toMessageFormatType() {
     switch (this) {
       case 'PlainText':

--- a/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
+++ b/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
@@ -2366,7 +2366,7 @@ enum AllowedOperation {
   createToken,
 }
 
-extension on AllowedOperation {
+extension AllowedOperationValue on AllowedOperation {
   String toValue() {
     switch (this) {
       case AllowedOperation.createGrant:
@@ -2387,7 +2387,7 @@ extension on AllowedOperation {
   }
 }
 
-extension on String {
+extension AllowedOperationFromString on String {
   AllowedOperation toAllowedOperation() {
     switch (this) {
       case 'CreateGrant':
@@ -2566,7 +2566,7 @@ enum CheckoutType {
   provisional,
 }
 
-extension on CheckoutType {
+extension CheckoutTypeValue on CheckoutType {
   String toValue() {
     switch (this) {
       case CheckoutType.provisional:
@@ -2575,7 +2575,7 @@ extension on CheckoutType {
   }
 }
 
-extension on String {
+extension CheckoutTypeFromString on String {
   CheckoutType toCheckoutType() {
     switch (this) {
       case 'PROVISIONAL':
@@ -2874,7 +2874,7 @@ enum DigitalSignatureMethod {
   jwtPs384,
 }
 
-extension on DigitalSignatureMethod {
+extension DigitalSignatureMethodValue on DigitalSignatureMethod {
   String toValue() {
     switch (this) {
       case DigitalSignatureMethod.jwtPs384:
@@ -2883,7 +2883,7 @@ extension on DigitalSignatureMethod {
   }
 }
 
-extension on String {
+extension DigitalSignatureMethodFromString on String {
   DigitalSignatureMethod toDigitalSignatureMethod() {
     switch (this) {
       case 'JWT_PS384':
@@ -3016,7 +3016,7 @@ enum EntitlementDataUnit {
   countSecond,
 }
 
-extension on EntitlementDataUnit {
+extension EntitlementDataUnitValue on EntitlementDataUnit {
   String toValue() {
     switch (this) {
       case EntitlementDataUnit.count:
@@ -3077,7 +3077,7 @@ extension on EntitlementDataUnit {
   }
 }
 
-extension on String {
+extension EntitlementDataUnitFromString on String {
   EntitlementDataUnit toEntitlementDataUnit() {
     switch (this) {
       case 'Count':
@@ -3169,7 +3169,7 @@ enum EntitlementUnit {
   countSecond,
 }
 
-extension on EntitlementUnit {
+extension EntitlementUnitValue on EntitlementUnit {
   String toValue() {
     switch (this) {
       case EntitlementUnit.count:
@@ -3230,7 +3230,7 @@ extension on EntitlementUnit {
   }
 }
 
-extension on String {
+extension EntitlementUnitFromString on String {
   EntitlementUnit toEntitlementUnit() {
     switch (this) {
       case 'Count':
@@ -3659,7 +3659,7 @@ enum GrantStatus {
   disabled,
 }
 
-extension on GrantStatus {
+extension GrantStatusValue on GrantStatus {
   String toValue() {
     switch (this) {
       case GrantStatus.pendingWorkflow:
@@ -3682,7 +3682,7 @@ extension on GrantStatus {
   }
 }
 
-extension on String {
+extension GrantStatusFromString on String {
   GrantStatus toGrantStatus() {
     switch (this) {
       case 'PENDING_WORKFLOW':
@@ -3843,7 +3843,7 @@ enum InventoryFilterCondition {
   contains,
 }
 
-extension on InventoryFilterCondition {
+extension InventoryFilterConditionValue on InventoryFilterCondition {
   String toValue() {
     switch (this) {
       case InventoryFilterCondition.equals:
@@ -3858,7 +3858,7 @@ extension on InventoryFilterCondition {
   }
 }
 
-extension on String {
+extension InventoryFilterConditionFromString on String {
   InventoryFilterCondition toInventoryFilterCondition() {
     switch (this) {
       case 'EQUALS':
@@ -4173,7 +4173,7 @@ enum LicenseConfigurationStatus {
   disabled,
 }
 
-extension on LicenseConfigurationStatus {
+extension LicenseConfigurationStatusValue on LicenseConfigurationStatus {
   String toValue() {
     switch (this) {
       case LicenseConfigurationStatus.available:
@@ -4184,7 +4184,7 @@ extension on LicenseConfigurationStatus {
   }
 }
 
-extension on String {
+extension LicenseConfigurationStatusFromString on String {
   LicenseConfigurationStatus toLicenseConfigurationStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -4245,7 +4245,7 @@ enum LicenseCountingType {
   socket,
 }
 
-extension on LicenseCountingType {
+extension LicenseCountingTypeValue on LicenseCountingType {
   String toValue() {
     switch (this) {
       case LicenseCountingType.vcpu:
@@ -4260,7 +4260,7 @@ extension on LicenseCountingType {
   }
 }
 
-extension on String {
+extension LicenseCountingTypeFromString on String {
   LicenseCountingType toLicenseCountingType() {
     switch (this) {
       case 'vCPU':
@@ -4281,7 +4281,7 @@ enum LicenseDeletionStatus {
   deleted,
 }
 
-extension on LicenseDeletionStatus {
+extension LicenseDeletionStatusValue on LicenseDeletionStatus {
   String toValue() {
     switch (this) {
       case LicenseDeletionStatus.pendingDelete:
@@ -4292,7 +4292,7 @@ extension on LicenseDeletionStatus {
   }
 }
 
-extension on String {
+extension LicenseDeletionStatusFromString on String {
   LicenseDeletionStatus toLicenseDeletionStatus() {
     switch (this) {
       case 'PENDING_DELETE':
@@ -4397,7 +4397,7 @@ enum LicenseStatus {
   deleted,
 }
 
-extension on LicenseStatus {
+extension LicenseStatusValue on LicenseStatus {
   String toValue() {
     switch (this) {
       case LicenseStatus.available:
@@ -4418,7 +4418,7 @@ extension on LicenseStatus {
   }
 }
 
-extension on String {
+extension LicenseStatusFromString on String {
   LicenseStatus toLicenseStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -5004,7 +5004,7 @@ enum ReceivedStatus {
   disabled,
 }
 
-extension on ReceivedStatus {
+extension ReceivedStatusValue on ReceivedStatus {
   String toValue() {
     switch (this) {
       case ReceivedStatus.pendingWorkflow:
@@ -5025,7 +5025,7 @@ extension on ReceivedStatus {
   }
 }
 
-extension on String {
+extension ReceivedStatusFromString on String {
   ReceivedStatus toReceivedStatus() {
     switch (this) {
       case 'PENDING_WORKFLOW':
@@ -5077,7 +5077,7 @@ enum RenewType {
   monthly,
 }
 
-extension on RenewType {
+extension RenewTypeValue on RenewType {
   String toValue() {
     switch (this) {
       case RenewType.none:
@@ -5090,7 +5090,7 @@ extension on RenewType {
   }
 }
 
-extension on String {
+extension RenewTypeFromString on String {
   RenewType toRenewType() {
     switch (this) {
       case 'None':
@@ -5152,7 +5152,7 @@ enum ResourceType {
   systemsManagerManagedInstance,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.ec2Instance:
@@ -5169,7 +5169,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'EC2_INSTANCE':
@@ -5279,7 +5279,7 @@ enum TokenType {
   refreshToken,
 }
 
-extension on TokenType {
+extension TokenTypeValue on TokenType {
   String toValue() {
     switch (this) {
       case TokenType.refreshToken:
@@ -5288,7 +5288,7 @@ extension on TokenType {
   }
 }
 
-extension on String {
+extension TokenTypeFromString on String {
   TokenType toTokenType() {
     switch (this) {
       case 'REFRESH_TOKEN':

--- a/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
+++ b/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
@@ -2366,7 +2366,7 @@ enum AllowedOperation {
   createToken,
 }
 
-extension AllowedOperationValue on AllowedOperation {
+extension AllowedOperationValueExtension on AllowedOperation {
   String toValue() {
     switch (this) {
       case AllowedOperation.createGrant:
@@ -2566,7 +2566,7 @@ enum CheckoutType {
   provisional,
 }
 
-extension CheckoutTypeValue on CheckoutType {
+extension CheckoutTypeValueExtension on CheckoutType {
   String toValue() {
     switch (this) {
       case CheckoutType.provisional:
@@ -2874,7 +2874,7 @@ enum DigitalSignatureMethod {
   jwtPs384,
 }
 
-extension DigitalSignatureMethodValue on DigitalSignatureMethod {
+extension DigitalSignatureMethodValueExtension on DigitalSignatureMethod {
   String toValue() {
     switch (this) {
       case DigitalSignatureMethod.jwtPs384:
@@ -3016,7 +3016,7 @@ enum EntitlementDataUnit {
   countSecond,
 }
 
-extension EntitlementDataUnitValue on EntitlementDataUnit {
+extension EntitlementDataUnitValueExtension on EntitlementDataUnit {
   String toValue() {
     switch (this) {
       case EntitlementDataUnit.count:
@@ -3169,7 +3169,7 @@ enum EntitlementUnit {
   countSecond,
 }
 
-extension EntitlementUnitValue on EntitlementUnit {
+extension EntitlementUnitValueExtension on EntitlementUnit {
   String toValue() {
     switch (this) {
       case EntitlementUnit.count:
@@ -3659,7 +3659,7 @@ enum GrantStatus {
   disabled,
 }
 
-extension GrantStatusValue on GrantStatus {
+extension GrantStatusValueExtension on GrantStatus {
   String toValue() {
     switch (this) {
       case GrantStatus.pendingWorkflow:
@@ -3843,7 +3843,7 @@ enum InventoryFilterCondition {
   contains,
 }
 
-extension InventoryFilterConditionValue on InventoryFilterCondition {
+extension InventoryFilterConditionValueExtension on InventoryFilterCondition {
   String toValue() {
     switch (this) {
       case InventoryFilterCondition.equals:
@@ -4173,7 +4173,8 @@ enum LicenseConfigurationStatus {
   disabled,
 }
 
-extension LicenseConfigurationStatusValue on LicenseConfigurationStatus {
+extension LicenseConfigurationStatusValueExtension
+    on LicenseConfigurationStatus {
   String toValue() {
     switch (this) {
       case LicenseConfigurationStatus.available:
@@ -4245,7 +4246,7 @@ enum LicenseCountingType {
   socket,
 }
 
-extension LicenseCountingTypeValue on LicenseCountingType {
+extension LicenseCountingTypeValueExtension on LicenseCountingType {
   String toValue() {
     switch (this) {
       case LicenseCountingType.vcpu:
@@ -4281,7 +4282,7 @@ enum LicenseDeletionStatus {
   deleted,
 }
 
-extension LicenseDeletionStatusValue on LicenseDeletionStatus {
+extension LicenseDeletionStatusValueExtension on LicenseDeletionStatus {
   String toValue() {
     switch (this) {
       case LicenseDeletionStatus.pendingDelete:
@@ -4397,7 +4398,7 @@ enum LicenseStatus {
   deleted,
 }
 
-extension LicenseStatusValue on LicenseStatus {
+extension LicenseStatusValueExtension on LicenseStatus {
   String toValue() {
     switch (this) {
       case LicenseStatus.available:
@@ -5004,7 +5005,7 @@ enum ReceivedStatus {
   disabled,
 }
 
-extension ReceivedStatusValue on ReceivedStatus {
+extension ReceivedStatusValueExtension on ReceivedStatus {
   String toValue() {
     switch (this) {
       case ReceivedStatus.pendingWorkflow:
@@ -5077,7 +5078,7 @@ enum RenewType {
   monthly,
 }
 
-extension RenewTypeValue on RenewType {
+extension RenewTypeValueExtension on RenewType {
   String toValue() {
     switch (this) {
       case RenewType.none:
@@ -5152,7 +5153,7 @@ enum ResourceType {
   systemsManagerManagedInstance,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.ec2Instance:
@@ -5279,7 +5280,7 @@ enum TokenType {
   refreshToken,
 }
 
-extension TokenTypeValue on TokenType {
+extension TokenTypeValueExtension on TokenType {
   String toValue() {
     switch (this) {
       case TokenType.refreshToken:

--- a/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
+++ b/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
@@ -8872,7 +8872,7 @@ enum AccessDirection {
   outbound,
 }
 
-extension AccessDirectionValue on AccessDirection {
+extension AccessDirectionValueExtension on AccessDirection {
   String toValue() {
     switch (this) {
       case AccessDirection.inbound:
@@ -8971,7 +8971,7 @@ enum AddOnType {
   autoSnapshot,
 }
 
-extension AddOnTypeValue on AddOnType {
+extension AddOnTypeValueExtension on AddOnType {
   String toValue() {
     switch (this) {
       case AddOnType.autoSnapshot:
@@ -9199,7 +9199,7 @@ enum AlarmState {
   insufficientData,
 }
 
-extension AlarmStateValue on AlarmState {
+extension AlarmStateValueExtension on AlarmState {
   String toValue() {
     switch (this) {
       case AlarmState.ok:
@@ -9475,7 +9475,7 @@ enum AutoSnapshotStatus {
   notFound,
 }
 
-extension AutoSnapshotStatusValue on AutoSnapshotStatus {
+extension AutoSnapshotStatusValueExtension on AutoSnapshotStatus {
   String toValue() {
     switch (this) {
       case AutoSnapshotStatus.success:
@@ -9532,7 +9532,7 @@ enum BehaviorEnum {
   cache,
 }
 
-extension BehaviorEnumValue on BehaviorEnum {
+extension BehaviorEnumValueExtension on BehaviorEnum {
   String toValue() {
     switch (this) {
       case BehaviorEnum.dontCache:
@@ -9640,7 +9640,7 @@ enum BlueprintType {
   app,
 }
 
-extension BlueprintTypeValue on BlueprintType {
+extension BlueprintTypeValueExtension on BlueprintType {
   String toValue() {
     switch (this) {
       case BlueprintType.os:
@@ -10233,7 +10233,7 @@ enum CertificateStatus {
   failed,
 }
 
-extension CertificateStatusValue on CertificateStatus {
+extension CertificateStatusValueExtension on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.pendingValidation:
@@ -10438,7 +10438,7 @@ enum CloudFormationStackRecordSourceType {
   exportSnapshotRecord,
 }
 
-extension CloudFormationStackRecordSourceTypeValue
+extension CloudFormationStackRecordSourceTypeValueExtension
     on CloudFormationStackRecordSourceType {
   String toValue() {
     switch (this) {
@@ -10466,7 +10466,7 @@ enum ComparisonOperator {
   lessThanOrEqualToThreshold,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -10582,7 +10582,7 @@ enum ContactMethodStatus {
   invalid,
 }
 
-extension ContactMethodStatusValue on ContactMethodStatus {
+extension ContactMethodStatusValueExtension on ContactMethodStatus {
   String toValue() {
     switch (this) {
       case ContactMethodStatus.pendingVerification:
@@ -10613,7 +10613,7 @@ enum ContactMethodVerificationProtocol {
   email,
 }
 
-extension ContactMethodVerificationProtocolValue
+extension ContactMethodVerificationProtocolValueExtension
     on ContactMethodVerificationProtocol {
   String toValue() {
     switch (this) {
@@ -10639,7 +10639,7 @@ enum ContactProtocol {
   sms,
 }
 
-extension ContactProtocolValue on ContactProtocol {
+extension ContactProtocolValueExtension on ContactProtocol {
   String toValue() {
     switch (this) {
       case ContactProtocol.email:
@@ -11020,7 +11020,7 @@ enum ContainerServiceDeploymentState {
   failed,
 }
 
-extension ContainerServiceDeploymentStateValue
+extension ContainerServiceDeploymentStateValueExtension
     on ContainerServiceDeploymentState {
   String toValue() {
     switch (this) {
@@ -11173,7 +11173,8 @@ enum ContainerServiceMetricName {
   memoryUtilization,
 }
 
-extension ContainerServiceMetricNameValue on ContainerServiceMetricName {
+extension ContainerServiceMetricNameValueExtension
+    on ContainerServiceMetricName {
   String toValue() {
     switch (this) {
       case ContainerServiceMetricName.cPUUtilization:
@@ -11250,7 +11251,7 @@ enum ContainerServicePowerName {
   xlarge,
 }
 
-extension ContainerServicePowerNameValue on ContainerServicePowerName {
+extension ContainerServicePowerNameValueExtension on ContainerServicePowerName {
   String toValue() {
     switch (this) {
       case ContainerServicePowerName.nano:
@@ -11296,7 +11297,7 @@ enum ContainerServiceProtocol {
   udp,
 }
 
-extension ContainerServiceProtocolValue on ContainerServiceProtocol {
+extension ContainerServiceProtocolValueExtension on ContainerServiceProtocol {
   String toValue() {
     switch (this) {
       case ContainerServiceProtocol.http:
@@ -11375,7 +11376,7 @@ enum ContainerServiceState {
   disabled,
 }
 
-extension ContainerServiceStateValue on ContainerServiceState {
+extension ContainerServiceStateValueExtension on ContainerServiceState {
   String toValue() {
     switch (this) {
       case ContainerServiceState.pending:
@@ -12664,7 +12665,7 @@ enum DiskSnapshotState {
   unknown,
 }
 
-extension DiskSnapshotStateValue on DiskSnapshotState {
+extension DiskSnapshotStateValueExtension on DiskSnapshotState {
   String toValue() {
     switch (this) {
       case DiskSnapshotState.pending:
@@ -12703,7 +12704,7 @@ enum DiskState {
   unknown,
 }
 
-extension DiskStateValue on DiskState {
+extension DiskStateValueExtension on DiskState {
   String toValue() {
     switch (this) {
       case DiskState.pending:
@@ -12783,7 +12784,7 @@ enum DistributionMetricName {
   http5xxErrorRate,
 }
 
-extension DistributionMetricNameValue on DistributionMetricName {
+extension DistributionMetricNameValueExtension on DistributionMetricName {
   String toValue() {
     switch (this) {
       case DistributionMetricName.requests:
@@ -13200,7 +13201,7 @@ enum ExportSnapshotRecordSourceType {
   diskSnapshot,
 }
 
-extension ExportSnapshotRecordSourceTypeValue
+extension ExportSnapshotRecordSourceTypeValueExtension
     on ExportSnapshotRecordSourceType {
   String toValue() {
     switch (this) {
@@ -13250,7 +13251,7 @@ enum ForwardValues {
   all,
 }
 
-extension ForwardValuesValue on ForwardValues {
+extension ForwardValuesValueExtension on ForwardValues {
   String toValue() {
     switch (this) {
       case ForwardValues.none:
@@ -14641,7 +14642,7 @@ enum HeaderEnum {
   referer,
 }
 
-extension HeaderEnumValue on HeaderEnum {
+extension HeaderEnumValueExtension on HeaderEnum {
   String toValue() {
     switch (this) {
       case HeaderEnum.accept:
@@ -15133,7 +15134,7 @@ enum InstanceAccessProtocol {
   rdp,
 }
 
-extension InstanceAccessProtocolValue on InstanceAccessProtocol {
+extension InstanceAccessProtocolValueExtension on InstanceAccessProtocol {
   String toValue() {
     switch (this) {
       case InstanceAccessProtocol.ssh:
@@ -15275,7 +15276,7 @@ enum InstanceHealthReason {
   instanceIpUnusable,
 }
 
-extension InstanceHealthReasonValue on InstanceHealthReason {
+extension InstanceHealthReasonValueExtension on InstanceHealthReason {
   String toValue() {
     switch (this) {
       case InstanceHealthReason.lbRegistrationInProgress:
@@ -15343,7 +15344,7 @@ enum InstanceHealthState {
   unavailable,
 }
 
-extension InstanceHealthStateValue on InstanceHealthState {
+extension InstanceHealthStateValueExtension on InstanceHealthState {
   String toValue() {
     switch (this) {
       case InstanceHealthState.initial:
@@ -15493,7 +15494,7 @@ enum InstanceMetricName {
   burstCapacityPercentage,
 }
 
-extension InstanceMetricNameValue on InstanceMetricName {
+extension InstanceMetricNameValueExtension on InstanceMetricName {
   String toValue() {
     switch (this) {
       case InstanceMetricName.cPUUtilization:
@@ -15572,7 +15573,7 @@ enum InstancePlatform {
   windows,
 }
 
-extension InstancePlatformValue on InstancePlatform {
+extension InstancePlatformValueExtension on InstancePlatform {
   String toValue() {
     switch (this) {
       case InstancePlatform.linuxUnix:
@@ -16016,7 +16017,7 @@ enum InstanceSnapshotState {
   available,
 }
 
-extension InstanceSnapshotStateValue on InstanceSnapshotState {
+extension InstanceSnapshotStateValueExtension on InstanceSnapshotState {
   String toValue() {
     switch (this) {
       case InstanceSnapshotState.pending:
@@ -16417,7 +16418,7 @@ enum LoadBalancerAttributeName {
   sessionStickinessLbCookieDurationSeconds,
 }
 
-extension LoadBalancerAttributeNameValue on LoadBalancerAttributeName {
+extension LoadBalancerAttributeNameValueExtension on LoadBalancerAttributeName {
   String toValue() {
     switch (this) {
       case LoadBalancerAttributeName.healthCheckPath:
@@ -16460,7 +16461,7 @@ enum LoadBalancerMetricName {
   requestCount,
 }
 
-extension LoadBalancerMetricNameValue on LoadBalancerMetricName {
+extension LoadBalancerMetricNameValueExtension on LoadBalancerMetricName {
   String toValue() {
     switch (this) {
       case LoadBalancerMetricName.clientTLSNegotiationErrorCount:
@@ -16528,7 +16529,7 @@ enum LoadBalancerProtocol {
   http,
 }
 
-extension LoadBalancerProtocolValue on LoadBalancerProtocol {
+extension LoadBalancerProtocolValueExtension on LoadBalancerProtocol {
   String toValue() {
     switch (this) {
       case LoadBalancerProtocol.httpHttps:
@@ -16559,7 +16560,7 @@ enum LoadBalancerState {
   unknown,
 }
 
-extension LoadBalancerStateValue on LoadBalancerState {
+extension LoadBalancerStateValueExtension on LoadBalancerState {
   String toValue() {
     switch (this) {
       case LoadBalancerState.active:
@@ -16861,7 +16862,7 @@ enum LoadBalancerTlsCertificateDomainStatus {
   success,
 }
 
-extension LoadBalancerTlsCertificateDomainStatusValue
+extension LoadBalancerTlsCertificateDomainStatusValueExtension
     on LoadBalancerTlsCertificateDomainStatus {
   String toValue() {
     switch (this) {
@@ -16962,7 +16963,7 @@ enum LoadBalancerTlsCertificateFailureReason {
   other,
 }
 
-extension LoadBalancerTlsCertificateFailureReasonValue
+extension LoadBalancerTlsCertificateFailureReasonValueExtension
     on LoadBalancerTlsCertificateFailureReason {
   String toValue() {
     switch (this) {
@@ -17009,7 +17010,7 @@ enum LoadBalancerTlsCertificateRenewalStatus {
   failed,
 }
 
-extension LoadBalancerTlsCertificateRenewalStatusValue
+extension LoadBalancerTlsCertificateRenewalStatusValueExtension
     on LoadBalancerTlsCertificateRenewalStatus {
   String toValue() {
     switch (this) {
@@ -17146,7 +17147,7 @@ enum LoadBalancerTlsCertificateRevocationReason {
   aACompromise,
 }
 
-extension LoadBalancerTlsCertificateRevocationReasonValue
+extension LoadBalancerTlsCertificateRevocationReasonValueExtension
     on LoadBalancerTlsCertificateRevocationReason {
   String toValue() {
     switch (this) {
@@ -17215,7 +17216,7 @@ enum LoadBalancerTlsCertificateStatus {
   unknown,
 }
 
-extension LoadBalancerTlsCertificateStatusValue
+extension LoadBalancerTlsCertificateStatusValueExtension
     on LoadBalancerTlsCertificateStatus {
   String toValue() {
     switch (this) {
@@ -17379,7 +17380,7 @@ enum MetricName {
   burstCapacityPercentage,
 }
 
-extension MetricNameValue on MetricName {
+extension MetricNameValueExtension on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.cPUUtilization:
@@ -17502,7 +17503,7 @@ enum MetricStatistic {
   sampleCount,
 }
 
-extension MetricStatisticValue on MetricStatistic {
+extension MetricStatisticValueExtension on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.minimum:
@@ -17567,7 +17568,7 @@ enum MetricUnit {
   none,
 }
 
-extension MetricUnitValue on MetricUnit {
+extension MetricUnitValueExtension on MetricUnit {
   String toValue() {
     switch (this) {
       case MetricUnit.seconds:
@@ -17746,7 +17747,7 @@ enum NetworkProtocol {
   icmp,
 }
 
-extension NetworkProtocolValue on NetworkProtocol {
+extension NetworkProtocolValueExtension on NetworkProtocol {
   String toValue() {
     switch (this) {
       case NetworkProtocol.tcp:
@@ -17877,7 +17878,7 @@ enum OperationStatus {
   succeeded,
 }
 
-extension OperationStatusValue on OperationStatus {
+extension OperationStatusValueExtension on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.notStarted:
@@ -17986,7 +17987,7 @@ enum OperationType {
   deleteContainerImage,
 }
 
-extension OperationTypeValue on OperationType {
+extension OperationTypeValueExtension on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.deleteKnownHostKeys:
@@ -18327,7 +18328,7 @@ enum OriginProtocolPolicyEnum {
   httpsOnly,
 }
 
-extension OriginProtocolPolicyEnumValue on OriginProtocolPolicyEnum {
+extension OriginProtocolPolicyEnumValueExtension on OriginProtocolPolicyEnum {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicyEnum.httpOnly:
@@ -18466,7 +18467,7 @@ enum PortAccessType {
   private,
 }
 
-extension PortAccessTypeValue on PortAccessType {
+extension PortAccessTypeValueExtension on PortAccessType {
   String toValue() {
     switch (this) {
       case PortAccessType.public:
@@ -18626,7 +18627,7 @@ enum PortInfoSourceType {
   closed,
 }
 
-extension PortInfoSourceTypeValue on PortInfoSourceType {
+extension PortInfoSourceTypeValueExtension on PortInfoSourceType {
   String toValue() {
     switch (this) {
       case PortInfoSourceType.$default:
@@ -18662,7 +18663,7 @@ enum PortState {
   closed,
 }
 
-extension PortStateValue on PortState {
+extension PortStateValueExtension on PortState {
   String toValue() {
     switch (this) {
       case PortState.open:
@@ -18811,7 +18812,7 @@ enum RecordState {
   failed,
 }
 
-extension RecordStateValue on RecordState {
+extension RecordStateValueExtension on RecordState {
   String toValue() {
     switch (this) {
       case RecordState.started:
@@ -18905,7 +18906,7 @@ enum RegionName {
   apNortheast_2,
 }
 
-extension RegionNameValue on RegionName {
+extension RegionNameValueExtension on RegionName {
   String toValue() {
     switch (this) {
       case RegionName.usEast_1:
@@ -19295,7 +19296,7 @@ enum RelationalDatabaseEngine {
   mysql,
 }
 
-extension RelationalDatabaseEngineValue on RelationalDatabaseEngine {
+extension RelationalDatabaseEngineValueExtension on RelationalDatabaseEngine {
   String toValue() {
     switch (this) {
       case RelationalDatabaseEngine.mysql:
@@ -19381,7 +19382,8 @@ enum RelationalDatabaseMetricName {
   networkTransmitThroughput,
 }
 
-extension RelationalDatabaseMetricNameValue on RelationalDatabaseMetricName {
+extension RelationalDatabaseMetricNameValueExtension
+    on RelationalDatabaseMetricName {
   String toValue() {
     switch (this) {
       case RelationalDatabaseMetricName.cPUUtilization:
@@ -19499,7 +19501,7 @@ enum RelationalDatabasePasswordVersion {
   pending,
 }
 
-extension RelationalDatabasePasswordVersionValue
+extension RelationalDatabasePasswordVersionValueExtension
     on RelationalDatabasePasswordVersion {
   String toValue() {
     switch (this) {
@@ -19658,7 +19660,7 @@ enum RenewalStatus {
   failed,
 }
 
-extension RenewalStatusValue on RenewalStatus {
+extension RenewalStatusValueExtension on RenewalStatus {
   String toValue() {
     switch (this) {
       case RenewalStatus.pendingAutoRenewal:
@@ -19851,7 +19853,7 @@ enum ResourceType {
   certificate,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.containerService:
@@ -20185,7 +20187,7 @@ enum TreatMissingData {
   missing,
 }
 
-extension TreatMissingDataValue on TreatMissingData {
+extension TreatMissingDataValueExtension on TreatMissingData {
   String toValue() {
     switch (this) {
       case TreatMissingData.breaching:

--- a/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
+++ b/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
@@ -8872,7 +8872,7 @@ enum AccessDirection {
   outbound,
 }
 
-extension on AccessDirection {
+extension AccessDirectionValue on AccessDirection {
   String toValue() {
     switch (this) {
       case AccessDirection.inbound:
@@ -8883,7 +8883,7 @@ extension on AccessDirection {
   }
 }
 
-extension on String {
+extension AccessDirectionFromString on String {
   AccessDirection toAccessDirection() {
     switch (this) {
       case 'inbound':
@@ -8971,7 +8971,7 @@ enum AddOnType {
   autoSnapshot,
 }
 
-extension on AddOnType {
+extension AddOnTypeValue on AddOnType {
   String toValue() {
     switch (this) {
       case AddOnType.autoSnapshot:
@@ -8980,7 +8980,7 @@ extension on AddOnType {
   }
 }
 
-extension on String {
+extension AddOnTypeFromString on String {
   AddOnType toAddOnType() {
     switch (this) {
       case 'AutoSnapshot':
@@ -9199,7 +9199,7 @@ enum AlarmState {
   insufficientData,
 }
 
-extension on AlarmState {
+extension AlarmStateValue on AlarmState {
   String toValue() {
     switch (this) {
       case AlarmState.ok:
@@ -9212,7 +9212,7 @@ extension on AlarmState {
   }
 }
 
-extension on String {
+extension AlarmStateFromString on String {
   AlarmState toAlarmState() {
     switch (this) {
       case 'OK':
@@ -9475,7 +9475,7 @@ enum AutoSnapshotStatus {
   notFound,
 }
 
-extension on AutoSnapshotStatus {
+extension AutoSnapshotStatusValue on AutoSnapshotStatus {
   String toValue() {
     switch (this) {
       case AutoSnapshotStatus.success:
@@ -9490,7 +9490,7 @@ extension on AutoSnapshotStatus {
   }
 }
 
-extension on String {
+extension AutoSnapshotStatusFromString on String {
   AutoSnapshotStatus toAutoSnapshotStatus() {
     switch (this) {
       case 'Success':
@@ -9532,7 +9532,7 @@ enum BehaviorEnum {
   cache,
 }
 
-extension on BehaviorEnum {
+extension BehaviorEnumValue on BehaviorEnum {
   String toValue() {
     switch (this) {
       case BehaviorEnum.dontCache:
@@ -9543,7 +9543,7 @@ extension on BehaviorEnum {
   }
 }
 
-extension on String {
+extension BehaviorEnumFromString on String {
   BehaviorEnum toBehaviorEnum() {
     switch (this) {
       case 'dont-cache':
@@ -9640,7 +9640,7 @@ enum BlueprintType {
   app,
 }
 
-extension on BlueprintType {
+extension BlueprintTypeValue on BlueprintType {
   String toValue() {
     switch (this) {
       case BlueprintType.os:
@@ -9651,7 +9651,7 @@ extension on BlueprintType {
   }
 }
 
-extension on String {
+extension BlueprintTypeFromString on String {
   BlueprintType toBlueprintType() {
     switch (this) {
       case 'os':
@@ -10233,7 +10233,7 @@ enum CertificateStatus {
   failed,
 }
 
-extension on CertificateStatus {
+extension CertificateStatusValue on CertificateStatus {
   String toValue() {
     switch (this) {
       case CertificateStatus.pendingValidation:
@@ -10254,7 +10254,7 @@ extension on CertificateStatus {
   }
 }
 
-extension on String {
+extension CertificateStatusFromString on String {
   CertificateStatus toCertificateStatus() {
     switch (this) {
       case 'PENDING_VALIDATION':
@@ -10438,7 +10438,8 @@ enum CloudFormationStackRecordSourceType {
   exportSnapshotRecord,
 }
 
-extension on CloudFormationStackRecordSourceType {
+extension CloudFormationStackRecordSourceTypeValue
+    on CloudFormationStackRecordSourceType {
   String toValue() {
     switch (this) {
       case CloudFormationStackRecordSourceType.exportSnapshotRecord:
@@ -10447,7 +10448,7 @@ extension on CloudFormationStackRecordSourceType {
   }
 }
 
-extension on String {
+extension CloudFormationStackRecordSourceTypeFromString on String {
   CloudFormationStackRecordSourceType toCloudFormationStackRecordSourceType() {
     switch (this) {
       case 'ExportSnapshotRecord':
@@ -10465,7 +10466,7 @@ enum ComparisonOperator {
   lessThanOrEqualToThreshold,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -10480,7 +10481,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'GreaterThanOrEqualToThreshold':
@@ -10581,7 +10582,7 @@ enum ContactMethodStatus {
   invalid,
 }
 
-extension on ContactMethodStatus {
+extension ContactMethodStatusValue on ContactMethodStatus {
   String toValue() {
     switch (this) {
       case ContactMethodStatus.pendingVerification:
@@ -10594,7 +10595,7 @@ extension on ContactMethodStatus {
   }
 }
 
-extension on String {
+extension ContactMethodStatusFromString on String {
   ContactMethodStatus toContactMethodStatus() {
     switch (this) {
       case 'PendingVerification':
@@ -10612,7 +10613,8 @@ enum ContactMethodVerificationProtocol {
   email,
 }
 
-extension on ContactMethodVerificationProtocol {
+extension ContactMethodVerificationProtocolValue
+    on ContactMethodVerificationProtocol {
   String toValue() {
     switch (this) {
       case ContactMethodVerificationProtocol.email:
@@ -10621,7 +10623,7 @@ extension on ContactMethodVerificationProtocol {
   }
 }
 
-extension on String {
+extension ContactMethodVerificationProtocolFromString on String {
   ContactMethodVerificationProtocol toContactMethodVerificationProtocol() {
     switch (this) {
       case 'Email':
@@ -10637,7 +10639,7 @@ enum ContactProtocol {
   sms,
 }
 
-extension on ContactProtocol {
+extension ContactProtocolValue on ContactProtocol {
   String toValue() {
     switch (this) {
       case ContactProtocol.email:
@@ -10648,7 +10650,7 @@ extension on ContactProtocol {
   }
 }
 
-extension on String {
+extension ContactProtocolFromString on String {
   ContactProtocol toContactProtocol() {
     switch (this) {
       case 'Email':
@@ -11018,7 +11020,8 @@ enum ContainerServiceDeploymentState {
   failed,
 }
 
-extension on ContainerServiceDeploymentState {
+extension ContainerServiceDeploymentStateValue
+    on ContainerServiceDeploymentState {
   String toValue() {
     switch (this) {
       case ContainerServiceDeploymentState.activating:
@@ -11033,7 +11036,7 @@ extension on ContainerServiceDeploymentState {
   }
 }
 
-extension on String {
+extension ContainerServiceDeploymentStateFromString on String {
   ContainerServiceDeploymentState toContainerServiceDeploymentState() {
     switch (this) {
       case 'ACTIVATING':
@@ -11170,7 +11173,7 @@ enum ContainerServiceMetricName {
   memoryUtilization,
 }
 
-extension on ContainerServiceMetricName {
+extension ContainerServiceMetricNameValue on ContainerServiceMetricName {
   String toValue() {
     switch (this) {
       case ContainerServiceMetricName.cPUUtilization:
@@ -11181,7 +11184,7 @@ extension on ContainerServiceMetricName {
   }
 }
 
-extension on String {
+extension ContainerServiceMetricNameFromString on String {
   ContainerServiceMetricName toContainerServiceMetricName() {
     switch (this) {
       case 'CPUUtilization':
@@ -11247,7 +11250,7 @@ enum ContainerServicePowerName {
   xlarge,
 }
 
-extension on ContainerServicePowerName {
+extension ContainerServicePowerNameValue on ContainerServicePowerName {
   String toValue() {
     switch (this) {
       case ContainerServicePowerName.nano:
@@ -11266,7 +11269,7 @@ extension on ContainerServicePowerName {
   }
 }
 
-extension on String {
+extension ContainerServicePowerNameFromString on String {
   ContainerServicePowerName toContainerServicePowerName() {
     switch (this) {
       case 'nano':
@@ -11293,7 +11296,7 @@ enum ContainerServiceProtocol {
   udp,
 }
 
-extension on ContainerServiceProtocol {
+extension ContainerServiceProtocolValue on ContainerServiceProtocol {
   String toValue() {
     switch (this) {
       case ContainerServiceProtocol.http:
@@ -11308,7 +11311,7 @@ extension on ContainerServiceProtocol {
   }
 }
 
-extension on String {
+extension ContainerServiceProtocolFromString on String {
   ContainerServiceProtocol toContainerServiceProtocol() {
     switch (this) {
       case 'HTTP':
@@ -11372,7 +11375,7 @@ enum ContainerServiceState {
   disabled,
 }
 
-extension on ContainerServiceState {
+extension ContainerServiceStateValue on ContainerServiceState {
   String toValue() {
     switch (this) {
       case ContainerServiceState.pending:
@@ -11391,7 +11394,7 @@ extension on ContainerServiceState {
   }
 }
 
-extension on String {
+extension ContainerServiceStateFromString on String {
   ContainerServiceState toContainerServiceState() {
     switch (this) {
       case 'PENDING':
@@ -12661,7 +12664,7 @@ enum DiskSnapshotState {
   unknown,
 }
 
-extension on DiskSnapshotState {
+extension DiskSnapshotStateValue on DiskSnapshotState {
   String toValue() {
     switch (this) {
       case DiskSnapshotState.pending:
@@ -12676,7 +12679,7 @@ extension on DiskSnapshotState {
   }
 }
 
-extension on String {
+extension DiskSnapshotStateFromString on String {
   DiskSnapshotState toDiskSnapshotState() {
     switch (this) {
       case 'pending':
@@ -12700,7 +12703,7 @@ enum DiskState {
   unknown,
 }
 
-extension on DiskState {
+extension DiskStateValue on DiskState {
   String toValue() {
     switch (this) {
       case DiskState.pending:
@@ -12717,7 +12720,7 @@ extension on DiskState {
   }
 }
 
-extension on String {
+extension DiskStateFromString on String {
   DiskState toDiskState() {
     switch (this) {
       case 'pending':
@@ -12780,7 +12783,7 @@ enum DistributionMetricName {
   http5xxErrorRate,
 }
 
-extension on DistributionMetricName {
+extension DistributionMetricNameValue on DistributionMetricName {
   String toValue() {
     switch (this) {
       case DistributionMetricName.requests:
@@ -12799,7 +12802,7 @@ extension on DistributionMetricName {
   }
 }
 
-extension on String {
+extension DistributionMetricNameFromString on String {
   DistributionMetricName toDistributionMetricName() {
     switch (this) {
       case 'Requests':
@@ -13197,7 +13200,8 @@ enum ExportSnapshotRecordSourceType {
   diskSnapshot,
 }
 
-extension on ExportSnapshotRecordSourceType {
+extension ExportSnapshotRecordSourceTypeValue
+    on ExportSnapshotRecordSourceType {
   String toValue() {
     switch (this) {
       case ExportSnapshotRecordSourceType.instanceSnapshot:
@@ -13208,7 +13212,7 @@ extension on ExportSnapshotRecordSourceType {
   }
 }
 
-extension on String {
+extension ExportSnapshotRecordSourceTypeFromString on String {
   ExportSnapshotRecordSourceType toExportSnapshotRecordSourceType() {
     switch (this) {
       case 'InstanceSnapshot':
@@ -13246,7 +13250,7 @@ enum ForwardValues {
   all,
 }
 
-extension on ForwardValues {
+extension ForwardValuesValue on ForwardValues {
   String toValue() {
     switch (this) {
       case ForwardValues.none:
@@ -13259,7 +13263,7 @@ extension on ForwardValues {
   }
 }
 
-extension on String {
+extension ForwardValuesFromString on String {
   ForwardValues toForwardValues() {
     switch (this) {
       case 'none':
@@ -14637,7 +14641,7 @@ enum HeaderEnum {
   referer,
 }
 
-extension on HeaderEnum {
+extension HeaderEnumValue on HeaderEnum {
   String toValue() {
     switch (this) {
       case HeaderEnum.accept:
@@ -14674,7 +14678,7 @@ extension on HeaderEnum {
   }
 }
 
-extension on String {
+extension HeaderEnumFromString on String {
   HeaderEnum toHeaderEnum() {
     switch (this) {
       case 'Accept':
@@ -15129,7 +15133,7 @@ enum InstanceAccessProtocol {
   rdp,
 }
 
-extension on InstanceAccessProtocol {
+extension InstanceAccessProtocolValue on InstanceAccessProtocol {
   String toValue() {
     switch (this) {
       case InstanceAccessProtocol.ssh:
@@ -15140,7 +15144,7 @@ extension on InstanceAccessProtocol {
   }
 }
 
-extension on String {
+extension InstanceAccessProtocolFromString on String {
   InstanceAccessProtocol toInstanceAccessProtocol() {
     switch (this) {
       case 'ssh':
@@ -15271,7 +15275,7 @@ enum InstanceHealthReason {
   instanceIpUnusable,
 }
 
-extension on InstanceHealthReason {
+extension InstanceHealthReasonValue on InstanceHealthReason {
   String toValue() {
     switch (this) {
       case InstanceHealthReason.lbRegistrationInProgress:
@@ -15300,7 +15304,7 @@ extension on InstanceHealthReason {
   }
 }
 
-extension on String {
+extension InstanceHealthReasonFromString on String {
   InstanceHealthReason toInstanceHealthReason() {
     switch (this) {
       case 'Lb.RegistrationInProgress':
@@ -15339,7 +15343,7 @@ enum InstanceHealthState {
   unavailable,
 }
 
-extension on InstanceHealthState {
+extension InstanceHealthStateValue on InstanceHealthState {
   String toValue() {
     switch (this) {
       case InstanceHealthState.initial:
@@ -15358,7 +15362,7 @@ extension on InstanceHealthState {
   }
 }
 
-extension on String {
+extension InstanceHealthStateFromString on String {
   InstanceHealthState toInstanceHealthState() {
     switch (this) {
       case 'initial':
@@ -15489,7 +15493,7 @@ enum InstanceMetricName {
   burstCapacityPercentage,
 }
 
-extension on InstanceMetricName {
+extension InstanceMetricNameValue on InstanceMetricName {
   String toValue() {
     switch (this) {
       case InstanceMetricName.cPUUtilization:
@@ -15512,7 +15516,7 @@ extension on InstanceMetricName {
   }
 }
 
-extension on String {
+extension InstanceMetricNameFromString on String {
   InstanceMetricName toInstanceMetricName() {
     switch (this) {
       case 'CPUUtilization':
@@ -15568,7 +15572,7 @@ enum InstancePlatform {
   windows,
 }
 
-extension on InstancePlatform {
+extension InstancePlatformValue on InstancePlatform {
   String toValue() {
     switch (this) {
       case InstancePlatform.linuxUnix:
@@ -15579,7 +15583,7 @@ extension on InstancePlatform {
   }
 }
 
-extension on String {
+extension InstancePlatformFromString on String {
   InstancePlatform toInstancePlatform() {
     switch (this) {
       case 'LINUX_UNIX':
@@ -16012,7 +16016,7 @@ enum InstanceSnapshotState {
   available,
 }
 
-extension on InstanceSnapshotState {
+extension InstanceSnapshotStateValue on InstanceSnapshotState {
   String toValue() {
     switch (this) {
       case InstanceSnapshotState.pending:
@@ -16025,7 +16029,7 @@ extension on InstanceSnapshotState {
   }
 }
 
-extension on String {
+extension InstanceSnapshotStateFromString on String {
   InstanceSnapshotState toInstanceSnapshotState() {
     switch (this) {
       case 'pending':
@@ -16413,7 +16417,7 @@ enum LoadBalancerAttributeName {
   sessionStickinessLbCookieDurationSeconds,
 }
 
-extension on LoadBalancerAttributeName {
+extension LoadBalancerAttributeNameValue on LoadBalancerAttributeName {
   String toValue() {
     switch (this) {
       case LoadBalancerAttributeName.healthCheckPath:
@@ -16426,7 +16430,7 @@ extension on LoadBalancerAttributeName {
   }
 }
 
-extension on String {
+extension LoadBalancerAttributeNameFromString on String {
   LoadBalancerAttributeName toLoadBalancerAttributeName() {
     switch (this) {
       case 'HealthCheckPath':
@@ -16456,7 +16460,7 @@ enum LoadBalancerMetricName {
   requestCount,
 }
 
-extension on LoadBalancerMetricName {
+extension LoadBalancerMetricNameValue on LoadBalancerMetricName {
   String toValue() {
     switch (this) {
       case LoadBalancerMetricName.clientTLSNegotiationErrorCount:
@@ -16487,7 +16491,7 @@ extension on LoadBalancerMetricName {
   }
 }
 
-extension on String {
+extension LoadBalancerMetricNameFromString on String {
   LoadBalancerMetricName toLoadBalancerMetricName() {
     switch (this) {
       case 'ClientTLSNegotiationErrorCount':
@@ -16524,7 +16528,7 @@ enum LoadBalancerProtocol {
   http,
 }
 
-extension on LoadBalancerProtocol {
+extension LoadBalancerProtocolValue on LoadBalancerProtocol {
   String toValue() {
     switch (this) {
       case LoadBalancerProtocol.httpHttps:
@@ -16535,7 +16539,7 @@ extension on LoadBalancerProtocol {
   }
 }
 
-extension on String {
+extension LoadBalancerProtocolFromString on String {
   LoadBalancerProtocol toLoadBalancerProtocol() {
     switch (this) {
       case 'HTTP_HTTPS':
@@ -16555,7 +16559,7 @@ enum LoadBalancerState {
   unknown,
 }
 
-extension on LoadBalancerState {
+extension LoadBalancerStateValue on LoadBalancerState {
   String toValue() {
     switch (this) {
       case LoadBalancerState.active:
@@ -16572,7 +16576,7 @@ extension on LoadBalancerState {
   }
 }
 
-extension on String {
+extension LoadBalancerStateFromString on String {
   LoadBalancerState toLoadBalancerState() {
     switch (this) {
       case 'active':
@@ -16857,7 +16861,8 @@ enum LoadBalancerTlsCertificateDomainStatus {
   success,
 }
 
-extension on LoadBalancerTlsCertificateDomainStatus {
+extension LoadBalancerTlsCertificateDomainStatusValue
+    on LoadBalancerTlsCertificateDomainStatus {
   String toValue() {
     switch (this) {
       case LoadBalancerTlsCertificateDomainStatus.pendingValidation:
@@ -16870,7 +16875,7 @@ extension on LoadBalancerTlsCertificateDomainStatus {
   }
 }
 
-extension on String {
+extension LoadBalancerTlsCertificateDomainStatusFromString on String {
   LoadBalancerTlsCertificateDomainStatus
       toLoadBalancerTlsCertificateDomainStatus() {
     switch (this) {
@@ -16957,7 +16962,8 @@ enum LoadBalancerTlsCertificateFailureReason {
   other,
 }
 
-extension on LoadBalancerTlsCertificateFailureReason {
+extension LoadBalancerTlsCertificateFailureReasonValue
+    on LoadBalancerTlsCertificateFailureReason {
   String toValue() {
     switch (this) {
       case LoadBalancerTlsCertificateFailureReason.noAvailableContacts:
@@ -16975,7 +16981,7 @@ extension on LoadBalancerTlsCertificateFailureReason {
   }
 }
 
-extension on String {
+extension LoadBalancerTlsCertificateFailureReasonFromString on String {
   LoadBalancerTlsCertificateFailureReason
       toLoadBalancerTlsCertificateFailureReason() {
     switch (this) {
@@ -17003,7 +17009,8 @@ enum LoadBalancerTlsCertificateRenewalStatus {
   failed,
 }
 
-extension on LoadBalancerTlsCertificateRenewalStatus {
+extension LoadBalancerTlsCertificateRenewalStatusValue
+    on LoadBalancerTlsCertificateRenewalStatus {
   String toValue() {
     switch (this) {
       case LoadBalancerTlsCertificateRenewalStatus.pendingAutoRenewal:
@@ -17018,7 +17025,7 @@ extension on LoadBalancerTlsCertificateRenewalStatus {
   }
 }
 
-extension on String {
+extension LoadBalancerTlsCertificateRenewalStatusFromString on String {
   LoadBalancerTlsCertificateRenewalStatus
       toLoadBalancerTlsCertificateRenewalStatus() {
     switch (this) {
@@ -17139,7 +17146,8 @@ enum LoadBalancerTlsCertificateRevocationReason {
   aACompromise,
 }
 
-extension on LoadBalancerTlsCertificateRevocationReason {
+extension LoadBalancerTlsCertificateRevocationReasonValue
+    on LoadBalancerTlsCertificateRevocationReason {
   String toValue() {
     switch (this) {
       case LoadBalancerTlsCertificateRevocationReason.unspecified:
@@ -17166,7 +17174,7 @@ extension on LoadBalancerTlsCertificateRevocationReason {
   }
 }
 
-extension on String {
+extension LoadBalancerTlsCertificateRevocationReasonFromString on String {
   LoadBalancerTlsCertificateRevocationReason
       toLoadBalancerTlsCertificateRevocationReason() {
     switch (this) {
@@ -17207,7 +17215,8 @@ enum LoadBalancerTlsCertificateStatus {
   unknown,
 }
 
-extension on LoadBalancerTlsCertificateStatus {
+extension LoadBalancerTlsCertificateStatusValue
+    on LoadBalancerTlsCertificateStatus {
   String toValue() {
     switch (this) {
       case LoadBalancerTlsCertificateStatus.pendingValidation:
@@ -17230,7 +17239,7 @@ extension on LoadBalancerTlsCertificateStatus {
   }
 }
 
-extension on String {
+extension LoadBalancerTlsCertificateStatusFromString on String {
   LoadBalancerTlsCertificateStatus toLoadBalancerTlsCertificateStatus() {
     switch (this) {
       case 'PENDING_VALIDATION':
@@ -17370,7 +17379,7 @@ enum MetricName {
   burstCapacityPercentage,
 }
 
-extension on MetricName {
+extension MetricNameValue on MetricName {
   String toValue() {
     switch (this) {
       case MetricName.cPUUtilization:
@@ -17427,7 +17436,7 @@ extension on MetricName {
   }
 }
 
-extension on String {
+extension MetricNameFromString on String {
   MetricName toMetricName() {
     switch (this) {
       case 'CPUUtilization':
@@ -17493,7 +17502,7 @@ enum MetricStatistic {
   sampleCount,
 }
 
-extension on MetricStatistic {
+extension MetricStatisticValue on MetricStatistic {
   String toValue() {
     switch (this) {
       case MetricStatistic.minimum:
@@ -17510,7 +17519,7 @@ extension on MetricStatistic {
   }
 }
 
-extension on String {
+extension MetricStatisticFromString on String {
   MetricStatistic toMetricStatistic() {
     switch (this) {
       case 'Minimum':
@@ -17558,7 +17567,7 @@ enum MetricUnit {
   none,
 }
 
-extension on MetricUnit {
+extension MetricUnitValue on MetricUnit {
   String toValue() {
     switch (this) {
       case MetricUnit.seconds:
@@ -17619,7 +17628,7 @@ extension on MetricUnit {
   }
 }
 
-extension on String {
+extension MetricUnitFromString on String {
   MetricUnit toMetricUnit() {
     switch (this) {
       case 'Seconds':
@@ -17737,7 +17746,7 @@ enum NetworkProtocol {
   icmp,
 }
 
-extension on NetworkProtocol {
+extension NetworkProtocolValue on NetworkProtocol {
   String toValue() {
     switch (this) {
       case NetworkProtocol.tcp:
@@ -17752,7 +17761,7 @@ extension on NetworkProtocol {
   }
 }
 
-extension on String {
+extension NetworkProtocolFromString on String {
   NetworkProtocol toNetworkProtocol() {
     switch (this) {
       case 'tcp':
@@ -17868,7 +17877,7 @@ enum OperationStatus {
   succeeded,
 }
 
-extension on OperationStatus {
+extension OperationStatusValue on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.notStarted:
@@ -17885,7 +17894,7 @@ extension on OperationStatus {
   }
 }
 
-extension on String {
+extension OperationStatusFromString on String {
   OperationStatus toOperationStatus() {
     switch (this) {
       case 'NotStarted':
@@ -17977,7 +17986,7 @@ enum OperationType {
   deleteContainerImage,
 }
 
-extension on OperationType {
+extension OperationTypeValue on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.deleteKnownHostKeys:
@@ -18126,7 +18135,7 @@ extension on OperationType {
   }
 }
 
-extension on String {
+extension OperationTypeFromString on String {
   OperationType toOperationType() {
     switch (this) {
       case 'DeleteKnownHostKeys':
@@ -18318,7 +18327,7 @@ enum OriginProtocolPolicyEnum {
   httpsOnly,
 }
 
-extension on OriginProtocolPolicyEnum {
+extension OriginProtocolPolicyEnumValue on OriginProtocolPolicyEnum {
   String toValue() {
     switch (this) {
       case OriginProtocolPolicyEnum.httpOnly:
@@ -18329,7 +18338,7 @@ extension on OriginProtocolPolicyEnum {
   }
 }
 
-extension on String {
+extension OriginProtocolPolicyEnumFromString on String {
   OriginProtocolPolicyEnum toOriginProtocolPolicyEnum() {
     switch (this) {
       case 'http-only':
@@ -18457,7 +18466,7 @@ enum PortAccessType {
   private,
 }
 
-extension on PortAccessType {
+extension PortAccessTypeValue on PortAccessType {
   String toValue() {
     switch (this) {
       case PortAccessType.public:
@@ -18468,7 +18477,7 @@ extension on PortAccessType {
   }
 }
 
-extension on String {
+extension PortAccessTypeFromString on String {
   PortAccessType toPortAccessType() {
     switch (this) {
       case 'Public':
@@ -18617,7 +18626,7 @@ enum PortInfoSourceType {
   closed,
 }
 
-extension on PortInfoSourceType {
+extension PortInfoSourceTypeValue on PortInfoSourceType {
   String toValue() {
     switch (this) {
       case PortInfoSourceType.$default:
@@ -18632,7 +18641,7 @@ extension on PortInfoSourceType {
   }
 }
 
-extension on String {
+extension PortInfoSourceTypeFromString on String {
   PortInfoSourceType toPortInfoSourceType() {
     switch (this) {
       case 'DEFAULT':
@@ -18653,7 +18662,7 @@ enum PortState {
   closed,
 }
 
-extension on PortState {
+extension PortStateValue on PortState {
   String toValue() {
     switch (this) {
       case PortState.open:
@@ -18664,7 +18673,7 @@ extension on PortState {
   }
 }
 
-extension on String {
+extension PortStateFromString on String {
   PortState toPortState() {
     switch (this) {
       case 'open':
@@ -18802,7 +18811,7 @@ enum RecordState {
   failed,
 }
 
-extension on RecordState {
+extension RecordStateValue on RecordState {
   String toValue() {
     switch (this) {
       case RecordState.started:
@@ -18815,7 +18824,7 @@ extension on RecordState {
   }
 }
 
-extension on String {
+extension RecordStateFromString on String {
   RecordState toRecordState() {
     switch (this) {
       case 'Started':
@@ -18896,7 +18905,7 @@ enum RegionName {
   apNortheast_2,
 }
 
-extension on RegionName {
+extension RegionNameValue on RegionName {
   String toValue() {
     switch (this) {
       case RegionName.usEast_1:
@@ -18931,7 +18940,7 @@ extension on RegionName {
   }
 }
 
-extension on String {
+extension RegionNameFromString on String {
   RegionName toRegionName() {
     switch (this) {
       case 'us-east-1':
@@ -19286,7 +19295,7 @@ enum RelationalDatabaseEngine {
   mysql,
 }
 
-extension on RelationalDatabaseEngine {
+extension RelationalDatabaseEngineValue on RelationalDatabaseEngine {
   String toValue() {
     switch (this) {
       case RelationalDatabaseEngine.mysql:
@@ -19295,7 +19304,7 @@ extension on RelationalDatabaseEngine {
   }
 }
 
-extension on String {
+extension RelationalDatabaseEngineFromString on String {
   RelationalDatabaseEngine toRelationalDatabaseEngine() {
     switch (this) {
       case 'mysql':
@@ -19372,7 +19381,7 @@ enum RelationalDatabaseMetricName {
   networkTransmitThroughput,
 }
 
-extension on RelationalDatabaseMetricName {
+extension RelationalDatabaseMetricNameValue on RelationalDatabaseMetricName {
   String toValue() {
     switch (this) {
       case RelationalDatabaseMetricName.cPUUtilization:
@@ -19391,7 +19400,7 @@ extension on RelationalDatabaseMetricName {
   }
 }
 
-extension on String {
+extension RelationalDatabaseMetricNameFromString on String {
   RelationalDatabaseMetricName toRelationalDatabaseMetricName() {
     switch (this) {
       case 'CPUUtilization':
@@ -19490,7 +19499,8 @@ enum RelationalDatabasePasswordVersion {
   pending,
 }
 
-extension on RelationalDatabasePasswordVersion {
+extension RelationalDatabasePasswordVersionValue
+    on RelationalDatabasePasswordVersion {
   String toValue() {
     switch (this) {
       case RelationalDatabasePasswordVersion.current:
@@ -19503,7 +19513,7 @@ extension on RelationalDatabasePasswordVersion {
   }
 }
 
-extension on String {
+extension RelationalDatabasePasswordVersionFromString on String {
   RelationalDatabasePasswordVersion toRelationalDatabasePasswordVersion() {
     switch (this) {
       case 'CURRENT':
@@ -19648,7 +19658,7 @@ enum RenewalStatus {
   failed,
 }
 
-extension on RenewalStatus {
+extension RenewalStatusValue on RenewalStatus {
   String toValue() {
     switch (this) {
       case RenewalStatus.pendingAutoRenewal:
@@ -19663,7 +19673,7 @@ extension on RenewalStatus {
   }
 }
 
-extension on String {
+extension RenewalStatusFromString on String {
   RenewalStatus toRenewalStatus() {
     switch (this) {
       case 'PendingAutoRenewal':
@@ -19841,7 +19851,7 @@ enum ResourceType {
   certificate,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.containerService:
@@ -19886,7 +19896,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'ContainerService':
@@ -20175,7 +20185,7 @@ enum TreatMissingData {
   missing,
 }
 
-extension on TreatMissingData {
+extension TreatMissingDataValue on TreatMissingData {
   String toValue() {
     switch (this) {
       case TreatMissingData.breaching:
@@ -20190,7 +20200,7 @@ extension on TreatMissingData {
   }
 }
 
-extension on String {
+extension TreatMissingDataFromString on String {
   TreatMissingData toTreatMissingData() {
     switch (this) {
       case 'breaching':

--- a/generated/aws_logs_api/lib/logs-2014-03-28.dart
+++ b/generated/aws_logs_api/lib/logs-2014-03-28.dart
@@ -3226,7 +3226,7 @@ enum Distribution {
   byLogStream,
 }
 
-extension DistributionValue on Distribution {
+extension DistributionValueExtension on Distribution {
   String toValue() {
     switch (this) {
       case Distribution.random:
@@ -3363,7 +3363,7 @@ enum ExportTaskStatusCode {
   running,
 }
 
-extension ExportTaskStatusCodeValue on ExportTaskStatusCode {
+extension ExportTaskStatusCodeValueExtension on ExportTaskStatusCode {
   String toValue() {
     switch (this) {
       case ExportTaskStatusCode.cancelled:
@@ -3873,7 +3873,7 @@ enum OrderBy {
   lastEventTime,
 }
 
-extension OrderByValue on OrderBy {
+extension OrderByValueExtension on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.logStreamName:
@@ -4107,7 +4107,7 @@ enum QueryStatus {
   cancelled,
 }
 
-extension QueryStatusValue on QueryStatus {
+extension QueryStatusValueExtension on QueryStatus {
   String toValue() {
     switch (this) {
       case QueryStatus.scheduled:

--- a/generated/aws_logs_api/lib/logs-2014-03-28.dart
+++ b/generated/aws_logs_api/lib/logs-2014-03-28.dart
@@ -3226,7 +3226,7 @@ enum Distribution {
   byLogStream,
 }
 
-extension on Distribution {
+extension DistributionValue on Distribution {
   String toValue() {
     switch (this) {
       case Distribution.random:
@@ -3237,7 +3237,7 @@ extension on Distribution {
   }
 }
 
-extension on String {
+extension DistributionFromString on String {
   Distribution toDistribution() {
     switch (this) {
       case 'Random':
@@ -3363,7 +3363,7 @@ enum ExportTaskStatusCode {
   running,
 }
 
-extension on ExportTaskStatusCode {
+extension ExportTaskStatusCodeValue on ExportTaskStatusCode {
   String toValue() {
     switch (this) {
       case ExportTaskStatusCode.cancelled:
@@ -3382,7 +3382,7 @@ extension on ExportTaskStatusCode {
   }
 }
 
-extension on String {
+extension ExportTaskStatusCodeFromString on String {
   ExportTaskStatusCode toExportTaskStatusCode() {
     switch (this) {
       case 'CANCELLED':
@@ -3873,7 +3873,7 @@ enum OrderBy {
   lastEventTime,
 }
 
-extension on OrderBy {
+extension OrderByValue on OrderBy {
   String toValue() {
     switch (this) {
       case OrderBy.logStreamName:
@@ -3884,7 +3884,7 @@ extension on OrderBy {
   }
 }
 
-extension on String {
+extension OrderByFromString on String {
   OrderBy toOrderBy() {
     switch (this) {
       case 'LogStreamName':
@@ -4107,7 +4107,7 @@ enum QueryStatus {
   cancelled,
 }
 
-extension on QueryStatus {
+extension QueryStatusValue on QueryStatus {
   String toValue() {
     switch (this) {
       case QueryStatus.scheduled:
@@ -4124,7 +4124,7 @@ extension on QueryStatus {
   }
 }
 
-extension on String {
+extension QueryStatusFromString on String {
   QueryStatus toQueryStatus() {
     switch (this) {
       case 'Scheduled':

--- a/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
+++ b/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
@@ -2566,7 +2566,7 @@ enum Algorithm {
   sgd,
 }
 
-extension on Algorithm {
+extension AlgorithmValue on Algorithm {
   String toValue() {
     switch (this) {
       case Algorithm.sgd:
@@ -2575,7 +2575,7 @@ extension on Algorithm {
   }
 }
 
-extension on String {
+extension AlgorithmFromString on String {
   Algorithm toAlgorithm() {
     switch (this) {
       case 'sgd':
@@ -2725,7 +2725,7 @@ enum BatchPredictionFilterVariable {
   dataURI,
 }
 
-extension on BatchPredictionFilterVariable {
+extension BatchPredictionFilterVariableValue on BatchPredictionFilterVariable {
   String toValue() {
     switch (this) {
       case BatchPredictionFilterVariable.createdAt:
@@ -2748,7 +2748,7 @@ extension on BatchPredictionFilterVariable {
   }
 }
 
-extension on String {
+extension BatchPredictionFilterVariableFromString on String {
   BatchPredictionFilterVariable toBatchPredictionFilterVariable() {
     switch (this) {
       case 'CreatedAt':
@@ -3088,7 +3088,7 @@ enum DataSourceFilterVariable {
   iAMUser,
 }
 
-extension on DataSourceFilterVariable {
+extension DataSourceFilterVariableValue on DataSourceFilterVariable {
   String toValue() {
     switch (this) {
       case DataSourceFilterVariable.createdAt:
@@ -3107,7 +3107,7 @@ extension on DataSourceFilterVariable {
   }
 }
 
-extension on String {
+extension DataSourceFilterVariableFromString on String {
   DataSourceFilterVariable toDataSourceFilterVariable() {
     switch (this) {
       case 'CreatedAt':
@@ -3395,7 +3395,7 @@ enum DetailsAttributes {
   algorithm,
 }
 
-extension on DetailsAttributes {
+extension DetailsAttributesValue on DetailsAttributes {
   String toValue() {
     switch (this) {
       case DetailsAttributes.predictiveModelType:
@@ -3406,7 +3406,7 @@ extension on DetailsAttributes {
   }
 }
 
-extension on String {
+extension DetailsAttributesFromString on String {
   DetailsAttributes toDetailsAttributes() {
     switch (this) {
       case 'PredictiveModelType':
@@ -3435,7 +3435,7 @@ enum EntityStatus {
   deleted,
 }
 
-extension on EntityStatus {
+extension EntityStatusValue on EntityStatus {
   String toValue() {
     switch (this) {
       case EntityStatus.pending:
@@ -3452,7 +3452,7 @@ extension on EntityStatus {
   }
 }
 
-extension on String {
+extension EntityStatusFromString on String {
   EntityStatus toEntityStatus() {
     switch (this) {
       case 'PENDING':
@@ -3623,7 +3623,7 @@ enum EvaluationFilterVariable {
   dataURI,
 }
 
-extension on EvaluationFilterVariable {
+extension EvaluationFilterVariableValue on EvaluationFilterVariable {
   String toValue() {
     switch (this) {
       case EvaluationFilterVariable.createdAt:
@@ -3646,7 +3646,7 @@ extension on EvaluationFilterVariable {
   }
 }
 
-extension on String {
+extension EvaluationFilterVariableFromString on String {
   EvaluationFilterVariable toEvaluationFilterVariable() {
     switch (this) {
       case 'CreatedAt':
@@ -4610,7 +4610,7 @@ enum MLModelFilterVariable {
   trainingDataURI,
 }
 
-extension on MLModelFilterVariable {
+extension MLModelFilterVariableValue on MLModelFilterVariable {
   String toValue() {
     switch (this) {
       case MLModelFilterVariable.createdAt:
@@ -4637,7 +4637,7 @@ extension on MLModelFilterVariable {
   }
 }
 
-extension on String {
+extension MLModelFilterVariableFromString on String {
   MLModelFilterVariable toMLModelFilterVariable() {
     switch (this) {
       case 'CreatedAt':
@@ -4671,7 +4671,7 @@ enum MLModelType {
   multiclass,
 }
 
-extension on MLModelType {
+extension MLModelTypeValue on MLModelType {
   String toValue() {
     switch (this) {
       case MLModelType.regression:
@@ -4684,7 +4684,7 @@ extension on MLModelType {
   }
 }
 
-extension on String {
+extension MLModelTypeFromString on String {
   MLModelType toMLModelType() {
     switch (this) {
       case 'REGRESSION':
@@ -5190,7 +5190,7 @@ enum RealtimeEndpointStatus {
   failed,
 }
 
-extension on RealtimeEndpointStatus {
+extension RealtimeEndpointStatusValue on RealtimeEndpointStatus {
   String toValue() {
     switch (this) {
       case RealtimeEndpointStatus.none:
@@ -5205,7 +5205,7 @@ extension on RealtimeEndpointStatus {
   }
 }
 
-extension on String {
+extension RealtimeEndpointStatusFromString on String {
   RealtimeEndpointStatus toRealtimeEndpointStatus() {
     switch (this) {
       case 'NONE':
@@ -5678,7 +5678,7 @@ enum SortOrder {
   dsc,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -5689,7 +5689,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'asc':
@@ -5753,7 +5753,7 @@ enum TaggableResourceType {
   mLModel,
 }
 
-extension on TaggableResourceType {
+extension TaggableResourceTypeValue on TaggableResourceType {
   String toValue() {
     switch (this) {
       case TaggableResourceType.batchPrediction:
@@ -5768,7 +5768,7 @@ extension on TaggableResourceType {
   }
 }
 
-extension on String {
+extension TaggableResourceTypeFromString on String {
   TaggableResourceType toTaggableResourceType() {
     switch (this) {
       case 'BatchPrediction':

--- a/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
+++ b/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
@@ -2566,7 +2566,7 @@ enum Algorithm {
   sgd,
 }
 
-extension AlgorithmValue on Algorithm {
+extension AlgorithmValueExtension on Algorithm {
   String toValue() {
     switch (this) {
       case Algorithm.sgd:
@@ -2725,7 +2725,8 @@ enum BatchPredictionFilterVariable {
   dataURI,
 }
 
-extension BatchPredictionFilterVariableValue on BatchPredictionFilterVariable {
+extension BatchPredictionFilterVariableValueExtension
+    on BatchPredictionFilterVariable {
   String toValue() {
     switch (this) {
       case BatchPredictionFilterVariable.createdAt:
@@ -3088,7 +3089,7 @@ enum DataSourceFilterVariable {
   iAMUser,
 }
 
-extension DataSourceFilterVariableValue on DataSourceFilterVariable {
+extension DataSourceFilterVariableValueExtension on DataSourceFilterVariable {
   String toValue() {
     switch (this) {
       case DataSourceFilterVariable.createdAt:
@@ -3395,7 +3396,7 @@ enum DetailsAttributes {
   algorithm,
 }
 
-extension DetailsAttributesValue on DetailsAttributes {
+extension DetailsAttributesValueExtension on DetailsAttributes {
   String toValue() {
     switch (this) {
       case DetailsAttributes.predictiveModelType:
@@ -3435,7 +3436,7 @@ enum EntityStatus {
   deleted,
 }
 
-extension EntityStatusValue on EntityStatus {
+extension EntityStatusValueExtension on EntityStatus {
   String toValue() {
     switch (this) {
       case EntityStatus.pending:
@@ -3623,7 +3624,7 @@ enum EvaluationFilterVariable {
   dataURI,
 }
 
-extension EvaluationFilterVariableValue on EvaluationFilterVariable {
+extension EvaluationFilterVariableValueExtension on EvaluationFilterVariable {
   String toValue() {
     switch (this) {
       case EvaluationFilterVariable.createdAt:
@@ -4610,7 +4611,7 @@ enum MLModelFilterVariable {
   trainingDataURI,
 }
 
-extension MLModelFilterVariableValue on MLModelFilterVariable {
+extension MLModelFilterVariableValueExtension on MLModelFilterVariable {
   String toValue() {
     switch (this) {
       case MLModelFilterVariable.createdAt:
@@ -4671,7 +4672,7 @@ enum MLModelType {
   multiclass,
 }
 
-extension MLModelTypeValue on MLModelType {
+extension MLModelTypeValueExtension on MLModelType {
   String toValue() {
     switch (this) {
       case MLModelType.regression:
@@ -5190,7 +5191,7 @@ enum RealtimeEndpointStatus {
   failed,
 }
 
-extension RealtimeEndpointStatusValue on RealtimeEndpointStatus {
+extension RealtimeEndpointStatusValueExtension on RealtimeEndpointStatus {
   String toValue() {
     switch (this) {
       case RealtimeEndpointStatus.none:
@@ -5678,7 +5679,7 @@ enum SortOrder {
   dsc,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -5753,7 +5754,7 @@ enum TaggableResourceType {
   mLModel,
 }
 
-extension TaggableResourceTypeValue on TaggableResourceType {
+extension TaggableResourceTypeValueExtension on TaggableResourceType {
   String toValue() {
     switch (this) {
       case TaggableResourceType.batchPrediction:

--- a/generated/aws_macie_api/lib/macie-2017-12-19.dart
+++ b/generated/aws_macie_api/lib/macie-2017-12-19.dart
@@ -544,7 +544,8 @@ enum S3ContinuousClassificationType {
   full,
 }
 
-extension on S3ContinuousClassificationType {
+extension S3ContinuousClassificationTypeValue
+    on S3ContinuousClassificationType {
   String toValue() {
     switch (this) {
       case S3ContinuousClassificationType.full:
@@ -553,7 +554,7 @@ extension on S3ContinuousClassificationType {
   }
 }
 
-extension on String {
+extension S3ContinuousClassificationTypeFromString on String {
   S3ContinuousClassificationType toS3ContinuousClassificationType() {
     switch (this) {
       case 'FULL':
@@ -569,7 +570,7 @@ enum S3OneTimeClassificationType {
   none,
 }
 
-extension on S3OneTimeClassificationType {
+extension S3OneTimeClassificationTypeValue on S3OneTimeClassificationType {
   String toValue() {
     switch (this) {
       case S3OneTimeClassificationType.full:
@@ -580,7 +581,7 @@ extension on S3OneTimeClassificationType {
   }
 }
 
-extension on String {
+extension S3OneTimeClassificationTypeFromString on String {
   S3OneTimeClassificationType toS3OneTimeClassificationType() {
     switch (this) {
       case 'FULL':

--- a/generated/aws_macie_api/lib/macie-2017-12-19.dart
+++ b/generated/aws_macie_api/lib/macie-2017-12-19.dart
@@ -544,7 +544,7 @@ enum S3ContinuousClassificationType {
   full,
 }
 
-extension S3ContinuousClassificationTypeValue
+extension S3ContinuousClassificationTypeValueExtension
     on S3ContinuousClassificationType {
   String toValue() {
     switch (this) {
@@ -570,7 +570,8 @@ enum S3OneTimeClassificationType {
   none,
 }
 
-extension S3OneTimeClassificationTypeValue on S3OneTimeClassificationType {
+extension S3OneTimeClassificationTypeValueExtension
+    on S3OneTimeClassificationType {
   String toValue() {
     switch (this) {
       case S3OneTimeClassificationType.full:

--- a/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
+++ b/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
@@ -1469,7 +1469,7 @@ enum Edition {
   standard,
 }
 
-extension EditionValue on Edition {
+extension EditionValueExtension on Edition {
   String toValue() {
     switch (this) {
       case Edition.starter:
@@ -1497,7 +1497,7 @@ enum Framework {
   ethereum,
 }
 
-extension FrameworkValue on Framework {
+extension FrameworkValueExtension on Framework {
   String toValue() {
     switch (this) {
       case Framework.hyperledgerFabric:
@@ -1656,7 +1656,7 @@ enum InvitationStatus {
   expired,
 }
 
-extension InvitationStatusValue on InvitationStatus {
+extension InvitationStatusValueExtension on InvitationStatus {
   String toValue() {
     switch (this) {
       case InvitationStatus.pending:
@@ -2174,7 +2174,7 @@ enum MemberStatus {
   deleted,
 }
 
-extension MemberStatusValue on MemberStatus {
+extension MemberStatusValueExtension on MemberStatus {
   String toValue() {
     switch (this) {
       case MemberStatus.creating:
@@ -2475,7 +2475,7 @@ enum NetworkStatus {
   deleted,
 }
 
-extension NetworkStatusValue on NetworkStatus {
+extension NetworkStatusValueExtension on NetworkStatus {
   String toValue() {
     switch (this) {
       case NetworkStatus.creating:
@@ -2832,7 +2832,7 @@ enum NodeStatus {
   failed,
 }
 
-extension NodeStatusValue on NodeStatus {
+extension NodeStatusValueExtension on NodeStatus {
   String toValue() {
     switch (this) {
       case NodeStatus.creating:
@@ -3074,7 +3074,7 @@ enum ProposalStatus {
   actionFailed,
 }
 
-extension ProposalStatusValue on ProposalStatus {
+extension ProposalStatusValueExtension on ProposalStatus {
   String toValue() {
     switch (this) {
       case ProposalStatus.inProgress:
@@ -3228,7 +3228,7 @@ enum StateDBType {
   couchDB,
 }
 
-extension StateDBTypeValue on StateDBType {
+extension StateDBTypeValueExtension on StateDBType {
   String toValue() {
     switch (this) {
       case StateDBType.levelDB:
@@ -3256,7 +3256,7 @@ enum ThresholdComparator {
   greaterThanOrEqualTo,
 }
 
-extension ThresholdComparatorValue on ThresholdComparator {
+extension ThresholdComparatorValueExtension on ThresholdComparator {
   String toValue() {
     switch (this) {
       case ThresholdComparator.greaterThan:
@@ -3332,7 +3332,7 @@ enum VoteValue {
   no,
 }
 
-extension VoteValueValue on VoteValue {
+extension VoteValueValueExtension on VoteValue {
   String toValue() {
     switch (this) {
       case VoteValue.yes:

--- a/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
+++ b/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
@@ -1469,7 +1469,7 @@ enum Edition {
   standard,
 }
 
-extension on Edition {
+extension EditionValue on Edition {
   String toValue() {
     switch (this) {
       case Edition.starter:
@@ -1480,7 +1480,7 @@ extension on Edition {
   }
 }
 
-extension on String {
+extension EditionFromString on String {
   Edition toEdition() {
     switch (this) {
       case 'STARTER':
@@ -1497,7 +1497,7 @@ enum Framework {
   ethereum,
 }
 
-extension on Framework {
+extension FrameworkValue on Framework {
   String toValue() {
     switch (this) {
       case Framework.hyperledgerFabric:
@@ -1508,7 +1508,7 @@ extension on Framework {
   }
 }
 
-extension on String {
+extension FrameworkFromString on String {
   Framework toFramework() {
     switch (this) {
       case 'HYPERLEDGER_FABRIC':
@@ -1656,7 +1656,7 @@ enum InvitationStatus {
   expired,
 }
 
-extension on InvitationStatus {
+extension InvitationStatusValue on InvitationStatus {
   String toValue() {
     switch (this) {
       case InvitationStatus.pending:
@@ -1673,7 +1673,7 @@ extension on InvitationStatus {
   }
 }
 
-extension on String {
+extension InvitationStatusFromString on String {
   InvitationStatus toInvitationStatus() {
     switch (this) {
       case 'PENDING':
@@ -2174,7 +2174,7 @@ enum MemberStatus {
   deleted,
 }
 
-extension on MemberStatus {
+extension MemberStatusValue on MemberStatus {
   String toValue() {
     switch (this) {
       case MemberStatus.creating:
@@ -2193,7 +2193,7 @@ extension on MemberStatus {
   }
 }
 
-extension on String {
+extension MemberStatusFromString on String {
   MemberStatus toMemberStatus() {
     switch (this) {
       case 'CREATING':
@@ -2475,7 +2475,7 @@ enum NetworkStatus {
   deleted,
 }
 
-extension on NetworkStatus {
+extension NetworkStatusValue on NetworkStatus {
   String toValue() {
     switch (this) {
       case NetworkStatus.creating:
@@ -2492,7 +2492,7 @@ extension on NetworkStatus {
   }
 }
 
-extension on String {
+extension NetworkStatusFromString on String {
   NetworkStatus toNetworkStatus() {
     switch (this) {
       case 'CREATING':
@@ -2832,7 +2832,7 @@ enum NodeStatus {
   failed,
 }
 
-extension on NodeStatus {
+extension NodeStatusValue on NodeStatus {
   String toValue() {
     switch (this) {
       case NodeStatus.creating:
@@ -2855,7 +2855,7 @@ extension on NodeStatus {
   }
 }
 
-extension on String {
+extension NodeStatusFromString on String {
   NodeStatus toNodeStatus() {
     switch (this) {
       case 'CREATING':
@@ -3074,7 +3074,7 @@ enum ProposalStatus {
   actionFailed,
 }
 
-extension on ProposalStatus {
+extension ProposalStatusValue on ProposalStatus {
   String toValue() {
     switch (this) {
       case ProposalStatus.inProgress:
@@ -3091,7 +3091,7 @@ extension on ProposalStatus {
   }
 }
 
-extension on String {
+extension ProposalStatusFromString on String {
   ProposalStatus toProposalStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3228,7 +3228,7 @@ enum StateDBType {
   couchDB,
 }
 
-extension on StateDBType {
+extension StateDBTypeValue on StateDBType {
   String toValue() {
     switch (this) {
       case StateDBType.levelDB:
@@ -3239,7 +3239,7 @@ extension on StateDBType {
   }
 }
 
-extension on String {
+extension StateDBTypeFromString on String {
   StateDBType toStateDBType() {
     switch (this) {
       case 'LevelDB':
@@ -3256,7 +3256,7 @@ enum ThresholdComparator {
   greaterThanOrEqualTo,
 }
 
-extension on ThresholdComparator {
+extension ThresholdComparatorValue on ThresholdComparator {
   String toValue() {
     switch (this) {
       case ThresholdComparator.greaterThan:
@@ -3267,7 +3267,7 @@ extension on ThresholdComparator {
   }
 }
 
-extension on String {
+extension ThresholdComparatorFromString on String {
   ThresholdComparator toThresholdComparator() {
     switch (this) {
       case 'GREATER_THAN':
@@ -3332,7 +3332,7 @@ enum VoteValue {
   no,
 }
 
-extension on VoteValue {
+extension VoteValueValue on VoteValue {
   String toValue() {
     switch (this) {
       case VoteValue.yes:
@@ -3343,7 +3343,7 @@ extension on VoteValue {
   }
 }
 
-extension on String {
+extension VoteValueFromString on String {
   VoteValue toVoteValue() {
     switch (this) {
       case 'YES':

--- a/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
+++ b/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
@@ -565,7 +565,7 @@ enum ChangeStatus {
   failed,
 }
 
-extension ChangeStatusValue on ChangeStatus {
+extension ChangeStatusValueExtension on ChangeStatus {
   String toValue() {
     switch (this) {
       case ChangeStatus.preparing:
@@ -846,7 +846,7 @@ enum FailureCode {
   serverFault,
 }
 
-extension FailureCodeValue on FailureCode {
+extension FailureCodeValueExtension on FailureCode {
   String toValue() {
     switch (this) {
       case FailureCode.clientError:
@@ -1010,7 +1010,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:

--- a/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
+++ b/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
@@ -565,7 +565,7 @@ enum ChangeStatus {
   failed,
 }
 
-extension on ChangeStatus {
+extension ChangeStatusValue on ChangeStatus {
   String toValue() {
     switch (this) {
       case ChangeStatus.preparing:
@@ -582,7 +582,7 @@ extension on ChangeStatus {
   }
 }
 
-extension on String {
+extension ChangeStatusFromString on String {
   ChangeStatus toChangeStatus() {
     switch (this) {
       case 'PREPARING':
@@ -846,7 +846,7 @@ enum FailureCode {
   serverFault,
 }
 
-extension on FailureCode {
+extension FailureCodeValue on FailureCode {
   String toValue() {
     switch (this) {
       case FailureCode.clientError:
@@ -857,7 +857,7 @@ extension on FailureCode {
   }
 }
 
-extension on String {
+extension FailureCodeFromString on String {
   FailureCode toFailureCode() {
     switch (this) {
       case 'CLIENT_ERROR':
@@ -1010,7 +1010,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -1021,7 +1021,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASCENDING':

--- a/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
+++ b/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
@@ -202,7 +202,7 @@ enum GetEntitlementFilterName {
   dimension,
 }
 
-extension on GetEntitlementFilterName {
+extension GetEntitlementFilterNameValue on GetEntitlementFilterName {
   String toValue() {
     switch (this) {
       case GetEntitlementFilterName.customerIdentifier:
@@ -213,7 +213,7 @@ extension on GetEntitlementFilterName {
   }
 }
 
-extension on String {
+extension GetEntitlementFilterNameFromString on String {
   GetEntitlementFilterName toGetEntitlementFilterName() {
     switch (this) {
       case 'CUSTOMER_IDENTIFIER':

--- a/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
+++ b/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
@@ -202,7 +202,7 @@ enum GetEntitlementFilterName {
   dimension,
 }
 
-extension GetEntitlementFilterNameValue on GetEntitlementFilterName {
+extension GetEntitlementFilterNameValueExtension on GetEntitlementFilterName {
   String toValue() {
     switch (this) {
       case GetEntitlementFilterName.customerIdentifier:

--- a/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
@@ -407,7 +407,7 @@ enum DataSetType {
   usSalesAndUseTaxRecords,
 }
 
-extension DataSetTypeValue on DataSetType {
+extension DataSetTypeValueExtension on DataSetType {
   String toValue() {
     switch (this) {
       case DataSetType.customerSubscriberHourlyMonthlySubscriptions:
@@ -561,7 +561,7 @@ enum SupportDataSetType {
   testCustomerSupportContactsData,
 }
 
-extension SupportDataSetTypeValue on SupportDataSetType {
+extension SupportDataSetTypeValueExtension on SupportDataSetType {
   String toValue() {
     switch (this) {
       case SupportDataSetType.customerSupportContactsData:

--- a/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
@@ -407,7 +407,7 @@ enum DataSetType {
   usSalesAndUseTaxRecords,
 }
 
-extension on DataSetType {
+extension DataSetTypeValue on DataSetType {
   String toValue() {
     switch (this) {
       case DataSetType.customerSubscriberHourlyMonthlySubscriptions:
@@ -464,7 +464,7 @@ extension on DataSetType {
   }
 }
 
-extension on String {
+extension DataSetTypeFromString on String {
   DataSetType toDataSetType() {
     switch (this) {
       case 'customer_subscriber_hourly_monthly_subscriptions':
@@ -561,7 +561,7 @@ enum SupportDataSetType {
   testCustomerSupportContactsData,
 }
 
-extension on SupportDataSetType {
+extension SupportDataSetTypeValue on SupportDataSetType {
   String toValue() {
     switch (this) {
       case SupportDataSetType.customerSupportContactsData:
@@ -572,7 +572,7 @@ extension on SupportDataSetType {
   }
 }
 
-extension on String {
+extension SupportDataSetTypeFromString on String {
   SupportDataSetType toSupportDataSetType() {
     switch (this) {
       case 'customer_support_contacts_data':

--- a/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
+++ b/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
@@ -1271,7 +1271,7 @@ enum Algorithm {
   aes256,
 }
 
-extension on Algorithm {
+extension AlgorithmValue on Algorithm {
   String toValue() {
     switch (this) {
       case Algorithm.aes128:
@@ -1284,7 +1284,7 @@ extension on Algorithm {
   }
 }
 
-extension on String {
+extension AlgorithmFromString on String {
   Algorithm toAlgorithm() {
     switch (this) {
       case 'aes128':
@@ -1386,7 +1386,7 @@ enum DurationUnits {
   months,
 }
 
-extension on DurationUnits {
+extension DurationUnitsValue on DurationUnits {
   String toValue() {
     switch (this) {
       case DurationUnits.months:
@@ -1395,7 +1395,7 @@ extension on DurationUnits {
   }
 }
 
-extension on String {
+extension DurationUnitsFromString on String {
   DurationUnits toDurationUnits() {
     switch (this) {
       case 'MONTHS':
@@ -1562,7 +1562,7 @@ enum EntitlementStatus {
   disabled,
 }
 
-extension on EntitlementStatus {
+extension EntitlementStatusValue on EntitlementStatus {
   String toValue() {
     switch (this) {
       case EntitlementStatus.enabled:
@@ -1573,7 +1573,7 @@ extension on EntitlementStatus {
   }
 }
 
-extension on String {
+extension EntitlementStatusFromString on String {
   EntitlementStatus toEntitlementStatus() {
     switch (this) {
       case 'ENABLED':
@@ -1779,7 +1779,7 @@ enum KeyType {
   staticKey,
 }
 
-extension on KeyType {
+extension KeyTypeValue on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.speke:
@@ -1790,7 +1790,7 @@ extension on KeyType {
   }
 }
 
-extension on String {
+extension KeyTypeFromString on String {
   KeyType toKeyType() {
     switch (this) {
       case 'speke':
@@ -2152,7 +2152,7 @@ enum PriceUnits {
   hourly,
 }
 
-extension on PriceUnits {
+extension PriceUnitsValue on PriceUnits {
   String toValue() {
     switch (this) {
       case PriceUnits.hourly:
@@ -2161,7 +2161,7 @@ extension on PriceUnits {
   }
 }
 
-extension on String {
+extension PriceUnitsFromString on String {
   PriceUnits toPriceUnits() {
     switch (this) {
       case 'HOURLY':
@@ -2179,7 +2179,7 @@ enum Protocol {
   rist,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.zixiPush:
@@ -2196,7 +2196,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'zixi-push':
@@ -2399,7 +2399,7 @@ enum ReservationState {
   canceled,
 }
 
-extension on ReservationState {
+extension ReservationStateValue on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.active:
@@ -2414,7 +2414,7 @@ extension on ReservationState {
   }
 }
 
-extension on String {
+extension ReservationStateFromString on String {
   ReservationState toReservationState() {
     switch (this) {
       case 'ACTIVE':
@@ -2454,7 +2454,7 @@ enum ResourceType {
   mbpsOutboundBandwidth,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.mbpsOutboundBandwidth:
@@ -2463,7 +2463,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'Mbps_Outbound_Bandwidth':
@@ -2658,7 +2658,7 @@ enum SourceType {
   entitled,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.owned:
@@ -2669,7 +2669,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'OWNED':
@@ -2705,7 +2705,7 @@ enum State {
   disabled,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.enabled:
@@ -2716,7 +2716,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'ENABLED':
@@ -2738,7 +2738,7 @@ enum Status {
   error,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.standby:
@@ -2759,7 +2759,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'STANDBY':

--- a/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
+++ b/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
@@ -1271,7 +1271,7 @@ enum Algorithm {
   aes256,
 }
 
-extension AlgorithmValue on Algorithm {
+extension AlgorithmValueExtension on Algorithm {
   String toValue() {
     switch (this) {
       case Algorithm.aes128:
@@ -1386,7 +1386,7 @@ enum DurationUnits {
   months,
 }
 
-extension DurationUnitsValue on DurationUnits {
+extension DurationUnitsValueExtension on DurationUnits {
   String toValue() {
     switch (this) {
       case DurationUnits.months:
@@ -1562,7 +1562,7 @@ enum EntitlementStatus {
   disabled,
 }
 
-extension EntitlementStatusValue on EntitlementStatus {
+extension EntitlementStatusValueExtension on EntitlementStatus {
   String toValue() {
     switch (this) {
       case EntitlementStatus.enabled:
@@ -1779,7 +1779,7 @@ enum KeyType {
   staticKey,
 }
 
-extension KeyTypeValue on KeyType {
+extension KeyTypeValueExtension on KeyType {
   String toValue() {
     switch (this) {
       case KeyType.speke:
@@ -2152,7 +2152,7 @@ enum PriceUnits {
   hourly,
 }
 
-extension PriceUnitsValue on PriceUnits {
+extension PriceUnitsValueExtension on PriceUnits {
   String toValue() {
     switch (this) {
       case PriceUnits.hourly:
@@ -2179,7 +2179,7 @@ enum Protocol {
   rist,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.zixiPush:
@@ -2399,7 +2399,7 @@ enum ReservationState {
   canceled,
 }
 
-extension ReservationStateValue on ReservationState {
+extension ReservationStateValueExtension on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.active:
@@ -2454,7 +2454,7 @@ enum ResourceType {
   mbpsOutboundBandwidth,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.mbpsOutboundBandwidth:
@@ -2658,7 +2658,7 @@ enum SourceType {
   entitled,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.owned:
@@ -2705,7 +2705,7 @@ enum State {
   disabled,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.enabled:
@@ -2738,7 +2738,7 @@ enum Status {
   error,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.standby:

--- a/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
+++ b/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
@@ -1210,7 +1210,7 @@ enum AacAudioDescriptionBroadcasterMix {
   normal,
 }
 
-extension AacAudioDescriptionBroadcasterMixValue
+extension AacAudioDescriptionBroadcasterMixValueExtension
     on AacAudioDescriptionBroadcasterMix {
   String toValue() {
     switch (this) {
@@ -1242,7 +1242,7 @@ enum AacCodecProfile {
   hev2,
 }
 
-extension AacCodecProfileValue on AacCodecProfile {
+extension AacCodecProfileValueExtension on AacCodecProfile {
   String toValue() {
     switch (this) {
       case AacCodecProfile.lc:
@@ -1282,7 +1282,7 @@ enum AacCodingMode {
   codingMode_5_1,
 }
 
-extension AacCodingModeValue on AacCodingMode {
+extension AacCodingModeValueExtension on AacCodingMode {
   String toValue() {
     switch (this) {
       case AacCodingMode.adReceiverMix:
@@ -1323,7 +1323,7 @@ enum AacRateControlMode {
   vbr,
 }
 
-extension AacRateControlModeValue on AacRateControlMode {
+extension AacRateControlModeValueExtension on AacRateControlMode {
   String toValue() {
     switch (this) {
       case AacRateControlMode.cbr:
@@ -1353,7 +1353,7 @@ enum AacRawFormat {
   none,
 }
 
-extension AacRawFormatValue on AacRawFormat {
+extension AacRawFormatValueExtension on AacRawFormat {
   String toValue() {
     switch (this) {
       case AacRawFormat.latmLoas:
@@ -1493,7 +1493,7 @@ enum AacSpecification {
   mpeg4,
 }
 
-extension AacSpecificationValue on AacSpecification {
+extension AacSpecificationValueExtension on AacSpecification {
   String toValue() {
     switch (this) {
       case AacSpecification.mpeg2:
@@ -1524,7 +1524,7 @@ enum AacVbrQuality {
   high,
 }
 
-extension AacVbrQualityValue on AacVbrQuality {
+extension AacVbrQualityValueExtension on AacVbrQuality {
   String toValue() {
     switch (this) {
       case AacVbrQuality.low:
@@ -1568,7 +1568,7 @@ enum Ac3BitstreamMode {
   voiceOver,
 }
 
-extension Ac3BitstreamModeValue on Ac3BitstreamMode {
+extension Ac3BitstreamModeValueExtension on Ac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Ac3BitstreamMode.completeMain:
@@ -1623,7 +1623,7 @@ enum Ac3CodingMode {
   codingMode_3_2Lfe,
 }
 
-extension Ac3CodingModeValue on Ac3CodingMode {
+extension Ac3CodingModeValueExtension on Ac3CodingMode {
   String toValue() {
     switch (this) {
       case Ac3CodingMode.codingMode_1_0:
@@ -1661,7 +1661,7 @@ enum Ac3DynamicRangeCompressionProfile {
   none,
 }
 
-extension Ac3DynamicRangeCompressionProfileValue
+extension Ac3DynamicRangeCompressionProfileValueExtension
     on Ac3DynamicRangeCompressionProfile {
   String toValue() {
     switch (this) {
@@ -1693,7 +1693,7 @@ enum Ac3LfeFilter {
   disabled,
 }
 
-extension Ac3LfeFilterValue on Ac3LfeFilter {
+extension Ac3LfeFilterValueExtension on Ac3LfeFilter {
   String toValue() {
     switch (this) {
       case Ac3LfeFilter.enabled:
@@ -1724,7 +1724,7 @@ enum Ac3MetadataControl {
   useConfigured,
 }
 
-extension Ac3MetadataControlValue on Ac3MetadataControl {
+extension Ac3MetadataControlValueExtension on Ac3MetadataControl {
   String toValue() {
     switch (this) {
       case Ac3MetadataControl.followInput:
@@ -1844,7 +1844,7 @@ enum AccelerationMode {
   preferred,
 }
 
-extension AccelerationModeValue on AccelerationMode {
+extension AccelerationModeValueExtension on AccelerationMode {
   String toValue() {
     switch (this) {
       case AccelerationMode.disabled:
@@ -1914,7 +1914,7 @@ enum AccelerationStatus {
   notAccelerated,
 }
 
-extension AccelerationStatusValue on AccelerationStatus {
+extension AccelerationStatusValueExtension on AccelerationStatus {
   String toValue() {
     switch (this) {
       case AccelerationStatus.notApplicable:
@@ -1957,7 +1957,7 @@ enum AfdSignaling {
   fixed,
 }
 
-extension AfdSignalingValue on AfdSignaling {
+extension AfdSignalingValueExtension on AfdSignaling {
   String toValue() {
     switch (this) {
       case AfdSignaling.none:
@@ -2034,7 +2034,7 @@ enum AlphaBehavior {
   remapToLuma,
 }
 
-extension AlphaBehaviorValue on AlphaBehavior {
+extension AlphaBehaviorValueExtension on AlphaBehavior {
   String toValue() {
     switch (this) {
       case AlphaBehavior.discard:
@@ -2067,7 +2067,7 @@ enum AncillaryConvert608To708 {
   disabled,
 }
 
-extension AncillaryConvert608To708Value on AncillaryConvert608To708 {
+extension AncillaryConvert608To708ValueExtension on AncillaryConvert608To708 {
   String toValue() {
     switch (this) {
       case AncillaryConvert608To708.upconvert:
@@ -2146,7 +2146,8 @@ enum AncillaryTerminateCaptions {
   disabled,
 }
 
-extension AncillaryTerminateCaptionsValue on AncillaryTerminateCaptions {
+extension AncillaryTerminateCaptionsValueExtension
+    on AncillaryTerminateCaptions {
   String toValue() {
     switch (this) {
       case AncillaryTerminateCaptions.endOfInput:
@@ -2177,7 +2178,7 @@ enum AntiAlias {
   enabled,
 }
 
-extension AntiAliasValue on AntiAlias {
+extension AntiAliasValueExtension on AntiAlias {
   String toValue() {
     switch (this) {
       case AntiAlias.disabled:
@@ -2228,7 +2229,7 @@ enum AudioChannelTag {
   vhr,
 }
 
-extension AudioChannelTagValue on AudioChannelTag {
+extension AudioChannelTagValueExtension on AudioChannelTag {
   String toValue() {
     switch (this) {
       case AudioChannelTag.l:
@@ -2349,7 +2350,7 @@ enum AudioCodec {
   passthrough,
 }
 
-extension AudioCodecValue on AudioCodec {
+extension AudioCodecValueExtension on AudioCodec {
   String toValue() {
     switch (this) {
       case AudioCodec.aac:
@@ -2553,7 +2554,7 @@ enum AudioDefaultSelection {
   notDefault,
 }
 
-extension AudioDefaultSelectionValue on AudioDefaultSelection {
+extension AudioDefaultSelectionValueExtension on AudioDefaultSelection {
   String toValue() {
     switch (this) {
       case AudioDefaultSelection.$default:
@@ -2752,7 +2753,7 @@ enum AudioLanguageCodeControl {
   useConfigured,
 }
 
-extension AudioLanguageCodeControlValue on AudioLanguageCodeControl {
+extension AudioLanguageCodeControlValueExtension on AudioLanguageCodeControl {
   String toValue() {
     switch (this) {
       case AudioLanguageCodeControl.followInput:
@@ -2792,7 +2793,8 @@ enum AudioNormalizationAlgorithm {
   ituBs_1770_4,
 }
 
-extension AudioNormalizationAlgorithmValue on AudioNormalizationAlgorithm {
+extension AudioNormalizationAlgorithmValueExtension
+    on AudioNormalizationAlgorithm {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithm.ituBs_1770_1:
@@ -2830,7 +2832,7 @@ enum AudioNormalizationAlgorithmControl {
   measureOnly,
 }
 
-extension AudioNormalizationAlgorithmControlValue
+extension AudioNormalizationAlgorithmControlValueExtension
     on AudioNormalizationAlgorithmControl {
   String toValue() {
     switch (this) {
@@ -2861,7 +2863,7 @@ enum AudioNormalizationLoudnessLogging {
   dontLog,
 }
 
-extension AudioNormalizationLoudnessLoggingValue
+extension AudioNormalizationLoudnessLoggingValueExtension
     on AudioNormalizationLoudnessLogging {
   String toValue() {
     switch (this) {
@@ -2893,7 +2895,7 @@ enum AudioNormalizationPeakCalculation {
   none,
 }
 
-extension AudioNormalizationPeakCalculationValue
+extension AudioNormalizationPeakCalculationValueExtension
     on AudioNormalizationPeakCalculation {
   String toValue() {
     switch (this) {
@@ -3149,7 +3151,7 @@ enum AudioSelectorType {
   languageCode,
 }
 
-extension AudioSelectorTypeValue on AudioSelectorType {
+extension AudioSelectorTypeValueExtension on AudioSelectorType {
   String toValue() {
     switch (this) {
       case AudioSelectorType.pid:
@@ -3187,7 +3189,7 @@ enum AudioTypeControl {
   useConfigured,
 }
 
-extension AudioTypeControlValue on AudioTypeControl {
+extension AudioTypeControlValueExtension on AudioTypeControl {
   String toValue() {
     switch (this) {
       case AudioTypeControl.followInput:
@@ -3302,7 +3304,7 @@ enum Av1AdaptiveQuantization {
   max,
 }
 
-extension Av1AdaptiveQuantizationValue on Av1AdaptiveQuantization {
+extension Av1AdaptiveQuantizationValueExtension on Av1AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Av1AdaptiveQuantization.off:
@@ -3358,7 +3360,7 @@ enum Av1FramerateControl {
   specified,
 }
 
-extension Av1FramerateControlValue on Av1FramerateControl {
+extension Av1FramerateControlValueExtension on Av1FramerateControl {
   String toValue() {
     switch (this) {
       case Av1FramerateControl.initializeFromSource:
@@ -3398,7 +3400,7 @@ enum Av1FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension Av1FramerateConversionAlgorithmValue
+extension Av1FramerateConversionAlgorithmValueExtension
     on Av1FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -3479,7 +3481,7 @@ enum Av1RateControlMode {
   qvbr,
 }
 
-extension Av1RateControlModeValue on Av1RateControlMode {
+extension Av1RateControlModeValueExtension on Av1RateControlMode {
   String toValue() {
     switch (this) {
       case Av1RateControlMode.qvbr:
@@ -3697,7 +3699,7 @@ enum Av1SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension Av1SpatialAdaptiveQuantizationValue
+extension Av1SpatialAdaptiveQuantizationValueExtension
     on Av1SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -3755,7 +3757,7 @@ enum AvcIntraClass {
   class_200,
 }
 
-extension AvcIntraClassValue on AvcIntraClass {
+extension AvcIntraClassValueExtension on AvcIntraClass {
   String toValue() {
     switch (this) {
       case AvcIntraClass.class_50:
@@ -3799,7 +3801,7 @@ enum AvcIntraFramerateControl {
   specified,
 }
 
-extension AvcIntraFramerateControlValue on AvcIntraFramerateControl {
+extension AvcIntraFramerateControlValueExtension on AvcIntraFramerateControl {
   String toValue() {
     switch (this) {
       case AvcIntraFramerateControl.initializeFromSource:
@@ -3839,7 +3841,7 @@ enum AvcIntraFramerateConversionAlgorithm {
   frameformer,
 }
 
-extension AvcIntraFramerateConversionAlgorithmValue
+extension AvcIntraFramerateConversionAlgorithmValueExtension
     on AvcIntraFramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -3889,7 +3891,7 @@ enum AvcIntraInterlaceMode {
   followBottomField,
 }
 
-extension AvcIntraInterlaceModeValue on AvcIntraInterlaceMode {
+extension AvcIntraInterlaceModeValueExtension on AvcIntraInterlaceMode {
   String toValue() {
     switch (this) {
       case AvcIntraInterlaceMode.progressive:
@@ -4076,7 +4078,7 @@ enum AvcIntraSlowPal {
   enabled,
 }
 
-extension AvcIntraSlowPalValue on AvcIntraSlowPal {
+extension AvcIntraSlowPalValueExtension on AvcIntraSlowPal {
   String toValue() {
     switch (this) {
       case AvcIntraSlowPal.disabled:
@@ -4110,7 +4112,7 @@ enum AvcIntraTelecine {
   hard,
 }
 
-extension AvcIntraTelecineValue on AvcIntraTelecine {
+extension AvcIntraTelecineValueExtension on AvcIntraTelecine {
   String toValue() {
     switch (this) {
       case AvcIntraTelecine.none:
@@ -4142,7 +4144,7 @@ enum BillingTagsSource {
   job,
 }
 
-extension BillingTagsSourceValue on BillingTagsSource {
+extension BillingTagsSourceValueExtension on BillingTagsSource {
   String toValue() {
     switch (this) {
       case BillingTagsSource.queue:
@@ -4377,7 +4379,7 @@ enum BurninSubtitleAlignment {
   left,
 }
 
-extension BurninSubtitleAlignmentValue on BurninSubtitleAlignment {
+extension BurninSubtitleAlignmentValueExtension on BurninSubtitleAlignment {
   String toValue() {
     switch (this) {
       case BurninSubtitleAlignment.centered:
@@ -4408,7 +4410,8 @@ enum BurninSubtitleBackgroundColor {
   white,
 }
 
-extension BurninSubtitleBackgroundColorValue on BurninSubtitleBackgroundColor {
+extension BurninSubtitleBackgroundColorValueExtension
+    on BurninSubtitleBackgroundColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleBackgroundColor.none:
@@ -4448,7 +4451,7 @@ enum BurninSubtitleFontColor {
   blue,
 }
 
-extension BurninSubtitleFontColorValue on BurninSubtitleFontColor {
+extension BurninSubtitleFontColorValueExtension on BurninSubtitleFontColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleFontColor.white:
@@ -4500,7 +4503,8 @@ enum BurninSubtitleOutlineColor {
   blue,
 }
 
-extension BurninSubtitleOutlineColorValue on BurninSubtitleOutlineColor {
+extension BurninSubtitleOutlineColorValueExtension
+    on BurninSubtitleOutlineColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleOutlineColor.black:
@@ -4547,7 +4551,7 @@ enum BurninSubtitleShadowColor {
   white,
 }
 
-extension BurninSubtitleShadowColorValue on BurninSubtitleShadowColor {
+extension BurninSubtitleShadowColorValueExtension on BurninSubtitleShadowColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleShadowColor.none:
@@ -4585,7 +4589,8 @@ enum BurninSubtitleTeletextSpacing {
   proportional,
 }
 
-extension BurninSubtitleTeletextSpacingValue on BurninSubtitleTeletextSpacing {
+extension BurninSubtitleTeletextSpacingValueExtension
+    on BurninSubtitleTeletextSpacing {
   String toValue() {
     switch (this) {
       case BurninSubtitleTeletextSpacing.fixedGrid:
@@ -4890,7 +4895,7 @@ enum CaptionDestinationType {
   webvtt,
 }
 
-extension CaptionDestinationTypeValue on CaptionDestinationType {
+extension CaptionDestinationTypeValueExtension on CaptionDestinationType {
   String toValue() {
     switch (this) {
       case CaptionDestinationType.burnIn:
@@ -5161,7 +5166,7 @@ enum CaptionSourceType {
   imsc,
 }
 
-extension CaptionSourceTypeValue on CaptionSourceType {
+extension CaptionSourceTypeValueExtension on CaptionSourceType {
   String toValue() {
     switch (this) {
       case CaptionSourceType.ancillary:
@@ -5305,7 +5310,7 @@ enum CmafClientCache {
   enabled,
 }
 
-extension CmafClientCacheValue on CmafClientCache {
+extension CmafClientCacheValueExtension on CmafClientCache {
   String toValue() {
     switch (this) {
       case CmafClientCache.disabled:
@@ -5335,7 +5340,7 @@ enum CmafCodecSpecification {
   rfc_4281,
 }
 
-extension CmafCodecSpecificationValue on CmafCodecSpecification {
+extension CmafCodecSpecificationValueExtension on CmafCodecSpecification {
   String toValue() {
     switch (this) {
       case CmafCodecSpecification.rfc_6381:
@@ -5446,7 +5451,7 @@ enum CmafEncryptionType {
   aesCtr,
 }
 
-extension CmafEncryptionTypeValue on CmafEncryptionType {
+extension CmafEncryptionTypeValueExtension on CmafEncryptionType {
   String toValue() {
     switch (this) {
       case CmafEncryptionType.sampleAes:
@@ -5714,7 +5719,7 @@ enum CmafInitializationVectorInManifest {
   exclude,
 }
 
-extension CmafInitializationVectorInManifestValue
+extension CmafInitializationVectorInManifestValueExtension
     on CmafInitializationVectorInManifest {
   String toValue() {
     switch (this) {
@@ -5747,7 +5752,7 @@ enum CmafKeyProviderType {
   staticKey,
 }
 
-extension CmafKeyProviderTypeValue on CmafKeyProviderType {
+extension CmafKeyProviderTypeValueExtension on CmafKeyProviderType {
   String toValue() {
     switch (this) {
       case CmafKeyProviderType.speke:
@@ -5776,7 +5781,7 @@ enum CmafManifestCompression {
   none,
 }
 
-extension CmafManifestCompressionValue on CmafManifestCompression {
+extension CmafManifestCompressionValueExtension on CmafManifestCompression {
   String toValue() {
     switch (this) {
       case CmafManifestCompression.gzip:
@@ -5806,7 +5811,8 @@ enum CmafManifestDurationFormat {
   integer,
 }
 
-extension CmafManifestDurationFormatValue on CmafManifestDurationFormat {
+extension CmafManifestDurationFormatValueExtension
+    on CmafManifestDurationFormat {
   String toValue() {
     switch (this) {
       case CmafManifestDurationFormat.floatingPoint:
@@ -5841,7 +5847,7 @@ enum CmafMpdProfile {
   onDemandProfile,
 }
 
-extension CmafMpdProfileValue on CmafMpdProfile {
+extension CmafMpdProfileValueExtension on CmafMpdProfile {
   String toValue() {
     switch (this) {
       case CmafMpdProfile.mainProfile:
@@ -5872,7 +5878,7 @@ enum CmafSegmentControl {
   segmentedFiles,
 }
 
-extension CmafSegmentControlValue on CmafSegmentControl {
+extension CmafSegmentControlValueExtension on CmafSegmentControl {
   String toValue() {
     switch (this) {
       case CmafSegmentControl.singleFile:
@@ -5902,7 +5908,7 @@ enum CmafStreamInfResolution {
   exclude,
 }
 
-extension CmafStreamInfResolutionValue on CmafStreamInfResolution {
+extension CmafStreamInfResolutionValueExtension on CmafStreamInfResolution {
   String toValue() {
     switch (this) {
       case CmafStreamInfResolution.include:
@@ -5931,7 +5937,7 @@ enum CmafWriteDASHManifest {
   enabled,
 }
 
-extension CmafWriteDASHManifestValue on CmafWriteDASHManifest {
+extension CmafWriteDASHManifestValueExtension on CmafWriteDASHManifest {
   String toValue() {
     switch (this) {
       case CmafWriteDASHManifest.disabled:
@@ -5961,7 +5967,7 @@ enum CmafWriteHLSManifest {
   enabled,
 }
 
-extension CmafWriteHLSManifestValue on CmafWriteHLSManifest {
+extension CmafWriteHLSManifestValueExtension on CmafWriteHLSManifest {
   String toValue() {
     switch (this) {
       case CmafWriteHLSManifest.disabled:
@@ -5996,7 +6002,7 @@ enum CmafWriteSegmentTimelineInRepresentation {
   disabled,
 }
 
-extension CmafWriteSegmentTimelineInRepresentationValue
+extension CmafWriteSegmentTimelineInRepresentationValueExtension
     on CmafWriteSegmentTimelineInRepresentation {
   String toValue() {
     switch (this) {
@@ -6041,7 +6047,7 @@ enum CmfcAudioDuration {
   matchVideoDuration,
 }
 
-extension CmfcAudioDurationValue on CmfcAudioDuration {
+extension CmfcAudioDurationValueExtension on CmfcAudioDuration {
   String toValue() {
     switch (this) {
       case CmfcAudioDuration.defaultCodecDuration:
@@ -6073,7 +6079,7 @@ enum CmfcScte35Esam {
   none,
 }
 
-extension CmfcScte35EsamValue on CmfcScte35Esam {
+extension CmfcScte35EsamValueExtension on CmfcScte35Esam {
   String toValue() {
     switch (this) {
       case CmfcScte35Esam.insert:
@@ -6105,7 +6111,7 @@ enum CmfcScte35Source {
   none,
 }
 
-extension CmfcScte35SourceValue on CmfcScte35Source {
+extension CmfcScte35SourceValueExtension on CmfcScte35Source {
   String toValue() {
     switch (this) {
       case CmfcScte35Source.passthrough:
@@ -6269,7 +6275,7 @@ enum ColorMetadata {
   insert,
 }
 
-extension ColorMetadataValue on ColorMetadata {
+extension ColorMetadataValueExtension on ColorMetadata {
   String toValue() {
     switch (this) {
       case ColorMetadata.ignore:
@@ -6310,7 +6316,7 @@ enum ColorSpace {
   hlg_2020,
 }
 
-extension ColorSpaceValue on ColorSpace {
+extension ColorSpaceValueExtension on ColorSpace {
   String toValue() {
     switch (this) {
       case ColorSpace.follow:
@@ -6359,7 +6365,7 @@ enum ColorSpaceConversion {
   forceHlg_2020,
 }
 
-extension ColorSpaceConversionValue on ColorSpaceConversion {
+extension ColorSpaceConversionValueExtension on ColorSpaceConversion {
   String toValue() {
     switch (this) {
       case ColorSpaceConversion.none:
@@ -6408,7 +6414,7 @@ enum ColorSpaceUsage {
   fallback,
 }
 
-extension ColorSpaceUsageValue on ColorSpaceUsage {
+extension ColorSpaceUsageValueExtension on ColorSpaceUsage {
   String toValue() {
     switch (this) {
       case ColorSpaceUsage.force:
@@ -6436,7 +6442,7 @@ enum Commitment {
   oneYear,
 }
 
-extension CommitmentValue on Commitment {
+extension CommitmentValueExtension on Commitment {
   String toValue() {
     switch (this) {
       case Commitment.oneYear:
@@ -6576,7 +6582,7 @@ enum ContainerType {
   raw,
 }
 
-extension ContainerTypeValue on ContainerType {
+extension ContainerTypeValueExtension on ContainerType {
   String toValue() {
     switch (this) {
       case ContainerType.f4v:
@@ -6970,7 +6976,7 @@ enum DashIsoHbbtvCompliance {
   none,
 }
 
-extension DashIsoHbbtvComplianceValue on DashIsoHbbtvCompliance {
+extension DashIsoHbbtvComplianceValueExtension on DashIsoHbbtvCompliance {
   String toValue() {
     switch (this) {
       case DashIsoHbbtvCompliance.hbbtv_1_5:
@@ -7005,7 +7011,7 @@ enum DashIsoMpdProfile {
   onDemandProfile,
 }
 
-extension DashIsoMpdProfileValue on DashIsoMpdProfile {
+extension DashIsoMpdProfileValueExtension on DashIsoMpdProfile {
   String toValue() {
     switch (this) {
       case DashIsoMpdProfile.mainProfile:
@@ -7040,7 +7046,7 @@ enum DashIsoPlaybackDeviceCompatibility {
   unencryptedSei,
 }
 
-extension DashIsoPlaybackDeviceCompatibilityValue
+extension DashIsoPlaybackDeviceCompatibilityValueExtension
     on DashIsoPlaybackDeviceCompatibility {
   String toValue() {
     switch (this) {
@@ -7073,7 +7079,7 @@ enum DashIsoSegmentControl {
   segmentedFiles,
 }
 
-extension DashIsoSegmentControlValue on DashIsoSegmentControl {
+extension DashIsoSegmentControlValueExtension on DashIsoSegmentControl {
   String toValue() {
     switch (this) {
       case DashIsoSegmentControl.singleFile:
@@ -7108,7 +7114,7 @@ enum DashIsoWriteSegmentTimelineInRepresentation {
   disabled,
 }
 
-extension DashIsoWriteSegmentTimelineInRepresentationValue
+extension DashIsoWriteSegmentTimelineInRepresentationValueExtension
     on DashIsoWriteSegmentTimelineInRepresentation {
   String toValue() {
     switch (this) {
@@ -7141,7 +7147,7 @@ enum DecryptionMode {
   aesGcm,
 }
 
-extension DecryptionModeValue on DecryptionMode {
+extension DecryptionModeValueExtension on DecryptionMode {
   String toValue() {
     switch (this) {
       case DecryptionMode.aesCtr:
@@ -7181,7 +7187,7 @@ enum DeinterlaceAlgorithm {
   blendTicker,
 }
 
-extension DeinterlaceAlgorithmValue on DeinterlaceAlgorithm {
+extension DeinterlaceAlgorithmValueExtension on DeinterlaceAlgorithm {
   String toValue() {
     switch (this) {
       case DeinterlaceAlgorithm.interpolate:
@@ -7276,7 +7282,7 @@ enum DeinterlacerControl {
   normal,
 }
 
-extension DeinterlacerControlValue on DeinterlacerControl {
+extension DeinterlacerControlValueExtension on DeinterlacerControl {
   String toValue() {
     switch (this) {
       case DeinterlacerControl.forceAllFrames:
@@ -7309,7 +7315,7 @@ enum DeinterlacerMode {
   adaptive,
 }
 
-extension DeinterlacerModeValue on DeinterlacerMode {
+extension DeinterlacerModeValueExtension on DeinterlacerMode {
   String toValue() {
     switch (this) {
       case DeinterlacerMode.deinterlace:
@@ -7366,7 +7372,7 @@ enum DescribeEndpointsMode {
   getOnly,
 }
 
-extension DescribeEndpointsModeValue on DescribeEndpointsMode {
+extension DescribeEndpointsModeValueExtension on DescribeEndpointsMode {
   String toValue() {
     switch (this) {
       case DescribeEndpointsMode.$default:
@@ -7527,7 +7533,7 @@ enum DolbyVisionLevel6Mode {
   specify,
 }
 
-extension DolbyVisionLevel6ModeValue on DolbyVisionLevel6Mode {
+extension DolbyVisionLevel6ModeValueExtension on DolbyVisionLevel6Mode {
   String toValue() {
     switch (this) {
       case DolbyVisionLevel6Mode.passthrough:
@@ -7561,7 +7567,7 @@ enum DolbyVisionProfile {
   profile_5,
 }
 
-extension DolbyVisionProfileValue on DolbyVisionProfile {
+extension DolbyVisionProfileValueExtension on DolbyVisionProfile {
   String toValue() {
     switch (this) {
       case DolbyVisionProfile.profile_5:
@@ -7590,7 +7596,7 @@ enum DropFrameTimecode {
   enabled,
 }
 
-extension DropFrameTimecodeValue on DropFrameTimecode {
+extension DropFrameTimecodeValueExtension on DropFrameTimecode {
   String toValue() {
     switch (this) {
       case DropFrameTimecode.disabled:
@@ -7943,7 +7949,7 @@ enum DvbSubtitleAlignment {
   left,
 }
 
-extension DvbSubtitleAlignmentValue on DvbSubtitleAlignment {
+extension DvbSubtitleAlignmentValueExtension on DvbSubtitleAlignment {
   String toValue() {
     switch (this) {
       case DvbSubtitleAlignment.centered:
@@ -7974,7 +7980,8 @@ enum DvbSubtitleBackgroundColor {
   white,
 }
 
-extension DvbSubtitleBackgroundColorValue on DvbSubtitleBackgroundColor {
+extension DvbSubtitleBackgroundColorValueExtension
+    on DvbSubtitleBackgroundColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleBackgroundColor.none:
@@ -8014,7 +8021,7 @@ enum DvbSubtitleFontColor {
   blue,
 }
 
-extension DvbSubtitleFontColorValue on DvbSubtitleFontColor {
+extension DvbSubtitleFontColorValueExtension on DvbSubtitleFontColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleFontColor.white:
@@ -8066,7 +8073,7 @@ enum DvbSubtitleOutlineColor {
   blue,
 }
 
-extension DvbSubtitleOutlineColorValue on DvbSubtitleOutlineColor {
+extension DvbSubtitleOutlineColorValueExtension on DvbSubtitleOutlineColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleOutlineColor.black:
@@ -8113,7 +8120,7 @@ enum DvbSubtitleShadowColor {
   white,
 }
 
-extension DvbSubtitleShadowColorValue on DvbSubtitleShadowColor {
+extension DvbSubtitleShadowColorValueExtension on DvbSubtitleShadowColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleShadowColor.none:
@@ -8151,7 +8158,8 @@ enum DvbSubtitleTeletextSpacing {
   proportional,
 }
 
-extension DvbSubtitleTeletextSpacingValue on DvbSubtitleTeletextSpacing {
+extension DvbSubtitleTeletextSpacingValueExtension
+    on DvbSubtitleTeletextSpacing {
   String toValue() {
     switch (this) {
       case DvbSubtitleTeletextSpacing.fixedGrid:
@@ -8182,7 +8190,7 @@ enum DvbSubtitlingType {
   standard,
 }
 
-extension DvbSubtitlingTypeValue on DvbSubtitlingType {
+extension DvbSubtitlingTypeValueExtension on DvbSubtitlingType {
   String toValue() {
     switch (this) {
       case DvbSubtitlingType.hearingImpaired:
@@ -8236,7 +8244,7 @@ enum Eac3AtmosBitstreamMode {
   completeMain,
 }
 
-extension Eac3AtmosBitstreamModeValue on Eac3AtmosBitstreamMode {
+extension Eac3AtmosBitstreamModeValueExtension on Eac3AtmosBitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosBitstreamMode.completeMain:
@@ -8261,7 +8269,7 @@ enum Eac3AtmosCodingMode {
   codingMode_9_1_6,
 }
 
-extension Eac3AtmosCodingModeValue on Eac3AtmosCodingMode {
+extension Eac3AtmosCodingModeValueExtension on Eac3AtmosCodingMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosCodingMode.codingMode_9_1_6:
@@ -8287,7 +8295,8 @@ enum Eac3AtmosDialogueIntelligence {
   disabled,
 }
 
-extension Eac3AtmosDialogueIntelligenceValue on Eac3AtmosDialogueIntelligence {
+extension Eac3AtmosDialogueIntelligenceValueExtension
+    on Eac3AtmosDialogueIntelligence {
   String toValue() {
     switch (this) {
       case Eac3AtmosDialogueIntelligence.enabled:
@@ -8320,7 +8329,7 @@ enum Eac3AtmosDynamicRangeCompressionLine {
   speech,
 }
 
-extension Eac3AtmosDynamicRangeCompressionLineValue
+extension Eac3AtmosDynamicRangeCompressionLineValueExtension
     on Eac3AtmosDynamicRangeCompressionLine {
   String toValue() {
     switch (this) {
@@ -8373,7 +8382,7 @@ enum Eac3AtmosDynamicRangeCompressionRf {
   speech,
 }
 
-extension Eac3AtmosDynamicRangeCompressionRfValue
+extension Eac3AtmosDynamicRangeCompressionRfValueExtension
     on Eac3AtmosDynamicRangeCompressionRf {
   String toValue() {
     switch (this) {
@@ -8423,7 +8432,7 @@ enum Eac3AtmosMeteringMode {
   ituBs_1770_4,
 }
 
-extension Eac3AtmosMeteringModeValue on Eac3AtmosMeteringMode {
+extension Eac3AtmosMeteringModeValueExtension on Eac3AtmosMeteringMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosMeteringMode.leqA:
@@ -8626,7 +8635,7 @@ enum Eac3AtmosStereoDownmix {
   dpl2,
 }
 
-extension Eac3AtmosStereoDownmixValue on Eac3AtmosStereoDownmix {
+extension Eac3AtmosStereoDownmixValueExtension on Eac3AtmosStereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3AtmosStereoDownmix.notIndicated:
@@ -8665,7 +8674,7 @@ enum Eac3AtmosSurroundExMode {
   disabled,
 }
 
-extension Eac3AtmosSurroundExModeValue on Eac3AtmosSurroundExMode {
+extension Eac3AtmosSurroundExModeValueExtension on Eac3AtmosSurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosSurroundExMode.notIndicated:
@@ -8699,7 +8708,7 @@ enum Eac3AttenuationControl {
   none,
 }
 
-extension Eac3AttenuationControlValue on Eac3AttenuationControl {
+extension Eac3AttenuationControlValueExtension on Eac3AttenuationControl {
   String toValue() {
     switch (this) {
       case Eac3AttenuationControl.attenuate_3Db:
@@ -8733,7 +8742,7 @@ enum Eac3BitstreamMode {
   visuallyImpaired,
 }
 
-extension Eac3BitstreamModeValue on Eac3BitstreamMode {
+extension Eac3BitstreamModeValueExtension on Eac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3BitstreamMode.completeMain:
@@ -8775,7 +8784,7 @@ enum Eac3CodingMode {
   codingMode_3_2,
 }
 
-extension Eac3CodingModeValue on Eac3CodingMode {
+extension Eac3CodingModeValueExtension on Eac3CodingMode {
   String toValue() {
     switch (this) {
       case Eac3CodingMode.codingMode_1_0:
@@ -8808,7 +8817,7 @@ enum Eac3DcFilter {
   disabled,
 }
 
-extension Eac3DcFilterValue on Eac3DcFilter {
+extension Eac3DcFilterValueExtension on Eac3DcFilter {
   String toValue() {
     switch (this) {
       case Eac3DcFilter.enabled:
@@ -8841,7 +8850,7 @@ enum Eac3DynamicRangeCompressionLine {
   speech,
 }
 
-extension Eac3DynamicRangeCompressionLineValue
+extension Eac3DynamicRangeCompressionLineValueExtension
     on Eac3DynamicRangeCompressionLine {
   String toValue() {
     switch (this) {
@@ -8893,7 +8902,8 @@ enum Eac3DynamicRangeCompressionRf {
   speech,
 }
 
-extension Eac3DynamicRangeCompressionRfValue on Eac3DynamicRangeCompressionRf {
+extension Eac3DynamicRangeCompressionRfValueExtension
+    on Eac3DynamicRangeCompressionRf {
   String toValue() {
     switch (this) {
       case Eac3DynamicRangeCompressionRf.none:
@@ -8938,7 +8948,7 @@ enum Eac3LfeControl {
   noLfe,
 }
 
-extension Eac3LfeControlValue on Eac3LfeControl {
+extension Eac3LfeControlValueExtension on Eac3LfeControl {
   String toValue() {
     switch (this) {
       case Eac3LfeControl.lfe:
@@ -8968,7 +8978,7 @@ enum Eac3LfeFilter {
   disabled,
 }
 
-extension Eac3LfeFilterValue on Eac3LfeFilter {
+extension Eac3LfeFilterValueExtension on Eac3LfeFilter {
   String toValue() {
     switch (this) {
       case Eac3LfeFilter.enabled:
@@ -8999,7 +9009,7 @@ enum Eac3MetadataControl {
   useConfigured,
 }
 
-extension Eac3MetadataControlValue on Eac3MetadataControl {
+extension Eac3MetadataControlValueExtension on Eac3MetadataControl {
   String toValue() {
     switch (this) {
       case Eac3MetadataControl.followInput:
@@ -9032,7 +9042,7 @@ enum Eac3PassthroughControl {
   noPassthrough,
 }
 
-extension Eac3PassthroughControlValue on Eac3PassthroughControl {
+extension Eac3PassthroughControlValueExtension on Eac3PassthroughControl {
   String toValue() {
     switch (this) {
       case Eac3PassthroughControl.whenPossible:
@@ -9062,7 +9072,7 @@ enum Eac3PhaseControl {
   noShift,
 }
 
-extension Eac3PhaseControlValue on Eac3PhaseControl {
+extension Eac3PhaseControlValueExtension on Eac3PhaseControl {
   String toValue() {
     switch (this) {
       case Eac3PhaseControl.shift_90Degrees:
@@ -9323,7 +9333,7 @@ enum Eac3StereoDownmix {
   dpl2,
 }
 
-extension Eac3StereoDownmixValue on Eac3StereoDownmix {
+extension Eac3StereoDownmixValueExtension on Eac3StereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3StereoDownmix.notIndicated:
@@ -9362,7 +9372,7 @@ enum Eac3SurroundExMode {
   disabled,
 }
 
-extension Eac3SurroundExModeValue on Eac3SurroundExMode {
+extension Eac3SurroundExModeValueExtension on Eac3SurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundExMode.notIndicated:
@@ -9397,7 +9407,7 @@ enum Eac3SurroundMode {
   disabled,
 }
 
-extension Eac3SurroundModeValue on Eac3SurroundMode {
+extension Eac3SurroundModeValueExtension on Eac3SurroundMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundMode.notIndicated:
@@ -9434,7 +9444,7 @@ enum EmbeddedConvert608To708 {
   disabled,
 }
 
-extension EmbeddedConvert608To708Value on EmbeddedConvert608To708 {
+extension EmbeddedConvert608To708ValueExtension on EmbeddedConvert608To708 {
   String toValue() {
     switch (this) {
       case EmbeddedConvert608To708.upconvert:
@@ -9567,7 +9577,7 @@ enum EmbeddedTerminateCaptions {
   disabled,
 }
 
-extension EmbeddedTerminateCaptionsValue on EmbeddedTerminateCaptions {
+extension EmbeddedTerminateCaptionsValueExtension on EmbeddedTerminateCaptions {
   String toValue() {
     switch (this) {
       case EmbeddedTerminateCaptions.endOfInput:
@@ -9729,7 +9739,7 @@ enum F4vMoovPlacement {
   normal,
 }
 
-extension F4vMoovPlacementValue on F4vMoovPlacement {
+extension F4vMoovPlacementValueExtension on F4vMoovPlacement {
   String toValue() {
     switch (this) {
       case F4vMoovPlacement.progressiveDownload:
@@ -9825,7 +9835,7 @@ enum FileSourceConvert608To708 {
   disabled,
 }
 
-extension FileSourceConvert608To708Value on FileSourceConvert608To708 {
+extension FileSourceConvert608To708ValueExtension on FileSourceConvert608To708 {
   String toValue() {
     switch (this) {
       case FileSourceConvert608To708.upconvert:
@@ -9919,7 +9929,7 @@ enum FontScript {
   hant,
 }
 
-extension FontScriptValue on FontScript {
+extension FontScriptValueExtension on FontScript {
   String toValue() {
     switch (this) {
       case FontScript.automatic:
@@ -10093,7 +10103,7 @@ enum H264AdaptiveQuantization {
   max,
 }
 
-extension H264AdaptiveQuantizationValue on H264AdaptiveQuantization {
+extension H264AdaptiveQuantizationValueExtension on H264AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264AdaptiveQuantization.off:
@@ -10158,7 +10168,7 @@ enum H264CodecLevel {
   level_5_2,
 }
 
-extension H264CodecLevelValue on H264CodecLevel {
+extension H264CodecLevelValueExtension on H264CodecLevel {
   String toValue() {
     switch (this) {
       case H264CodecLevel.auto:
@@ -10252,7 +10262,7 @@ enum H264CodecProfile {
   main,
 }
 
-extension H264CodecProfileValue on H264CodecProfile {
+extension H264CodecProfileValueExtension on H264CodecProfile {
   String toValue() {
     switch (this) {
       case H264CodecProfile.baseline:
@@ -10302,7 +10312,7 @@ enum H264DynamicSubGop {
   static,
 }
 
-extension H264DynamicSubGopValue on H264DynamicSubGop {
+extension H264DynamicSubGopValueExtension on H264DynamicSubGop {
   String toValue() {
     switch (this) {
       case H264DynamicSubGop.adaptive:
@@ -10331,7 +10341,7 @@ enum H264EntropyEncoding {
   cavlc,
 }
 
-extension H264EntropyEncodingValue on H264EntropyEncoding {
+extension H264EntropyEncodingValueExtension on H264EntropyEncoding {
   String toValue() {
     switch (this) {
       case H264EntropyEncoding.cabac:
@@ -10362,7 +10372,7 @@ enum H264FieldEncoding {
   forceField,
 }
 
-extension H264FieldEncodingValue on H264FieldEncoding {
+extension H264FieldEncodingValueExtension on H264FieldEncoding {
   String toValue() {
     switch (this) {
       case H264FieldEncoding.paff:
@@ -10404,7 +10414,7 @@ enum H264FlickerAdaptiveQuantization {
   enabled,
 }
 
-extension H264FlickerAdaptiveQuantizationValue
+extension H264FlickerAdaptiveQuantizationValueExtension
     on H264FlickerAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -10446,7 +10456,7 @@ enum H264FramerateControl {
   specified,
 }
 
-extension H264FramerateControlValue on H264FramerateControl {
+extension H264FramerateControlValueExtension on H264FramerateControl {
   String toValue() {
     switch (this) {
       case H264FramerateControl.initializeFromSource:
@@ -10486,7 +10496,7 @@ enum H264FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension H264FramerateConversionAlgorithmValue
+extension H264FramerateConversionAlgorithmValueExtension
     on H264FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -10521,7 +10531,7 @@ enum H264GopBReference {
   enabled,
 }
 
-extension H264GopBReferenceValue on H264GopBReference {
+extension H264GopBReferenceValueExtension on H264GopBReference {
   String toValue() {
     switch (this) {
       case H264GopBReference.disabled:
@@ -10551,7 +10561,7 @@ enum H264GopSizeUnits {
   seconds,
 }
 
-extension H264GopSizeUnitsValue on H264GopSizeUnits {
+extension H264GopSizeUnitsValueExtension on H264GopSizeUnits {
   String toValue() {
     switch (this) {
       case H264GopSizeUnits.frames:
@@ -10594,7 +10604,7 @@ enum H264InterlaceMode {
   followBottomField,
 }
 
-extension H264InterlaceModeValue on H264InterlaceMode {
+extension H264InterlaceModeValueExtension on H264InterlaceMode {
   String toValue() {
     switch (this) {
       case H264InterlaceMode.progressive:
@@ -10642,7 +10652,7 @@ enum H264ParControl {
   specified,
 }
 
-extension H264ParControlValue on H264ParControl {
+extension H264ParControlValueExtension on H264ParControl {
   String toValue() {
     switch (this) {
       case H264ParControl.initializeFromSource:
@@ -10674,7 +10684,7 @@ enum H264QualityTuningLevel {
   multiPassHq,
 }
 
-extension H264QualityTuningLevelValue on H264QualityTuningLevel {
+extension H264QualityTuningLevelValueExtension on H264QualityTuningLevel {
   String toValue() {
     switch (this) {
       case H264QualityTuningLevel.singlePass:
@@ -10767,7 +10777,7 @@ enum H264RateControlMode {
   qvbr,
 }
 
-extension H264RateControlModeValue on H264RateControlMode {
+extension H264RateControlModeValueExtension on H264RateControlMode {
   String toValue() {
     switch (this) {
       case H264RateControlMode.vbr:
@@ -10800,7 +10810,7 @@ enum H264RepeatPps {
   enabled,
 }
 
-extension H264RepeatPpsValue on H264RepeatPps {
+extension H264RepeatPpsValueExtension on H264RepeatPps {
   String toValue() {
     switch (this) {
       case H264RepeatPps.disabled:
@@ -10835,7 +10845,7 @@ enum H264SceneChangeDetect {
   transitionDetection,
 }
 
-extension H264SceneChangeDetectValue on H264SceneChangeDetect {
+extension H264SceneChangeDetectValueExtension on H264SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H264SceneChangeDetect.disabled:
@@ -11387,7 +11397,7 @@ enum H264SlowPal {
   enabled,
 }
 
-extension H264SlowPalValue on H264SlowPal {
+extension H264SlowPalValueExtension on H264SlowPal {
   String toValue() {
     switch (this) {
       case H264SlowPal.disabled:
@@ -11439,7 +11449,7 @@ enum H264SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension H264SpatialAdaptiveQuantizationValue
+extension H264SpatialAdaptiveQuantizationValueExtension
     on H264SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -11470,7 +11480,7 @@ enum H264Syntax {
   rp2027,
 }
 
-extension H264SyntaxValue on H264Syntax {
+extension H264SyntaxValueExtension on H264Syntax {
   String toValue() {
     switch (this) {
       case H264Syntax.$default:
@@ -11507,7 +11517,7 @@ enum H264Telecine {
   hard,
 }
 
-extension H264TelecineValue on H264Telecine {
+extension H264TelecineValueExtension on H264Telecine {
   String toValue() {
     switch (this) {
       case H264Telecine.none:
@@ -11561,7 +11571,7 @@ enum H264TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension H264TemporalAdaptiveQuantizationValue
+extension H264TemporalAdaptiveQuantizationValueExtension
     on H264TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -11592,7 +11602,8 @@ enum H264UnregisteredSeiTimecode {
   enabled,
 }
 
-extension H264UnregisteredSeiTimecodeValue on H264UnregisteredSeiTimecode {
+extension H264UnregisteredSeiTimecodeValueExtension
+    on H264UnregisteredSeiTimecode {
   String toValue() {
     switch (this) {
       case H264UnregisteredSeiTimecode.disabled:
@@ -11629,7 +11640,7 @@ enum H265AdaptiveQuantization {
   max,
 }
 
-extension H265AdaptiveQuantizationValue on H265AdaptiveQuantization {
+extension H265AdaptiveQuantizationValueExtension on H265AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265AdaptiveQuantization.off:
@@ -11675,7 +11686,7 @@ enum H265AlternateTransferFunctionSei {
   enabled,
 }
 
-extension H265AlternateTransferFunctionSeiValue
+extension H265AlternateTransferFunctionSeiValueExtension
     on H265AlternateTransferFunctionSei {
   String toValue() {
     switch (this) {
@@ -11718,7 +11729,7 @@ enum H265CodecLevel {
   level_6_2,
 }
 
-extension H265CodecLevelValue on H265CodecLevel {
+extension H265CodecLevelValueExtension on H265CodecLevel {
   String toValue() {
     switch (this) {
       case H265CodecLevel.auto:
@@ -11804,7 +11815,7 @@ enum H265CodecProfile {
   main_422_10bitHigh,
 }
 
-extension H265CodecProfileValue on H265CodecProfile {
+extension H265CodecProfileValueExtension on H265CodecProfile {
   String toValue() {
     switch (this) {
       case H265CodecProfile.mainMain:
@@ -11862,7 +11873,7 @@ enum H265DynamicSubGop {
   static,
 }
 
-extension H265DynamicSubGopValue on H265DynamicSubGop {
+extension H265DynamicSubGopValueExtension on H265DynamicSubGop {
   String toValue() {
     switch (this) {
       case H265DynamicSubGop.adaptive:
@@ -11897,7 +11908,7 @@ enum H265FlickerAdaptiveQuantization {
   enabled,
 }
 
-extension H265FlickerAdaptiveQuantizationValue
+extension H265FlickerAdaptiveQuantizationValueExtension
     on H265FlickerAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -11939,7 +11950,7 @@ enum H265FramerateControl {
   specified,
 }
 
-extension H265FramerateControlValue on H265FramerateControl {
+extension H265FramerateControlValueExtension on H265FramerateControl {
   String toValue() {
     switch (this) {
       case H265FramerateControl.initializeFromSource:
@@ -11979,7 +11990,7 @@ enum H265FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension H265FramerateConversionAlgorithmValue
+extension H265FramerateConversionAlgorithmValueExtension
     on H265FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -12014,7 +12025,7 @@ enum H265GopBReference {
   enabled,
 }
 
-extension H265GopBReferenceValue on H265GopBReference {
+extension H265GopBReferenceValueExtension on H265GopBReference {
   String toValue() {
     switch (this) {
       case H265GopBReference.disabled:
@@ -12044,7 +12055,7 @@ enum H265GopSizeUnits {
   seconds,
 }
 
-extension H265GopSizeUnitsValue on H265GopSizeUnits {
+extension H265GopSizeUnitsValueExtension on H265GopSizeUnits {
   String toValue() {
     switch (this) {
       case H265GopSizeUnits.frames:
@@ -12087,7 +12098,7 @@ enum H265InterlaceMode {
   followBottomField,
 }
 
-extension H265InterlaceModeValue on H265InterlaceMode {
+extension H265InterlaceModeValueExtension on H265InterlaceMode {
   String toValue() {
     switch (this) {
       case H265InterlaceMode.progressive:
@@ -12135,7 +12146,7 @@ enum H265ParControl {
   specified,
 }
 
-extension H265ParControlValue on H265ParControl {
+extension H265ParControlValueExtension on H265ParControl {
   String toValue() {
     switch (this) {
       case H265ParControl.initializeFromSource:
@@ -12167,7 +12178,7 @@ enum H265QualityTuningLevel {
   multiPassHq,
 }
 
-extension H265QualityTuningLevelValue on H265QualityTuningLevel {
+extension H265QualityTuningLevelValueExtension on H265QualityTuningLevel {
   String toValue() {
     switch (this) {
       case H265QualityTuningLevel.singlePass:
@@ -12260,7 +12271,7 @@ enum H265RateControlMode {
   qvbr,
 }
 
-extension H265RateControlModeValue on H265RateControlMode {
+extension H265RateControlModeValueExtension on H265RateControlMode {
   String toValue() {
     switch (this) {
       case H265RateControlMode.vbr:
@@ -12295,7 +12306,7 @@ enum H265SampleAdaptiveOffsetFilterMode {
   off,
 }
 
-extension H265SampleAdaptiveOffsetFilterModeValue
+extension H265SampleAdaptiveOffsetFilterModeValueExtension
     on H265SampleAdaptiveOffsetFilterMode {
   String toValue() {
     switch (this) {
@@ -12336,7 +12347,7 @@ enum H265SceneChangeDetect {
   transitionDetection,
 }
 
-extension H265SceneChangeDetectValue on H265SceneChangeDetect {
+extension H265SceneChangeDetectValueExtension on H265SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H265SceneChangeDetect.disabled:
@@ -12873,7 +12884,7 @@ enum H265SlowPal {
   enabled,
 }
 
-extension H265SlowPalValue on H265SlowPal {
+extension H265SlowPalValueExtension on H265SlowPal {
   String toValue() {
     switch (this) {
       case H265SlowPal.disabled:
@@ -12916,7 +12927,7 @@ enum H265SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension H265SpatialAdaptiveQuantizationValue
+extension H265SpatialAdaptiveQuantizationValueExtension
     on H265SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -12954,7 +12965,7 @@ enum H265Telecine {
   hard,
 }
 
-extension H265TelecineValue on H265Telecine {
+extension H265TelecineValueExtension on H265Telecine {
   String toValue() {
     switch (this) {
       case H265Telecine.none:
@@ -12999,7 +13010,7 @@ enum H265TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension H265TemporalAdaptiveQuantizationValue
+extension H265TemporalAdaptiveQuantizationValueExtension
     on H265TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -13037,7 +13048,7 @@ enum H265TemporalIds {
   enabled,
 }
 
-extension H265TemporalIdsValue on H265TemporalIds {
+extension H265TemporalIdsValueExtension on H265TemporalIds {
   String toValue() {
     switch (this) {
       case H265TemporalIds.disabled:
@@ -13067,7 +13078,7 @@ enum H265Tiles {
   enabled,
 }
 
-extension H265TilesValue on H265Tiles {
+extension H265TilesValueExtension on H265Tiles {
   String toValue() {
     switch (this) {
       case H265Tiles.disabled:
@@ -13096,7 +13107,8 @@ enum H265UnregisteredSeiTimecode {
   enabled,
 }
 
-extension H265UnregisteredSeiTimecodeValue on H265UnregisteredSeiTimecode {
+extension H265UnregisteredSeiTimecodeValueExtension
+    on H265UnregisteredSeiTimecode {
   String toValue() {
     switch (this) {
       case H265UnregisteredSeiTimecode.disabled:
@@ -13135,7 +13147,7 @@ enum H265WriteMp4PackagingType {
   hev1,
 }
 
-extension H265WriteMp4PackagingTypeValue on H265WriteMp4PackagingType {
+extension H265WriteMp4PackagingTypeValueExtension on H265WriteMp4PackagingType {
   String toValue() {
     switch (this) {
       case H265WriteMp4PackagingType.hvc1:
@@ -13298,7 +13310,7 @@ enum HlsAdMarkers {
   elementalScte35,
 }
 
-extension HlsAdMarkersValue on HlsAdMarkers {
+extension HlsAdMarkersValueExtension on HlsAdMarkers {
   String toValue() {
     switch (this) {
       case HlsAdMarkers.elemental:
@@ -13375,7 +13387,7 @@ enum HlsAudioOnlyContainer {
   m2ts,
 }
 
-extension HlsAudioOnlyContainerValue on HlsAudioOnlyContainer {
+extension HlsAudioOnlyContainerValueExtension on HlsAudioOnlyContainer {
   String toValue() {
     switch (this) {
       case HlsAudioOnlyContainer.automatic:
@@ -13407,7 +13419,7 @@ enum HlsAudioOnlyHeader {
   exclude,
 }
 
-extension HlsAudioOnlyHeaderValue on HlsAudioOnlyHeader {
+extension HlsAudioOnlyHeaderValueExtension on HlsAudioOnlyHeader {
   String toValue() {
     switch (this) {
       case HlsAudioOnlyHeader.include:
@@ -13448,7 +13460,7 @@ enum HlsAudioTrackType {
   audioOnlyVariantStream,
 }
 
-extension HlsAudioTrackTypeValue on HlsAudioTrackType {
+extension HlsAudioTrackTypeValueExtension on HlsAudioTrackType {
   String toValue() {
     switch (this) {
       case HlsAudioTrackType.alternateAudioAutoSelectDefault:
@@ -13540,7 +13552,7 @@ enum HlsCaptionLanguageSetting {
   none,
 }
 
-extension HlsCaptionLanguageSettingValue on HlsCaptionLanguageSetting {
+extension HlsCaptionLanguageSettingValueExtension on HlsCaptionLanguageSetting {
   String toValue() {
     switch (this) {
       case HlsCaptionLanguageSetting.insert:
@@ -13576,7 +13588,7 @@ enum HlsClientCache {
   enabled,
 }
 
-extension HlsClientCacheValue on HlsClientCache {
+extension HlsClientCacheValueExtension on HlsClientCache {
   String toValue() {
     switch (this) {
       case HlsClientCache.disabled:
@@ -13606,7 +13618,7 @@ enum HlsCodecSpecification {
   rfc_4281,
 }
 
-extension HlsCodecSpecificationValue on HlsCodecSpecification {
+extension HlsCodecSpecificationValueExtension on HlsCodecSpecification {
   String toValue() {
     switch (this) {
       case HlsCodecSpecification.rfc_6381:
@@ -13635,7 +13647,7 @@ enum HlsDirectoryStructure {
   subdirectoryPerStream,
 }
 
-extension HlsDirectoryStructureValue on HlsDirectoryStructure {
+extension HlsDirectoryStructureValueExtension on HlsDirectoryStructure {
   String toValue() {
     switch (this) {
       case HlsDirectoryStructure.singleDirectory:
@@ -13757,7 +13769,7 @@ enum HlsEncryptionType {
   sampleAes,
 }
 
-extension HlsEncryptionTypeValue on HlsEncryptionType {
+extension HlsEncryptionTypeValueExtension on HlsEncryptionType {
   String toValue() {
     switch (this) {
       case HlsEncryptionType.aes128:
@@ -14079,7 +14091,7 @@ enum HlsIFrameOnlyManifest {
   exclude,
 }
 
-extension HlsIFrameOnlyManifestValue on HlsIFrameOnlyManifest {
+extension HlsIFrameOnlyManifestValueExtension on HlsIFrameOnlyManifest {
   String toValue() {
     switch (this) {
       case HlsIFrameOnlyManifest.include:
@@ -14111,7 +14123,7 @@ enum HlsInitializationVectorInManifest {
   exclude,
 }
 
-extension HlsInitializationVectorInManifestValue
+extension HlsInitializationVectorInManifestValueExtension
     on HlsInitializationVectorInManifest {
   String toValue() {
     switch (this) {
@@ -14144,7 +14156,7 @@ enum HlsKeyProviderType {
   staticKey,
 }
 
-extension HlsKeyProviderTypeValue on HlsKeyProviderType {
+extension HlsKeyProviderTypeValueExtension on HlsKeyProviderType {
   String toValue() {
     switch (this) {
       case HlsKeyProviderType.speke:
@@ -14173,7 +14185,7 @@ enum HlsManifestCompression {
   none,
 }
 
-extension HlsManifestCompressionValue on HlsManifestCompression {
+extension HlsManifestCompressionValueExtension on HlsManifestCompression {
   String toValue() {
     switch (this) {
       case HlsManifestCompression.gzip:
@@ -14203,7 +14215,7 @@ enum HlsManifestDurationFormat {
   integer,
 }
 
-extension HlsManifestDurationFormatValue on HlsManifestDurationFormat {
+extension HlsManifestDurationFormatValueExtension on HlsManifestDurationFormat {
   String toValue() {
     switch (this) {
       case HlsManifestDurationFormat.floatingPoint:
@@ -14233,7 +14245,7 @@ enum HlsOfflineEncrypted {
   disabled,
 }
 
-extension HlsOfflineEncryptedValue on HlsOfflineEncrypted {
+extension HlsOfflineEncryptedValueExtension on HlsOfflineEncrypted {
   String toValue() {
     switch (this) {
       case HlsOfflineEncrypted.enabled:
@@ -14263,7 +14275,7 @@ enum HlsOutputSelection {
   segmentsOnly,
 }
 
-extension HlsOutputSelectionValue on HlsOutputSelection {
+extension HlsOutputSelectionValueExtension on HlsOutputSelection {
   String toValue() {
     switch (this) {
       case HlsOutputSelection.manifestsAndSegments:
@@ -14296,7 +14308,7 @@ enum HlsProgramDateTime {
   exclude,
 }
 
-extension HlsProgramDateTimeValue on HlsProgramDateTime {
+extension HlsProgramDateTimeValueExtension on HlsProgramDateTime {
   String toValue() {
     switch (this) {
       case HlsProgramDateTime.include:
@@ -14326,7 +14338,7 @@ enum HlsSegmentControl {
   segmentedFiles,
 }
 
-extension HlsSegmentControlValue on HlsSegmentControl {
+extension HlsSegmentControlValueExtension on HlsSegmentControl {
   String toValue() {
     switch (this) {
       case HlsSegmentControl.singleFile:
@@ -14438,7 +14450,7 @@ enum HlsStreamInfResolution {
   exclude,
 }
 
-extension HlsStreamInfResolutionValue on HlsStreamInfResolution {
+extension HlsStreamInfResolutionValueExtension on HlsStreamInfResolution {
   String toValue() {
     switch (this) {
       case HlsStreamInfResolution.include:
@@ -14468,7 +14480,7 @@ enum HlsTimedMetadataId3Frame {
   tdrl,
 }
 
-extension HlsTimedMetadataId3FrameValue on HlsTimedMetadataId3Frame {
+extension HlsTimedMetadataId3FrameValueExtension on HlsTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case HlsTimedMetadataId3Frame.none:
@@ -14637,7 +14649,7 @@ enum ImscStylePassthrough {
   disabled,
 }
 
-extension ImscStylePassthroughValue on ImscStylePassthrough {
+extension ImscStylePassthroughValueExtension on ImscStylePassthrough {
   String toValue() {
     switch (this) {
       case ImscStylePassthrough.enabled:
@@ -14973,7 +14985,7 @@ enum InputDeblockFilter {
   disabled,
 }
 
-extension InputDeblockFilterValue on InputDeblockFilter {
+extension InputDeblockFilterValueExtension on InputDeblockFilter {
   String toValue() {
     switch (this) {
       case InputDeblockFilter.enabled:
@@ -15062,7 +15074,7 @@ enum InputDenoiseFilter {
   disabled,
 }
 
-extension InputDenoiseFilterValue on InputDenoiseFilter {
+extension InputDenoiseFilterValueExtension on InputDenoiseFilter {
   String toValue() {
     switch (this) {
       case InputDenoiseFilter.enabled:
@@ -15099,7 +15111,7 @@ enum InputFilterEnable {
   force,
 }
 
-extension InputFilterEnableValue on InputFilterEnable {
+extension InputFilterEnableValueExtension on InputFilterEnable {
   String toValue() {
     switch (this) {
       case InputFilterEnable.auto:
@@ -15134,7 +15146,7 @@ enum InputPsiControl {
   usePsi,
 }
 
-extension InputPsiControlValue on InputPsiControl {
+extension InputPsiControlValueExtension on InputPsiControl {
   String toValue() {
     switch (this) {
       case InputPsiControl.ignorePsi:
@@ -15175,7 +15187,7 @@ enum InputRotate {
   auto,
 }
 
-extension InputRotateValue on InputRotate {
+extension InputRotateValueExtension on InputRotate {
   String toValue() {
     switch (this) {
       case InputRotate.degree_0:
@@ -15222,7 +15234,7 @@ enum InputScanType {
   psf,
 }
 
-extension InputScanTypeValue on InputScanType {
+extension InputScanTypeValueExtension on InputScanType {
   String toValue() {
     switch (this) {
       case InputScanType.auto:
@@ -15479,7 +15491,7 @@ enum InputTimecodeSource {
   specifiedstart,
 }
 
-extension InputTimecodeSourceValue on InputTimecodeSource {
+extension InputTimecodeSourceValueExtension on InputTimecodeSource {
   String toValue() {
     switch (this) {
       case InputTimecodeSource.embedded:
@@ -15854,7 +15866,7 @@ enum JobPhase {
   uploading,
 }
 
-extension JobPhaseValue on JobPhase {
+extension JobPhaseValueExtension on JobPhase {
   String toValue() {
     switch (this) {
       case JobPhase.probing:
@@ -16036,7 +16048,7 @@ enum JobStatus {
   error,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -16173,7 +16185,7 @@ enum JobTemplateListBy {
   system,
 }
 
-extension JobTemplateListByValue on JobTemplateListBy {
+extension JobTemplateListByValueExtension on JobTemplateListBy {
   String toValue() {
     switch (this) {
       case JobTemplateListBy.name:
@@ -16543,7 +16555,7 @@ enum LanguageCode {
   tng,
 }
 
-extension LanguageCodeValue on LanguageCode {
+extension LanguageCodeValueExtension on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.eng:
@@ -17433,7 +17445,7 @@ enum M2tsAudioBufferModel {
   atsc,
 }
 
-extension M2tsAudioBufferModelValue on M2tsAudioBufferModel {
+extension M2tsAudioBufferModelValueExtension on M2tsAudioBufferModel {
   String toValue() {
     switch (this) {
       case M2tsAudioBufferModel.dvb:
@@ -17475,7 +17487,7 @@ enum M2tsAudioDuration {
   matchVideoDuration,
 }
 
-extension M2tsAudioDurationValue on M2tsAudioDuration {
+extension M2tsAudioDurationValueExtension on M2tsAudioDuration {
   String toValue() {
     switch (this) {
       case M2tsAudioDuration.defaultCodecDuration:
@@ -17507,7 +17519,7 @@ enum M2tsBufferModel {
   none,
 }
 
-extension M2tsBufferModelValue on M2tsBufferModel {
+extension M2tsBufferModelValueExtension on M2tsBufferModel {
   String toValue() {
     switch (this) {
       case M2tsBufferModel.multiplex:
@@ -17541,7 +17553,7 @@ enum M2tsEbpAudioInterval {
   videoInterval,
 }
 
-extension M2tsEbpAudioIntervalValue on M2tsEbpAudioInterval {
+extension M2tsEbpAudioIntervalValueExtension on M2tsEbpAudioInterval {
   String toValue() {
     switch (this) {
       case M2tsEbpAudioInterval.videoAndFixedIntervals:
@@ -17573,7 +17585,7 @@ enum M2tsEbpPlacement {
   videoPid,
 }
 
-extension M2tsEbpPlacementValue on M2tsEbpPlacement {
+extension M2tsEbpPlacementValueExtension on M2tsEbpPlacement {
   String toValue() {
     switch (this) {
       case M2tsEbpPlacement.videoAndAudioPids:
@@ -17602,7 +17614,7 @@ enum M2tsEsRateInPes {
   exclude,
 }
 
-extension M2tsEsRateInPesValue on M2tsEsRateInPes {
+extension M2tsEsRateInPesValueExtension on M2tsEsRateInPes {
   String toValue() {
     switch (this) {
       case M2tsEsRateInPes.include:
@@ -17633,7 +17645,7 @@ enum M2tsForceTsVideoEbpOrder {
   $default,
 }
 
-extension M2tsForceTsVideoEbpOrderValue on M2tsForceTsVideoEbpOrder {
+extension M2tsForceTsVideoEbpOrderValueExtension on M2tsForceTsVideoEbpOrder {
   String toValue() {
     switch (this) {
       case M2tsForceTsVideoEbpOrder.force:
@@ -17663,7 +17675,7 @@ enum M2tsNielsenId3 {
   none,
 }
 
-extension M2tsNielsenId3Value on M2tsNielsenId3 {
+extension M2tsNielsenId3ValueExtension on M2tsNielsenId3 {
   String toValue() {
     switch (this) {
       case M2tsNielsenId3.insert:
@@ -17695,7 +17707,7 @@ enum M2tsPcrControl {
   configuredPcrPeriod,
 }
 
-extension M2tsPcrControlValue on M2tsPcrControl {
+extension M2tsPcrControlValueExtension on M2tsPcrControl {
   String toValue() {
     switch (this) {
       case M2tsPcrControl.pcrEveryPesPacket:
@@ -17726,7 +17738,7 @@ enum M2tsRateMode {
   cbr,
 }
 
-extension M2tsRateModeValue on M2tsRateMode {
+extension M2tsRateModeValueExtension on M2tsRateMode {
   String toValue() {
     switch (this) {
       case M2tsRateMode.vbr:
@@ -17787,7 +17799,7 @@ enum M2tsScte35Source {
   none,
 }
 
-extension M2tsScte35SourceValue on M2tsScte35Source {
+extension M2tsScte35SourceValueExtension on M2tsScte35Source {
   String toValue() {
     switch (this) {
       case M2tsScte35Source.passthrough:
@@ -17826,7 +17838,7 @@ enum M2tsSegmentationMarkers {
   ebpLegacy,
 }
 
-extension M2tsSegmentationMarkersValue on M2tsSegmentationMarkers {
+extension M2tsSegmentationMarkersValueExtension on M2tsSegmentationMarkers {
   String toValue() {
     switch (this) {
       case M2tsSegmentationMarkers.none:
@@ -17882,7 +17894,7 @@ enum M2tsSegmentationStyle {
   resetCadence,
 }
 
-extension M2tsSegmentationStyleValue on M2tsSegmentationStyle {
+extension M2tsSegmentationStyleValueExtension on M2tsSegmentationStyle {
   String toValue() {
     switch (this) {
       case M2tsSegmentationStyle.maintainCadence:
@@ -18324,7 +18336,7 @@ enum M3u8AudioDuration {
   matchVideoDuration,
 }
 
-extension M3u8AudioDurationValue on M3u8AudioDuration {
+extension M3u8AudioDurationValueExtension on M3u8AudioDuration {
   String toValue() {
     switch (this) {
       case M3u8AudioDuration.defaultCodecDuration:
@@ -18354,7 +18366,7 @@ enum M3u8NielsenId3 {
   none,
 }
 
-extension M3u8NielsenId3Value on M3u8NielsenId3 {
+extension M3u8NielsenId3ValueExtension on M3u8NielsenId3 {
   String toValue() {
     switch (this) {
       case M3u8NielsenId3.insert:
@@ -18386,7 +18398,7 @@ enum M3u8PcrControl {
   configuredPcrPeriod,
 }
 
-extension M3u8PcrControlValue on M3u8PcrControl {
+extension M3u8PcrControlValueExtension on M3u8PcrControl {
   String toValue() {
     switch (this) {
       case M3u8PcrControl.pcrEveryPesPacket:
@@ -18422,7 +18434,7 @@ enum M3u8Scte35Source {
   none,
 }
 
-extension M3u8Scte35SourceValue on M3u8Scte35Source {
+extension M3u8Scte35SourceValueExtension on M3u8Scte35Source {
   String toValue() {
     switch (this) {
       case M3u8Scte35Source.passthrough:
@@ -18756,7 +18768,7 @@ enum MotionImageInsertionMode {
   png,
 }
 
-extension MotionImageInsertionModeValue on MotionImageInsertionMode {
+extension MotionImageInsertionModeValueExtension on MotionImageInsertionMode {
   String toValue() {
     switch (this) {
       case MotionImageInsertionMode.mov:
@@ -18818,7 +18830,7 @@ enum MotionImagePlayback {
   repeat,
 }
 
-extension MotionImagePlaybackValue on MotionImagePlayback {
+extension MotionImagePlaybackValueExtension on MotionImagePlayback {
   String toValue() {
     switch (this) {
       case MotionImagePlayback.once:
@@ -18848,7 +18860,7 @@ enum MovClapAtom {
   exclude,
 }
 
-extension MovClapAtomValue on MovClapAtom {
+extension MovClapAtomValueExtension on MovClapAtom {
   String toValue() {
     switch (this) {
       case MovClapAtom.include:
@@ -18881,7 +18893,7 @@ enum MovCslgAtom {
   exclude,
 }
 
-extension MovCslgAtomValue on MovCslgAtom {
+extension MovCslgAtomValueExtension on MovCslgAtom {
   String toValue() {
     switch (this) {
       case MovCslgAtom.include:
@@ -18913,7 +18925,7 @@ enum MovMpeg2FourCCControl {
   mpeg,
 }
 
-extension MovMpeg2FourCCControlValue on MovMpeg2FourCCControl {
+extension MovMpeg2FourCCControlValueExtension on MovMpeg2FourCCControl {
   String toValue() {
     switch (this) {
       case MovMpeg2FourCCControl.xdcam:
@@ -18946,7 +18958,7 @@ enum MovPaddingControl {
   none,
 }
 
-extension MovPaddingControlValue on MovPaddingControl {
+extension MovPaddingControlValueExtension on MovPaddingControl {
   String toValue() {
     switch (this) {
       case MovPaddingControl.omneon:
@@ -18975,7 +18987,7 @@ enum MovReference {
   external,
 }
 
-extension MovReferenceValue on MovReference {
+extension MovReferenceValueExtension on MovReference {
   String toValue() {
     switch (this) {
       case MovReference.selfContained:
@@ -19109,7 +19121,7 @@ enum Mp3RateControlMode {
   vbr,
 }
 
-extension Mp3RateControlModeValue on Mp3RateControlMode {
+extension Mp3RateControlModeValueExtension on Mp3RateControlMode {
   String toValue() {
     switch (this) {
       case Mp3RateControlMode.cbr:
@@ -19199,7 +19211,7 @@ enum Mp4CslgAtom {
   exclude,
 }
 
-extension Mp4CslgAtomValue on Mp4CslgAtom {
+extension Mp4CslgAtomValueExtension on Mp4CslgAtom {
   String toValue() {
     switch (this) {
       case Mp4CslgAtom.include:
@@ -19228,7 +19240,7 @@ enum Mp4FreeSpaceBox {
   exclude,
 }
 
-extension Mp4FreeSpaceBoxValue on Mp4FreeSpaceBox {
+extension Mp4FreeSpaceBoxValueExtension on Mp4FreeSpaceBox {
   String toValue() {
     switch (this) {
       case Mp4FreeSpaceBox.include:
@@ -19259,7 +19271,7 @@ enum Mp4MoovPlacement {
   normal,
 }
 
-extension Mp4MoovPlacementValue on Mp4MoovPlacement {
+extension Mp4MoovPlacementValueExtension on Mp4MoovPlacement {
   String toValue() {
     switch (this) {
       case Mp4MoovPlacement.progressiveDownload:
@@ -19377,7 +19389,8 @@ enum MpdAccessibilityCaptionHints {
   exclude,
 }
 
-extension MpdAccessibilityCaptionHintsValue on MpdAccessibilityCaptionHints {
+extension MpdAccessibilityCaptionHintsValueExtension
+    on MpdAccessibilityCaptionHints {
   String toValue() {
     switch (this) {
       case MpdAccessibilityCaptionHints.include:
@@ -19419,7 +19432,7 @@ enum MpdAudioDuration {
   matchVideoDuration,
 }
 
-extension MpdAudioDurationValue on MpdAudioDuration {
+extension MpdAudioDurationValueExtension on MpdAudioDuration {
   String toValue() {
     switch (this) {
       case MpdAudioDuration.defaultCodecDuration:
@@ -19453,7 +19466,7 @@ enum MpdCaptionContainerType {
   fragmentedMp4,
 }
 
-extension MpdCaptionContainerTypeValue on MpdCaptionContainerType {
+extension MpdCaptionContainerTypeValueExtension on MpdCaptionContainerType {
   String toValue() {
     switch (this) {
       case MpdCaptionContainerType.raw:
@@ -19485,7 +19498,7 @@ enum MpdScte35Esam {
   none,
 }
 
-extension MpdScte35EsamValue on MpdScte35Esam {
+extension MpdScte35EsamValueExtension on MpdScte35Esam {
   String toValue() {
     switch (this) {
       case MpdScte35Esam.insert:
@@ -19517,7 +19530,7 @@ enum MpdScte35Source {
   none,
 }
 
-extension MpdScte35SourceValue on MpdScte35Source {
+extension MpdScte35SourceValueExtension on MpdScte35Source {
   String toValue() {
     switch (this) {
       case MpdScte35Source.passthrough:
@@ -19635,7 +19648,7 @@ enum Mpeg2AdaptiveQuantization {
   high,
 }
 
-extension Mpeg2AdaptiveQuantizationValue on Mpeg2AdaptiveQuantization {
+extension Mpeg2AdaptiveQuantizationValueExtension on Mpeg2AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2AdaptiveQuantization.off:
@@ -19675,7 +19688,7 @@ enum Mpeg2CodecLevel {
   high,
 }
 
-extension Mpeg2CodecLevelValue on Mpeg2CodecLevel {
+extension Mpeg2CodecLevelValueExtension on Mpeg2CodecLevel {
   String toValue() {
     switch (this) {
       case Mpeg2CodecLevel.auto:
@@ -19717,7 +19730,7 @@ enum Mpeg2CodecProfile {
   profile_422,
 }
 
-extension Mpeg2CodecProfileValue on Mpeg2CodecProfile {
+extension Mpeg2CodecProfileValueExtension on Mpeg2CodecProfile {
   String toValue() {
     switch (this) {
       case Mpeg2CodecProfile.main:
@@ -19751,7 +19764,7 @@ enum Mpeg2DynamicSubGop {
   static,
 }
 
-extension Mpeg2DynamicSubGopValue on Mpeg2DynamicSubGop {
+extension Mpeg2DynamicSubGopValueExtension on Mpeg2DynamicSubGop {
   String toValue() {
     switch (this) {
       case Mpeg2DynamicSubGop.adaptive:
@@ -19791,7 +19804,7 @@ enum Mpeg2FramerateControl {
   specified,
 }
 
-extension Mpeg2FramerateControlValue on Mpeg2FramerateControl {
+extension Mpeg2FramerateControlValueExtension on Mpeg2FramerateControl {
   String toValue() {
     switch (this) {
       case Mpeg2FramerateControl.initializeFromSource:
@@ -19831,7 +19844,7 @@ enum Mpeg2FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension Mpeg2FramerateConversionAlgorithmValue
+extension Mpeg2FramerateConversionAlgorithmValueExtension
     on Mpeg2FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -19867,7 +19880,7 @@ enum Mpeg2GopSizeUnits {
   seconds,
 }
 
-extension Mpeg2GopSizeUnitsValue on Mpeg2GopSizeUnits {
+extension Mpeg2GopSizeUnitsValueExtension on Mpeg2GopSizeUnits {
   String toValue() {
     switch (this) {
       case Mpeg2GopSizeUnits.frames:
@@ -19910,7 +19923,7 @@ enum Mpeg2InterlaceMode {
   followBottomField,
 }
 
-extension Mpeg2InterlaceModeValue on Mpeg2InterlaceMode {
+extension Mpeg2InterlaceModeValueExtension on Mpeg2InterlaceMode {
   String toValue() {
     switch (this) {
       case Mpeg2InterlaceMode.progressive:
@@ -19957,7 +19970,7 @@ enum Mpeg2IntraDcPrecision {
   intraDcPrecision_11,
 }
 
-extension Mpeg2IntraDcPrecisionValue on Mpeg2IntraDcPrecision {
+extension Mpeg2IntraDcPrecisionValueExtension on Mpeg2IntraDcPrecision {
   String toValue() {
     switch (this) {
       case Mpeg2IntraDcPrecision.auto:
@@ -20005,7 +20018,7 @@ enum Mpeg2ParControl {
   specified,
 }
 
-extension Mpeg2ParControlValue on Mpeg2ParControl {
+extension Mpeg2ParControlValueExtension on Mpeg2ParControl {
   String toValue() {
     switch (this) {
       case Mpeg2ParControl.initializeFromSource:
@@ -20036,7 +20049,7 @@ enum Mpeg2QualityTuningLevel {
   multiPass,
 }
 
-extension Mpeg2QualityTuningLevelValue on Mpeg2QualityTuningLevel {
+extension Mpeg2QualityTuningLevelValueExtension on Mpeg2QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Mpeg2QualityTuningLevel.singlePass:
@@ -20066,7 +20079,7 @@ enum Mpeg2RateControlMode {
   cbr,
 }
 
-extension Mpeg2RateControlModeValue on Mpeg2RateControlMode {
+extension Mpeg2RateControlModeValueExtension on Mpeg2RateControlMode {
   String toValue() {
     switch (this) {
       case Mpeg2RateControlMode.vbr:
@@ -20097,7 +20110,7 @@ enum Mpeg2SceneChangeDetect {
   enabled,
 }
 
-extension Mpeg2SceneChangeDetectValue on Mpeg2SceneChangeDetect {
+extension Mpeg2SceneChangeDetectValueExtension on Mpeg2SceneChangeDetect {
   String toValue() {
     switch (this) {
       case Mpeg2SceneChangeDetect.disabled:
@@ -20537,7 +20550,7 @@ enum Mpeg2SlowPal {
   enabled,
 }
 
-extension Mpeg2SlowPalValue on Mpeg2SlowPal {
+extension Mpeg2SlowPalValueExtension on Mpeg2SlowPal {
   String toValue() {
     switch (this) {
       case Mpeg2SlowPal.disabled:
@@ -20580,7 +20593,7 @@ enum Mpeg2SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension Mpeg2SpatialAdaptiveQuantizationValue
+extension Mpeg2SpatialAdaptiveQuantizationValueExtension
     on Mpeg2SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -20614,7 +20627,7 @@ enum Mpeg2Syntax {
   d_10,
 }
 
-extension Mpeg2SyntaxValue on Mpeg2Syntax {
+extension Mpeg2SyntaxValueExtension on Mpeg2Syntax {
   String toValue() {
     switch (this) {
       case Mpeg2Syntax.$default:
@@ -20651,7 +20664,7 @@ enum Mpeg2Telecine {
   hard,
 }
 
-extension Mpeg2TelecineValue on Mpeg2Telecine {
+extension Mpeg2TelecineValueExtension on Mpeg2Telecine {
   String toValue() {
     switch (this) {
       case Mpeg2Telecine.none:
@@ -20696,7 +20709,7 @@ enum Mpeg2TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension Mpeg2TemporalAdaptiveQuantizationValue
+extension Mpeg2TemporalAdaptiveQuantizationValueExtension
     on Mpeg2TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
@@ -20769,7 +20782,8 @@ enum MsSmoothAudioDeduplication {
   none,
 }
 
-extension MsSmoothAudioDeduplicationValue on MsSmoothAudioDeduplication {
+extension MsSmoothAudioDeduplicationValueExtension
+    on MsSmoothAudioDeduplication {
   String toValue() {
     switch (this) {
       case MsSmoothAudioDeduplication.combineDuplicateStreams:
@@ -20922,7 +20936,7 @@ enum MsSmoothManifestEncoding {
   utf16,
 }
 
-extension MsSmoothManifestEncodingValue on MsSmoothManifestEncoding {
+extension MsSmoothManifestEncodingValueExtension on MsSmoothManifestEncoding {
   String toValue() {
     switch (this) {
       case MsSmoothManifestEncoding.utf8:
@@ -20959,7 +20973,7 @@ enum MxfAfdSignaling {
   copyFromVideo,
 }
 
-extension MxfAfdSignalingValue on MxfAfdSignaling {
+extension MxfAfdSignalingValueExtension on MxfAfdSignaling {
   String toValue() {
     switch (this) {
       case MxfAfdSignaling.noCopy:
@@ -20994,7 +21008,7 @@ enum MxfProfile {
   op1a,
 }
 
-extension MxfProfileValue on MxfProfile {
+extension MxfProfileValueExtension on MxfProfile {
   String toValue() {
     switch (this) {
       case MxfProfile.d_10:
@@ -21138,7 +21152,7 @@ enum NielsenActiveWatermarkProcessType {
   naes2AndNwAndCbet,
 }
 
-extension NielsenActiveWatermarkProcessTypeValue
+extension NielsenActiveWatermarkProcessTypeValueExtension
     on NielsenActiveWatermarkProcessType {
   String toValue() {
     switch (this) {
@@ -21359,7 +21373,7 @@ enum NielsenSourceWatermarkStatusType {
   watermarked,
 }
 
-extension NielsenSourceWatermarkStatusTypeValue
+extension NielsenSourceWatermarkStatusTypeValueExtension
     on NielsenSourceWatermarkStatusType {
   String toValue() {
     switch (this) {
@@ -21393,7 +21407,7 @@ enum NielsenUniqueTicPerAudioTrackType {
   sameTicsPerTrack,
 }
 
-extension NielsenUniqueTicPerAudioTrackTypeValue
+extension NielsenUniqueTicPerAudioTrackTypeValueExtension
     on NielsenUniqueTicPerAudioTrackType {
   String toValue() {
     switch (this) {
@@ -21430,7 +21444,7 @@ enum NoiseFilterPostTemporalSharpening {
   auto,
 }
 
-extension NoiseFilterPostTemporalSharpeningValue
+extension NoiseFilterPostTemporalSharpeningValueExtension
     on NoiseFilterPostTemporalSharpening {
   String toValue() {
     switch (this) {
@@ -21541,7 +21555,7 @@ enum NoiseReducerFilter {
   temporal,
 }
 
-extension NoiseReducerFilterValue on NoiseReducerFilter {
+extension NoiseReducerFilterValueExtension on NoiseReducerFilter {
   String toValue() {
     switch (this) {
       case NoiseReducerFilter.bilateral:
@@ -21760,7 +21774,7 @@ enum Order {
   descending,
 }
 
-extension OrderValue on Order {
+extension OrderValueExtension on Order {
   String toValue() {
     switch (this) {
       case Order.ascending:
@@ -22113,7 +22127,7 @@ enum OutputGroupType {
   cmafGroupSettings,
 }
 
-extension OutputGroupTypeValue on OutputGroupType {
+extension OutputGroupTypeValueExtension on OutputGroupType {
   String toValue() {
     switch (this) {
       case OutputGroupType.hlsGroupSettings:
@@ -22162,7 +22176,7 @@ enum OutputSdt {
   sdtNone,
 }
 
-extension OutputSdtValue on OutputSdt {
+extension OutputSdtValueExtension on OutputSdt {
   String toValue() {
     switch (this) {
       case OutputSdt.sdtFollow:
@@ -22310,7 +22324,7 @@ enum PresetListBy {
   system,
 }
 
-extension PresetListByValue on PresetListBy {
+extension PresetListByValueExtension on PresetListBy {
   String toValue() {
     switch (this) {
       case PresetListBy.name:
@@ -22410,7 +22424,7 @@ enum PricingPlan {
   reserved,
 }
 
-extension PricingPlanValue on PricingPlan {
+extension PricingPlanValueExtension on PricingPlan {
   String toValue() {
     switch (this) {
       case PricingPlan.onDemand:
@@ -22442,7 +22456,7 @@ enum ProresCodecProfile {
   appleProres_422Proxy,
 }
 
-extension ProresCodecProfileValue on ProresCodecProfile {
+extension ProresCodecProfileValueExtension on ProresCodecProfile {
   String toValue() {
     switch (this) {
       case ProresCodecProfile.appleProres_422:
@@ -22490,7 +22504,7 @@ enum ProresFramerateControl {
   specified,
 }
 
-extension ProresFramerateControlValue on ProresFramerateControl {
+extension ProresFramerateControlValueExtension on ProresFramerateControl {
   String toValue() {
     switch (this) {
       case ProresFramerateControl.initializeFromSource:
@@ -22530,7 +22544,7 @@ enum ProresFramerateConversionAlgorithm {
   frameformer,
 }
 
-extension ProresFramerateConversionAlgorithmValue
+extension ProresFramerateConversionAlgorithmValueExtension
     on ProresFramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -22579,7 +22593,7 @@ enum ProresInterlaceMode {
   followBottomField,
 }
 
-extension ProresInterlaceModeValue on ProresInterlaceMode {
+extension ProresInterlaceModeValueExtension on ProresInterlaceMode {
   String toValue() {
     switch (this) {
       case ProresInterlaceMode.progressive:
@@ -22627,7 +22641,7 @@ enum ProresParControl {
   specified,
 }
 
-extension ProresParControlValue on ProresParControl {
+extension ProresParControlValueExtension on ProresParControl {
   String toValue() {
     switch (this) {
       case ProresParControl.initializeFromSource:
@@ -22836,7 +22850,7 @@ enum ProresSlowPal {
   enabled,
 }
 
-extension ProresSlowPalValue on ProresSlowPal {
+extension ProresSlowPalValueExtension on ProresSlowPal {
   String toValue() {
     switch (this) {
       case ProresSlowPal.disabled:
@@ -22870,7 +22884,7 @@ enum ProresTelecine {
   hard,
 }
 
-extension ProresTelecineValue on ProresTelecine {
+extension ProresTelecineValueExtension on ProresTelecine {
   String toValue() {
     switch (this) {
       case ProresTelecine.none:
@@ -22983,7 +22997,7 @@ enum QueueListBy {
   creationDate,
 }
 
-extension QueueListByValue on QueueListBy {
+extension QueueListByValueExtension on QueueListBy {
   String toValue() {
     switch (this) {
       case QueueListBy.name:
@@ -23014,7 +23028,7 @@ enum QueueStatus {
   paused,
 }
 
-extension QueueStatusValue on QueueStatus {
+extension QueueStatusValueExtension on QueueStatus {
   String toValue() {
     switch (this) {
       case QueueStatus.active:
@@ -23164,7 +23178,7 @@ enum RenewalType {
   expire,
 }
 
-extension RenewalTypeValue on RenewalType {
+extension RenewalTypeValueExtension on RenewalType {
   String toValue() {
     switch (this) {
       case RenewalType.autoRenew:
@@ -23284,7 +23298,7 @@ enum ReservationPlanStatus {
   expired,
 }
 
-extension ReservationPlanStatusValue on ReservationPlanStatus {
+extension ReservationPlanStatusValueExtension on ReservationPlanStatus {
   String toValue() {
     switch (this) {
       case ReservationPlanStatus.active:
@@ -23343,7 +23357,7 @@ enum RespondToAfd {
   passthrough,
 }
 
-extension RespondToAfdValue on RespondToAfd {
+extension RespondToAfdValueExtension on RespondToAfd {
   String toValue() {
     switch (this) {
       case RespondToAfd.none:
@@ -23487,7 +23501,7 @@ enum S3ObjectCannedAcl {
   bucketOwnerFullControl,
 }
 
-extension S3ObjectCannedAclValue on S3ObjectCannedAcl {
+extension S3ObjectCannedAclValueExtension on S3ObjectCannedAcl {
   String toValue() {
     switch (this) {
       case S3ObjectCannedAcl.publicRead:
@@ -23534,7 +23548,8 @@ enum S3ServerSideEncryptionType {
   serverSideEncryptionKms,
 }
 
-extension S3ServerSideEncryptionTypeValue on S3ServerSideEncryptionType {
+extension S3ServerSideEncryptionTypeValueExtension
+    on S3ServerSideEncryptionType {
   String toValue() {
     switch (this) {
       case S3ServerSideEncryptionType.serverSideEncryptionS3:
@@ -23568,7 +23583,7 @@ enum ScalingBehavior {
   stretchToOutput,
 }
 
-extension ScalingBehaviorValue on ScalingBehavior {
+extension ScalingBehaviorValueExtension on ScalingBehavior {
   String toValue() {
     switch (this) {
       case ScalingBehavior.$default:
@@ -23605,7 +23620,7 @@ enum SccDestinationFramerate {
   framerate_29_97NonDropframe,
 }
 
-extension SccDestinationFramerateValue on SccDestinationFramerate {
+extension SccDestinationFramerateValueExtension on SccDestinationFramerate {
   String toValue() {
     switch (this) {
       case SccDestinationFramerate.framerate_23_97:
@@ -23676,7 +23691,7 @@ enum SimulateReservedQueue {
   enabled,
 }
 
-extension SimulateReservedQueueValue on SimulateReservedQueue {
+extension SimulateReservedQueueValueExtension on SimulateReservedQueue {
   String toValue() {
     switch (this) {
       case SimulateReservedQueue.disabled:
@@ -23898,7 +23913,7 @@ enum StatusUpdateInterval {
   seconds_600,
 }
 
-extension StatusUpdateIntervalValue on StatusUpdateInterval {
+extension StatusUpdateIntervalValueExtension on StatusUpdateInterval {
   String toValue() {
     switch (this) {
       case StatusUpdateInterval.seconds_10:
@@ -24029,7 +24044,7 @@ enum TeletextPageType {
   pageTypeHearingImpairedSubtitle,
 }
 
-extension TeletextPageTypeValue on TeletextPageType {
+extension TeletextPageTypeValueExtension on TeletextPageType {
   String toValue() {
     switch (this) {
       case TeletextPageType.pageTypeInitial:
@@ -24146,7 +24161,7 @@ enum TimecodeBurninPosition {
   bottomRight,
 }
 
-extension TimecodeBurninPositionValue on TimecodeBurninPosition {
+extension TimecodeBurninPositionValueExtension on TimecodeBurninPosition {
   String toValue() {
     switch (this) {
       case TimecodeBurninPosition.topCenter:
@@ -24289,7 +24304,7 @@ enum TimecodeSource {
   specifiedstart,
 }
 
-extension TimecodeSourceValue on TimecodeSource {
+extension TimecodeSourceValueExtension on TimecodeSource {
   String toValue() {
     switch (this) {
       case TimecodeSource.embedded:
@@ -24323,7 +24338,7 @@ enum TimedMetadata {
   none,
 }
 
-extension TimedMetadataValue on TimedMetadata {
+extension TimedMetadataValueExtension on TimedMetadata {
   String toValue() {
     switch (this) {
       case TimedMetadata.passthrough:
@@ -24464,7 +24479,7 @@ enum TtmlStylePassthrough {
   disabled,
 }
 
-extension TtmlStylePassthroughValue on TtmlStylePassthrough {
+extension TtmlStylePassthroughValueExtension on TtmlStylePassthrough {
   String toValue() {
     switch (this) {
       case TtmlStylePassthrough.enabled:
@@ -24492,7 +24507,7 @@ enum Type {
   custom,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.system:
@@ -24590,7 +24605,7 @@ enum Vc3Class {
   class_220_10bit,
 }
 
-extension Vc3ClassValue on Vc3Class {
+extension Vc3ClassValueExtension on Vc3Class {
   String toValue() {
     switch (this) {
       case Vc3Class.class_145_8bit:
@@ -24634,7 +24649,7 @@ enum Vc3FramerateControl {
   specified,
 }
 
-extension Vc3FramerateControlValue on Vc3FramerateControl {
+extension Vc3FramerateControlValueExtension on Vc3FramerateControl {
   String toValue() {
     switch (this) {
       case Vc3FramerateControl.initializeFromSource:
@@ -24674,7 +24689,7 @@ enum Vc3FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension Vc3FramerateConversionAlgorithmValue
+extension Vc3FramerateConversionAlgorithmValueExtension
     on Vc3FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -24710,7 +24725,7 @@ enum Vc3InterlaceMode {
   progressive,
 }
 
-extension Vc3InterlaceModeValue on Vc3InterlaceMode {
+extension Vc3InterlaceModeValueExtension on Vc3InterlaceMode {
   String toValue() {
     switch (this) {
       case Vc3InterlaceMode.interlaced:
@@ -24872,7 +24887,7 @@ enum Vc3SlowPal {
   enabled,
 }
 
-extension Vc3SlowPalValue on Vc3SlowPal {
+extension Vc3SlowPalValueExtension on Vc3SlowPal {
   String toValue() {
     switch (this) {
       case Vc3SlowPal.disabled:
@@ -24906,7 +24921,7 @@ enum Vc3Telecine {
   hard,
 }
 
-extension Vc3TelecineValue on Vc3Telecine {
+extension Vc3TelecineValueExtension on Vc3Telecine {
   String toValue() {
     switch (this) {
       case Vc3Telecine.none:
@@ -24943,7 +24958,7 @@ enum VideoCodec {
   vp9,
 }
 
-extension VideoCodecValue on VideoCodec {
+extension VideoCodecValueExtension on VideoCodec {
   String toValue() {
     switch (this) {
       case VideoCodec.av1:
@@ -25574,7 +25589,7 @@ enum VideoTimecodeInsertion {
   picTimingSei,
 }
 
-extension VideoTimecodeInsertionValue on VideoTimecodeInsertion {
+extension VideoTimecodeInsertionValueExtension on VideoTimecodeInsertion {
   String toValue() {
     switch (this) {
       case VideoTimecodeInsertion.disabled:
@@ -25657,7 +25672,7 @@ enum Vp8FramerateControl {
   specified,
 }
 
-extension Vp8FramerateControlValue on Vp8FramerateControl {
+extension Vp8FramerateControlValueExtension on Vp8FramerateControl {
   String toValue() {
     switch (this) {
       case Vp8FramerateControl.initializeFromSource:
@@ -25697,7 +25712,7 @@ enum Vp8FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension Vp8FramerateConversionAlgorithmValue
+extension Vp8FramerateConversionAlgorithmValueExtension
     on Vp8FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -25739,7 +25754,7 @@ enum Vp8ParControl {
   specified,
 }
 
-extension Vp8ParControlValue on Vp8ParControl {
+extension Vp8ParControlValueExtension on Vp8ParControl {
   String toValue() {
     switch (this) {
       case Vp8ParControl.initializeFromSource:
@@ -25770,7 +25785,7 @@ enum Vp8QualityTuningLevel {
   multiPassHq,
 }
 
-extension Vp8QualityTuningLevelValue on Vp8QualityTuningLevel {
+extension Vp8QualityTuningLevelValueExtension on Vp8QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Vp8QualityTuningLevel.multiPass:
@@ -25799,7 +25814,7 @@ enum Vp8RateControlMode {
   vbr,
 }
 
-extension Vp8RateControlModeValue on Vp8RateControlMode {
+extension Vp8RateControlModeValueExtension on Vp8RateControlMode {
   String toValue() {
     switch (this) {
       case Vp8RateControlMode.vbr:
@@ -26008,7 +26023,7 @@ enum Vp9FramerateControl {
   specified,
 }
 
-extension Vp9FramerateControlValue on Vp9FramerateControl {
+extension Vp9FramerateControlValueExtension on Vp9FramerateControl {
   String toValue() {
     switch (this) {
       case Vp9FramerateControl.initializeFromSource:
@@ -26048,7 +26063,7 @@ enum Vp9FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension Vp9FramerateConversionAlgorithmValue
+extension Vp9FramerateConversionAlgorithmValueExtension
     on Vp9FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
@@ -26090,7 +26105,7 @@ enum Vp9ParControl {
   specified,
 }
 
-extension Vp9ParControlValue on Vp9ParControl {
+extension Vp9ParControlValueExtension on Vp9ParControl {
   String toValue() {
     switch (this) {
       case Vp9ParControl.initializeFromSource:
@@ -26121,7 +26136,7 @@ enum Vp9QualityTuningLevel {
   multiPassHq,
 }
 
-extension Vp9QualityTuningLevelValue on Vp9QualityTuningLevel {
+extension Vp9QualityTuningLevelValueExtension on Vp9QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Vp9QualityTuningLevel.multiPass:
@@ -26150,7 +26165,7 @@ enum Vp9RateControlMode {
   vbr,
 }
 
-extension Vp9RateControlModeValue on Vp9RateControlMode {
+extension Vp9RateControlModeValueExtension on Vp9RateControlMode {
   String toValue() {
     switch (this) {
       case Vp9RateControlMode.vbr:
@@ -26348,7 +26363,7 @@ enum WatermarkingStrength {
   strongest,
 }
 
-extension WatermarkingStrengthValue on WatermarkingStrength {
+extension WatermarkingStrengthValueExtension on WatermarkingStrength {
   String toValue() {
     switch (this) {
       case WatermarkingStrength.lightest:
@@ -26391,7 +26406,7 @@ enum WavFormat {
   rf64,
 }
 
-extension WavFormatValue on WavFormat {
+extension WavFormatValueExtension on WavFormat {
   String toValue() {
     switch (this) {
       case WavFormat.riff:

--- a/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
+++ b/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
@@ -1210,7 +1210,8 @@ enum AacAudioDescriptionBroadcasterMix {
   normal,
 }
 
-extension on AacAudioDescriptionBroadcasterMix {
+extension AacAudioDescriptionBroadcasterMixValue
+    on AacAudioDescriptionBroadcasterMix {
   String toValue() {
     switch (this) {
       case AacAudioDescriptionBroadcasterMix.broadcasterMixedAd:
@@ -1221,7 +1222,7 @@ extension on AacAudioDescriptionBroadcasterMix {
   }
 }
 
-extension on String {
+extension AacAudioDescriptionBroadcasterMixFromString on String {
   AacAudioDescriptionBroadcasterMix toAacAudioDescriptionBroadcasterMix() {
     switch (this) {
       case 'BROADCASTER_MIXED_AD':
@@ -1241,7 +1242,7 @@ enum AacCodecProfile {
   hev2,
 }
 
-extension on AacCodecProfile {
+extension AacCodecProfileValue on AacCodecProfile {
   String toValue() {
     switch (this) {
       case AacCodecProfile.lc:
@@ -1254,7 +1255,7 @@ extension on AacCodecProfile {
   }
 }
 
-extension on String {
+extension AacCodecProfileFromString on String {
   AacCodecProfile toAacCodecProfile() {
     switch (this) {
       case 'LC':
@@ -1281,7 +1282,7 @@ enum AacCodingMode {
   codingMode_5_1,
 }
 
-extension on AacCodingMode {
+extension AacCodingModeValue on AacCodingMode {
   String toValue() {
     switch (this) {
       case AacCodingMode.adReceiverMix:
@@ -1298,7 +1299,7 @@ extension on AacCodingMode {
   }
 }
 
-extension on String {
+extension AacCodingModeFromString on String {
   AacCodingMode toAacCodingMode() {
     switch (this) {
       case 'AD_RECEIVER_MIX':
@@ -1322,7 +1323,7 @@ enum AacRateControlMode {
   vbr,
 }
 
-extension on AacRateControlMode {
+extension AacRateControlModeValue on AacRateControlMode {
   String toValue() {
     switch (this) {
       case AacRateControlMode.cbr:
@@ -1333,7 +1334,7 @@ extension on AacRateControlMode {
   }
 }
 
-extension on String {
+extension AacRateControlModeFromString on String {
   AacRateControlMode toAacRateControlMode() {
     switch (this) {
       case 'CBR':
@@ -1352,7 +1353,7 @@ enum AacRawFormat {
   none,
 }
 
-extension on AacRawFormat {
+extension AacRawFormatValue on AacRawFormat {
   String toValue() {
     switch (this) {
       case AacRawFormat.latmLoas:
@@ -1363,7 +1364,7 @@ extension on AacRawFormat {
   }
 }
 
-extension on String {
+extension AacRawFormatFromString on String {
   AacRawFormat toAacRawFormat() {
     switch (this) {
       case 'LATM_LOAS':
@@ -1492,7 +1493,7 @@ enum AacSpecification {
   mpeg4,
 }
 
-extension on AacSpecification {
+extension AacSpecificationValue on AacSpecification {
   String toValue() {
     switch (this) {
       case AacSpecification.mpeg2:
@@ -1503,7 +1504,7 @@ extension on AacSpecification {
   }
 }
 
-extension on String {
+extension AacSpecificationFromString on String {
   AacSpecification toAacSpecification() {
     switch (this) {
       case 'MPEG2':
@@ -1523,7 +1524,7 @@ enum AacVbrQuality {
   high,
 }
 
-extension on AacVbrQuality {
+extension AacVbrQualityValue on AacVbrQuality {
   String toValue() {
     switch (this) {
       case AacVbrQuality.low:
@@ -1538,7 +1539,7 @@ extension on AacVbrQuality {
   }
 }
 
-extension on String {
+extension AacVbrQualityFromString on String {
   AacVbrQuality toAacVbrQuality() {
     switch (this) {
       case 'LOW':
@@ -1567,7 +1568,7 @@ enum Ac3BitstreamMode {
   voiceOver,
 }
 
-extension on Ac3BitstreamMode {
+extension Ac3BitstreamModeValue on Ac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Ac3BitstreamMode.completeMain:
@@ -1590,7 +1591,7 @@ extension on Ac3BitstreamMode {
   }
 }
 
-extension on String {
+extension Ac3BitstreamModeFromString on String {
   Ac3BitstreamMode toAc3BitstreamMode() {
     switch (this) {
       case 'COMPLETE_MAIN':
@@ -1622,7 +1623,7 @@ enum Ac3CodingMode {
   codingMode_3_2Lfe,
 }
 
-extension on Ac3CodingMode {
+extension Ac3CodingModeValue on Ac3CodingMode {
   String toValue() {
     switch (this) {
       case Ac3CodingMode.codingMode_1_0:
@@ -1637,7 +1638,7 @@ extension on Ac3CodingMode {
   }
 }
 
-extension on String {
+extension Ac3CodingModeFromString on String {
   Ac3CodingMode toAc3CodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -1660,7 +1661,8 @@ enum Ac3DynamicRangeCompressionProfile {
   none,
 }
 
-extension on Ac3DynamicRangeCompressionProfile {
+extension Ac3DynamicRangeCompressionProfileValue
+    on Ac3DynamicRangeCompressionProfile {
   String toValue() {
     switch (this) {
       case Ac3DynamicRangeCompressionProfile.filmStandard:
@@ -1671,7 +1673,7 @@ extension on Ac3DynamicRangeCompressionProfile {
   }
 }
 
-extension on String {
+extension Ac3DynamicRangeCompressionProfileFromString on String {
   Ac3DynamicRangeCompressionProfile toAc3DynamicRangeCompressionProfile() {
     switch (this) {
       case 'FILM_STANDARD':
@@ -1691,7 +1693,7 @@ enum Ac3LfeFilter {
   disabled,
 }
 
-extension on Ac3LfeFilter {
+extension Ac3LfeFilterValue on Ac3LfeFilter {
   String toValue() {
     switch (this) {
       case Ac3LfeFilter.enabled:
@@ -1702,7 +1704,7 @@ extension on Ac3LfeFilter {
   }
 }
 
-extension on String {
+extension Ac3LfeFilterFromString on String {
   Ac3LfeFilter toAc3LfeFilter() {
     switch (this) {
       case 'ENABLED':
@@ -1722,7 +1724,7 @@ enum Ac3MetadataControl {
   useConfigured,
 }
 
-extension on Ac3MetadataControl {
+extension Ac3MetadataControlValue on Ac3MetadataControl {
   String toValue() {
     switch (this) {
       case Ac3MetadataControl.followInput:
@@ -1733,7 +1735,7 @@ extension on Ac3MetadataControl {
   }
 }
 
-extension on String {
+extension Ac3MetadataControlFromString on String {
   Ac3MetadataControl toAc3MetadataControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -1842,7 +1844,7 @@ enum AccelerationMode {
   preferred,
 }
 
-extension on AccelerationMode {
+extension AccelerationModeValue on AccelerationMode {
   String toValue() {
     switch (this) {
       case AccelerationMode.disabled:
@@ -1855,7 +1857,7 @@ extension on AccelerationMode {
   }
 }
 
-extension on String {
+extension AccelerationModeFromString on String {
   AccelerationMode toAccelerationMode() {
     switch (this) {
       case 'DISABLED':
@@ -1912,7 +1914,7 @@ enum AccelerationStatus {
   notAccelerated,
 }
 
-extension on AccelerationStatus {
+extension AccelerationStatusValue on AccelerationStatus {
   String toValue() {
     switch (this) {
       case AccelerationStatus.notApplicable:
@@ -1927,7 +1929,7 @@ extension on AccelerationStatus {
   }
 }
 
-extension on String {
+extension AccelerationStatusFromString on String {
   AccelerationStatus toAccelerationStatus() {
     switch (this) {
       case 'NOT_APPLICABLE':
@@ -1955,7 +1957,7 @@ enum AfdSignaling {
   fixed,
 }
 
-extension on AfdSignaling {
+extension AfdSignalingValue on AfdSignaling {
   String toValue() {
     switch (this) {
       case AfdSignaling.none:
@@ -1968,7 +1970,7 @@ extension on AfdSignaling {
   }
 }
 
-extension on String {
+extension AfdSignalingFromString on String {
   AfdSignaling toAfdSignaling() {
     switch (this) {
       case 'NONE':
@@ -2032,7 +2034,7 @@ enum AlphaBehavior {
   remapToLuma,
 }
 
-extension on AlphaBehavior {
+extension AlphaBehaviorValue on AlphaBehavior {
   String toValue() {
     switch (this) {
       case AlphaBehavior.discard:
@@ -2043,7 +2045,7 @@ extension on AlphaBehavior {
   }
 }
 
-extension on String {
+extension AlphaBehaviorFromString on String {
   AlphaBehavior toAlphaBehavior() {
     switch (this) {
       case 'DISCARD':
@@ -2065,7 +2067,7 @@ enum AncillaryConvert608To708 {
   disabled,
 }
 
-extension on AncillaryConvert608To708 {
+extension AncillaryConvert608To708Value on AncillaryConvert608To708 {
   String toValue() {
     switch (this) {
       case AncillaryConvert608To708.upconvert:
@@ -2076,7 +2078,7 @@ extension on AncillaryConvert608To708 {
   }
 }
 
-extension on String {
+extension AncillaryConvert608To708FromString on String {
   AncillaryConvert608To708 toAncillaryConvert608To708() {
     switch (this) {
       case 'UPCONVERT':
@@ -2144,7 +2146,7 @@ enum AncillaryTerminateCaptions {
   disabled,
 }
 
-extension on AncillaryTerminateCaptions {
+extension AncillaryTerminateCaptionsValue on AncillaryTerminateCaptions {
   String toValue() {
     switch (this) {
       case AncillaryTerminateCaptions.endOfInput:
@@ -2155,7 +2157,7 @@ extension on AncillaryTerminateCaptions {
   }
 }
 
-extension on String {
+extension AncillaryTerminateCaptionsFromString on String {
   AncillaryTerminateCaptions toAncillaryTerminateCaptions() {
     switch (this) {
       case 'END_OF_INPUT':
@@ -2175,7 +2177,7 @@ enum AntiAlias {
   enabled,
 }
 
-extension on AntiAlias {
+extension AntiAliasValue on AntiAlias {
   String toValue() {
     switch (this) {
       case AntiAlias.disabled:
@@ -2186,7 +2188,7 @@ extension on AntiAlias {
   }
 }
 
-extension on String {
+extension AntiAliasFromString on String {
   AntiAlias toAntiAlias() {
     switch (this) {
       case 'DISABLED':
@@ -2226,7 +2228,7 @@ enum AudioChannelTag {
   vhr,
 }
 
-extension on AudioChannelTag {
+extension AudioChannelTagValue on AudioChannelTag {
   String toValue() {
     switch (this) {
       case AudioChannelTag.l:
@@ -2263,7 +2265,7 @@ extension on AudioChannelTag {
   }
 }
 
-extension on String {
+extension AudioChannelTagFromString on String {
   AudioChannelTag toAudioChannelTag() {
     switch (this) {
       case 'L':
@@ -2347,7 +2349,7 @@ enum AudioCodec {
   passthrough,
 }
 
-extension on AudioCodec {
+extension AudioCodecValue on AudioCodec {
   String toValue() {
     switch (this) {
       case AudioCodec.aac:
@@ -2376,7 +2378,7 @@ extension on AudioCodec {
   }
 }
 
-extension on String {
+extension AudioCodecFromString on String {
   AudioCodec toAudioCodec() {
     switch (this) {
       case 'AAC':
@@ -2551,7 +2553,7 @@ enum AudioDefaultSelection {
   notDefault,
 }
 
-extension on AudioDefaultSelection {
+extension AudioDefaultSelectionValue on AudioDefaultSelection {
   String toValue() {
     switch (this) {
       case AudioDefaultSelection.$default:
@@ -2562,7 +2564,7 @@ extension on AudioDefaultSelection {
   }
 }
 
-extension on String {
+extension AudioDefaultSelectionFromString on String {
   AudioDefaultSelection toAudioDefaultSelection() {
     switch (this) {
       case 'DEFAULT':
@@ -2750,7 +2752,7 @@ enum AudioLanguageCodeControl {
   useConfigured,
 }
 
-extension on AudioLanguageCodeControl {
+extension AudioLanguageCodeControlValue on AudioLanguageCodeControl {
   String toValue() {
     switch (this) {
       case AudioLanguageCodeControl.followInput:
@@ -2761,7 +2763,7 @@ extension on AudioLanguageCodeControl {
   }
 }
 
-extension on String {
+extension AudioLanguageCodeControlFromString on String {
   AudioLanguageCodeControl toAudioLanguageCodeControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -2790,7 +2792,7 @@ enum AudioNormalizationAlgorithm {
   ituBs_1770_4,
 }
 
-extension on AudioNormalizationAlgorithm {
+extension AudioNormalizationAlgorithmValue on AudioNormalizationAlgorithm {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithm.ituBs_1770_1:
@@ -2805,7 +2807,7 @@ extension on AudioNormalizationAlgorithm {
   }
 }
 
-extension on String {
+extension AudioNormalizationAlgorithmFromString on String {
   AudioNormalizationAlgorithm toAudioNormalizationAlgorithm() {
     switch (this) {
       case 'ITU_BS_1770_1':
@@ -2828,7 +2830,8 @@ enum AudioNormalizationAlgorithmControl {
   measureOnly,
 }
 
-extension on AudioNormalizationAlgorithmControl {
+extension AudioNormalizationAlgorithmControlValue
+    on AudioNormalizationAlgorithmControl {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithmControl.correctAudio:
@@ -2839,7 +2842,7 @@ extension on AudioNormalizationAlgorithmControl {
   }
 }
 
-extension on String {
+extension AudioNormalizationAlgorithmControlFromString on String {
   AudioNormalizationAlgorithmControl toAudioNormalizationAlgorithmControl() {
     switch (this) {
       case 'CORRECT_AUDIO':
@@ -2858,7 +2861,8 @@ enum AudioNormalizationLoudnessLogging {
   dontLog,
 }
 
-extension on AudioNormalizationLoudnessLogging {
+extension AudioNormalizationLoudnessLoggingValue
+    on AudioNormalizationLoudnessLogging {
   String toValue() {
     switch (this) {
       case AudioNormalizationLoudnessLogging.log:
@@ -2869,7 +2873,7 @@ extension on AudioNormalizationLoudnessLogging {
   }
 }
 
-extension on String {
+extension AudioNormalizationLoudnessLoggingFromString on String {
   AudioNormalizationLoudnessLogging toAudioNormalizationLoudnessLogging() {
     switch (this) {
       case 'LOG':
@@ -2889,7 +2893,8 @@ enum AudioNormalizationPeakCalculation {
   none,
 }
 
-extension on AudioNormalizationPeakCalculation {
+extension AudioNormalizationPeakCalculationValue
+    on AudioNormalizationPeakCalculation {
   String toValue() {
     switch (this) {
       case AudioNormalizationPeakCalculation.truePeak:
@@ -2900,7 +2905,7 @@ extension on AudioNormalizationPeakCalculation {
   }
 }
 
-extension on String {
+extension AudioNormalizationPeakCalculationFromString on String {
   AudioNormalizationPeakCalculation toAudioNormalizationPeakCalculation() {
     switch (this) {
       case 'TRUE_PEAK':
@@ -3144,7 +3149,7 @@ enum AudioSelectorType {
   languageCode,
 }
 
-extension on AudioSelectorType {
+extension AudioSelectorTypeValue on AudioSelectorType {
   String toValue() {
     switch (this) {
       case AudioSelectorType.pid:
@@ -3157,7 +3162,7 @@ extension on AudioSelectorType {
   }
 }
 
-extension on String {
+extension AudioSelectorTypeFromString on String {
   AudioSelectorType toAudioSelectorType() {
     switch (this) {
       case 'PID':
@@ -3182,7 +3187,7 @@ enum AudioTypeControl {
   useConfigured,
 }
 
-extension on AudioTypeControl {
+extension AudioTypeControlValue on AudioTypeControl {
   String toValue() {
     switch (this) {
       case AudioTypeControl.followInput:
@@ -3193,7 +3198,7 @@ extension on AudioTypeControl {
   }
 }
 
-extension on String {
+extension AudioTypeControlFromString on String {
   AudioTypeControl toAudioTypeControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -3297,7 +3302,7 @@ enum Av1AdaptiveQuantization {
   max,
 }
 
-extension on Av1AdaptiveQuantization {
+extension Av1AdaptiveQuantizationValue on Av1AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Av1AdaptiveQuantization.off:
@@ -3316,7 +3321,7 @@ extension on Av1AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Av1AdaptiveQuantizationFromString on String {
   Av1AdaptiveQuantization toAv1AdaptiveQuantization() {
     switch (this) {
       case 'OFF':
@@ -3353,7 +3358,7 @@ enum Av1FramerateControl {
   specified,
 }
 
-extension on Av1FramerateControl {
+extension Av1FramerateControlValue on Av1FramerateControl {
   String toValue() {
     switch (this) {
       case Av1FramerateControl.initializeFromSource:
@@ -3364,7 +3369,7 @@ extension on Av1FramerateControl {
   }
 }
 
-extension on String {
+extension Av1FramerateControlFromString on String {
   Av1FramerateControl toAv1FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -3393,7 +3398,8 @@ enum Av1FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on Av1FramerateConversionAlgorithm {
+extension Av1FramerateConversionAlgorithmValue
+    on Av1FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case Av1FramerateConversionAlgorithm.duplicateDrop:
@@ -3406,7 +3412,7 @@ extension on Av1FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension Av1FramerateConversionAlgorithmFromString on String {
   Av1FramerateConversionAlgorithm toAv1FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -3473,7 +3479,7 @@ enum Av1RateControlMode {
   qvbr,
 }
 
-extension on Av1RateControlMode {
+extension Av1RateControlModeValue on Av1RateControlMode {
   String toValue() {
     switch (this) {
       case Av1RateControlMode.qvbr:
@@ -3482,7 +3488,7 @@ extension on Av1RateControlMode {
   }
 }
 
-extension on String {
+extension Av1RateControlModeFromString on String {
   Av1RateControlMode toAv1RateControlMode() {
     switch (this) {
       case 'QVBR':
@@ -3691,7 +3697,8 @@ enum Av1SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension on Av1SpatialAdaptiveQuantization {
+extension Av1SpatialAdaptiveQuantizationValue
+    on Av1SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Av1SpatialAdaptiveQuantization.disabled:
@@ -3702,7 +3709,7 @@ extension on Av1SpatialAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Av1SpatialAdaptiveQuantizationFromString on String {
   Av1SpatialAdaptiveQuantization toAv1SpatialAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -3748,7 +3755,7 @@ enum AvcIntraClass {
   class_200,
 }
 
-extension on AvcIntraClass {
+extension AvcIntraClassValue on AvcIntraClass {
   String toValue() {
     switch (this) {
       case AvcIntraClass.class_50:
@@ -3761,7 +3768,7 @@ extension on AvcIntraClass {
   }
 }
 
-extension on String {
+extension AvcIntraClassFromString on String {
   AvcIntraClass toAvcIntraClass() {
     switch (this) {
       case 'CLASS_50':
@@ -3792,7 +3799,7 @@ enum AvcIntraFramerateControl {
   specified,
 }
 
-extension on AvcIntraFramerateControl {
+extension AvcIntraFramerateControlValue on AvcIntraFramerateControl {
   String toValue() {
     switch (this) {
       case AvcIntraFramerateControl.initializeFromSource:
@@ -3803,7 +3810,7 @@ extension on AvcIntraFramerateControl {
   }
 }
 
-extension on String {
+extension AvcIntraFramerateControlFromString on String {
   AvcIntraFramerateControl toAvcIntraFramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -3832,7 +3839,8 @@ enum AvcIntraFramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on AvcIntraFramerateConversionAlgorithm {
+extension AvcIntraFramerateConversionAlgorithmValue
+    on AvcIntraFramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case AvcIntraFramerateConversionAlgorithm.duplicateDrop:
@@ -3845,7 +3853,7 @@ extension on AvcIntraFramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension AvcIntraFramerateConversionAlgorithmFromString on String {
   AvcIntraFramerateConversionAlgorithm
       toAvcIntraFramerateConversionAlgorithm() {
     switch (this) {
@@ -3881,7 +3889,7 @@ enum AvcIntraInterlaceMode {
   followBottomField,
 }
 
-extension on AvcIntraInterlaceMode {
+extension AvcIntraInterlaceModeValue on AvcIntraInterlaceMode {
   String toValue() {
     switch (this) {
       case AvcIntraInterlaceMode.progressive:
@@ -3898,7 +3906,7 @@ extension on AvcIntraInterlaceMode {
   }
 }
 
-extension on String {
+extension AvcIntraInterlaceModeFromString on String {
   AvcIntraInterlaceMode toAvcIntraInterlaceMode() {
     switch (this) {
       case 'PROGRESSIVE':
@@ -4068,7 +4076,7 @@ enum AvcIntraSlowPal {
   enabled,
 }
 
-extension on AvcIntraSlowPal {
+extension AvcIntraSlowPalValue on AvcIntraSlowPal {
   String toValue() {
     switch (this) {
       case AvcIntraSlowPal.disabled:
@@ -4079,7 +4087,7 @@ extension on AvcIntraSlowPal {
   }
 }
 
-extension on String {
+extension AvcIntraSlowPalFromString on String {
   AvcIntraSlowPal toAvcIntraSlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -4102,7 +4110,7 @@ enum AvcIntraTelecine {
   hard,
 }
 
-extension on AvcIntraTelecine {
+extension AvcIntraTelecineValue on AvcIntraTelecine {
   String toValue() {
     switch (this) {
       case AvcIntraTelecine.none:
@@ -4113,7 +4121,7 @@ extension on AvcIntraTelecine {
   }
 }
 
-extension on String {
+extension AvcIntraTelecineFromString on String {
   AvcIntraTelecine toAvcIntraTelecine() {
     switch (this) {
       case 'NONE':
@@ -4134,7 +4142,7 @@ enum BillingTagsSource {
   job,
 }
 
-extension on BillingTagsSource {
+extension BillingTagsSourceValue on BillingTagsSource {
   String toValue() {
     switch (this) {
       case BillingTagsSource.queue:
@@ -4149,7 +4157,7 @@ extension on BillingTagsSource {
   }
 }
 
-extension on String {
+extension BillingTagsSourceFromString on String {
   BillingTagsSource toBillingTagsSource() {
     switch (this) {
       case 'QUEUE':
@@ -4369,7 +4377,7 @@ enum BurninSubtitleAlignment {
   left,
 }
 
-extension on BurninSubtitleAlignment {
+extension BurninSubtitleAlignmentValue on BurninSubtitleAlignment {
   String toValue() {
     switch (this) {
       case BurninSubtitleAlignment.centered:
@@ -4380,7 +4388,7 @@ extension on BurninSubtitleAlignment {
   }
 }
 
-extension on String {
+extension BurninSubtitleAlignmentFromString on String {
   BurninSubtitleAlignment toBurninSubtitleAlignment() {
     switch (this) {
       case 'CENTERED':
@@ -4400,7 +4408,7 @@ enum BurninSubtitleBackgroundColor {
   white,
 }
 
-extension on BurninSubtitleBackgroundColor {
+extension BurninSubtitleBackgroundColorValue on BurninSubtitleBackgroundColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleBackgroundColor.none:
@@ -4413,7 +4421,7 @@ extension on BurninSubtitleBackgroundColor {
   }
 }
 
-extension on String {
+extension BurninSubtitleBackgroundColorFromString on String {
   BurninSubtitleBackgroundColor toBurninSubtitleBackgroundColor() {
     switch (this) {
       case 'NONE':
@@ -4440,7 +4448,7 @@ enum BurninSubtitleFontColor {
   blue,
 }
 
-extension on BurninSubtitleFontColor {
+extension BurninSubtitleFontColorValue on BurninSubtitleFontColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleFontColor.white:
@@ -4459,7 +4467,7 @@ extension on BurninSubtitleFontColor {
   }
 }
 
-extension on String {
+extension BurninSubtitleFontColorFromString on String {
   BurninSubtitleFontColor toBurninSubtitleFontColor() {
     switch (this) {
       case 'WHITE':
@@ -4492,7 +4500,7 @@ enum BurninSubtitleOutlineColor {
   blue,
 }
 
-extension on BurninSubtitleOutlineColor {
+extension BurninSubtitleOutlineColorValue on BurninSubtitleOutlineColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleOutlineColor.black:
@@ -4511,7 +4519,7 @@ extension on BurninSubtitleOutlineColor {
   }
 }
 
-extension on String {
+extension BurninSubtitleOutlineColorFromString on String {
   BurninSubtitleOutlineColor toBurninSubtitleOutlineColor() {
     switch (this) {
       case 'BLACK':
@@ -4539,7 +4547,7 @@ enum BurninSubtitleShadowColor {
   white,
 }
 
-extension on BurninSubtitleShadowColor {
+extension BurninSubtitleShadowColorValue on BurninSubtitleShadowColor {
   String toValue() {
     switch (this) {
       case BurninSubtitleShadowColor.none:
@@ -4552,7 +4560,7 @@ extension on BurninSubtitleShadowColor {
   }
 }
 
-extension on String {
+extension BurninSubtitleShadowColorFromString on String {
   BurninSubtitleShadowColor toBurninSubtitleShadowColor() {
     switch (this) {
       case 'NONE':
@@ -4577,7 +4585,7 @@ enum BurninSubtitleTeletextSpacing {
   proportional,
 }
 
-extension on BurninSubtitleTeletextSpacing {
+extension BurninSubtitleTeletextSpacingValue on BurninSubtitleTeletextSpacing {
   String toValue() {
     switch (this) {
       case BurninSubtitleTeletextSpacing.fixedGrid:
@@ -4588,7 +4596,7 @@ extension on BurninSubtitleTeletextSpacing {
   }
 }
 
-extension on String {
+extension BurninSubtitleTeletextSpacingFromString on String {
   BurninSubtitleTeletextSpacing toBurninSubtitleTeletextSpacing() {
     switch (this) {
       case 'FIXED_GRID':
@@ -4882,7 +4890,7 @@ enum CaptionDestinationType {
   webvtt,
 }
 
-extension on CaptionDestinationType {
+extension CaptionDestinationTypeValue on CaptionDestinationType {
   String toValue() {
     switch (this) {
       case CaptionDestinationType.burnIn:
@@ -4913,7 +4921,7 @@ extension on CaptionDestinationType {
   }
 }
 
-extension on String {
+extension CaptionDestinationTypeFromString on String {
   CaptionDestinationType toCaptionDestinationType() {
     switch (this) {
       case 'BURN_IN':
@@ -5153,7 +5161,7 @@ enum CaptionSourceType {
   imsc,
 }
 
-extension on CaptionSourceType {
+extension CaptionSourceTypeValue on CaptionSourceType {
   String toValue() {
     switch (this) {
       case CaptionSourceType.ancillary:
@@ -5184,7 +5192,7 @@ extension on CaptionSourceType {
   }
 }
 
-extension on String {
+extension CaptionSourceTypeFromString on String {
   CaptionSourceType toCaptionSourceType() {
     switch (this) {
       case 'ANCILLARY':
@@ -5297,7 +5305,7 @@ enum CmafClientCache {
   enabled,
 }
 
-extension on CmafClientCache {
+extension CmafClientCacheValue on CmafClientCache {
   String toValue() {
     switch (this) {
       case CmafClientCache.disabled:
@@ -5308,7 +5316,7 @@ extension on CmafClientCache {
   }
 }
 
-extension on String {
+extension CmafClientCacheFromString on String {
   CmafClientCache toCmafClientCache() {
     switch (this) {
       case 'DISABLED':
@@ -5327,7 +5335,7 @@ enum CmafCodecSpecification {
   rfc_4281,
 }
 
-extension on CmafCodecSpecification {
+extension CmafCodecSpecificationValue on CmafCodecSpecification {
   String toValue() {
     switch (this) {
       case CmafCodecSpecification.rfc_6381:
@@ -5338,7 +5346,7 @@ extension on CmafCodecSpecification {
   }
 }
 
-extension on String {
+extension CmafCodecSpecificationFromString on String {
   CmafCodecSpecification toCmafCodecSpecification() {
     switch (this) {
       case 'RFC_6381':
@@ -5438,7 +5446,7 @@ enum CmafEncryptionType {
   aesCtr,
 }
 
-extension on CmafEncryptionType {
+extension CmafEncryptionTypeValue on CmafEncryptionType {
   String toValue() {
     switch (this) {
       case CmafEncryptionType.sampleAes:
@@ -5449,7 +5457,7 @@ extension on CmafEncryptionType {
   }
 }
 
-extension on String {
+extension CmafEncryptionTypeFromString on String {
   CmafEncryptionType toCmafEncryptionType() {
     switch (this) {
       case 'SAMPLE_AES':
@@ -5706,7 +5714,8 @@ enum CmafInitializationVectorInManifest {
   exclude,
 }
 
-extension on CmafInitializationVectorInManifest {
+extension CmafInitializationVectorInManifestValue
+    on CmafInitializationVectorInManifest {
   String toValue() {
     switch (this) {
       case CmafInitializationVectorInManifest.include:
@@ -5717,7 +5726,7 @@ extension on CmafInitializationVectorInManifest {
   }
 }
 
-extension on String {
+extension CmafInitializationVectorInManifestFromString on String {
   CmafInitializationVectorInManifest toCmafInitializationVectorInManifest() {
     switch (this) {
       case 'INCLUDE':
@@ -5738,7 +5747,7 @@ enum CmafKeyProviderType {
   staticKey,
 }
 
-extension on CmafKeyProviderType {
+extension CmafKeyProviderTypeValue on CmafKeyProviderType {
   String toValue() {
     switch (this) {
       case CmafKeyProviderType.speke:
@@ -5749,7 +5758,7 @@ extension on CmafKeyProviderType {
   }
 }
 
-extension on String {
+extension CmafKeyProviderTypeFromString on String {
   CmafKeyProviderType toCmafKeyProviderType() {
     switch (this) {
       case 'SPEKE':
@@ -5767,7 +5776,7 @@ enum CmafManifestCompression {
   none,
 }
 
-extension on CmafManifestCompression {
+extension CmafManifestCompressionValue on CmafManifestCompression {
   String toValue() {
     switch (this) {
       case CmafManifestCompression.gzip:
@@ -5778,7 +5787,7 @@ extension on CmafManifestCompression {
   }
 }
 
-extension on String {
+extension CmafManifestCompressionFromString on String {
   CmafManifestCompression toCmafManifestCompression() {
     switch (this) {
       case 'GZIP':
@@ -5797,7 +5806,7 @@ enum CmafManifestDurationFormat {
   integer,
 }
 
-extension on CmafManifestDurationFormat {
+extension CmafManifestDurationFormatValue on CmafManifestDurationFormat {
   String toValue() {
     switch (this) {
       case CmafManifestDurationFormat.floatingPoint:
@@ -5808,7 +5817,7 @@ extension on CmafManifestDurationFormat {
   }
 }
 
-extension on String {
+extension CmafManifestDurationFormatFromString on String {
   CmafManifestDurationFormat toCmafManifestDurationFormat() {
     switch (this) {
       case 'FLOATING_POINT':
@@ -5832,7 +5841,7 @@ enum CmafMpdProfile {
   onDemandProfile,
 }
 
-extension on CmafMpdProfile {
+extension CmafMpdProfileValue on CmafMpdProfile {
   String toValue() {
     switch (this) {
       case CmafMpdProfile.mainProfile:
@@ -5843,7 +5852,7 @@ extension on CmafMpdProfile {
   }
 }
 
-extension on String {
+extension CmafMpdProfileFromString on String {
   CmafMpdProfile toCmafMpdProfile() {
     switch (this) {
       case 'MAIN_PROFILE':
@@ -5863,7 +5872,7 @@ enum CmafSegmentControl {
   segmentedFiles,
 }
 
-extension on CmafSegmentControl {
+extension CmafSegmentControlValue on CmafSegmentControl {
   String toValue() {
     switch (this) {
       case CmafSegmentControl.singleFile:
@@ -5874,7 +5883,7 @@ extension on CmafSegmentControl {
   }
 }
 
-extension on String {
+extension CmafSegmentControlFromString on String {
   CmafSegmentControl toCmafSegmentControl() {
     switch (this) {
       case 'SINGLE_FILE':
@@ -5893,7 +5902,7 @@ enum CmafStreamInfResolution {
   exclude,
 }
 
-extension on CmafStreamInfResolution {
+extension CmafStreamInfResolutionValue on CmafStreamInfResolution {
   String toValue() {
     switch (this) {
       case CmafStreamInfResolution.include:
@@ -5904,7 +5913,7 @@ extension on CmafStreamInfResolution {
   }
 }
 
-extension on String {
+extension CmafStreamInfResolutionFromString on String {
   CmafStreamInfResolution toCmafStreamInfResolution() {
     switch (this) {
       case 'INCLUDE':
@@ -5922,7 +5931,7 @@ enum CmafWriteDASHManifest {
   enabled,
 }
 
-extension on CmafWriteDASHManifest {
+extension CmafWriteDASHManifestValue on CmafWriteDASHManifest {
   String toValue() {
     switch (this) {
       case CmafWriteDASHManifest.disabled:
@@ -5933,7 +5942,7 @@ extension on CmafWriteDASHManifest {
   }
 }
 
-extension on String {
+extension CmafWriteDASHManifestFromString on String {
   CmafWriteDASHManifest toCmafWriteDASHManifest() {
     switch (this) {
       case 'DISABLED':
@@ -5952,7 +5961,7 @@ enum CmafWriteHLSManifest {
   enabled,
 }
 
-extension on CmafWriteHLSManifest {
+extension CmafWriteHLSManifestValue on CmafWriteHLSManifest {
   String toValue() {
     switch (this) {
       case CmafWriteHLSManifest.disabled:
@@ -5963,7 +5972,7 @@ extension on CmafWriteHLSManifest {
   }
 }
 
-extension on String {
+extension CmafWriteHLSManifestFromString on String {
   CmafWriteHLSManifest toCmafWriteHLSManifest() {
     switch (this) {
       case 'DISABLED':
@@ -5987,7 +5996,8 @@ enum CmafWriteSegmentTimelineInRepresentation {
   disabled,
 }
 
-extension on CmafWriteSegmentTimelineInRepresentation {
+extension CmafWriteSegmentTimelineInRepresentationValue
+    on CmafWriteSegmentTimelineInRepresentation {
   String toValue() {
     switch (this) {
       case CmafWriteSegmentTimelineInRepresentation.enabled:
@@ -5998,7 +6008,7 @@ extension on CmafWriteSegmentTimelineInRepresentation {
   }
 }
 
-extension on String {
+extension CmafWriteSegmentTimelineInRepresentationFromString on String {
   CmafWriteSegmentTimelineInRepresentation
       toCmafWriteSegmentTimelineInRepresentation() {
     switch (this) {
@@ -6031,7 +6041,7 @@ enum CmfcAudioDuration {
   matchVideoDuration,
 }
 
-extension on CmfcAudioDuration {
+extension CmfcAudioDurationValue on CmfcAudioDuration {
   String toValue() {
     switch (this) {
       case CmfcAudioDuration.defaultCodecDuration:
@@ -6042,7 +6052,7 @@ extension on CmfcAudioDuration {
   }
 }
 
-extension on String {
+extension CmfcAudioDurationFromString on String {
   CmfcAudioDuration toCmfcAudioDuration() {
     switch (this) {
       case 'DEFAULT_CODEC_DURATION':
@@ -6063,7 +6073,7 @@ enum CmfcScte35Esam {
   none,
 }
 
-extension on CmfcScte35Esam {
+extension CmfcScte35EsamValue on CmfcScte35Esam {
   String toValue() {
     switch (this) {
       case CmfcScte35Esam.insert:
@@ -6074,7 +6084,7 @@ extension on CmfcScte35Esam {
   }
 }
 
-extension on String {
+extension CmfcScte35EsamFromString on String {
   CmfcScte35Esam toCmfcScte35Esam() {
     switch (this) {
       case 'INSERT':
@@ -6095,7 +6105,7 @@ enum CmfcScte35Source {
   none,
 }
 
-extension on CmfcScte35Source {
+extension CmfcScte35SourceValue on CmfcScte35Source {
   String toValue() {
     switch (this) {
       case CmfcScte35Source.passthrough:
@@ -6106,7 +6116,7 @@ extension on CmfcScte35Source {
   }
 }
 
-extension on String {
+extension CmfcScte35SourceFromString on String {
   CmfcScte35Source toCmfcScte35Source() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -6259,7 +6269,7 @@ enum ColorMetadata {
   insert,
 }
 
-extension on ColorMetadata {
+extension ColorMetadataValue on ColorMetadata {
   String toValue() {
     switch (this) {
       case ColorMetadata.ignore:
@@ -6270,7 +6280,7 @@ extension on ColorMetadata {
   }
 }
 
-extension on String {
+extension ColorMetadataFromString on String {
   ColorMetadata toColorMetadata() {
     switch (this) {
       case 'IGNORE':
@@ -6300,7 +6310,7 @@ enum ColorSpace {
   hlg_2020,
 }
 
-extension on ColorSpace {
+extension ColorSpaceValue on ColorSpace {
   String toValue() {
     switch (this) {
       case ColorSpace.follow:
@@ -6317,7 +6327,7 @@ extension on ColorSpace {
   }
 }
 
-extension on String {
+extension ColorSpaceFromString on String {
   ColorSpace toColorSpace() {
     switch (this) {
       case 'FOLLOW':
@@ -6349,7 +6359,7 @@ enum ColorSpaceConversion {
   forceHlg_2020,
 }
 
-extension on ColorSpaceConversion {
+extension ColorSpaceConversionValue on ColorSpaceConversion {
   String toValue() {
     switch (this) {
       case ColorSpaceConversion.none:
@@ -6366,7 +6376,7 @@ extension on ColorSpaceConversion {
   }
 }
 
-extension on String {
+extension ColorSpaceConversionFromString on String {
   ColorSpaceConversion toColorSpaceConversion() {
     switch (this) {
       case 'NONE':
@@ -6398,7 +6408,7 @@ enum ColorSpaceUsage {
   fallback,
 }
 
-extension on ColorSpaceUsage {
+extension ColorSpaceUsageValue on ColorSpaceUsage {
   String toValue() {
     switch (this) {
       case ColorSpaceUsage.force:
@@ -6409,7 +6419,7 @@ extension on ColorSpaceUsage {
   }
 }
 
-extension on String {
+extension ColorSpaceUsageFromString on String {
   ColorSpaceUsage toColorSpaceUsage() {
     switch (this) {
       case 'FORCE':
@@ -6426,7 +6436,7 @@ enum Commitment {
   oneYear,
 }
 
-extension on Commitment {
+extension CommitmentValue on Commitment {
   String toValue() {
     switch (this) {
       case Commitment.oneYear:
@@ -6435,7 +6445,7 @@ extension on Commitment {
   }
 }
 
-extension on String {
+extension CommitmentFromString on String {
   Commitment toCommitment() {
     switch (this) {
       case 'ONE_YEAR':
@@ -6566,7 +6576,7 @@ enum ContainerType {
   raw,
 }
 
-extension on ContainerType {
+extension ContainerTypeValue on ContainerType {
   String toValue() {
     switch (this) {
       case ContainerType.f4v:
@@ -6595,7 +6605,7 @@ extension on ContainerType {
   }
 }
 
-extension on String {
+extension ContainerTypeFromString on String {
   ContainerType toContainerType() {
     switch (this) {
       case 'F4V':
@@ -6960,7 +6970,7 @@ enum DashIsoHbbtvCompliance {
   none,
 }
 
-extension on DashIsoHbbtvCompliance {
+extension DashIsoHbbtvComplianceValue on DashIsoHbbtvCompliance {
   String toValue() {
     switch (this) {
       case DashIsoHbbtvCompliance.hbbtv_1_5:
@@ -6971,7 +6981,7 @@ extension on DashIsoHbbtvCompliance {
   }
 }
 
-extension on String {
+extension DashIsoHbbtvComplianceFromString on String {
   DashIsoHbbtvCompliance toDashIsoHbbtvCompliance() {
     switch (this) {
       case 'HBBTV_1_5':
@@ -6995,7 +7005,7 @@ enum DashIsoMpdProfile {
   onDemandProfile,
 }
 
-extension on DashIsoMpdProfile {
+extension DashIsoMpdProfileValue on DashIsoMpdProfile {
   String toValue() {
     switch (this) {
       case DashIsoMpdProfile.mainProfile:
@@ -7006,7 +7016,7 @@ extension on DashIsoMpdProfile {
   }
 }
 
-extension on String {
+extension DashIsoMpdProfileFromString on String {
   DashIsoMpdProfile toDashIsoMpdProfile() {
     switch (this) {
       case 'MAIN_PROFILE':
@@ -7030,7 +7040,8 @@ enum DashIsoPlaybackDeviceCompatibility {
   unencryptedSei,
 }
 
-extension on DashIsoPlaybackDeviceCompatibility {
+extension DashIsoPlaybackDeviceCompatibilityValue
+    on DashIsoPlaybackDeviceCompatibility {
   String toValue() {
     switch (this) {
       case DashIsoPlaybackDeviceCompatibility.cencV1:
@@ -7041,7 +7052,7 @@ extension on DashIsoPlaybackDeviceCompatibility {
   }
 }
 
-extension on String {
+extension DashIsoPlaybackDeviceCompatibilityFromString on String {
   DashIsoPlaybackDeviceCompatibility toDashIsoPlaybackDeviceCompatibility() {
     switch (this) {
       case 'CENC_V1':
@@ -7062,7 +7073,7 @@ enum DashIsoSegmentControl {
   segmentedFiles,
 }
 
-extension on DashIsoSegmentControl {
+extension DashIsoSegmentControlValue on DashIsoSegmentControl {
   String toValue() {
     switch (this) {
       case DashIsoSegmentControl.singleFile:
@@ -7073,7 +7084,7 @@ extension on DashIsoSegmentControl {
   }
 }
 
-extension on String {
+extension DashIsoSegmentControlFromString on String {
   DashIsoSegmentControl toDashIsoSegmentControl() {
     switch (this) {
       case 'SINGLE_FILE':
@@ -7097,7 +7108,8 @@ enum DashIsoWriteSegmentTimelineInRepresentation {
   disabled,
 }
 
-extension on DashIsoWriteSegmentTimelineInRepresentation {
+extension DashIsoWriteSegmentTimelineInRepresentationValue
+    on DashIsoWriteSegmentTimelineInRepresentation {
   String toValue() {
     switch (this) {
       case DashIsoWriteSegmentTimelineInRepresentation.enabled:
@@ -7108,7 +7120,7 @@ extension on DashIsoWriteSegmentTimelineInRepresentation {
   }
 }
 
-extension on String {
+extension DashIsoWriteSegmentTimelineInRepresentationFromString on String {
   DashIsoWriteSegmentTimelineInRepresentation
       toDashIsoWriteSegmentTimelineInRepresentation() {
     switch (this) {
@@ -7129,7 +7141,7 @@ enum DecryptionMode {
   aesGcm,
 }
 
-extension on DecryptionMode {
+extension DecryptionModeValue on DecryptionMode {
   String toValue() {
     switch (this) {
       case DecryptionMode.aesCtr:
@@ -7142,7 +7154,7 @@ extension on DecryptionMode {
   }
 }
 
-extension on String {
+extension DecryptionModeFromString on String {
   DecryptionMode toDecryptionMode() {
     switch (this) {
       case 'AES_CTR':
@@ -7169,7 +7181,7 @@ enum DeinterlaceAlgorithm {
   blendTicker,
 }
 
-extension on DeinterlaceAlgorithm {
+extension DeinterlaceAlgorithmValue on DeinterlaceAlgorithm {
   String toValue() {
     switch (this) {
       case DeinterlaceAlgorithm.interpolate:
@@ -7184,7 +7196,7 @@ extension on DeinterlaceAlgorithm {
   }
 }
 
-extension on String {
+extension DeinterlaceAlgorithmFromString on String {
   DeinterlaceAlgorithm toDeinterlaceAlgorithm() {
     switch (this) {
       case 'INTERPOLATE':
@@ -7264,7 +7276,7 @@ enum DeinterlacerControl {
   normal,
 }
 
-extension on DeinterlacerControl {
+extension DeinterlacerControlValue on DeinterlacerControl {
   String toValue() {
     switch (this) {
       case DeinterlacerControl.forceAllFrames:
@@ -7275,7 +7287,7 @@ extension on DeinterlacerControl {
   }
 }
 
-extension on String {
+extension DeinterlacerControlFromString on String {
   DeinterlacerControl toDeinterlacerControl() {
     switch (this) {
       case 'FORCE_ALL_FRAMES':
@@ -7297,7 +7309,7 @@ enum DeinterlacerMode {
   adaptive,
 }
 
-extension on DeinterlacerMode {
+extension DeinterlacerModeValue on DeinterlacerMode {
   String toValue() {
     switch (this) {
       case DeinterlacerMode.deinterlace:
@@ -7310,7 +7322,7 @@ extension on DeinterlacerMode {
   }
 }
 
-extension on String {
+extension DeinterlacerModeFromString on String {
   DeinterlacerMode toDeinterlacerMode() {
     switch (this) {
       case 'DEINTERLACE':
@@ -7354,7 +7366,7 @@ enum DescribeEndpointsMode {
   getOnly,
 }
 
-extension on DescribeEndpointsMode {
+extension DescribeEndpointsModeValue on DescribeEndpointsMode {
   String toValue() {
     switch (this) {
       case DescribeEndpointsMode.$default:
@@ -7365,7 +7377,7 @@ extension on DescribeEndpointsMode {
   }
 }
 
-extension on String {
+extension DescribeEndpointsModeFromString on String {
   DescribeEndpointsMode toDescribeEndpointsMode() {
     switch (this) {
       case 'DEFAULT':
@@ -7515,7 +7527,7 @@ enum DolbyVisionLevel6Mode {
   specify,
 }
 
-extension on DolbyVisionLevel6Mode {
+extension DolbyVisionLevel6ModeValue on DolbyVisionLevel6Mode {
   String toValue() {
     switch (this) {
       case DolbyVisionLevel6Mode.passthrough:
@@ -7528,7 +7540,7 @@ extension on DolbyVisionLevel6Mode {
   }
 }
 
-extension on String {
+extension DolbyVisionLevel6ModeFromString on String {
   DolbyVisionLevel6Mode toDolbyVisionLevel6Mode() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -7549,7 +7561,7 @@ enum DolbyVisionProfile {
   profile_5,
 }
 
-extension on DolbyVisionProfile {
+extension DolbyVisionProfileValue on DolbyVisionProfile {
   String toValue() {
     switch (this) {
       case DolbyVisionProfile.profile_5:
@@ -7558,7 +7570,7 @@ extension on DolbyVisionProfile {
   }
 }
 
-extension on String {
+extension DolbyVisionProfileFromString on String {
   DolbyVisionProfile toDolbyVisionProfile() {
     switch (this) {
       case 'PROFILE_5':
@@ -7578,7 +7590,7 @@ enum DropFrameTimecode {
   enabled,
 }
 
-extension on DropFrameTimecode {
+extension DropFrameTimecodeValue on DropFrameTimecode {
   String toValue() {
     switch (this) {
       case DropFrameTimecode.disabled:
@@ -7589,7 +7601,7 @@ extension on DropFrameTimecode {
   }
 }
 
-extension on String {
+extension DropFrameTimecodeFromString on String {
   DropFrameTimecode toDropFrameTimecode() {
     switch (this) {
       case 'DISABLED':
@@ -7931,7 +7943,7 @@ enum DvbSubtitleAlignment {
   left,
 }
 
-extension on DvbSubtitleAlignment {
+extension DvbSubtitleAlignmentValue on DvbSubtitleAlignment {
   String toValue() {
     switch (this) {
       case DvbSubtitleAlignment.centered:
@@ -7942,7 +7954,7 @@ extension on DvbSubtitleAlignment {
   }
 }
 
-extension on String {
+extension DvbSubtitleAlignmentFromString on String {
   DvbSubtitleAlignment toDvbSubtitleAlignment() {
     switch (this) {
       case 'CENTERED':
@@ -7962,7 +7974,7 @@ enum DvbSubtitleBackgroundColor {
   white,
 }
 
-extension on DvbSubtitleBackgroundColor {
+extension DvbSubtitleBackgroundColorValue on DvbSubtitleBackgroundColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleBackgroundColor.none:
@@ -7975,7 +7987,7 @@ extension on DvbSubtitleBackgroundColor {
   }
 }
 
-extension on String {
+extension DvbSubtitleBackgroundColorFromString on String {
   DvbSubtitleBackgroundColor toDvbSubtitleBackgroundColor() {
     switch (this) {
       case 'NONE':
@@ -8002,7 +8014,7 @@ enum DvbSubtitleFontColor {
   blue,
 }
 
-extension on DvbSubtitleFontColor {
+extension DvbSubtitleFontColorValue on DvbSubtitleFontColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleFontColor.white:
@@ -8021,7 +8033,7 @@ extension on DvbSubtitleFontColor {
   }
 }
 
-extension on String {
+extension DvbSubtitleFontColorFromString on String {
   DvbSubtitleFontColor toDvbSubtitleFontColor() {
     switch (this) {
       case 'WHITE':
@@ -8054,7 +8066,7 @@ enum DvbSubtitleOutlineColor {
   blue,
 }
 
-extension on DvbSubtitleOutlineColor {
+extension DvbSubtitleOutlineColorValue on DvbSubtitleOutlineColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleOutlineColor.black:
@@ -8073,7 +8085,7 @@ extension on DvbSubtitleOutlineColor {
   }
 }
 
-extension on String {
+extension DvbSubtitleOutlineColorFromString on String {
   DvbSubtitleOutlineColor toDvbSubtitleOutlineColor() {
     switch (this) {
       case 'BLACK':
@@ -8101,7 +8113,7 @@ enum DvbSubtitleShadowColor {
   white,
 }
 
-extension on DvbSubtitleShadowColor {
+extension DvbSubtitleShadowColorValue on DvbSubtitleShadowColor {
   String toValue() {
     switch (this) {
       case DvbSubtitleShadowColor.none:
@@ -8114,7 +8126,7 @@ extension on DvbSubtitleShadowColor {
   }
 }
 
-extension on String {
+extension DvbSubtitleShadowColorFromString on String {
   DvbSubtitleShadowColor toDvbSubtitleShadowColor() {
     switch (this) {
       case 'NONE':
@@ -8139,7 +8151,7 @@ enum DvbSubtitleTeletextSpacing {
   proportional,
 }
 
-extension on DvbSubtitleTeletextSpacing {
+extension DvbSubtitleTeletextSpacingValue on DvbSubtitleTeletextSpacing {
   String toValue() {
     switch (this) {
       case DvbSubtitleTeletextSpacing.fixedGrid:
@@ -8150,7 +8162,7 @@ extension on DvbSubtitleTeletextSpacing {
   }
 }
 
-extension on String {
+extension DvbSubtitleTeletextSpacingFromString on String {
   DvbSubtitleTeletextSpacing toDvbSubtitleTeletextSpacing() {
     switch (this) {
       case 'FIXED_GRID':
@@ -8170,7 +8182,7 @@ enum DvbSubtitlingType {
   standard,
 }
 
-extension on DvbSubtitlingType {
+extension DvbSubtitlingTypeValue on DvbSubtitlingType {
   String toValue() {
     switch (this) {
       case DvbSubtitlingType.hearingImpaired:
@@ -8181,7 +8193,7 @@ extension on DvbSubtitlingType {
   }
 }
 
-extension on String {
+extension DvbSubtitlingTypeFromString on String {
   DvbSubtitlingType toDvbSubtitlingType() {
     switch (this) {
       case 'HEARING_IMPAIRED':
@@ -8224,7 +8236,7 @@ enum Eac3AtmosBitstreamMode {
   completeMain,
 }
 
-extension on Eac3AtmosBitstreamMode {
+extension Eac3AtmosBitstreamModeValue on Eac3AtmosBitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosBitstreamMode.completeMain:
@@ -8233,7 +8245,7 @@ extension on Eac3AtmosBitstreamMode {
   }
 }
 
-extension on String {
+extension Eac3AtmosBitstreamModeFromString on String {
   Eac3AtmosBitstreamMode toEac3AtmosBitstreamMode() {
     switch (this) {
       case 'COMPLETE_MAIN':
@@ -8249,7 +8261,7 @@ enum Eac3AtmosCodingMode {
   codingMode_9_1_6,
 }
 
-extension on Eac3AtmosCodingMode {
+extension Eac3AtmosCodingModeValue on Eac3AtmosCodingMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosCodingMode.codingMode_9_1_6:
@@ -8258,7 +8270,7 @@ extension on Eac3AtmosCodingMode {
   }
 }
 
-extension on String {
+extension Eac3AtmosCodingModeFromString on String {
   Eac3AtmosCodingMode toEac3AtmosCodingMode() {
     switch (this) {
       case 'CODING_MODE_9_1_6':
@@ -8275,7 +8287,7 @@ enum Eac3AtmosDialogueIntelligence {
   disabled,
 }
 
-extension on Eac3AtmosDialogueIntelligence {
+extension Eac3AtmosDialogueIntelligenceValue on Eac3AtmosDialogueIntelligence {
   String toValue() {
     switch (this) {
       case Eac3AtmosDialogueIntelligence.enabled:
@@ -8286,7 +8298,7 @@ extension on Eac3AtmosDialogueIntelligence {
   }
 }
 
-extension on String {
+extension Eac3AtmosDialogueIntelligenceFromString on String {
   Eac3AtmosDialogueIntelligence toEac3AtmosDialogueIntelligence() {
     switch (this) {
       case 'ENABLED':
@@ -8308,7 +8320,8 @@ enum Eac3AtmosDynamicRangeCompressionLine {
   speech,
 }
 
-extension on Eac3AtmosDynamicRangeCompressionLine {
+extension Eac3AtmosDynamicRangeCompressionLineValue
+    on Eac3AtmosDynamicRangeCompressionLine {
   String toValue() {
     switch (this) {
       case Eac3AtmosDynamicRangeCompressionLine.none:
@@ -8327,7 +8340,7 @@ extension on Eac3AtmosDynamicRangeCompressionLine {
   }
 }
 
-extension on String {
+extension Eac3AtmosDynamicRangeCompressionLineFromString on String {
   Eac3AtmosDynamicRangeCompressionLine
       toEac3AtmosDynamicRangeCompressionLine() {
     switch (this) {
@@ -8360,7 +8373,8 @@ enum Eac3AtmosDynamicRangeCompressionRf {
   speech,
 }
 
-extension on Eac3AtmosDynamicRangeCompressionRf {
+extension Eac3AtmosDynamicRangeCompressionRfValue
+    on Eac3AtmosDynamicRangeCompressionRf {
   String toValue() {
     switch (this) {
       case Eac3AtmosDynamicRangeCompressionRf.none:
@@ -8379,7 +8393,7 @@ extension on Eac3AtmosDynamicRangeCompressionRf {
   }
 }
 
-extension on String {
+extension Eac3AtmosDynamicRangeCompressionRfFromString on String {
   Eac3AtmosDynamicRangeCompressionRf toEac3AtmosDynamicRangeCompressionRf() {
     switch (this) {
       case 'NONE':
@@ -8409,7 +8423,7 @@ enum Eac3AtmosMeteringMode {
   ituBs_1770_4,
 }
 
-extension on Eac3AtmosMeteringMode {
+extension Eac3AtmosMeteringModeValue on Eac3AtmosMeteringMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosMeteringMode.leqA:
@@ -8426,7 +8440,7 @@ extension on Eac3AtmosMeteringMode {
   }
 }
 
-extension on String {
+extension Eac3AtmosMeteringModeFromString on String {
   Eac3AtmosMeteringMode toEac3AtmosMeteringMode() {
     switch (this) {
       case 'LEQ_A':
@@ -8612,7 +8626,7 @@ enum Eac3AtmosStereoDownmix {
   dpl2,
 }
 
-extension on Eac3AtmosStereoDownmix {
+extension Eac3AtmosStereoDownmixValue on Eac3AtmosStereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3AtmosStereoDownmix.notIndicated:
@@ -8627,7 +8641,7 @@ extension on Eac3AtmosStereoDownmix {
   }
 }
 
-extension on String {
+extension Eac3AtmosStereoDownmixFromString on String {
   Eac3AtmosStereoDownmix toEac3AtmosStereoDownmix() {
     switch (this) {
       case 'NOT_INDICATED':
@@ -8651,7 +8665,7 @@ enum Eac3AtmosSurroundExMode {
   disabled,
 }
 
-extension on Eac3AtmosSurroundExMode {
+extension Eac3AtmosSurroundExModeValue on Eac3AtmosSurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3AtmosSurroundExMode.notIndicated:
@@ -8664,7 +8678,7 @@ extension on Eac3AtmosSurroundExMode {
   }
 }
 
-extension on String {
+extension Eac3AtmosSurroundExModeFromString on String {
   Eac3AtmosSurroundExMode toEac3AtmosSurroundExMode() {
     switch (this) {
       case 'NOT_INDICATED':
@@ -8685,7 +8699,7 @@ enum Eac3AttenuationControl {
   none,
 }
 
-extension on Eac3AttenuationControl {
+extension Eac3AttenuationControlValue on Eac3AttenuationControl {
   String toValue() {
     switch (this) {
       case Eac3AttenuationControl.attenuate_3Db:
@@ -8696,7 +8710,7 @@ extension on Eac3AttenuationControl {
   }
 }
 
-extension on String {
+extension Eac3AttenuationControlFromString on String {
   Eac3AttenuationControl toEac3AttenuationControl() {
     switch (this) {
       case 'ATTENUATE_3_DB':
@@ -8719,7 +8733,7 @@ enum Eac3BitstreamMode {
   visuallyImpaired,
 }
 
-extension on Eac3BitstreamMode {
+extension Eac3BitstreamModeValue on Eac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3BitstreamMode.completeMain:
@@ -8736,7 +8750,7 @@ extension on Eac3BitstreamMode {
   }
 }
 
-extension on String {
+extension Eac3BitstreamModeFromString on String {
   Eac3BitstreamMode toEac3BitstreamMode() {
     switch (this) {
       case 'COMPLETE_MAIN':
@@ -8761,7 +8775,7 @@ enum Eac3CodingMode {
   codingMode_3_2,
 }
 
-extension on Eac3CodingMode {
+extension Eac3CodingModeValue on Eac3CodingMode {
   String toValue() {
     switch (this) {
       case Eac3CodingMode.codingMode_1_0:
@@ -8774,7 +8788,7 @@ extension on Eac3CodingMode {
   }
 }
 
-extension on String {
+extension Eac3CodingModeFromString on String {
   Eac3CodingMode toEac3CodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -8794,7 +8808,7 @@ enum Eac3DcFilter {
   disabled,
 }
 
-extension on Eac3DcFilter {
+extension Eac3DcFilterValue on Eac3DcFilter {
   String toValue() {
     switch (this) {
       case Eac3DcFilter.enabled:
@@ -8805,7 +8819,7 @@ extension on Eac3DcFilter {
   }
 }
 
-extension on String {
+extension Eac3DcFilterFromString on String {
   Eac3DcFilter toEac3DcFilter() {
     switch (this) {
       case 'ENABLED':
@@ -8827,7 +8841,8 @@ enum Eac3DynamicRangeCompressionLine {
   speech,
 }
 
-extension on Eac3DynamicRangeCompressionLine {
+extension Eac3DynamicRangeCompressionLineValue
+    on Eac3DynamicRangeCompressionLine {
   String toValue() {
     switch (this) {
       case Eac3DynamicRangeCompressionLine.none:
@@ -8846,7 +8861,7 @@ extension on Eac3DynamicRangeCompressionLine {
   }
 }
 
-extension on String {
+extension Eac3DynamicRangeCompressionLineFromString on String {
   Eac3DynamicRangeCompressionLine toEac3DynamicRangeCompressionLine() {
     switch (this) {
       case 'NONE':
@@ -8878,7 +8893,7 @@ enum Eac3DynamicRangeCompressionRf {
   speech,
 }
 
-extension on Eac3DynamicRangeCompressionRf {
+extension Eac3DynamicRangeCompressionRfValue on Eac3DynamicRangeCompressionRf {
   String toValue() {
     switch (this) {
       case Eac3DynamicRangeCompressionRf.none:
@@ -8897,7 +8912,7 @@ extension on Eac3DynamicRangeCompressionRf {
   }
 }
 
-extension on String {
+extension Eac3DynamicRangeCompressionRfFromString on String {
   Eac3DynamicRangeCompressionRf toEac3DynamicRangeCompressionRf() {
     switch (this) {
       case 'NONE':
@@ -8923,7 +8938,7 @@ enum Eac3LfeControl {
   noLfe,
 }
 
-extension on Eac3LfeControl {
+extension Eac3LfeControlValue on Eac3LfeControl {
   String toValue() {
     switch (this) {
       case Eac3LfeControl.lfe:
@@ -8934,7 +8949,7 @@ extension on Eac3LfeControl {
   }
 }
 
-extension on String {
+extension Eac3LfeControlFromString on String {
   Eac3LfeControl toEac3LfeControl() {
     switch (this) {
       case 'LFE':
@@ -8953,7 +8968,7 @@ enum Eac3LfeFilter {
   disabled,
 }
 
-extension on Eac3LfeFilter {
+extension Eac3LfeFilterValue on Eac3LfeFilter {
   String toValue() {
     switch (this) {
       case Eac3LfeFilter.enabled:
@@ -8964,7 +8979,7 @@ extension on Eac3LfeFilter {
   }
 }
 
-extension on String {
+extension Eac3LfeFilterFromString on String {
   Eac3LfeFilter toEac3LfeFilter() {
     switch (this) {
       case 'ENABLED':
@@ -8984,7 +8999,7 @@ enum Eac3MetadataControl {
   useConfigured,
 }
 
-extension on Eac3MetadataControl {
+extension Eac3MetadataControlValue on Eac3MetadataControl {
   String toValue() {
     switch (this) {
       case Eac3MetadataControl.followInput:
@@ -8995,7 +9010,7 @@ extension on Eac3MetadataControl {
   }
 }
 
-extension on String {
+extension Eac3MetadataControlFromString on String {
   Eac3MetadataControl toEac3MetadataControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -9017,7 +9032,7 @@ enum Eac3PassthroughControl {
   noPassthrough,
 }
 
-extension on Eac3PassthroughControl {
+extension Eac3PassthroughControlValue on Eac3PassthroughControl {
   String toValue() {
     switch (this) {
       case Eac3PassthroughControl.whenPossible:
@@ -9028,7 +9043,7 @@ extension on Eac3PassthroughControl {
   }
 }
 
-extension on String {
+extension Eac3PassthroughControlFromString on String {
   Eac3PassthroughControl toEac3PassthroughControl() {
     switch (this) {
       case 'WHEN_POSSIBLE':
@@ -9047,7 +9062,7 @@ enum Eac3PhaseControl {
   noShift,
 }
 
-extension on Eac3PhaseControl {
+extension Eac3PhaseControlValue on Eac3PhaseControl {
   String toValue() {
     switch (this) {
       case Eac3PhaseControl.shift_90Degrees:
@@ -9058,7 +9073,7 @@ extension on Eac3PhaseControl {
   }
 }
 
-extension on String {
+extension Eac3PhaseControlFromString on String {
   Eac3PhaseControl toEac3PhaseControl() {
     switch (this) {
       case 'SHIFT_90_DEGREES':
@@ -9308,7 +9323,7 @@ enum Eac3StereoDownmix {
   dpl2,
 }
 
-extension on Eac3StereoDownmix {
+extension Eac3StereoDownmixValue on Eac3StereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3StereoDownmix.notIndicated:
@@ -9323,7 +9338,7 @@ extension on Eac3StereoDownmix {
   }
 }
 
-extension on String {
+extension Eac3StereoDownmixFromString on String {
   Eac3StereoDownmix toEac3StereoDownmix() {
     switch (this) {
       case 'NOT_INDICATED':
@@ -9347,7 +9362,7 @@ enum Eac3SurroundExMode {
   disabled,
 }
 
-extension on Eac3SurroundExMode {
+extension Eac3SurroundExModeValue on Eac3SurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundExMode.notIndicated:
@@ -9360,7 +9375,7 @@ extension on Eac3SurroundExMode {
   }
 }
 
-extension on String {
+extension Eac3SurroundExModeFromString on String {
   Eac3SurroundExMode toEac3SurroundExMode() {
     switch (this) {
       case 'NOT_INDICATED':
@@ -9382,7 +9397,7 @@ enum Eac3SurroundMode {
   disabled,
 }
 
-extension on Eac3SurroundMode {
+extension Eac3SurroundModeValue on Eac3SurroundMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundMode.notIndicated:
@@ -9395,7 +9410,7 @@ extension on Eac3SurroundMode {
   }
 }
 
-extension on String {
+extension Eac3SurroundModeFromString on String {
   Eac3SurroundMode toEac3SurroundMode() {
     switch (this) {
       case 'NOT_INDICATED':
@@ -9419,7 +9434,7 @@ enum EmbeddedConvert608To708 {
   disabled,
 }
 
-extension on EmbeddedConvert608To708 {
+extension EmbeddedConvert608To708Value on EmbeddedConvert608To708 {
   String toValue() {
     switch (this) {
       case EmbeddedConvert608To708.upconvert:
@@ -9430,7 +9445,7 @@ extension on EmbeddedConvert608To708 {
   }
 }
 
-extension on String {
+extension EmbeddedConvert608To708FromString on String {
   EmbeddedConvert608To708 toEmbeddedConvert608To708() {
     switch (this) {
       case 'UPCONVERT':
@@ -9552,7 +9567,7 @@ enum EmbeddedTerminateCaptions {
   disabled,
 }
 
-extension on EmbeddedTerminateCaptions {
+extension EmbeddedTerminateCaptionsValue on EmbeddedTerminateCaptions {
   String toValue() {
     switch (this) {
       case EmbeddedTerminateCaptions.endOfInput:
@@ -9563,7 +9578,7 @@ extension on EmbeddedTerminateCaptions {
   }
 }
 
-extension on String {
+extension EmbeddedTerminateCaptionsFromString on String {
   EmbeddedTerminateCaptions toEmbeddedTerminateCaptions() {
     switch (this) {
       case 'END_OF_INPUT':
@@ -9714,7 +9729,7 @@ enum F4vMoovPlacement {
   normal,
 }
 
-extension on F4vMoovPlacement {
+extension F4vMoovPlacementValue on F4vMoovPlacement {
   String toValue() {
     switch (this) {
       case F4vMoovPlacement.progressiveDownload:
@@ -9725,7 +9740,7 @@ extension on F4vMoovPlacement {
   }
 }
 
-extension on String {
+extension F4vMoovPlacementFromString on String {
   F4vMoovPlacement toF4vMoovPlacement() {
     switch (this) {
       case 'PROGRESSIVE_DOWNLOAD':
@@ -9810,7 +9825,7 @@ enum FileSourceConvert608To708 {
   disabled,
 }
 
-extension on FileSourceConvert608To708 {
+extension FileSourceConvert608To708Value on FileSourceConvert608To708 {
   String toValue() {
     switch (this) {
       case FileSourceConvert608To708.upconvert:
@@ -9821,7 +9836,7 @@ extension on FileSourceConvert608To708 {
   }
 }
 
-extension on String {
+extension FileSourceConvert608To708FromString on String {
   FileSourceConvert608To708 toFileSourceConvert608To708() {
     switch (this) {
       case 'UPCONVERT':
@@ -9904,7 +9919,7 @@ enum FontScript {
   hant,
 }
 
-extension on FontScript {
+extension FontScriptValue on FontScript {
   String toValue() {
     switch (this) {
       case FontScript.automatic:
@@ -9917,7 +9932,7 @@ extension on FontScript {
   }
 }
 
-extension on String {
+extension FontScriptFromString on String {
   FontScript toFontScript() {
     switch (this) {
       case 'AUTOMATIC':
@@ -10078,7 +10093,7 @@ enum H264AdaptiveQuantization {
   max,
 }
 
-extension on H264AdaptiveQuantization {
+extension H264AdaptiveQuantizationValue on H264AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264AdaptiveQuantization.off:
@@ -10099,7 +10114,7 @@ extension on H264AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H264AdaptiveQuantizationFromString on String {
   H264AdaptiveQuantization toH264AdaptiveQuantization() {
     switch (this) {
       case 'OFF':
@@ -10143,7 +10158,7 @@ enum H264CodecLevel {
   level_5_2,
 }
 
-extension on H264CodecLevel {
+extension H264CodecLevelValue on H264CodecLevel {
   String toValue() {
     switch (this) {
       case H264CodecLevel.auto:
@@ -10184,7 +10199,7 @@ extension on H264CodecLevel {
   }
 }
 
-extension on String {
+extension H264CodecLevelFromString on String {
   H264CodecLevel toH264CodecLevel() {
     switch (this) {
       case 'AUTO':
@@ -10237,7 +10252,7 @@ enum H264CodecProfile {
   main,
 }
 
-extension on H264CodecProfile {
+extension H264CodecProfileValue on H264CodecProfile {
   String toValue() {
     switch (this) {
       case H264CodecProfile.baseline:
@@ -10256,7 +10271,7 @@ extension on H264CodecProfile {
   }
 }
 
-extension on String {
+extension H264CodecProfileFromString on String {
   H264CodecProfile toH264CodecProfile() {
     switch (this) {
       case 'BASELINE':
@@ -10287,7 +10302,7 @@ enum H264DynamicSubGop {
   static,
 }
 
-extension on H264DynamicSubGop {
+extension H264DynamicSubGopValue on H264DynamicSubGop {
   String toValue() {
     switch (this) {
       case H264DynamicSubGop.adaptive:
@@ -10298,7 +10313,7 @@ extension on H264DynamicSubGop {
   }
 }
 
-extension on String {
+extension H264DynamicSubGopFromString on String {
   H264DynamicSubGop toH264DynamicSubGop() {
     switch (this) {
       case 'ADAPTIVE':
@@ -10316,7 +10331,7 @@ enum H264EntropyEncoding {
   cavlc,
 }
 
-extension on H264EntropyEncoding {
+extension H264EntropyEncodingValue on H264EntropyEncoding {
   String toValue() {
     switch (this) {
       case H264EntropyEncoding.cabac:
@@ -10327,7 +10342,7 @@ extension on H264EntropyEncoding {
   }
 }
 
-extension on String {
+extension H264EntropyEncodingFromString on String {
   H264EntropyEncoding toH264EntropyEncoding() {
     switch (this) {
       case 'CABAC':
@@ -10347,7 +10362,7 @@ enum H264FieldEncoding {
   forceField,
 }
 
-extension on H264FieldEncoding {
+extension H264FieldEncodingValue on H264FieldEncoding {
   String toValue() {
     switch (this) {
       case H264FieldEncoding.paff:
@@ -10358,7 +10373,7 @@ extension on H264FieldEncoding {
   }
 }
 
-extension on String {
+extension H264FieldEncodingFromString on String {
   H264FieldEncoding toH264FieldEncoding() {
     switch (this) {
       case 'PAFF':
@@ -10389,7 +10404,8 @@ enum H264FlickerAdaptiveQuantization {
   enabled,
 }
 
-extension on H264FlickerAdaptiveQuantization {
+extension H264FlickerAdaptiveQuantizationValue
+    on H264FlickerAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264FlickerAdaptiveQuantization.disabled:
@@ -10400,7 +10416,7 @@ extension on H264FlickerAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H264FlickerAdaptiveQuantizationFromString on String {
   H264FlickerAdaptiveQuantization toH264FlickerAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -10430,7 +10446,7 @@ enum H264FramerateControl {
   specified,
 }
 
-extension on H264FramerateControl {
+extension H264FramerateControlValue on H264FramerateControl {
   String toValue() {
     switch (this) {
       case H264FramerateControl.initializeFromSource:
@@ -10441,7 +10457,7 @@ extension on H264FramerateControl {
   }
 }
 
-extension on String {
+extension H264FramerateControlFromString on String {
   H264FramerateControl toH264FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -10470,7 +10486,8 @@ enum H264FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on H264FramerateConversionAlgorithm {
+extension H264FramerateConversionAlgorithmValue
+    on H264FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case H264FramerateConversionAlgorithm.duplicateDrop:
@@ -10483,7 +10500,7 @@ extension on H264FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension H264FramerateConversionAlgorithmFromString on String {
   H264FramerateConversionAlgorithm toH264FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -10504,7 +10521,7 @@ enum H264GopBReference {
   enabled,
 }
 
-extension on H264GopBReference {
+extension H264GopBReferenceValue on H264GopBReference {
   String toValue() {
     switch (this) {
       case H264GopBReference.disabled:
@@ -10515,7 +10532,7 @@ extension on H264GopBReference {
   }
 }
 
-extension on String {
+extension H264GopBReferenceFromString on String {
   H264GopBReference toH264GopBReference() {
     switch (this) {
       case 'DISABLED':
@@ -10534,7 +10551,7 @@ enum H264GopSizeUnits {
   seconds,
 }
 
-extension on H264GopSizeUnits {
+extension H264GopSizeUnitsValue on H264GopSizeUnits {
   String toValue() {
     switch (this) {
       case H264GopSizeUnits.frames:
@@ -10545,7 +10562,7 @@ extension on H264GopSizeUnits {
   }
 }
 
-extension on String {
+extension H264GopSizeUnitsFromString on String {
   H264GopSizeUnits toH264GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -10577,7 +10594,7 @@ enum H264InterlaceMode {
   followBottomField,
 }
 
-extension on H264InterlaceMode {
+extension H264InterlaceModeValue on H264InterlaceMode {
   String toValue() {
     switch (this) {
       case H264InterlaceMode.progressive:
@@ -10594,7 +10611,7 @@ extension on H264InterlaceMode {
   }
 }
 
-extension on String {
+extension H264InterlaceModeFromString on String {
   H264InterlaceMode toH264InterlaceMode() {
     switch (this) {
       case 'PROGRESSIVE':
@@ -10625,7 +10642,7 @@ enum H264ParControl {
   specified,
 }
 
-extension on H264ParControl {
+extension H264ParControlValue on H264ParControl {
   String toValue() {
     switch (this) {
       case H264ParControl.initializeFromSource:
@@ -10636,7 +10653,7 @@ extension on H264ParControl {
   }
 }
 
-extension on String {
+extension H264ParControlFromString on String {
   H264ParControl toH264ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -10657,7 +10674,7 @@ enum H264QualityTuningLevel {
   multiPassHq,
 }
 
-extension on H264QualityTuningLevel {
+extension H264QualityTuningLevelValue on H264QualityTuningLevel {
   String toValue() {
     switch (this) {
       case H264QualityTuningLevel.singlePass:
@@ -10670,7 +10687,7 @@ extension on H264QualityTuningLevel {
   }
 }
 
-extension on String {
+extension H264QualityTuningLevelFromString on String {
   H264QualityTuningLevel toH264QualityTuningLevel() {
     switch (this) {
       case 'SINGLE_PASS':
@@ -10750,7 +10767,7 @@ enum H264RateControlMode {
   qvbr,
 }
 
-extension on H264RateControlMode {
+extension H264RateControlModeValue on H264RateControlMode {
   String toValue() {
     switch (this) {
       case H264RateControlMode.vbr:
@@ -10763,7 +10780,7 @@ extension on H264RateControlMode {
   }
 }
 
-extension on String {
+extension H264RateControlModeFromString on String {
   H264RateControlMode toH264RateControlMode() {
     switch (this) {
       case 'VBR':
@@ -10783,7 +10800,7 @@ enum H264RepeatPps {
   enabled,
 }
 
-extension on H264RepeatPps {
+extension H264RepeatPpsValue on H264RepeatPps {
   String toValue() {
     switch (this) {
       case H264RepeatPps.disabled:
@@ -10794,7 +10811,7 @@ extension on H264RepeatPps {
   }
 }
 
-extension on String {
+extension H264RepeatPpsFromString on String {
   H264RepeatPps toH264RepeatPps() {
     switch (this) {
       case 'DISABLED':
@@ -10818,7 +10835,7 @@ enum H264SceneChangeDetect {
   transitionDetection,
 }
 
-extension on H264SceneChangeDetect {
+extension H264SceneChangeDetectValue on H264SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H264SceneChangeDetect.disabled:
@@ -10831,7 +10848,7 @@ extension on H264SceneChangeDetect {
   }
 }
 
-extension on String {
+extension H264SceneChangeDetectFromString on String {
   H264SceneChangeDetect toH264SceneChangeDetect() {
     switch (this) {
       case 'DISABLED':
@@ -11370,7 +11387,7 @@ enum H264SlowPal {
   enabled,
 }
 
-extension on H264SlowPal {
+extension H264SlowPalValue on H264SlowPal {
   String toValue() {
     switch (this) {
       case H264SlowPal.disabled:
@@ -11381,7 +11398,7 @@ extension on H264SlowPal {
   }
 }
 
-extension on String {
+extension H264SlowPalFromString on String {
   H264SlowPal toH264SlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -11422,7 +11439,8 @@ enum H264SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension on H264SpatialAdaptiveQuantization {
+extension H264SpatialAdaptiveQuantizationValue
+    on H264SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264SpatialAdaptiveQuantization.disabled:
@@ -11433,7 +11451,7 @@ extension on H264SpatialAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H264SpatialAdaptiveQuantizationFromString on String {
   H264SpatialAdaptiveQuantization toH264SpatialAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -11452,7 +11470,7 @@ enum H264Syntax {
   rp2027,
 }
 
-extension on H264Syntax {
+extension H264SyntaxValue on H264Syntax {
   String toValue() {
     switch (this) {
       case H264Syntax.$default:
@@ -11463,7 +11481,7 @@ extension on H264Syntax {
   }
 }
 
-extension on String {
+extension H264SyntaxFromString on String {
   H264Syntax toH264Syntax() {
     switch (this) {
       case 'DEFAULT':
@@ -11489,7 +11507,7 @@ enum H264Telecine {
   hard,
 }
 
-extension on H264Telecine {
+extension H264TelecineValue on H264Telecine {
   String toValue() {
     switch (this) {
       case H264Telecine.none:
@@ -11502,7 +11520,7 @@ extension on H264Telecine {
   }
 }
 
-extension on String {
+extension H264TelecineFromString on String {
   H264Telecine toH264Telecine() {
     switch (this) {
       case 'NONE':
@@ -11543,7 +11561,8 @@ enum H264TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension on H264TemporalAdaptiveQuantization {
+extension H264TemporalAdaptiveQuantizationValue
+    on H264TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264TemporalAdaptiveQuantization.disabled:
@@ -11554,7 +11573,7 @@ extension on H264TemporalAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H264TemporalAdaptiveQuantizationFromString on String {
   H264TemporalAdaptiveQuantization toH264TemporalAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -11573,7 +11592,7 @@ enum H264UnregisteredSeiTimecode {
   enabled,
 }
 
-extension on H264UnregisteredSeiTimecode {
+extension H264UnregisteredSeiTimecodeValue on H264UnregisteredSeiTimecode {
   String toValue() {
     switch (this) {
       case H264UnregisteredSeiTimecode.disabled:
@@ -11584,7 +11603,7 @@ extension on H264UnregisteredSeiTimecode {
   }
 }
 
-extension on String {
+extension H264UnregisteredSeiTimecodeFromString on String {
   H264UnregisteredSeiTimecode toH264UnregisteredSeiTimecode() {
     switch (this) {
       case 'DISABLED':
@@ -11610,7 +11629,7 @@ enum H265AdaptiveQuantization {
   max,
 }
 
-extension on H265AdaptiveQuantization {
+extension H265AdaptiveQuantizationValue on H265AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265AdaptiveQuantization.off:
@@ -11629,7 +11648,7 @@ extension on H265AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H265AdaptiveQuantizationFromString on String {
   H265AdaptiveQuantization toH265AdaptiveQuantization() {
     switch (this) {
       case 'OFF':
@@ -11656,7 +11675,8 @@ enum H265AlternateTransferFunctionSei {
   enabled,
 }
 
-extension on H265AlternateTransferFunctionSei {
+extension H265AlternateTransferFunctionSeiValue
+    on H265AlternateTransferFunctionSei {
   String toValue() {
     switch (this) {
       case H265AlternateTransferFunctionSei.disabled:
@@ -11667,7 +11687,7 @@ extension on H265AlternateTransferFunctionSei {
   }
 }
 
-extension on String {
+extension H265AlternateTransferFunctionSeiFromString on String {
   H265AlternateTransferFunctionSei toH265AlternateTransferFunctionSei() {
     switch (this) {
       case 'DISABLED':
@@ -11698,7 +11718,7 @@ enum H265CodecLevel {
   level_6_2,
 }
 
-extension on H265CodecLevel {
+extension H265CodecLevelValue on H265CodecLevel {
   String toValue() {
     switch (this) {
       case H265CodecLevel.auto:
@@ -11733,7 +11753,7 @@ extension on H265CodecLevel {
   }
 }
 
-extension on String {
+extension H265CodecLevelFromString on String {
   H265CodecLevel toH265CodecLevel() {
     switch (this) {
       case 'AUTO':
@@ -11784,7 +11804,7 @@ enum H265CodecProfile {
   main_422_10bitHigh,
 }
 
-extension on H265CodecProfile {
+extension H265CodecProfileValue on H265CodecProfile {
   String toValue() {
     switch (this) {
       case H265CodecProfile.mainMain:
@@ -11807,7 +11827,7 @@ extension on H265CodecProfile {
   }
 }
 
-extension on String {
+extension H265CodecProfileFromString on String {
   H265CodecProfile toH265CodecProfile() {
     switch (this) {
       case 'MAIN_MAIN':
@@ -11842,7 +11862,7 @@ enum H265DynamicSubGop {
   static,
 }
 
-extension on H265DynamicSubGop {
+extension H265DynamicSubGopValue on H265DynamicSubGop {
   String toValue() {
     switch (this) {
       case H265DynamicSubGop.adaptive:
@@ -11853,7 +11873,7 @@ extension on H265DynamicSubGop {
   }
 }
 
-extension on String {
+extension H265DynamicSubGopFromString on String {
   H265DynamicSubGop toH265DynamicSubGop() {
     switch (this) {
       case 'ADAPTIVE':
@@ -11877,7 +11897,8 @@ enum H265FlickerAdaptiveQuantization {
   enabled,
 }
 
-extension on H265FlickerAdaptiveQuantization {
+extension H265FlickerAdaptiveQuantizationValue
+    on H265FlickerAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265FlickerAdaptiveQuantization.disabled:
@@ -11888,7 +11909,7 @@ extension on H265FlickerAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H265FlickerAdaptiveQuantizationFromString on String {
   H265FlickerAdaptiveQuantization toH265FlickerAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -11918,7 +11939,7 @@ enum H265FramerateControl {
   specified,
 }
 
-extension on H265FramerateControl {
+extension H265FramerateControlValue on H265FramerateControl {
   String toValue() {
     switch (this) {
       case H265FramerateControl.initializeFromSource:
@@ -11929,7 +11950,7 @@ extension on H265FramerateControl {
   }
 }
 
-extension on String {
+extension H265FramerateControlFromString on String {
   H265FramerateControl toH265FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -11958,7 +11979,8 @@ enum H265FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on H265FramerateConversionAlgorithm {
+extension H265FramerateConversionAlgorithmValue
+    on H265FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case H265FramerateConversionAlgorithm.duplicateDrop:
@@ -11971,7 +11993,7 @@ extension on H265FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension H265FramerateConversionAlgorithmFromString on String {
   H265FramerateConversionAlgorithm toH265FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -11992,7 +12014,7 @@ enum H265GopBReference {
   enabled,
 }
 
-extension on H265GopBReference {
+extension H265GopBReferenceValue on H265GopBReference {
   String toValue() {
     switch (this) {
       case H265GopBReference.disabled:
@@ -12003,7 +12025,7 @@ extension on H265GopBReference {
   }
 }
 
-extension on String {
+extension H265GopBReferenceFromString on String {
   H265GopBReference toH265GopBReference() {
     switch (this) {
       case 'DISABLED':
@@ -12022,7 +12044,7 @@ enum H265GopSizeUnits {
   seconds,
 }
 
-extension on H265GopSizeUnits {
+extension H265GopSizeUnitsValue on H265GopSizeUnits {
   String toValue() {
     switch (this) {
       case H265GopSizeUnits.frames:
@@ -12033,7 +12055,7 @@ extension on H265GopSizeUnits {
   }
 }
 
-extension on String {
+extension H265GopSizeUnitsFromString on String {
   H265GopSizeUnits toH265GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -12065,7 +12087,7 @@ enum H265InterlaceMode {
   followBottomField,
 }
 
-extension on H265InterlaceMode {
+extension H265InterlaceModeValue on H265InterlaceMode {
   String toValue() {
     switch (this) {
       case H265InterlaceMode.progressive:
@@ -12082,7 +12104,7 @@ extension on H265InterlaceMode {
   }
 }
 
-extension on String {
+extension H265InterlaceModeFromString on String {
   H265InterlaceMode toH265InterlaceMode() {
     switch (this) {
       case 'PROGRESSIVE':
@@ -12113,7 +12135,7 @@ enum H265ParControl {
   specified,
 }
 
-extension on H265ParControl {
+extension H265ParControlValue on H265ParControl {
   String toValue() {
     switch (this) {
       case H265ParControl.initializeFromSource:
@@ -12124,7 +12146,7 @@ extension on H265ParControl {
   }
 }
 
-extension on String {
+extension H265ParControlFromString on String {
   H265ParControl toH265ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -12145,7 +12167,7 @@ enum H265QualityTuningLevel {
   multiPassHq,
 }
 
-extension on H265QualityTuningLevel {
+extension H265QualityTuningLevelValue on H265QualityTuningLevel {
   String toValue() {
     switch (this) {
       case H265QualityTuningLevel.singlePass:
@@ -12158,7 +12180,7 @@ extension on H265QualityTuningLevel {
   }
 }
 
-extension on String {
+extension H265QualityTuningLevelFromString on String {
   H265QualityTuningLevel toH265QualityTuningLevel() {
     switch (this) {
       case 'SINGLE_PASS':
@@ -12238,7 +12260,7 @@ enum H265RateControlMode {
   qvbr,
 }
 
-extension on H265RateControlMode {
+extension H265RateControlModeValue on H265RateControlMode {
   String toValue() {
     switch (this) {
       case H265RateControlMode.vbr:
@@ -12251,7 +12273,7 @@ extension on H265RateControlMode {
   }
 }
 
-extension on String {
+extension H265RateControlModeFromString on String {
   H265RateControlMode toH265RateControlMode() {
     switch (this) {
       case 'VBR':
@@ -12273,7 +12295,8 @@ enum H265SampleAdaptiveOffsetFilterMode {
   off,
 }
 
-extension on H265SampleAdaptiveOffsetFilterMode {
+extension H265SampleAdaptiveOffsetFilterModeValue
+    on H265SampleAdaptiveOffsetFilterMode {
   String toValue() {
     switch (this) {
       case H265SampleAdaptiveOffsetFilterMode.$default:
@@ -12286,7 +12309,7 @@ extension on H265SampleAdaptiveOffsetFilterMode {
   }
 }
 
-extension on String {
+extension H265SampleAdaptiveOffsetFilterModeFromString on String {
   H265SampleAdaptiveOffsetFilterMode toH265SampleAdaptiveOffsetFilterMode() {
     switch (this) {
       case 'DEFAULT':
@@ -12313,7 +12336,7 @@ enum H265SceneChangeDetect {
   transitionDetection,
 }
 
-extension on H265SceneChangeDetect {
+extension H265SceneChangeDetectValue on H265SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H265SceneChangeDetect.disabled:
@@ -12326,7 +12349,7 @@ extension on H265SceneChangeDetect {
   }
 }
 
-extension on String {
+extension H265SceneChangeDetectFromString on String {
   H265SceneChangeDetect toH265SceneChangeDetect() {
     switch (this) {
       case 'DISABLED':
@@ -12850,7 +12873,7 @@ enum H265SlowPal {
   enabled,
 }
 
-extension on H265SlowPal {
+extension H265SlowPalValue on H265SlowPal {
   String toValue() {
     switch (this) {
       case H265SlowPal.disabled:
@@ -12861,7 +12884,7 @@ extension on H265SlowPal {
   }
 }
 
-extension on String {
+extension H265SlowPalFromString on String {
   H265SlowPal toH265SlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -12893,7 +12916,8 @@ enum H265SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension on H265SpatialAdaptiveQuantization {
+extension H265SpatialAdaptiveQuantizationValue
+    on H265SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265SpatialAdaptiveQuantization.disabled:
@@ -12904,7 +12928,7 @@ extension on H265SpatialAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H265SpatialAdaptiveQuantizationFromString on String {
   H265SpatialAdaptiveQuantization toH265SpatialAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -12930,7 +12954,7 @@ enum H265Telecine {
   hard,
 }
 
-extension on H265Telecine {
+extension H265TelecineValue on H265Telecine {
   String toValue() {
     switch (this) {
       case H265Telecine.none:
@@ -12943,7 +12967,7 @@ extension on H265Telecine {
   }
 }
 
-extension on String {
+extension H265TelecineFromString on String {
   H265Telecine toH265Telecine() {
     switch (this) {
       case 'NONE':
@@ -12975,7 +12999,8 @@ enum H265TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension on H265TemporalAdaptiveQuantization {
+extension H265TemporalAdaptiveQuantizationValue
+    on H265TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265TemporalAdaptiveQuantization.disabled:
@@ -12986,7 +13011,7 @@ extension on H265TemporalAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H265TemporalAdaptiveQuantizationFromString on String {
   H265TemporalAdaptiveQuantization toH265TemporalAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -13012,7 +13037,7 @@ enum H265TemporalIds {
   enabled,
 }
 
-extension on H265TemporalIds {
+extension H265TemporalIdsValue on H265TemporalIds {
   String toValue() {
     switch (this) {
       case H265TemporalIds.disabled:
@@ -13023,7 +13048,7 @@ extension on H265TemporalIds {
   }
 }
 
-extension on String {
+extension H265TemporalIdsFromString on String {
   H265TemporalIds toH265TemporalIds() {
     switch (this) {
       case 'DISABLED':
@@ -13042,7 +13067,7 @@ enum H265Tiles {
   enabled,
 }
 
-extension on H265Tiles {
+extension H265TilesValue on H265Tiles {
   String toValue() {
     switch (this) {
       case H265Tiles.disabled:
@@ -13053,7 +13078,7 @@ extension on H265Tiles {
   }
 }
 
-extension on String {
+extension H265TilesFromString on String {
   H265Tiles toH265Tiles() {
     switch (this) {
       case 'DISABLED':
@@ -13071,7 +13096,7 @@ enum H265UnregisteredSeiTimecode {
   enabled,
 }
 
-extension on H265UnregisteredSeiTimecode {
+extension H265UnregisteredSeiTimecodeValue on H265UnregisteredSeiTimecode {
   String toValue() {
     switch (this) {
       case H265UnregisteredSeiTimecode.disabled:
@@ -13082,7 +13107,7 @@ extension on H265UnregisteredSeiTimecode {
   }
 }
 
-extension on String {
+extension H265UnregisteredSeiTimecodeFromString on String {
   H265UnregisteredSeiTimecode toH265UnregisteredSeiTimecode() {
     switch (this) {
       case 'DISABLED':
@@ -13110,7 +13135,7 @@ enum H265WriteMp4PackagingType {
   hev1,
 }
 
-extension on H265WriteMp4PackagingType {
+extension H265WriteMp4PackagingTypeValue on H265WriteMp4PackagingType {
   String toValue() {
     switch (this) {
       case H265WriteMp4PackagingType.hvc1:
@@ -13121,7 +13146,7 @@ extension on H265WriteMp4PackagingType {
   }
 }
 
-extension on String {
+extension H265WriteMp4PackagingTypeFromString on String {
   H265WriteMp4PackagingType toH265WriteMp4PackagingType() {
     switch (this) {
       case 'HVC1':
@@ -13273,7 +13298,7 @@ enum HlsAdMarkers {
   elementalScte35,
 }
 
-extension on HlsAdMarkers {
+extension HlsAdMarkersValue on HlsAdMarkers {
   String toValue() {
     switch (this) {
       case HlsAdMarkers.elemental:
@@ -13284,7 +13309,7 @@ extension on HlsAdMarkers {
   }
 }
 
-extension on String {
+extension HlsAdMarkersFromString on String {
   HlsAdMarkers toHlsAdMarkers() {
     switch (this) {
       case 'ELEMENTAL':
@@ -13350,7 +13375,7 @@ enum HlsAudioOnlyContainer {
   m2ts,
 }
 
-extension on HlsAudioOnlyContainer {
+extension HlsAudioOnlyContainerValue on HlsAudioOnlyContainer {
   String toValue() {
     switch (this) {
       case HlsAudioOnlyContainer.automatic:
@@ -13361,7 +13386,7 @@ extension on HlsAudioOnlyContainer {
   }
 }
 
-extension on String {
+extension HlsAudioOnlyContainerFromString on String {
   HlsAudioOnlyContainer toHlsAudioOnlyContainer() {
     switch (this) {
       case 'AUTOMATIC':
@@ -13382,7 +13407,7 @@ enum HlsAudioOnlyHeader {
   exclude,
 }
 
-extension on HlsAudioOnlyHeader {
+extension HlsAudioOnlyHeaderValue on HlsAudioOnlyHeader {
   String toValue() {
     switch (this) {
       case HlsAudioOnlyHeader.include:
@@ -13393,7 +13418,7 @@ extension on HlsAudioOnlyHeader {
   }
 }
 
-extension on String {
+extension HlsAudioOnlyHeaderFromString on String {
   HlsAudioOnlyHeader toHlsAudioOnlyHeader() {
     switch (this) {
       case 'INCLUDE':
@@ -13423,7 +13448,7 @@ enum HlsAudioTrackType {
   audioOnlyVariantStream,
 }
 
-extension on HlsAudioTrackType {
+extension HlsAudioTrackTypeValue on HlsAudioTrackType {
   String toValue() {
     switch (this) {
       case HlsAudioTrackType.alternateAudioAutoSelectDefault:
@@ -13438,7 +13463,7 @@ extension on HlsAudioTrackType {
   }
 }
 
-extension on String {
+extension HlsAudioTrackTypeFromString on String {
   HlsAudioTrackType toHlsAudioTrackType() {
     switch (this) {
       case 'ALTERNATE_AUDIO_AUTO_SELECT_DEFAULT':
@@ -13515,7 +13540,7 @@ enum HlsCaptionLanguageSetting {
   none,
 }
 
-extension on HlsCaptionLanguageSetting {
+extension HlsCaptionLanguageSettingValue on HlsCaptionLanguageSetting {
   String toValue() {
     switch (this) {
       case HlsCaptionLanguageSetting.insert:
@@ -13528,7 +13553,7 @@ extension on HlsCaptionLanguageSetting {
   }
 }
 
-extension on String {
+extension HlsCaptionLanguageSettingFromString on String {
   HlsCaptionLanguageSetting toHlsCaptionLanguageSetting() {
     switch (this) {
       case 'INSERT':
@@ -13551,7 +13576,7 @@ enum HlsClientCache {
   enabled,
 }
 
-extension on HlsClientCache {
+extension HlsClientCacheValue on HlsClientCache {
   String toValue() {
     switch (this) {
       case HlsClientCache.disabled:
@@ -13562,7 +13587,7 @@ extension on HlsClientCache {
   }
 }
 
-extension on String {
+extension HlsClientCacheFromString on String {
   HlsClientCache toHlsClientCache() {
     switch (this) {
       case 'DISABLED':
@@ -13581,7 +13606,7 @@ enum HlsCodecSpecification {
   rfc_4281,
 }
 
-extension on HlsCodecSpecification {
+extension HlsCodecSpecificationValue on HlsCodecSpecification {
   String toValue() {
     switch (this) {
       case HlsCodecSpecification.rfc_6381:
@@ -13592,7 +13617,7 @@ extension on HlsCodecSpecification {
   }
 }
 
-extension on String {
+extension HlsCodecSpecificationFromString on String {
   HlsCodecSpecification toHlsCodecSpecification() {
     switch (this) {
       case 'RFC_6381':
@@ -13610,7 +13635,7 @@ enum HlsDirectoryStructure {
   subdirectoryPerStream,
 }
 
-extension on HlsDirectoryStructure {
+extension HlsDirectoryStructureValue on HlsDirectoryStructure {
   String toValue() {
     switch (this) {
       case HlsDirectoryStructure.singleDirectory:
@@ -13621,7 +13646,7 @@ extension on HlsDirectoryStructure {
   }
 }
 
-extension on String {
+extension HlsDirectoryStructureFromString on String {
   HlsDirectoryStructure toHlsDirectoryStructure() {
     switch (this) {
       case 'SINGLE_DIRECTORY':
@@ -13732,7 +13757,7 @@ enum HlsEncryptionType {
   sampleAes,
 }
 
-extension on HlsEncryptionType {
+extension HlsEncryptionTypeValue on HlsEncryptionType {
   String toValue() {
     switch (this) {
       case HlsEncryptionType.aes128:
@@ -13743,7 +13768,7 @@ extension on HlsEncryptionType {
   }
 }
 
-extension on String {
+extension HlsEncryptionTypeFromString on String {
   HlsEncryptionType toHlsEncryptionType() {
     switch (this) {
       case 'AES128':
@@ -14054,7 +14079,7 @@ enum HlsIFrameOnlyManifest {
   exclude,
 }
 
-extension on HlsIFrameOnlyManifest {
+extension HlsIFrameOnlyManifestValue on HlsIFrameOnlyManifest {
   String toValue() {
     switch (this) {
       case HlsIFrameOnlyManifest.include:
@@ -14065,7 +14090,7 @@ extension on HlsIFrameOnlyManifest {
   }
 }
 
-extension on String {
+extension HlsIFrameOnlyManifestFromString on String {
   HlsIFrameOnlyManifest toHlsIFrameOnlyManifest() {
     switch (this) {
       case 'INCLUDE':
@@ -14086,7 +14111,8 @@ enum HlsInitializationVectorInManifest {
   exclude,
 }
 
-extension on HlsInitializationVectorInManifest {
+extension HlsInitializationVectorInManifestValue
+    on HlsInitializationVectorInManifest {
   String toValue() {
     switch (this) {
       case HlsInitializationVectorInManifest.include:
@@ -14097,7 +14123,7 @@ extension on HlsInitializationVectorInManifest {
   }
 }
 
-extension on String {
+extension HlsInitializationVectorInManifestFromString on String {
   HlsInitializationVectorInManifest toHlsInitializationVectorInManifest() {
     switch (this) {
       case 'INCLUDE':
@@ -14118,7 +14144,7 @@ enum HlsKeyProviderType {
   staticKey,
 }
 
-extension on HlsKeyProviderType {
+extension HlsKeyProviderTypeValue on HlsKeyProviderType {
   String toValue() {
     switch (this) {
       case HlsKeyProviderType.speke:
@@ -14129,7 +14155,7 @@ extension on HlsKeyProviderType {
   }
 }
 
-extension on String {
+extension HlsKeyProviderTypeFromString on String {
   HlsKeyProviderType toHlsKeyProviderType() {
     switch (this) {
       case 'SPEKE':
@@ -14147,7 +14173,7 @@ enum HlsManifestCompression {
   none,
 }
 
-extension on HlsManifestCompression {
+extension HlsManifestCompressionValue on HlsManifestCompression {
   String toValue() {
     switch (this) {
       case HlsManifestCompression.gzip:
@@ -14158,7 +14184,7 @@ extension on HlsManifestCompression {
   }
 }
 
-extension on String {
+extension HlsManifestCompressionFromString on String {
   HlsManifestCompression toHlsManifestCompression() {
     switch (this) {
       case 'GZIP':
@@ -14177,7 +14203,7 @@ enum HlsManifestDurationFormat {
   integer,
 }
 
-extension on HlsManifestDurationFormat {
+extension HlsManifestDurationFormatValue on HlsManifestDurationFormat {
   String toValue() {
     switch (this) {
       case HlsManifestDurationFormat.floatingPoint:
@@ -14188,7 +14214,7 @@ extension on HlsManifestDurationFormat {
   }
 }
 
-extension on String {
+extension HlsManifestDurationFormatFromString on String {
   HlsManifestDurationFormat toHlsManifestDurationFormat() {
     switch (this) {
       case 'FLOATING_POINT':
@@ -14207,7 +14233,7 @@ enum HlsOfflineEncrypted {
   disabled,
 }
 
-extension on HlsOfflineEncrypted {
+extension HlsOfflineEncryptedValue on HlsOfflineEncrypted {
   String toValue() {
     switch (this) {
       case HlsOfflineEncrypted.enabled:
@@ -14218,7 +14244,7 @@ extension on HlsOfflineEncrypted {
   }
 }
 
-extension on String {
+extension HlsOfflineEncryptedFromString on String {
   HlsOfflineEncrypted toHlsOfflineEncrypted() {
     switch (this) {
       case 'ENABLED':
@@ -14237,7 +14263,7 @@ enum HlsOutputSelection {
   segmentsOnly,
 }
 
-extension on HlsOutputSelection {
+extension HlsOutputSelectionValue on HlsOutputSelection {
   String toValue() {
     switch (this) {
       case HlsOutputSelection.manifestsAndSegments:
@@ -14248,7 +14274,7 @@ extension on HlsOutputSelection {
   }
 }
 
-extension on String {
+extension HlsOutputSelectionFromString on String {
   HlsOutputSelection toHlsOutputSelection() {
     switch (this) {
       case 'MANIFESTS_AND_SEGMENTS':
@@ -14270,7 +14296,7 @@ enum HlsProgramDateTime {
   exclude,
 }
 
-extension on HlsProgramDateTime {
+extension HlsProgramDateTimeValue on HlsProgramDateTime {
   String toValue() {
     switch (this) {
       case HlsProgramDateTime.include:
@@ -14281,7 +14307,7 @@ extension on HlsProgramDateTime {
   }
 }
 
-extension on String {
+extension HlsProgramDateTimeFromString on String {
   HlsProgramDateTime toHlsProgramDateTime() {
     switch (this) {
       case 'INCLUDE':
@@ -14300,7 +14326,7 @@ enum HlsSegmentControl {
   segmentedFiles,
 }
 
-extension on HlsSegmentControl {
+extension HlsSegmentControlValue on HlsSegmentControl {
   String toValue() {
     switch (this) {
       case HlsSegmentControl.singleFile:
@@ -14311,7 +14337,7 @@ extension on HlsSegmentControl {
   }
 }
 
-extension on String {
+extension HlsSegmentControlFromString on String {
   HlsSegmentControl toHlsSegmentControl() {
     switch (this) {
       case 'SINGLE_FILE':
@@ -14412,7 +14438,7 @@ enum HlsStreamInfResolution {
   exclude,
 }
 
-extension on HlsStreamInfResolution {
+extension HlsStreamInfResolutionValue on HlsStreamInfResolution {
   String toValue() {
     switch (this) {
       case HlsStreamInfResolution.include:
@@ -14423,7 +14449,7 @@ extension on HlsStreamInfResolution {
   }
 }
 
-extension on String {
+extension HlsStreamInfResolutionFromString on String {
   HlsStreamInfResolution toHlsStreamInfResolution() {
     switch (this) {
       case 'INCLUDE':
@@ -14442,7 +14468,7 @@ enum HlsTimedMetadataId3Frame {
   tdrl,
 }
 
-extension on HlsTimedMetadataId3Frame {
+extension HlsTimedMetadataId3FrameValue on HlsTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case HlsTimedMetadataId3Frame.none:
@@ -14455,7 +14481,7 @@ extension on HlsTimedMetadataId3Frame {
   }
 }
 
-extension on String {
+extension HlsTimedMetadataId3FrameFromString on String {
   HlsTimedMetadataId3Frame toHlsTimedMetadataId3Frame() {
     switch (this) {
       case 'NONE':
@@ -14611,7 +14637,7 @@ enum ImscStylePassthrough {
   disabled,
 }
 
-extension on ImscStylePassthrough {
+extension ImscStylePassthroughValue on ImscStylePassthrough {
   String toValue() {
     switch (this) {
       case ImscStylePassthrough.enabled:
@@ -14622,7 +14648,7 @@ extension on ImscStylePassthrough {
   }
 }
 
-extension on String {
+extension ImscStylePassthroughFromString on String {
   ImscStylePassthrough toImscStylePassthrough() {
     switch (this) {
       case 'ENABLED':
@@ -14947,7 +14973,7 @@ enum InputDeblockFilter {
   disabled,
 }
 
-extension on InputDeblockFilter {
+extension InputDeblockFilterValue on InputDeblockFilter {
   String toValue() {
     switch (this) {
       case InputDeblockFilter.enabled:
@@ -14958,7 +14984,7 @@ extension on InputDeblockFilter {
   }
 }
 
-extension on String {
+extension InputDeblockFilterFromString on String {
   InputDeblockFilter toInputDeblockFilter() {
     switch (this) {
       case 'ENABLED':
@@ -15036,7 +15062,7 @@ enum InputDenoiseFilter {
   disabled,
 }
 
-extension on InputDenoiseFilter {
+extension InputDenoiseFilterValue on InputDenoiseFilter {
   String toValue() {
     switch (this) {
       case InputDenoiseFilter.enabled:
@@ -15047,7 +15073,7 @@ extension on InputDenoiseFilter {
   }
 }
 
-extension on String {
+extension InputDenoiseFilterFromString on String {
   InputDenoiseFilter toInputDenoiseFilter() {
     switch (this) {
       case 'ENABLED':
@@ -15073,7 +15099,7 @@ enum InputFilterEnable {
   force,
 }
 
-extension on InputFilterEnable {
+extension InputFilterEnableValue on InputFilterEnable {
   String toValue() {
     switch (this) {
       case InputFilterEnable.auto:
@@ -15086,7 +15112,7 @@ extension on InputFilterEnable {
   }
 }
 
-extension on String {
+extension InputFilterEnableFromString on String {
   InputFilterEnable toInputFilterEnable() {
     switch (this) {
       case 'AUTO':
@@ -15108,7 +15134,7 @@ enum InputPsiControl {
   usePsi,
 }
 
-extension on InputPsiControl {
+extension InputPsiControlValue on InputPsiControl {
   String toValue() {
     switch (this) {
       case InputPsiControl.ignorePsi:
@@ -15119,7 +15145,7 @@ extension on InputPsiControl {
   }
 }
 
-extension on String {
+extension InputPsiControlFromString on String {
   InputPsiControl toInputPsiControl() {
     switch (this) {
       case 'IGNORE_PSI':
@@ -15149,7 +15175,7 @@ enum InputRotate {
   auto,
 }
 
-extension on InputRotate {
+extension InputRotateValue on InputRotate {
   String toValue() {
     switch (this) {
       case InputRotate.degree_0:
@@ -15166,7 +15192,7 @@ extension on InputRotate {
   }
 }
 
-extension on String {
+extension InputRotateFromString on String {
   InputRotate toInputRotate() {
     switch (this) {
       case 'DEGREE_0':
@@ -15196,7 +15222,7 @@ enum InputScanType {
   psf,
 }
 
-extension on InputScanType {
+extension InputScanTypeValue on InputScanType {
   String toValue() {
     switch (this) {
       case InputScanType.auto:
@@ -15207,7 +15233,7 @@ extension on InputScanType {
   }
 }
 
-extension on String {
+extension InputScanTypeFromString on String {
   InputScanType toInputScanType() {
     switch (this) {
       case 'AUTO':
@@ -15453,7 +15479,7 @@ enum InputTimecodeSource {
   specifiedstart,
 }
 
-extension on InputTimecodeSource {
+extension InputTimecodeSourceValue on InputTimecodeSource {
   String toValue() {
     switch (this) {
       case InputTimecodeSource.embedded:
@@ -15466,7 +15492,7 @@ extension on InputTimecodeSource {
   }
 }
 
-extension on String {
+extension InputTimecodeSourceFromString on String {
   InputTimecodeSource toInputTimecodeSource() {
     switch (this) {
       case 'EMBEDDED':
@@ -15828,7 +15854,7 @@ enum JobPhase {
   uploading,
 }
 
-extension on JobPhase {
+extension JobPhaseValue on JobPhase {
   String toValue() {
     switch (this) {
       case JobPhase.probing:
@@ -15841,7 +15867,7 @@ extension on JobPhase {
   }
 }
 
-extension on String {
+extension JobPhaseFromString on String {
   JobPhase toJobPhase() {
     switch (this) {
       case 'PROBING':
@@ -16010,7 +16036,7 @@ enum JobStatus {
   error,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -16027,7 +16053,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -16147,7 +16173,7 @@ enum JobTemplateListBy {
   system,
 }
 
-extension on JobTemplateListBy {
+extension JobTemplateListByValue on JobTemplateListBy {
   String toValue() {
     switch (this) {
       case JobTemplateListBy.name:
@@ -16160,7 +16186,7 @@ extension on JobTemplateListBy {
   }
 }
 
-extension on String {
+extension JobTemplateListByFromString on String {
   JobTemplateListBy toJobTemplateListBy() {
     switch (this) {
       case 'NAME':
@@ -16517,7 +16543,7 @@ enum LanguageCode {
   tng,
 }
 
-extension on LanguageCode {
+extension LanguageCodeValue on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.eng:
@@ -16906,7 +16932,7 @@ extension on LanguageCode {
   }
 }
 
-extension on String {
+extension LanguageCodeFromString on String {
   LanguageCode toLanguageCode() {
     switch (this) {
       case 'ENG':
@@ -17407,7 +17433,7 @@ enum M2tsAudioBufferModel {
   atsc,
 }
 
-extension on M2tsAudioBufferModel {
+extension M2tsAudioBufferModelValue on M2tsAudioBufferModel {
   String toValue() {
     switch (this) {
       case M2tsAudioBufferModel.dvb:
@@ -17418,7 +17444,7 @@ extension on M2tsAudioBufferModel {
   }
 }
 
-extension on String {
+extension M2tsAudioBufferModelFromString on String {
   M2tsAudioBufferModel toM2tsAudioBufferModel() {
     switch (this) {
       case 'DVB':
@@ -17449,7 +17475,7 @@ enum M2tsAudioDuration {
   matchVideoDuration,
 }
 
-extension on M2tsAudioDuration {
+extension M2tsAudioDurationValue on M2tsAudioDuration {
   String toValue() {
     switch (this) {
       case M2tsAudioDuration.defaultCodecDuration:
@@ -17460,7 +17486,7 @@ extension on M2tsAudioDuration {
   }
 }
 
-extension on String {
+extension M2tsAudioDurationFromString on String {
   M2tsAudioDuration toM2tsAudioDuration() {
     switch (this) {
       case 'DEFAULT_CODEC_DURATION':
@@ -17481,7 +17507,7 @@ enum M2tsBufferModel {
   none,
 }
 
-extension on M2tsBufferModel {
+extension M2tsBufferModelValue on M2tsBufferModel {
   String toValue() {
     switch (this) {
       case M2tsBufferModel.multiplex:
@@ -17492,7 +17518,7 @@ extension on M2tsBufferModel {
   }
 }
 
-extension on String {
+extension M2tsBufferModelFromString on String {
   M2tsBufferModel toM2tsBufferModel() {
     switch (this) {
       case 'MULTIPLEX':
@@ -17515,7 +17541,7 @@ enum M2tsEbpAudioInterval {
   videoInterval,
 }
 
-extension on M2tsEbpAudioInterval {
+extension M2tsEbpAudioIntervalValue on M2tsEbpAudioInterval {
   String toValue() {
     switch (this) {
       case M2tsEbpAudioInterval.videoAndFixedIntervals:
@@ -17526,7 +17552,7 @@ extension on M2tsEbpAudioInterval {
   }
 }
 
-extension on String {
+extension M2tsEbpAudioIntervalFromString on String {
   M2tsEbpAudioInterval toM2tsEbpAudioInterval() {
     switch (this) {
       case 'VIDEO_AND_FIXED_INTERVALS':
@@ -17547,7 +17573,7 @@ enum M2tsEbpPlacement {
   videoPid,
 }
 
-extension on M2tsEbpPlacement {
+extension M2tsEbpPlacementValue on M2tsEbpPlacement {
   String toValue() {
     switch (this) {
       case M2tsEbpPlacement.videoAndAudioPids:
@@ -17558,7 +17584,7 @@ extension on M2tsEbpPlacement {
   }
 }
 
-extension on String {
+extension M2tsEbpPlacementFromString on String {
   M2tsEbpPlacement toM2tsEbpPlacement() {
     switch (this) {
       case 'VIDEO_AND_AUDIO_PIDS':
@@ -17576,7 +17602,7 @@ enum M2tsEsRateInPes {
   exclude,
 }
 
-extension on M2tsEsRateInPes {
+extension M2tsEsRateInPesValue on M2tsEsRateInPes {
   String toValue() {
     switch (this) {
       case M2tsEsRateInPes.include:
@@ -17587,7 +17613,7 @@ extension on M2tsEsRateInPes {
   }
 }
 
-extension on String {
+extension M2tsEsRateInPesFromString on String {
   M2tsEsRateInPes toM2tsEsRateInPes() {
     switch (this) {
       case 'INCLUDE':
@@ -17607,7 +17633,7 @@ enum M2tsForceTsVideoEbpOrder {
   $default,
 }
 
-extension on M2tsForceTsVideoEbpOrder {
+extension M2tsForceTsVideoEbpOrderValue on M2tsForceTsVideoEbpOrder {
   String toValue() {
     switch (this) {
       case M2tsForceTsVideoEbpOrder.force:
@@ -17618,7 +17644,7 @@ extension on M2tsForceTsVideoEbpOrder {
   }
 }
 
-extension on String {
+extension M2tsForceTsVideoEbpOrderFromString on String {
   M2tsForceTsVideoEbpOrder toM2tsForceTsVideoEbpOrder() {
     switch (this) {
       case 'FORCE':
@@ -17637,7 +17663,7 @@ enum M2tsNielsenId3 {
   none,
 }
 
-extension on M2tsNielsenId3 {
+extension M2tsNielsenId3Value on M2tsNielsenId3 {
   String toValue() {
     switch (this) {
       case M2tsNielsenId3.insert:
@@ -17648,7 +17674,7 @@ extension on M2tsNielsenId3 {
   }
 }
 
-extension on String {
+extension M2tsNielsenId3FromString on String {
   M2tsNielsenId3 toM2tsNielsenId3() {
     switch (this) {
       case 'INSERT':
@@ -17669,7 +17695,7 @@ enum M2tsPcrControl {
   configuredPcrPeriod,
 }
 
-extension on M2tsPcrControl {
+extension M2tsPcrControlValue on M2tsPcrControl {
   String toValue() {
     switch (this) {
       case M2tsPcrControl.pcrEveryPesPacket:
@@ -17680,7 +17706,7 @@ extension on M2tsPcrControl {
   }
 }
 
-extension on String {
+extension M2tsPcrControlFromString on String {
   M2tsPcrControl toM2tsPcrControl() {
     switch (this) {
       case 'PCR_EVERY_PES_PACKET':
@@ -17700,7 +17726,7 @@ enum M2tsRateMode {
   cbr,
 }
 
-extension on M2tsRateMode {
+extension M2tsRateModeValue on M2tsRateMode {
   String toValue() {
     switch (this) {
       case M2tsRateMode.vbr:
@@ -17711,7 +17737,7 @@ extension on M2tsRateMode {
   }
 }
 
-extension on String {
+extension M2tsRateModeFromString on String {
   M2tsRateMode toM2tsRateMode() {
     switch (this) {
       case 'VBR':
@@ -17761,7 +17787,7 @@ enum M2tsScte35Source {
   none,
 }
 
-extension on M2tsScte35Source {
+extension M2tsScte35SourceValue on M2tsScte35Source {
   String toValue() {
     switch (this) {
       case M2tsScte35Source.passthrough:
@@ -17772,7 +17798,7 @@ extension on M2tsScte35Source {
   }
 }
 
-extension on String {
+extension M2tsScte35SourceFromString on String {
   M2tsScte35Source toM2tsScte35Source() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -17800,7 +17826,7 @@ enum M2tsSegmentationMarkers {
   ebpLegacy,
 }
 
-extension on M2tsSegmentationMarkers {
+extension M2tsSegmentationMarkersValue on M2tsSegmentationMarkers {
   String toValue() {
     switch (this) {
       case M2tsSegmentationMarkers.none:
@@ -17819,7 +17845,7 @@ extension on M2tsSegmentationMarkers {
   }
 }
 
-extension on String {
+extension M2tsSegmentationMarkersFromString on String {
   M2tsSegmentationMarkers toM2tsSegmentationMarkers() {
     switch (this) {
       case 'NONE':
@@ -17856,7 +17882,7 @@ enum M2tsSegmentationStyle {
   resetCadence,
 }
 
-extension on M2tsSegmentationStyle {
+extension M2tsSegmentationStyleValue on M2tsSegmentationStyle {
   String toValue() {
     switch (this) {
       case M2tsSegmentationStyle.maintainCadence:
@@ -17867,7 +17893,7 @@ extension on M2tsSegmentationStyle {
   }
 }
 
-extension on String {
+extension M2tsSegmentationStyleFromString on String {
   M2tsSegmentationStyle toM2tsSegmentationStyle() {
     switch (this) {
       case 'MAINTAIN_CADENCE':
@@ -18298,7 +18324,7 @@ enum M3u8AudioDuration {
   matchVideoDuration,
 }
 
-extension on M3u8AudioDuration {
+extension M3u8AudioDurationValue on M3u8AudioDuration {
   String toValue() {
     switch (this) {
       case M3u8AudioDuration.defaultCodecDuration:
@@ -18309,7 +18335,7 @@ extension on M3u8AudioDuration {
   }
 }
 
-extension on String {
+extension M3u8AudioDurationFromString on String {
   M3u8AudioDuration toM3u8AudioDuration() {
     switch (this) {
       case 'DEFAULT_CODEC_DURATION':
@@ -18328,7 +18354,7 @@ enum M3u8NielsenId3 {
   none,
 }
 
-extension on M3u8NielsenId3 {
+extension M3u8NielsenId3Value on M3u8NielsenId3 {
   String toValue() {
     switch (this) {
       case M3u8NielsenId3.insert:
@@ -18339,7 +18365,7 @@ extension on M3u8NielsenId3 {
   }
 }
 
-extension on String {
+extension M3u8NielsenId3FromString on String {
   M3u8NielsenId3 toM3u8NielsenId3() {
     switch (this) {
       case 'INSERT':
@@ -18360,7 +18386,7 @@ enum M3u8PcrControl {
   configuredPcrPeriod,
 }
 
-extension on M3u8PcrControl {
+extension M3u8PcrControlValue on M3u8PcrControl {
   String toValue() {
     switch (this) {
       case M3u8PcrControl.pcrEveryPesPacket:
@@ -18371,7 +18397,7 @@ extension on M3u8PcrControl {
   }
 }
 
-extension on String {
+extension M3u8PcrControlFromString on String {
   M3u8PcrControl toM3u8PcrControl() {
     switch (this) {
       case 'PCR_EVERY_PES_PACKET':
@@ -18396,7 +18422,7 @@ enum M3u8Scte35Source {
   none,
 }
 
-extension on M3u8Scte35Source {
+extension M3u8Scte35SourceValue on M3u8Scte35Source {
   String toValue() {
     switch (this) {
       case M3u8Scte35Source.passthrough:
@@ -18407,7 +18433,7 @@ extension on M3u8Scte35Source {
   }
 }
 
-extension on String {
+extension M3u8Scte35SourceFromString on String {
   M3u8Scte35Source toM3u8Scte35Source() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -18730,7 +18756,7 @@ enum MotionImageInsertionMode {
   png,
 }
 
-extension on MotionImageInsertionMode {
+extension MotionImageInsertionModeValue on MotionImageInsertionMode {
   String toValue() {
     switch (this) {
       case MotionImageInsertionMode.mov:
@@ -18741,7 +18767,7 @@ extension on MotionImageInsertionMode {
   }
 }
 
-extension on String {
+extension MotionImageInsertionModeFromString on String {
   MotionImageInsertionMode toMotionImageInsertionMode() {
     switch (this) {
       case 'MOV':
@@ -18792,7 +18818,7 @@ enum MotionImagePlayback {
   repeat,
 }
 
-extension on MotionImagePlayback {
+extension MotionImagePlaybackValue on MotionImagePlayback {
   String toValue() {
     switch (this) {
       case MotionImagePlayback.once:
@@ -18803,7 +18829,7 @@ extension on MotionImagePlayback {
   }
 }
 
-extension on String {
+extension MotionImagePlaybackFromString on String {
   MotionImagePlayback toMotionImagePlayback() {
     switch (this) {
       case 'ONCE':
@@ -18822,7 +18848,7 @@ enum MovClapAtom {
   exclude,
 }
 
-extension on MovClapAtom {
+extension MovClapAtomValue on MovClapAtom {
   String toValue() {
     switch (this) {
       case MovClapAtom.include:
@@ -18833,7 +18859,7 @@ extension on MovClapAtom {
   }
 }
 
-extension on String {
+extension MovClapAtomFromString on String {
   MovClapAtom toMovClapAtom() {
     switch (this) {
       case 'INCLUDE':
@@ -18855,7 +18881,7 @@ enum MovCslgAtom {
   exclude,
 }
 
-extension on MovCslgAtom {
+extension MovCslgAtomValue on MovCslgAtom {
   String toValue() {
     switch (this) {
       case MovCslgAtom.include:
@@ -18866,7 +18892,7 @@ extension on MovCslgAtom {
   }
 }
 
-extension on String {
+extension MovCslgAtomFromString on String {
   MovCslgAtom toMovCslgAtom() {
     switch (this) {
       case 'INCLUDE':
@@ -18887,7 +18913,7 @@ enum MovMpeg2FourCCControl {
   mpeg,
 }
 
-extension on MovMpeg2FourCCControl {
+extension MovMpeg2FourCCControlValue on MovMpeg2FourCCControl {
   String toValue() {
     switch (this) {
       case MovMpeg2FourCCControl.xdcam:
@@ -18898,7 +18924,7 @@ extension on MovMpeg2FourCCControl {
   }
 }
 
-extension on String {
+extension MovMpeg2FourCCControlFromString on String {
   MovMpeg2FourCCControl toMovMpeg2FourCCControl() {
     switch (this) {
       case 'XDCAM':
@@ -18920,7 +18946,7 @@ enum MovPaddingControl {
   none,
 }
 
-extension on MovPaddingControl {
+extension MovPaddingControlValue on MovPaddingControl {
   String toValue() {
     switch (this) {
       case MovPaddingControl.omneon:
@@ -18931,7 +18957,7 @@ extension on MovPaddingControl {
   }
 }
 
-extension on String {
+extension MovPaddingControlFromString on String {
   MovPaddingControl toMovPaddingControl() {
     switch (this) {
       case 'OMNEON':
@@ -18949,7 +18975,7 @@ enum MovReference {
   external,
 }
 
-extension on MovReference {
+extension MovReferenceValue on MovReference {
   String toValue() {
     switch (this) {
       case MovReference.selfContained:
@@ -18960,7 +18986,7 @@ extension on MovReference {
   }
 }
 
-extension on String {
+extension MovReferenceFromString on String {
   MovReference toMovReference() {
     switch (this) {
       case 'SELF_CONTAINED':
@@ -19083,7 +19109,7 @@ enum Mp3RateControlMode {
   vbr,
 }
 
-extension on Mp3RateControlMode {
+extension Mp3RateControlModeValue on Mp3RateControlMode {
   String toValue() {
     switch (this) {
       case Mp3RateControlMode.cbr:
@@ -19094,7 +19120,7 @@ extension on Mp3RateControlMode {
   }
 }
 
-extension on String {
+extension Mp3RateControlModeFromString on String {
   Mp3RateControlMode toMp3RateControlMode() {
     switch (this) {
       case 'CBR':
@@ -19173,7 +19199,7 @@ enum Mp4CslgAtom {
   exclude,
 }
 
-extension on Mp4CslgAtom {
+extension Mp4CslgAtomValue on Mp4CslgAtom {
   String toValue() {
     switch (this) {
       case Mp4CslgAtom.include:
@@ -19184,7 +19210,7 @@ extension on Mp4CslgAtom {
   }
 }
 
-extension on String {
+extension Mp4CslgAtomFromString on String {
   Mp4CslgAtom toMp4CslgAtom() {
     switch (this) {
       case 'INCLUDE':
@@ -19202,7 +19228,7 @@ enum Mp4FreeSpaceBox {
   exclude,
 }
 
-extension on Mp4FreeSpaceBox {
+extension Mp4FreeSpaceBoxValue on Mp4FreeSpaceBox {
   String toValue() {
     switch (this) {
       case Mp4FreeSpaceBox.include:
@@ -19213,7 +19239,7 @@ extension on Mp4FreeSpaceBox {
   }
 }
 
-extension on String {
+extension Mp4FreeSpaceBoxFromString on String {
   Mp4FreeSpaceBox toMp4FreeSpaceBox() {
     switch (this) {
       case 'INCLUDE':
@@ -19233,7 +19259,7 @@ enum Mp4MoovPlacement {
   normal,
 }
 
-extension on Mp4MoovPlacement {
+extension Mp4MoovPlacementValue on Mp4MoovPlacement {
   String toValue() {
     switch (this) {
       case Mp4MoovPlacement.progressiveDownload:
@@ -19244,7 +19270,7 @@ extension on Mp4MoovPlacement {
   }
 }
 
-extension on String {
+extension Mp4MoovPlacementFromString on String {
   Mp4MoovPlacement toMp4MoovPlacement() {
     switch (this) {
       case 'PROGRESSIVE_DOWNLOAD':
@@ -19351,7 +19377,7 @@ enum MpdAccessibilityCaptionHints {
   exclude,
 }
 
-extension on MpdAccessibilityCaptionHints {
+extension MpdAccessibilityCaptionHintsValue on MpdAccessibilityCaptionHints {
   String toValue() {
     switch (this) {
       case MpdAccessibilityCaptionHints.include:
@@ -19362,7 +19388,7 @@ extension on MpdAccessibilityCaptionHints {
   }
 }
 
-extension on String {
+extension MpdAccessibilityCaptionHintsFromString on String {
   MpdAccessibilityCaptionHints toMpdAccessibilityCaptionHints() {
     switch (this) {
       case 'INCLUDE':
@@ -19393,7 +19419,7 @@ enum MpdAudioDuration {
   matchVideoDuration,
 }
 
-extension on MpdAudioDuration {
+extension MpdAudioDurationValue on MpdAudioDuration {
   String toValue() {
     switch (this) {
       case MpdAudioDuration.defaultCodecDuration:
@@ -19404,7 +19430,7 @@ extension on MpdAudioDuration {
   }
 }
 
-extension on String {
+extension MpdAudioDurationFromString on String {
   MpdAudioDuration toMpdAudioDuration() {
     switch (this) {
       case 'DEFAULT_CODEC_DURATION':
@@ -19427,7 +19453,7 @@ enum MpdCaptionContainerType {
   fragmentedMp4,
 }
 
-extension on MpdCaptionContainerType {
+extension MpdCaptionContainerTypeValue on MpdCaptionContainerType {
   String toValue() {
     switch (this) {
       case MpdCaptionContainerType.raw:
@@ -19438,7 +19464,7 @@ extension on MpdCaptionContainerType {
   }
 }
 
-extension on String {
+extension MpdCaptionContainerTypeFromString on String {
   MpdCaptionContainerType toMpdCaptionContainerType() {
     switch (this) {
       case 'RAW':
@@ -19459,7 +19485,7 @@ enum MpdScte35Esam {
   none,
 }
 
-extension on MpdScte35Esam {
+extension MpdScte35EsamValue on MpdScte35Esam {
   String toValue() {
     switch (this) {
       case MpdScte35Esam.insert:
@@ -19470,7 +19496,7 @@ extension on MpdScte35Esam {
   }
 }
 
-extension on String {
+extension MpdScte35EsamFromString on String {
   MpdScte35Esam toMpdScte35Esam() {
     switch (this) {
       case 'INSERT':
@@ -19491,7 +19517,7 @@ enum MpdScte35Source {
   none,
 }
 
-extension on MpdScte35Source {
+extension MpdScte35SourceValue on MpdScte35Source {
   String toValue() {
     switch (this) {
       case MpdScte35Source.passthrough:
@@ -19502,7 +19528,7 @@ extension on MpdScte35Source {
   }
 }
 
-extension on String {
+extension MpdScte35SourceFromString on String {
   MpdScte35Source toMpdScte35Source() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -19609,7 +19635,7 @@ enum Mpeg2AdaptiveQuantization {
   high,
 }
 
-extension on Mpeg2AdaptiveQuantization {
+extension Mpeg2AdaptiveQuantizationValue on Mpeg2AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2AdaptiveQuantization.off:
@@ -19624,7 +19650,7 @@ extension on Mpeg2AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Mpeg2AdaptiveQuantizationFromString on String {
   Mpeg2AdaptiveQuantization toMpeg2AdaptiveQuantization() {
     switch (this) {
       case 'OFF':
@@ -19649,7 +19675,7 @@ enum Mpeg2CodecLevel {
   high,
 }
 
-extension on Mpeg2CodecLevel {
+extension Mpeg2CodecLevelValue on Mpeg2CodecLevel {
   String toValue() {
     switch (this) {
       case Mpeg2CodecLevel.auto:
@@ -19666,7 +19692,7 @@ extension on Mpeg2CodecLevel {
   }
 }
 
-extension on String {
+extension Mpeg2CodecLevelFromString on String {
   Mpeg2CodecLevel toMpeg2CodecLevel() {
     switch (this) {
       case 'AUTO':
@@ -19691,7 +19717,7 @@ enum Mpeg2CodecProfile {
   profile_422,
 }
 
-extension on Mpeg2CodecProfile {
+extension Mpeg2CodecProfileValue on Mpeg2CodecProfile {
   String toValue() {
     switch (this) {
       case Mpeg2CodecProfile.main:
@@ -19702,7 +19728,7 @@ extension on Mpeg2CodecProfile {
   }
 }
 
-extension on String {
+extension Mpeg2CodecProfileFromString on String {
   Mpeg2CodecProfile toMpeg2CodecProfile() {
     switch (this) {
       case 'MAIN':
@@ -19725,7 +19751,7 @@ enum Mpeg2DynamicSubGop {
   static,
 }
 
-extension on Mpeg2DynamicSubGop {
+extension Mpeg2DynamicSubGopValue on Mpeg2DynamicSubGop {
   String toValue() {
     switch (this) {
       case Mpeg2DynamicSubGop.adaptive:
@@ -19736,7 +19762,7 @@ extension on Mpeg2DynamicSubGop {
   }
 }
 
-extension on String {
+extension Mpeg2DynamicSubGopFromString on String {
   Mpeg2DynamicSubGop toMpeg2DynamicSubGop() {
     switch (this) {
       case 'ADAPTIVE':
@@ -19765,7 +19791,7 @@ enum Mpeg2FramerateControl {
   specified,
 }
 
-extension on Mpeg2FramerateControl {
+extension Mpeg2FramerateControlValue on Mpeg2FramerateControl {
   String toValue() {
     switch (this) {
       case Mpeg2FramerateControl.initializeFromSource:
@@ -19776,7 +19802,7 @@ extension on Mpeg2FramerateControl {
   }
 }
 
-extension on String {
+extension Mpeg2FramerateControlFromString on String {
   Mpeg2FramerateControl toMpeg2FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -19805,7 +19831,8 @@ enum Mpeg2FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on Mpeg2FramerateConversionAlgorithm {
+extension Mpeg2FramerateConversionAlgorithmValue
+    on Mpeg2FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case Mpeg2FramerateConversionAlgorithm.duplicateDrop:
@@ -19818,7 +19845,7 @@ extension on Mpeg2FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension Mpeg2FramerateConversionAlgorithmFromString on String {
   Mpeg2FramerateConversionAlgorithm toMpeg2FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -19840,7 +19867,7 @@ enum Mpeg2GopSizeUnits {
   seconds,
 }
 
-extension on Mpeg2GopSizeUnits {
+extension Mpeg2GopSizeUnitsValue on Mpeg2GopSizeUnits {
   String toValue() {
     switch (this) {
       case Mpeg2GopSizeUnits.frames:
@@ -19851,7 +19878,7 @@ extension on Mpeg2GopSizeUnits {
   }
 }
 
-extension on String {
+extension Mpeg2GopSizeUnitsFromString on String {
   Mpeg2GopSizeUnits toMpeg2GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -19883,7 +19910,7 @@ enum Mpeg2InterlaceMode {
   followBottomField,
 }
 
-extension on Mpeg2InterlaceMode {
+extension Mpeg2InterlaceModeValue on Mpeg2InterlaceMode {
   String toValue() {
     switch (this) {
       case Mpeg2InterlaceMode.progressive:
@@ -19900,7 +19927,7 @@ extension on Mpeg2InterlaceMode {
   }
 }
 
-extension on String {
+extension Mpeg2InterlaceModeFromString on String {
   Mpeg2InterlaceMode toMpeg2InterlaceMode() {
     switch (this) {
       case 'PROGRESSIVE':
@@ -19930,7 +19957,7 @@ enum Mpeg2IntraDcPrecision {
   intraDcPrecision_11,
 }
 
-extension on Mpeg2IntraDcPrecision {
+extension Mpeg2IntraDcPrecisionValue on Mpeg2IntraDcPrecision {
   String toValue() {
     switch (this) {
       case Mpeg2IntraDcPrecision.auto:
@@ -19947,7 +19974,7 @@ extension on Mpeg2IntraDcPrecision {
   }
 }
 
-extension on String {
+extension Mpeg2IntraDcPrecisionFromString on String {
   Mpeg2IntraDcPrecision toMpeg2IntraDcPrecision() {
     switch (this) {
       case 'AUTO':
@@ -19978,7 +20005,7 @@ enum Mpeg2ParControl {
   specified,
 }
 
-extension on Mpeg2ParControl {
+extension Mpeg2ParControlValue on Mpeg2ParControl {
   String toValue() {
     switch (this) {
       case Mpeg2ParControl.initializeFromSource:
@@ -19989,7 +20016,7 @@ extension on Mpeg2ParControl {
   }
 }
 
-extension on String {
+extension Mpeg2ParControlFromString on String {
   Mpeg2ParControl toMpeg2ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -20009,7 +20036,7 @@ enum Mpeg2QualityTuningLevel {
   multiPass,
 }
 
-extension on Mpeg2QualityTuningLevel {
+extension Mpeg2QualityTuningLevelValue on Mpeg2QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Mpeg2QualityTuningLevel.singlePass:
@@ -20020,7 +20047,7 @@ extension on Mpeg2QualityTuningLevel {
   }
 }
 
-extension on String {
+extension Mpeg2QualityTuningLevelFromString on String {
   Mpeg2QualityTuningLevel toMpeg2QualityTuningLevel() {
     switch (this) {
       case 'SINGLE_PASS':
@@ -20039,7 +20066,7 @@ enum Mpeg2RateControlMode {
   cbr,
 }
 
-extension on Mpeg2RateControlMode {
+extension Mpeg2RateControlModeValue on Mpeg2RateControlMode {
   String toValue() {
     switch (this) {
       case Mpeg2RateControlMode.vbr:
@@ -20050,7 +20077,7 @@ extension on Mpeg2RateControlMode {
   }
 }
 
-extension on String {
+extension Mpeg2RateControlModeFromString on String {
   Mpeg2RateControlMode toMpeg2RateControlMode() {
     switch (this) {
       case 'VBR':
@@ -20070,7 +20097,7 @@ enum Mpeg2SceneChangeDetect {
   enabled,
 }
 
-extension on Mpeg2SceneChangeDetect {
+extension Mpeg2SceneChangeDetectValue on Mpeg2SceneChangeDetect {
   String toValue() {
     switch (this) {
       case Mpeg2SceneChangeDetect.disabled:
@@ -20081,7 +20108,7 @@ extension on Mpeg2SceneChangeDetect {
   }
 }
 
-extension on String {
+extension Mpeg2SceneChangeDetectFromString on String {
   Mpeg2SceneChangeDetect toMpeg2SceneChangeDetect() {
     switch (this) {
       case 'DISABLED':
@@ -20510,7 +20537,7 @@ enum Mpeg2SlowPal {
   enabled,
 }
 
-extension on Mpeg2SlowPal {
+extension Mpeg2SlowPalValue on Mpeg2SlowPal {
   String toValue() {
     switch (this) {
       case Mpeg2SlowPal.disabled:
@@ -20521,7 +20548,7 @@ extension on Mpeg2SlowPal {
   }
 }
 
-extension on String {
+extension Mpeg2SlowPalFromString on String {
   Mpeg2SlowPal toMpeg2SlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -20553,7 +20580,8 @@ enum Mpeg2SpatialAdaptiveQuantization {
   enabled,
 }
 
-extension on Mpeg2SpatialAdaptiveQuantization {
+extension Mpeg2SpatialAdaptiveQuantizationValue
+    on Mpeg2SpatialAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2SpatialAdaptiveQuantization.disabled:
@@ -20564,7 +20592,7 @@ extension on Mpeg2SpatialAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Mpeg2SpatialAdaptiveQuantizationFromString on String {
   Mpeg2SpatialAdaptiveQuantization toMpeg2SpatialAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -20586,7 +20614,7 @@ enum Mpeg2Syntax {
   d_10,
 }
 
-extension on Mpeg2Syntax {
+extension Mpeg2SyntaxValue on Mpeg2Syntax {
   String toValue() {
     switch (this) {
       case Mpeg2Syntax.$default:
@@ -20597,7 +20625,7 @@ extension on Mpeg2Syntax {
   }
 }
 
-extension on String {
+extension Mpeg2SyntaxFromString on String {
   Mpeg2Syntax toMpeg2Syntax() {
     switch (this) {
       case 'DEFAULT':
@@ -20623,7 +20651,7 @@ enum Mpeg2Telecine {
   hard,
 }
 
-extension on Mpeg2Telecine {
+extension Mpeg2TelecineValue on Mpeg2Telecine {
   String toValue() {
     switch (this) {
       case Mpeg2Telecine.none:
@@ -20636,7 +20664,7 @@ extension on Mpeg2Telecine {
   }
 }
 
-extension on String {
+extension Mpeg2TelecineFromString on String {
   Mpeg2Telecine toMpeg2Telecine() {
     switch (this) {
       case 'NONE':
@@ -20668,7 +20696,8 @@ enum Mpeg2TemporalAdaptiveQuantization {
   enabled,
 }
 
-extension on Mpeg2TemporalAdaptiveQuantization {
+extension Mpeg2TemporalAdaptiveQuantizationValue
+    on Mpeg2TemporalAdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2TemporalAdaptiveQuantization.disabled:
@@ -20679,7 +20708,7 @@ extension on Mpeg2TemporalAdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Mpeg2TemporalAdaptiveQuantizationFromString on String {
   Mpeg2TemporalAdaptiveQuantization toMpeg2TemporalAdaptiveQuantization() {
     switch (this) {
       case 'DISABLED':
@@ -20740,7 +20769,7 @@ enum MsSmoothAudioDeduplication {
   none,
 }
 
-extension on MsSmoothAudioDeduplication {
+extension MsSmoothAudioDeduplicationValue on MsSmoothAudioDeduplication {
   String toValue() {
     switch (this) {
       case MsSmoothAudioDeduplication.combineDuplicateStreams:
@@ -20751,7 +20780,7 @@ extension on MsSmoothAudioDeduplication {
   }
 }
 
-extension on String {
+extension MsSmoothAudioDeduplicationFromString on String {
   MsSmoothAudioDeduplication toMsSmoothAudioDeduplication() {
     switch (this) {
       case 'COMBINE_DUPLICATE_STREAMS':
@@ -20893,7 +20922,7 @@ enum MsSmoothManifestEncoding {
   utf16,
 }
 
-extension on MsSmoothManifestEncoding {
+extension MsSmoothManifestEncodingValue on MsSmoothManifestEncoding {
   String toValue() {
     switch (this) {
       case MsSmoothManifestEncoding.utf8:
@@ -20904,7 +20933,7 @@ extension on MsSmoothManifestEncoding {
   }
 }
 
-extension on String {
+extension MsSmoothManifestEncodingFromString on String {
   MsSmoothManifestEncoding toMsSmoothManifestEncoding() {
     switch (this) {
       case 'UTF8':
@@ -20930,7 +20959,7 @@ enum MxfAfdSignaling {
   copyFromVideo,
 }
 
-extension on MxfAfdSignaling {
+extension MxfAfdSignalingValue on MxfAfdSignaling {
   String toValue() {
     switch (this) {
       case MxfAfdSignaling.noCopy:
@@ -20941,7 +20970,7 @@ extension on MxfAfdSignaling {
   }
 }
 
-extension on String {
+extension MxfAfdSignalingFromString on String {
   MxfAfdSignaling toMxfAfdSignaling() {
     switch (this) {
       case 'NO_COPY':
@@ -20965,7 +20994,7 @@ enum MxfProfile {
   op1a,
 }
 
-extension on MxfProfile {
+extension MxfProfileValue on MxfProfile {
   String toValue() {
     switch (this) {
       case MxfProfile.d_10:
@@ -20978,7 +21007,7 @@ extension on MxfProfile {
   }
 }
 
-extension on String {
+extension MxfProfileFromString on String {
   MxfProfile toMxfProfile() {
     switch (this) {
       case 'D_10':
@@ -21109,7 +21138,8 @@ enum NielsenActiveWatermarkProcessType {
   naes2AndNwAndCbet,
 }
 
-extension on NielsenActiveWatermarkProcessType {
+extension NielsenActiveWatermarkProcessTypeValue
+    on NielsenActiveWatermarkProcessType {
   String toValue() {
     switch (this) {
       case NielsenActiveWatermarkProcessType.naes2AndNw:
@@ -21122,7 +21152,7 @@ extension on NielsenActiveWatermarkProcessType {
   }
 }
 
-extension on String {
+extension NielsenActiveWatermarkProcessTypeFromString on String {
   NielsenActiveWatermarkProcessType toNielsenActiveWatermarkProcessType() {
     switch (this) {
       case 'NAES2_AND_NW':
@@ -21329,7 +21359,8 @@ enum NielsenSourceWatermarkStatusType {
   watermarked,
 }
 
-extension on NielsenSourceWatermarkStatusType {
+extension NielsenSourceWatermarkStatusTypeValue
+    on NielsenSourceWatermarkStatusType {
   String toValue() {
     switch (this) {
       case NielsenSourceWatermarkStatusType.clean:
@@ -21340,7 +21371,7 @@ extension on NielsenSourceWatermarkStatusType {
   }
 }
 
-extension on String {
+extension NielsenSourceWatermarkStatusTypeFromString on String {
   NielsenSourceWatermarkStatusType toNielsenSourceWatermarkStatusType() {
     switch (this) {
       case 'CLEAN':
@@ -21362,7 +21393,8 @@ enum NielsenUniqueTicPerAudioTrackType {
   sameTicsPerTrack,
 }
 
-extension on NielsenUniqueTicPerAudioTrackType {
+extension NielsenUniqueTicPerAudioTrackTypeValue
+    on NielsenUniqueTicPerAudioTrackType {
   String toValue() {
     switch (this) {
       case NielsenUniqueTicPerAudioTrackType.reserveUniqueTicsPerTrack:
@@ -21373,7 +21405,7 @@ extension on NielsenUniqueTicPerAudioTrackType {
   }
 }
 
-extension on String {
+extension NielsenUniqueTicPerAudioTrackTypeFromString on String {
   NielsenUniqueTicPerAudioTrackType toNielsenUniqueTicPerAudioTrackType() {
     switch (this) {
       case 'RESERVE_UNIQUE_TICS_PER_TRACK':
@@ -21398,7 +21430,8 @@ enum NoiseFilterPostTemporalSharpening {
   auto,
 }
 
-extension on NoiseFilterPostTemporalSharpening {
+extension NoiseFilterPostTemporalSharpeningValue
+    on NoiseFilterPostTemporalSharpening {
   String toValue() {
     switch (this) {
       case NoiseFilterPostTemporalSharpening.disabled:
@@ -21411,7 +21444,7 @@ extension on NoiseFilterPostTemporalSharpening {
   }
 }
 
-extension on String {
+extension NoiseFilterPostTemporalSharpeningFromString on String {
   NoiseFilterPostTemporalSharpening toNoiseFilterPostTemporalSharpening() {
     switch (this) {
       case 'DISABLED':
@@ -21508,7 +21541,7 @@ enum NoiseReducerFilter {
   temporal,
 }
 
-extension on NoiseReducerFilter {
+extension NoiseReducerFilterValue on NoiseReducerFilter {
   String toValue() {
     switch (this) {
       case NoiseReducerFilter.bilateral:
@@ -21531,7 +21564,7 @@ extension on NoiseReducerFilter {
   }
 }
 
-extension on String {
+extension NoiseReducerFilterFromString on String {
   NoiseReducerFilter toNoiseReducerFilter() {
     switch (this) {
       case 'BILATERAL':
@@ -21727,7 +21760,7 @@ enum Order {
   descending,
 }
 
-extension on Order {
+extension OrderValue on Order {
   String toValue() {
     switch (this) {
       case Order.ascending:
@@ -21738,7 +21771,7 @@ extension on Order {
   }
 }
 
-extension on String {
+extension OrderFromString on String {
   Order toOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -22080,7 +22113,7 @@ enum OutputGroupType {
   cmafGroupSettings,
 }
 
-extension on OutputGroupType {
+extension OutputGroupTypeValue on OutputGroupType {
   String toValue() {
     switch (this) {
       case OutputGroupType.hlsGroupSettings:
@@ -22097,7 +22130,7 @@ extension on OutputGroupType {
   }
 }
 
-extension on String {
+extension OutputGroupTypeFromString on String {
   OutputGroupType toOutputGroupType() {
     switch (this) {
       case 'HLS_GROUP_SETTINGS':
@@ -22129,7 +22162,7 @@ enum OutputSdt {
   sdtNone,
 }
 
-extension on OutputSdt {
+extension OutputSdtValue on OutputSdt {
   String toValue() {
     switch (this) {
       case OutputSdt.sdtFollow:
@@ -22144,7 +22177,7 @@ extension on OutputSdt {
   }
 }
 
-extension on String {
+extension OutputSdtFromString on String {
   OutputSdt toOutputSdt() {
     switch (this) {
       case 'SDT_FOLLOW':
@@ -22277,7 +22310,7 @@ enum PresetListBy {
   system,
 }
 
-extension on PresetListBy {
+extension PresetListByValue on PresetListBy {
   String toValue() {
     switch (this) {
       case PresetListBy.name:
@@ -22290,7 +22323,7 @@ extension on PresetListBy {
   }
 }
 
-extension on String {
+extension PresetListByFromString on String {
   PresetListBy toPresetListBy() {
     switch (this) {
       case 'NAME':
@@ -22377,7 +22410,7 @@ enum PricingPlan {
   reserved,
 }
 
-extension on PricingPlan {
+extension PricingPlanValue on PricingPlan {
   String toValue() {
     switch (this) {
       case PricingPlan.onDemand:
@@ -22388,7 +22421,7 @@ extension on PricingPlan {
   }
 }
 
-extension on String {
+extension PricingPlanFromString on String {
   PricingPlan toPricingPlan() {
     switch (this) {
       case 'ON_DEMAND':
@@ -22409,7 +22442,7 @@ enum ProresCodecProfile {
   appleProres_422Proxy,
 }
 
-extension on ProresCodecProfile {
+extension ProresCodecProfileValue on ProresCodecProfile {
   String toValue() {
     switch (this) {
       case ProresCodecProfile.appleProres_422:
@@ -22424,7 +22457,7 @@ extension on ProresCodecProfile {
   }
 }
 
-extension on String {
+extension ProresCodecProfileFromString on String {
   ProresCodecProfile toProresCodecProfile() {
     switch (this) {
       case 'APPLE_PRORES_422':
@@ -22457,7 +22490,7 @@ enum ProresFramerateControl {
   specified,
 }
 
-extension on ProresFramerateControl {
+extension ProresFramerateControlValue on ProresFramerateControl {
   String toValue() {
     switch (this) {
       case ProresFramerateControl.initializeFromSource:
@@ -22468,7 +22501,7 @@ extension on ProresFramerateControl {
   }
 }
 
-extension on String {
+extension ProresFramerateControlFromString on String {
   ProresFramerateControl toProresFramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -22497,7 +22530,8 @@ enum ProresFramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on ProresFramerateConversionAlgorithm {
+extension ProresFramerateConversionAlgorithmValue
+    on ProresFramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case ProresFramerateConversionAlgorithm.duplicateDrop:
@@ -22510,7 +22544,7 @@ extension on ProresFramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension ProresFramerateConversionAlgorithmFromString on String {
   ProresFramerateConversionAlgorithm toProresFramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -22545,7 +22579,7 @@ enum ProresInterlaceMode {
   followBottomField,
 }
 
-extension on ProresInterlaceMode {
+extension ProresInterlaceModeValue on ProresInterlaceMode {
   String toValue() {
     switch (this) {
       case ProresInterlaceMode.progressive:
@@ -22562,7 +22596,7 @@ extension on ProresInterlaceMode {
   }
 }
 
-extension on String {
+extension ProresInterlaceModeFromString on String {
   ProresInterlaceMode toProresInterlaceMode() {
     switch (this) {
       case 'PROGRESSIVE':
@@ -22593,7 +22627,7 @@ enum ProresParControl {
   specified,
 }
 
-extension on ProresParControl {
+extension ProresParControlValue on ProresParControl {
   String toValue() {
     switch (this) {
       case ProresParControl.initializeFromSource:
@@ -22604,7 +22638,7 @@ extension on ProresParControl {
   }
 }
 
-extension on String {
+extension ProresParControlFromString on String {
   ProresParControl toProresParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -22802,7 +22836,7 @@ enum ProresSlowPal {
   enabled,
 }
 
-extension on ProresSlowPal {
+extension ProresSlowPalValue on ProresSlowPal {
   String toValue() {
     switch (this) {
       case ProresSlowPal.disabled:
@@ -22813,7 +22847,7 @@ extension on ProresSlowPal {
   }
 }
 
-extension on String {
+extension ProresSlowPalFromString on String {
   ProresSlowPal toProresSlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -22836,7 +22870,7 @@ enum ProresTelecine {
   hard,
 }
 
-extension on ProresTelecine {
+extension ProresTelecineValue on ProresTelecine {
   String toValue() {
     switch (this) {
       case ProresTelecine.none:
@@ -22847,7 +22881,7 @@ extension on ProresTelecine {
   }
 }
 
-extension on String {
+extension ProresTelecineFromString on String {
   ProresTelecine toProresTelecine() {
     switch (this) {
       case 'NONE':
@@ -22949,7 +22983,7 @@ enum QueueListBy {
   creationDate,
 }
 
-extension on QueueListBy {
+extension QueueListByValue on QueueListBy {
   String toValue() {
     switch (this) {
       case QueueListBy.name:
@@ -22960,7 +22994,7 @@ extension on QueueListBy {
   }
 }
 
-extension on String {
+extension QueueListByFromString on String {
   QueueListBy toQueueListBy() {
     switch (this) {
       case 'NAME':
@@ -22980,7 +23014,7 @@ enum QueueStatus {
   paused,
 }
 
-extension on QueueStatus {
+extension QueueStatusValue on QueueStatus {
   String toValue() {
     switch (this) {
       case QueueStatus.active:
@@ -22991,7 +23025,7 @@ extension on QueueStatus {
   }
 }
 
-extension on String {
+extension QueueStatusFromString on String {
   QueueStatus toQueueStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -23130,7 +23164,7 @@ enum RenewalType {
   expire,
 }
 
-extension on RenewalType {
+extension RenewalTypeValue on RenewalType {
   String toValue() {
     switch (this) {
       case RenewalType.autoRenew:
@@ -23141,7 +23175,7 @@ extension on RenewalType {
   }
 }
 
-extension on String {
+extension RenewalTypeFromString on String {
   RenewalType toRenewalType() {
     switch (this) {
       case 'AUTO_RENEW':
@@ -23250,7 +23284,7 @@ enum ReservationPlanStatus {
   expired,
 }
 
-extension on ReservationPlanStatus {
+extension ReservationPlanStatusValue on ReservationPlanStatus {
   String toValue() {
     switch (this) {
       case ReservationPlanStatus.active:
@@ -23261,7 +23295,7 @@ extension on ReservationPlanStatus {
   }
 }
 
-extension on String {
+extension ReservationPlanStatusFromString on String {
   ReservationPlanStatus toReservationPlanStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -23309,7 +23343,7 @@ enum RespondToAfd {
   passthrough,
 }
 
-extension on RespondToAfd {
+extension RespondToAfdValue on RespondToAfd {
   String toValue() {
     switch (this) {
       case RespondToAfd.none:
@@ -23322,7 +23356,7 @@ extension on RespondToAfd {
   }
 }
 
-extension on String {
+extension RespondToAfdFromString on String {
   RespondToAfd toRespondToAfd() {
     switch (this) {
       case 'NONE':
@@ -23453,7 +23487,7 @@ enum S3ObjectCannedAcl {
   bucketOwnerFullControl,
 }
 
-extension on S3ObjectCannedAcl {
+extension S3ObjectCannedAclValue on S3ObjectCannedAcl {
   String toValue() {
     switch (this) {
       case S3ObjectCannedAcl.publicRead:
@@ -23468,7 +23502,7 @@ extension on S3ObjectCannedAcl {
   }
 }
 
-extension on String {
+extension S3ObjectCannedAclFromString on String {
   S3ObjectCannedAcl toS3ObjectCannedAcl() {
     switch (this) {
       case 'PUBLIC_READ':
@@ -23500,7 +23534,7 @@ enum S3ServerSideEncryptionType {
   serverSideEncryptionKms,
 }
 
-extension on S3ServerSideEncryptionType {
+extension S3ServerSideEncryptionTypeValue on S3ServerSideEncryptionType {
   String toValue() {
     switch (this) {
       case S3ServerSideEncryptionType.serverSideEncryptionS3:
@@ -23511,7 +23545,7 @@ extension on S3ServerSideEncryptionType {
   }
 }
 
-extension on String {
+extension S3ServerSideEncryptionTypeFromString on String {
   S3ServerSideEncryptionType toS3ServerSideEncryptionType() {
     switch (this) {
       case 'SERVER_SIDE_ENCRYPTION_S3':
@@ -23534,7 +23568,7 @@ enum ScalingBehavior {
   stretchToOutput,
 }
 
-extension on ScalingBehavior {
+extension ScalingBehaviorValue on ScalingBehavior {
   String toValue() {
     switch (this) {
       case ScalingBehavior.$default:
@@ -23545,7 +23579,7 @@ extension on ScalingBehavior {
   }
 }
 
-extension on String {
+extension ScalingBehaviorFromString on String {
   ScalingBehavior toScalingBehavior() {
     switch (this) {
       case 'DEFAULT':
@@ -23571,7 +23605,7 @@ enum SccDestinationFramerate {
   framerate_29_97NonDropframe,
 }
 
-extension on SccDestinationFramerate {
+extension SccDestinationFramerateValue on SccDestinationFramerate {
   String toValue() {
     switch (this) {
       case SccDestinationFramerate.framerate_23_97:
@@ -23588,7 +23622,7 @@ extension on SccDestinationFramerate {
   }
 }
 
-extension on String {
+extension SccDestinationFramerateFromString on String {
   SccDestinationFramerate toSccDestinationFramerate() {
     switch (this) {
       case 'FRAMERATE_23_97':
@@ -23642,7 +23676,7 @@ enum SimulateReservedQueue {
   enabled,
 }
 
-extension on SimulateReservedQueue {
+extension SimulateReservedQueueValue on SimulateReservedQueue {
   String toValue() {
     switch (this) {
       case SimulateReservedQueue.disabled:
@@ -23653,7 +23687,7 @@ extension on SimulateReservedQueue {
   }
 }
 
-extension on String {
+extension SimulateReservedQueueFromString on String {
   SimulateReservedQueue toSimulateReservedQueue() {
     switch (this) {
       case 'DISABLED':
@@ -23864,7 +23898,7 @@ enum StatusUpdateInterval {
   seconds_600,
 }
 
-extension on StatusUpdateInterval {
+extension StatusUpdateIntervalValue on StatusUpdateInterval {
   String toValue() {
     switch (this) {
       case StatusUpdateInterval.seconds_10:
@@ -23901,7 +23935,7 @@ extension on StatusUpdateInterval {
   }
 }
 
-extension on String {
+extension StatusUpdateIntervalFromString on String {
   StatusUpdateInterval toStatusUpdateInterval() {
     switch (this) {
       case 'SECONDS_10':
@@ -23995,7 +24029,7 @@ enum TeletextPageType {
   pageTypeHearingImpairedSubtitle,
 }
 
-extension on TeletextPageType {
+extension TeletextPageTypeValue on TeletextPageType {
   String toValue() {
     switch (this) {
       case TeletextPageType.pageTypeInitial:
@@ -24012,7 +24046,7 @@ extension on TeletextPageType {
   }
 }
 
-extension on String {
+extension TeletextPageTypeFromString on String {
   TeletextPageType toTeletextPageType() {
     switch (this) {
       case 'PAGE_TYPE_INITIAL':
@@ -24112,7 +24146,7 @@ enum TimecodeBurninPosition {
   bottomRight,
 }
 
-extension on TimecodeBurninPosition {
+extension TimecodeBurninPositionValue on TimecodeBurninPosition {
   String toValue() {
     switch (this) {
       case TimecodeBurninPosition.topCenter:
@@ -24137,7 +24171,7 @@ extension on TimecodeBurninPosition {
   }
 }
 
-extension on String {
+extension TimecodeBurninPositionFromString on String {
   TimecodeBurninPosition toTimecodeBurninPosition() {
     switch (this) {
       case 'TOP_CENTER':
@@ -24255,7 +24289,7 @@ enum TimecodeSource {
   specifiedstart,
 }
 
-extension on TimecodeSource {
+extension TimecodeSourceValue on TimecodeSource {
   String toValue() {
     switch (this) {
       case TimecodeSource.embedded:
@@ -24268,7 +24302,7 @@ extension on TimecodeSource {
   }
 }
 
-extension on String {
+extension TimecodeSourceFromString on String {
   TimecodeSource toTimecodeSource() {
     switch (this) {
       case 'EMBEDDED':
@@ -24289,7 +24323,7 @@ enum TimedMetadata {
   none,
 }
 
-extension on TimedMetadata {
+extension TimedMetadataValue on TimedMetadata {
   String toValue() {
     switch (this) {
       case TimedMetadata.passthrough:
@@ -24300,7 +24334,7 @@ extension on TimedMetadata {
   }
 }
 
-extension on String {
+extension TimedMetadataFromString on String {
   TimedMetadata toTimedMetadata() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -24430,7 +24464,7 @@ enum TtmlStylePassthrough {
   disabled,
 }
 
-extension on TtmlStylePassthrough {
+extension TtmlStylePassthroughValue on TtmlStylePassthrough {
   String toValue() {
     switch (this) {
       case TtmlStylePassthrough.enabled:
@@ -24441,7 +24475,7 @@ extension on TtmlStylePassthrough {
   }
 }
 
-extension on String {
+extension TtmlStylePassthroughFromString on String {
   TtmlStylePassthrough toTtmlStylePassthrough() {
     switch (this) {
       case 'ENABLED':
@@ -24458,7 +24492,7 @@ enum Type {
   custom,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.system:
@@ -24469,7 +24503,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'SYSTEM':
@@ -24556,7 +24590,7 @@ enum Vc3Class {
   class_220_10bit,
 }
 
-extension on Vc3Class {
+extension Vc3ClassValue on Vc3Class {
   String toValue() {
     switch (this) {
       case Vc3Class.class_145_8bit:
@@ -24569,7 +24603,7 @@ extension on Vc3Class {
   }
 }
 
-extension on String {
+extension Vc3ClassFromString on String {
   Vc3Class toVc3Class() {
     switch (this) {
       case 'CLASS_145_8BIT':
@@ -24600,7 +24634,7 @@ enum Vc3FramerateControl {
   specified,
 }
 
-extension on Vc3FramerateControl {
+extension Vc3FramerateControlValue on Vc3FramerateControl {
   String toValue() {
     switch (this) {
       case Vc3FramerateControl.initializeFromSource:
@@ -24611,7 +24645,7 @@ extension on Vc3FramerateControl {
   }
 }
 
-extension on String {
+extension Vc3FramerateControlFromString on String {
   Vc3FramerateControl toVc3FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -24640,7 +24674,8 @@ enum Vc3FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on Vc3FramerateConversionAlgorithm {
+extension Vc3FramerateConversionAlgorithmValue
+    on Vc3FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case Vc3FramerateConversionAlgorithm.duplicateDrop:
@@ -24653,7 +24688,7 @@ extension on Vc3FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension Vc3FramerateConversionAlgorithmFromString on String {
   Vc3FramerateConversionAlgorithm toVc3FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -24675,7 +24710,7 @@ enum Vc3InterlaceMode {
   progressive,
 }
 
-extension on Vc3InterlaceMode {
+extension Vc3InterlaceModeValue on Vc3InterlaceMode {
   String toValue() {
     switch (this) {
       case Vc3InterlaceMode.interlaced:
@@ -24686,7 +24721,7 @@ extension on Vc3InterlaceMode {
   }
 }
 
-extension on String {
+extension Vc3InterlaceModeFromString on String {
   Vc3InterlaceMode toVc3InterlaceMode() {
     switch (this) {
       case 'INTERLACED':
@@ -24837,7 +24872,7 @@ enum Vc3SlowPal {
   enabled,
 }
 
-extension on Vc3SlowPal {
+extension Vc3SlowPalValue on Vc3SlowPal {
   String toValue() {
     switch (this) {
       case Vc3SlowPal.disabled:
@@ -24848,7 +24883,7 @@ extension on Vc3SlowPal {
   }
 }
 
-extension on String {
+extension Vc3SlowPalFromString on String {
   Vc3SlowPal toVc3SlowPal() {
     switch (this) {
       case 'DISABLED':
@@ -24871,7 +24906,7 @@ enum Vc3Telecine {
   hard,
 }
 
-extension on Vc3Telecine {
+extension Vc3TelecineValue on Vc3Telecine {
   String toValue() {
     switch (this) {
       case Vc3Telecine.none:
@@ -24882,7 +24917,7 @@ extension on Vc3Telecine {
   }
 }
 
-extension on String {
+extension Vc3TelecineFromString on String {
   Vc3Telecine toVc3Telecine() {
     switch (this) {
       case 'NONE':
@@ -24908,7 +24943,7 @@ enum VideoCodec {
   vp9,
 }
 
-extension on VideoCodec {
+extension VideoCodecValue on VideoCodec {
   String toValue() {
     switch (this) {
       case VideoCodec.av1:
@@ -24935,7 +24970,7 @@ extension on VideoCodec {
   }
 }
 
-extension on String {
+extension VideoCodecFromString on String {
   VideoCodec toVideoCodec() {
     switch (this) {
       case 'AV1':
@@ -25539,7 +25574,7 @@ enum VideoTimecodeInsertion {
   picTimingSei,
 }
 
-extension on VideoTimecodeInsertion {
+extension VideoTimecodeInsertionValue on VideoTimecodeInsertion {
   String toValue() {
     switch (this) {
       case VideoTimecodeInsertion.disabled:
@@ -25550,7 +25585,7 @@ extension on VideoTimecodeInsertion {
   }
 }
 
-extension on String {
+extension VideoTimecodeInsertionFromString on String {
   VideoTimecodeInsertion toVideoTimecodeInsertion() {
     switch (this) {
       case 'DISABLED':
@@ -25622,7 +25657,7 @@ enum Vp8FramerateControl {
   specified,
 }
 
-extension on Vp8FramerateControl {
+extension Vp8FramerateControlValue on Vp8FramerateControl {
   String toValue() {
     switch (this) {
       case Vp8FramerateControl.initializeFromSource:
@@ -25633,7 +25668,7 @@ extension on Vp8FramerateControl {
   }
 }
 
-extension on String {
+extension Vp8FramerateControlFromString on String {
   Vp8FramerateControl toVp8FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -25662,7 +25697,8 @@ enum Vp8FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on Vp8FramerateConversionAlgorithm {
+extension Vp8FramerateConversionAlgorithmValue
+    on Vp8FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case Vp8FramerateConversionAlgorithm.duplicateDrop:
@@ -25675,7 +25711,7 @@ extension on Vp8FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension Vp8FramerateConversionAlgorithmFromString on String {
   Vp8FramerateConversionAlgorithm toVp8FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -25703,7 +25739,7 @@ enum Vp8ParControl {
   specified,
 }
 
-extension on Vp8ParControl {
+extension Vp8ParControlValue on Vp8ParControl {
   String toValue() {
     switch (this) {
       case Vp8ParControl.initializeFromSource:
@@ -25714,7 +25750,7 @@ extension on Vp8ParControl {
   }
 }
 
-extension on String {
+extension Vp8ParControlFromString on String {
   Vp8ParControl toVp8ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -25734,7 +25770,7 @@ enum Vp8QualityTuningLevel {
   multiPassHq,
 }
 
-extension on Vp8QualityTuningLevel {
+extension Vp8QualityTuningLevelValue on Vp8QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Vp8QualityTuningLevel.multiPass:
@@ -25745,7 +25781,7 @@ extension on Vp8QualityTuningLevel {
   }
 }
 
-extension on String {
+extension Vp8QualityTuningLevelFromString on String {
   Vp8QualityTuningLevel toVp8QualityTuningLevel() {
     switch (this) {
       case 'MULTI_PASS':
@@ -25763,7 +25799,7 @@ enum Vp8RateControlMode {
   vbr,
 }
 
-extension on Vp8RateControlMode {
+extension Vp8RateControlModeValue on Vp8RateControlMode {
   String toValue() {
     switch (this) {
       case Vp8RateControlMode.vbr:
@@ -25772,7 +25808,7 @@ extension on Vp8RateControlMode {
   }
 }
 
-extension on String {
+extension Vp8RateControlModeFromString on String {
   Vp8RateControlMode toVp8RateControlMode() {
     switch (this) {
       case 'VBR':
@@ -25972,7 +26008,7 @@ enum Vp9FramerateControl {
   specified,
 }
 
-extension on Vp9FramerateControl {
+extension Vp9FramerateControlValue on Vp9FramerateControl {
   String toValue() {
     switch (this) {
       case Vp9FramerateControl.initializeFromSource:
@@ -25983,7 +26019,7 @@ extension on Vp9FramerateControl {
   }
 }
 
-extension on String {
+extension Vp9FramerateControlFromString on String {
   Vp9FramerateControl toVp9FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -26012,7 +26048,8 @@ enum Vp9FramerateConversionAlgorithm {
   frameformer,
 }
 
-extension on Vp9FramerateConversionAlgorithm {
+extension Vp9FramerateConversionAlgorithmValue
+    on Vp9FramerateConversionAlgorithm {
   String toValue() {
     switch (this) {
       case Vp9FramerateConversionAlgorithm.duplicateDrop:
@@ -26025,7 +26062,7 @@ extension on Vp9FramerateConversionAlgorithm {
   }
 }
 
-extension on String {
+extension Vp9FramerateConversionAlgorithmFromString on String {
   Vp9FramerateConversionAlgorithm toVp9FramerateConversionAlgorithm() {
     switch (this) {
       case 'DUPLICATE_DROP':
@@ -26053,7 +26090,7 @@ enum Vp9ParControl {
   specified,
 }
 
-extension on Vp9ParControl {
+extension Vp9ParControlValue on Vp9ParControl {
   String toValue() {
     switch (this) {
       case Vp9ParControl.initializeFromSource:
@@ -26064,7 +26101,7 @@ extension on Vp9ParControl {
   }
 }
 
-extension on String {
+extension Vp9ParControlFromString on String {
   Vp9ParControl toVp9ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -26084,7 +26121,7 @@ enum Vp9QualityTuningLevel {
   multiPassHq,
 }
 
-extension on Vp9QualityTuningLevel {
+extension Vp9QualityTuningLevelValue on Vp9QualityTuningLevel {
   String toValue() {
     switch (this) {
       case Vp9QualityTuningLevel.multiPass:
@@ -26095,7 +26132,7 @@ extension on Vp9QualityTuningLevel {
   }
 }
 
-extension on String {
+extension Vp9QualityTuningLevelFromString on String {
   Vp9QualityTuningLevel toVp9QualityTuningLevel() {
     switch (this) {
       case 'MULTI_PASS':
@@ -26113,7 +26150,7 @@ enum Vp9RateControlMode {
   vbr,
 }
 
-extension on Vp9RateControlMode {
+extension Vp9RateControlModeValue on Vp9RateControlMode {
   String toValue() {
     switch (this) {
       case Vp9RateControlMode.vbr:
@@ -26122,7 +26159,7 @@ extension on Vp9RateControlMode {
   }
 }
 
-extension on String {
+extension Vp9RateControlModeFromString on String {
   Vp9RateControlMode toVp9RateControlMode() {
     switch (this) {
       case 'VBR':
@@ -26311,7 +26348,7 @@ enum WatermarkingStrength {
   strongest,
 }
 
-extension on WatermarkingStrength {
+extension WatermarkingStrengthValue on WatermarkingStrength {
   String toValue() {
     switch (this) {
       case WatermarkingStrength.lightest:
@@ -26328,7 +26365,7 @@ extension on WatermarkingStrength {
   }
 }
 
-extension on String {
+extension WatermarkingStrengthFromString on String {
   WatermarkingStrength toWatermarkingStrength() {
     switch (this) {
       case 'LIGHTEST':
@@ -26354,7 +26391,7 @@ enum WavFormat {
   rf64,
 }
 
-extension on WavFormat {
+extension WavFormatValue on WavFormat {
   String toValue() {
     switch (this) {
       case WavFormat.riff:
@@ -26365,7 +26402,7 @@ extension on WavFormat {
   }
 }
 
-extension on String {
+extension WavFormatFromString on String {
   WavFormat toWavFormat() {
     switch (this) {
       case 'RIFF':

--- a/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
+++ b/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
@@ -2112,7 +2112,7 @@ enum AacCodingMode {
   codingMode_5_1,
 }
 
-extension AacCodingModeValue on AacCodingMode {
+extension AacCodingModeValueExtension on AacCodingMode {
   String toValue() {
     switch (this) {
       case AacCodingMode.adReceiverMix:
@@ -2153,7 +2153,7 @@ enum AacInputType {
   normal,
 }
 
-extension AacInputTypeValue on AacInputType {
+extension AacInputTypeValueExtension on AacInputType {
   String toValue() {
     switch (this) {
       case AacInputType.broadcasterMixedAd:
@@ -2183,7 +2183,7 @@ enum AacProfile {
   lc,
 }
 
-extension AacProfileValue on AacProfile {
+extension AacProfileValueExtension on AacProfile {
   String toValue() {
     switch (this) {
       case AacProfile.hev1:
@@ -2216,7 +2216,7 @@ enum AacRateControlMode {
   vbr,
 }
 
-extension AacRateControlModeValue on AacRateControlMode {
+extension AacRateControlModeValueExtension on AacRateControlMode {
   String toValue() {
     switch (this) {
       case AacRateControlMode.cbr:
@@ -2245,7 +2245,7 @@ enum AacRawFormat {
   none,
 }
 
-extension AacRawFormatValue on AacRawFormat {
+extension AacRawFormatValueExtension on AacRawFormat {
   String toValue() {
     switch (this) {
       case AacRawFormat.latmLoas:
@@ -2366,7 +2366,7 @@ enum AacSpec {
   mpeg4,
 }
 
-extension AacSpecValue on AacSpec {
+extension AacSpecValueExtension on AacSpec {
   String toValue() {
     switch (this) {
       case AacSpec.mpeg2:
@@ -2397,7 +2397,7 @@ enum AacVbrQuality {
   mediumLow,
 }
 
-extension AacVbrQualityValue on AacVbrQuality {
+extension AacVbrQualityValueExtension on AacVbrQuality {
   String toValue() {
     switch (this) {
       case AacVbrQuality.high:
@@ -2440,7 +2440,7 @@ enum Ac3BitstreamMode {
   voiceOver,
 }
 
-extension Ac3BitstreamModeValue on Ac3BitstreamMode {
+extension Ac3BitstreamModeValueExtension on Ac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Ac3BitstreamMode.commentary:
@@ -2495,7 +2495,7 @@ enum Ac3CodingMode {
   codingMode_3_2Lfe,
 }
 
-extension Ac3CodingModeValue on Ac3CodingMode {
+extension Ac3CodingModeValueExtension on Ac3CodingMode {
   String toValue() {
     switch (this) {
       case Ac3CodingMode.codingMode_1_0:
@@ -2532,7 +2532,7 @@ enum Ac3DrcProfile {
   none,
 }
 
-extension Ac3DrcProfileValue on Ac3DrcProfile {
+extension Ac3DrcProfileValueExtension on Ac3DrcProfile {
   String toValue() {
     switch (this) {
       case Ac3DrcProfile.filmStandard:
@@ -2561,7 +2561,7 @@ enum Ac3LfeFilter {
   enabled,
 }
 
-extension Ac3LfeFilterValue on Ac3LfeFilter {
+extension Ac3LfeFilterValueExtension on Ac3LfeFilter {
   String toValue() {
     switch (this) {
       case Ac3LfeFilter.disabled:
@@ -2590,7 +2590,7 @@ enum Ac3MetadataControl {
   useConfigured,
 }
 
-extension Ac3MetadataControlValue on Ac3MetadataControl {
+extension Ac3MetadataControlValueExtension on Ac3MetadataControl {
   String toValue() {
     switch (this) {
       case Ac3MetadataControl.followInput:
@@ -2700,7 +2700,7 @@ enum AfdSignaling {
   none,
 }
 
-extension AfdSignalingValue on AfdSignaling {
+extension AfdSignalingValueExtension on AfdSignaling {
   String toValue() {
     switch (this) {
       case AfdSignaling.auto:
@@ -3094,7 +3094,7 @@ enum AudioDescriptionAudioTypeControl {
   useConfigured,
 }
 
-extension AudioDescriptionAudioTypeControlValue
+extension AudioDescriptionAudioTypeControlValueExtension
     on AudioDescriptionAudioTypeControl {
   String toValue() {
     switch (this) {
@@ -3125,7 +3125,7 @@ enum AudioDescriptionLanguageCodeControl {
   useConfigured,
 }
 
-extension AudioDescriptionLanguageCodeControlValue
+extension AudioDescriptionLanguageCodeControlValueExtension
     on AudioDescriptionLanguageCodeControl {
   String toValue() {
     switch (this) {
@@ -3192,7 +3192,8 @@ enum AudioLanguageSelectionPolicy {
   strict,
 }
 
-extension AudioLanguageSelectionPolicyValue on AudioLanguageSelectionPolicy {
+extension AudioLanguageSelectionPolicyValueExtension
+    on AudioLanguageSelectionPolicy {
   String toValue() {
     switch (this) {
       case AudioLanguageSelectionPolicy.loose:
@@ -3221,7 +3222,8 @@ enum AudioNormalizationAlgorithm {
   itu_1770_2,
 }
 
-extension AudioNormalizationAlgorithmValue on AudioNormalizationAlgorithm {
+extension AudioNormalizationAlgorithmValueExtension
+    on AudioNormalizationAlgorithm {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithm.itu_1770_1:
@@ -3249,7 +3251,7 @@ enum AudioNormalizationAlgorithmControl {
   correctAudio,
 }
 
-extension AudioNormalizationAlgorithmControlValue
+extension AudioNormalizationAlgorithmControlValueExtension
     on AudioNormalizationAlgorithmControl {
   String toValue() {
     switch (this) {
@@ -3321,7 +3323,7 @@ enum AudioOnlyHlsSegmentType {
   fmp4,
 }
 
-extension AudioOnlyHlsSegmentTypeValue on AudioOnlyHlsSegmentType {
+extension AudioOnlyHlsSegmentTypeValueExtension on AudioOnlyHlsSegmentType {
   String toValue() {
     switch (this) {
       case AudioOnlyHlsSegmentType.aac:
@@ -3425,7 +3427,7 @@ enum AudioOnlyHlsTrackType {
   audioOnlyVariantStream,
 }
 
-extension AudioOnlyHlsTrackTypeValue on AudioOnlyHlsTrackType {
+extension AudioOnlyHlsTrackTypeValueExtension on AudioOnlyHlsTrackType {
   String toValue() {
     switch (this) {
       case AudioOnlyHlsTrackType.alternateAudioAutoSelect:
@@ -3642,7 +3644,7 @@ enum AudioType {
   visualImpairedCommentary,
 }
 
-extension AudioTypeValue on AudioType {
+extension AudioTypeValueExtension on AudioType {
   String toValue() {
     switch (this) {
       case AudioType.cleanEffects:
@@ -3679,7 +3681,7 @@ enum AuthenticationScheme {
   common,
 }
 
-extension AuthenticationSchemeValue on AuthenticationScheme {
+extension AuthenticationSchemeValueExtension on AuthenticationScheme {
   String toValue() {
     switch (this) {
       case AuthenticationScheme.akamai:
@@ -3796,7 +3798,7 @@ enum AvailBlankingState {
   enabled,
 }
 
-extension AvailBlankingStateValue on AvailBlankingState {
+extension AvailBlankingStateValueExtension on AvailBlankingState {
   String toValue() {
     switch (this) {
       case AvailBlankingState.disabled:
@@ -4185,7 +4187,7 @@ enum BlackoutSlateNetworkEndBlackout {
   enabled,
 }
 
-extension BlackoutSlateNetworkEndBlackoutValue
+extension BlackoutSlateNetworkEndBlackoutValueExtension
     on BlackoutSlateNetworkEndBlackout {
   String toValue() {
     switch (this) {
@@ -4216,7 +4218,7 @@ enum BlackoutSlateState {
   enabled,
 }
 
-extension BlackoutSlateStateValue on BlackoutSlateState {
+extension BlackoutSlateStateValueExtension on BlackoutSlateState {
   String toValue() {
     switch (this) {
       case BlackoutSlateState.disabled:
@@ -4246,7 +4248,7 @@ enum BurnInAlignment {
   smart,
 }
 
-extension BurnInAlignmentValue on BurnInAlignment {
+extension BurnInAlignmentValueExtension on BurnInAlignment {
   String toValue() {
     switch (this) {
       case BurnInAlignment.centered:
@@ -4280,7 +4282,7 @@ enum BurnInBackgroundColor {
   white,
 }
 
-extension BurnInBackgroundColorValue on BurnInBackgroundColor {
+extension BurnInBackgroundColorValueExtension on BurnInBackgroundColor {
   String toValue() {
     switch (this) {
       case BurnInBackgroundColor.black:
@@ -4501,7 +4503,7 @@ enum BurnInFontColor {
   yellow,
 }
 
-extension BurnInFontColorValue on BurnInFontColor {
+extension BurnInFontColorValueExtension on BurnInFontColor {
   String toValue() {
     switch (this) {
       case BurnInFontColor.black:
@@ -4550,7 +4552,7 @@ enum BurnInOutlineColor {
   yellow,
 }
 
-extension BurnInOutlineColorValue on BurnInOutlineColor {
+extension BurnInOutlineColorValueExtension on BurnInOutlineColor {
   String toValue() {
     switch (this) {
       case BurnInOutlineColor.black:
@@ -4596,7 +4598,7 @@ enum BurnInShadowColor {
   white,
 }
 
-extension BurnInShadowColorValue on BurnInShadowColor {
+extension BurnInShadowColorValueExtension on BurnInShadowColor {
   String toValue() {
     switch (this) {
       case BurnInShadowColor.black:
@@ -4629,7 +4631,7 @@ enum BurnInTeletextGridControl {
   scaled,
 }
 
-extension BurnInTeletextGridControlValue on BurnInTeletextGridControl {
+extension BurnInTeletextGridControlValueExtension on BurnInTeletextGridControl {
   String toValue() {
     switch (this) {
       case BurnInTeletextGridControl.fixed:
@@ -5036,7 +5038,7 @@ enum CdiInputResolution {
   uhd,
 }
 
-extension CdiInputResolutionValue on CdiInputResolution {
+extension CdiInputResolutionValueExtension on CdiInputResolution {
   String toValue() {
     switch (this) {
       case CdiInputResolution.sd:
@@ -5207,7 +5209,7 @@ enum ChannelClass {
   singlePipeline,
 }
 
-extension ChannelClassValue on ChannelClass {
+extension ChannelClassValueExtension on ChannelClass {
   String toValue() {
     switch (this) {
       case ChannelClass.standard:
@@ -5260,7 +5262,7 @@ enum ChannelState {
   updateFailed,
 }
 
-extension ChannelStateValue on ChannelState {
+extension ChannelStateValueExtension on ChannelState {
   String toValue() {
     switch (this) {
       case ChannelState.creating:
@@ -6597,7 +6599,7 @@ enum DeviceSettingsSyncState {
   syncing,
 }
 
-extension DeviceSettingsSyncStateValue on DeviceSettingsSyncState {
+extension DeviceSettingsSyncStateValueExtension on DeviceSettingsSyncState {
   String toValue() {
     switch (this) {
       case DeviceSettingsSyncState.synced:
@@ -6626,7 +6628,7 @@ enum DeviceUpdateStatus {
   notUpToDate,
 }
 
-extension DeviceUpdateStatusValue on DeviceUpdateStatus {
+extension DeviceUpdateStatusValueExtension on DeviceUpdateStatus {
   String toValue() {
     switch (this) {
       case DeviceUpdateStatus.upToDate:
@@ -6695,7 +6697,7 @@ enum DvbSdtOutputSdt {
   sdtNone,
 }
 
-extension DvbSdtOutputSdtValue on DvbSdtOutputSdt {
+extension DvbSdtOutputSdtValueExtension on DvbSdtOutputSdt {
   String toValue() {
     switch (this) {
       case DvbSdtOutputSdt.sdtFollow:
@@ -6786,7 +6788,8 @@ enum DvbSubDestinationAlignment {
   smart,
 }
 
-extension DvbSubDestinationAlignmentValue on DvbSubDestinationAlignment {
+extension DvbSubDestinationAlignmentValueExtension
+    on DvbSubDestinationAlignment {
   String toValue() {
     switch (this) {
       case DvbSubDestinationAlignment.centered:
@@ -6820,7 +6823,7 @@ enum DvbSubDestinationBackgroundColor {
   white,
 }
 
-extension DvbSubDestinationBackgroundColorValue
+extension DvbSubDestinationBackgroundColorValueExtension
     on DvbSubDestinationBackgroundColor {
   String toValue() {
     switch (this) {
@@ -6859,7 +6862,8 @@ enum DvbSubDestinationFontColor {
   yellow,
 }
 
-extension DvbSubDestinationFontColorValue on DvbSubDestinationFontColor {
+extension DvbSubDestinationFontColorValueExtension
+    on DvbSubDestinationFontColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationFontColor.black:
@@ -6908,7 +6912,8 @@ enum DvbSubDestinationOutlineColor {
   yellow,
 }
 
-extension DvbSubDestinationOutlineColorValue on DvbSubDestinationOutlineColor {
+extension DvbSubDestinationOutlineColorValueExtension
+    on DvbSubDestinationOutlineColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationOutlineColor.black:
@@ -7146,7 +7151,8 @@ enum DvbSubDestinationShadowColor {
   white,
 }
 
-extension DvbSubDestinationShadowColorValue on DvbSubDestinationShadowColor {
+extension DvbSubDestinationShadowColorValueExtension
+    on DvbSubDestinationShadowColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationShadowColor.black:
@@ -7179,7 +7185,7 @@ enum DvbSubDestinationTeletextGridControl {
   scaled,
 }
 
-extension DvbSubDestinationTeletextGridControlValue
+extension DvbSubDestinationTeletextGridControlValueExtension
     on DvbSubDestinationTeletextGridControl {
   String toValue() {
     switch (this) {
@@ -7258,7 +7264,7 @@ enum Eac3AttenuationControl {
   none,
 }
 
-extension Eac3AttenuationControlValue on Eac3AttenuationControl {
+extension Eac3AttenuationControlValueExtension on Eac3AttenuationControl {
   String toValue() {
     switch (this) {
       case Eac3AttenuationControl.attenuate_3Db:
@@ -7290,7 +7296,7 @@ enum Eac3BitstreamMode {
   visuallyImpaired,
 }
 
-extension Eac3BitstreamModeValue on Eac3BitstreamMode {
+extension Eac3BitstreamModeValueExtension on Eac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3BitstreamMode.commentary:
@@ -7332,7 +7338,7 @@ enum Eac3CodingMode {
   codingMode_3_2,
 }
 
-extension Eac3CodingModeValue on Eac3CodingMode {
+extension Eac3CodingModeValueExtension on Eac3CodingMode {
   String toValue() {
     switch (this) {
       case Eac3CodingMode.codingMode_1_0:
@@ -7365,7 +7371,7 @@ enum Eac3DcFilter {
   enabled,
 }
 
-extension Eac3DcFilterValue on Eac3DcFilter {
+extension Eac3DcFilterValueExtension on Eac3DcFilter {
   String toValue() {
     switch (this) {
       case Eac3DcFilter.disabled:
@@ -7398,7 +7404,7 @@ enum Eac3DrcLine {
   speech,
 }
 
-extension Eac3DrcLineValue on Eac3DrcLine {
+extension Eac3DrcLineValueExtension on Eac3DrcLine {
   String toValue() {
     switch (this) {
       case Eac3DrcLine.filmLight:
@@ -7447,7 +7453,7 @@ enum Eac3DrcRf {
   speech,
 }
 
-extension Eac3DrcRfValue on Eac3DrcRf {
+extension Eac3DrcRfValueExtension on Eac3DrcRf {
   String toValue() {
     switch (this) {
       case Eac3DrcRf.filmLight:
@@ -7492,7 +7498,7 @@ enum Eac3LfeControl {
   noLfe,
 }
 
-extension Eac3LfeControlValue on Eac3LfeControl {
+extension Eac3LfeControlValueExtension on Eac3LfeControl {
   String toValue() {
     switch (this) {
       case Eac3LfeControl.lfe:
@@ -7521,7 +7527,7 @@ enum Eac3LfeFilter {
   enabled,
 }
 
-extension Eac3LfeFilterValue on Eac3LfeFilter {
+extension Eac3LfeFilterValueExtension on Eac3LfeFilter {
   String toValue() {
     switch (this) {
       case Eac3LfeFilter.disabled:
@@ -7550,7 +7556,7 @@ enum Eac3MetadataControl {
   useConfigured,
 }
 
-extension Eac3MetadataControlValue on Eac3MetadataControl {
+extension Eac3MetadataControlValueExtension on Eac3MetadataControl {
   String toValue() {
     switch (this) {
       case Eac3MetadataControl.followInput:
@@ -7579,7 +7585,7 @@ enum Eac3PassthroughControl {
   whenPossible,
 }
 
-extension Eac3PassthroughControlValue on Eac3PassthroughControl {
+extension Eac3PassthroughControlValueExtension on Eac3PassthroughControl {
   String toValue() {
     switch (this) {
       case Eac3PassthroughControl.noPassthrough:
@@ -7608,7 +7614,7 @@ enum Eac3PhaseControl {
   shift_90Degrees,
 }
 
-extension Eac3PhaseControlValue on Eac3PhaseControl {
+extension Eac3PhaseControlValueExtension on Eac3PhaseControl {
   String toValue() {
     switch (this) {
       case Eac3PhaseControl.noShift:
@@ -7816,7 +7822,7 @@ enum Eac3StereoDownmix {
   notIndicated,
 }
 
-extension Eac3StereoDownmixValue on Eac3StereoDownmix {
+extension Eac3StereoDownmixValueExtension on Eac3StereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3StereoDownmix.dpl2:
@@ -7854,7 +7860,7 @@ enum Eac3SurroundExMode {
   notIndicated,
 }
 
-extension Eac3SurroundExModeValue on Eac3SurroundExMode {
+extension Eac3SurroundExModeValueExtension on Eac3SurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundExMode.disabled:
@@ -7888,7 +7894,7 @@ enum Eac3SurroundMode {
   notIndicated,
 }
 
-extension Eac3SurroundModeValue on Eac3SurroundMode {
+extension Eac3SurroundModeValueExtension on Eac3SurroundMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundMode.disabled:
@@ -7984,7 +7990,8 @@ enum EbuTtDDestinationStyleControl {
   include,
 }
 
-extension EbuTtDDestinationStyleControlValue on EbuTtDDestinationStyleControl {
+extension EbuTtDDestinationStyleControlValueExtension
+    on EbuTtDDestinationStyleControl {
   String toValue() {
     switch (this) {
       case EbuTtDDestinationStyleControl.exclude:
@@ -8013,7 +8020,7 @@ enum EbuTtDFillLineGapControl {
   enabled,
 }
 
-extension EbuTtDFillLineGapControlValue on EbuTtDFillLineGapControl {
+extension EbuTtDFillLineGapControlValueExtension on EbuTtDFillLineGapControl {
   String toValue() {
     switch (this) {
       case EbuTtDFillLineGapControl.disabled:
@@ -8042,7 +8049,7 @@ enum EmbeddedConvert608To708 {
   upconvert,
 }
 
-extension EmbeddedConvert608To708Value on EmbeddedConvert608To708 {
+extension EmbeddedConvert608To708ValueExtension on EmbeddedConvert608To708 {
   String toValue() {
     switch (this) {
       case EmbeddedConvert608To708.disabled:
@@ -8096,7 +8103,7 @@ enum EmbeddedScte20Detection {
   off,
 }
 
-extension EmbeddedScte20DetectionValue on EmbeddedScte20Detection {
+extension EmbeddedScte20DetectionValueExtension on EmbeddedScte20Detection {
   String toValue() {
     switch (this) {
       case EmbeddedScte20Detection.auto:
@@ -8403,7 +8410,7 @@ enum FeatureActivationsInputPrepareScheduleActions {
   enabled,
 }
 
-extension FeatureActivationsInputPrepareScheduleActionsValue
+extension FeatureActivationsInputPrepareScheduleActionsValueExtension
     on FeatureActivationsInputPrepareScheduleActions {
   String toValue() {
     switch (this) {
@@ -8435,7 +8442,7 @@ enum FecOutputIncludeFec {
   columnAndRow,
 }
 
-extension FecOutputIncludeFecValue on FecOutputIncludeFec {
+extension FecOutputIncludeFecValueExtension on FecOutputIncludeFec {
   String toValue() {
     switch (this) {
       case FecOutputIncludeFec.column:
@@ -8516,7 +8523,7 @@ enum FixedAfd {
   afd_1111,
 }
 
-extension FixedAfdValue on FixedAfd {
+extension FixedAfdValueExtension on FixedAfd {
   String toValue() {
     switch (this) {
       case FixedAfd.afd_0000:
@@ -8652,7 +8659,7 @@ enum Fmp4NielsenId3Behavior {
   passthrough,
 }
 
-extension Fmp4NielsenId3BehaviorValue on Fmp4NielsenId3Behavior {
+extension Fmp4NielsenId3BehaviorValueExtension on Fmp4NielsenId3Behavior {
   String toValue() {
     switch (this) {
       case Fmp4NielsenId3Behavior.noPassthrough:
@@ -8681,7 +8688,7 @@ enum Fmp4TimedMetadataBehavior {
   passthrough,
 }
 
-extension Fmp4TimedMetadataBehaviorValue on Fmp4TimedMetadataBehavior {
+extension Fmp4TimedMetadataBehaviorValueExtension on Fmp4TimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case Fmp4TimedMetadataBehavior.noPassthrough:
@@ -8741,7 +8748,7 @@ enum FollowPoint {
   start,
 }
 
-extension FollowPointValue on FollowPoint {
+extension FollowPointValueExtension on FollowPoint {
   String toValue() {
     switch (this) {
       case FollowPoint.end:
@@ -8800,7 +8807,7 @@ enum FrameCaptureIntervalUnit {
   seconds,
 }
 
-extension FrameCaptureIntervalUnitValue on FrameCaptureIntervalUnit {
+extension FrameCaptureIntervalUnitValueExtension on FrameCaptureIntervalUnit {
   String toValue() {
     switch (this) {
       case FrameCaptureIntervalUnit.milliseconds:
@@ -8967,7 +8974,7 @@ enum GlobalConfigurationInputEndAction {
   switchAndLoopInputs,
 }
 
-extension GlobalConfigurationInputEndActionValue
+extension GlobalConfigurationInputEndActionValueExtension
     on GlobalConfigurationInputEndAction {
   String toValue() {
     switch (this) {
@@ -8998,7 +9005,7 @@ enum GlobalConfigurationLowFramerateInputs {
   enabled,
 }
 
-extension GlobalConfigurationLowFramerateInputsValue
+extension GlobalConfigurationLowFramerateInputsValueExtension
     on GlobalConfigurationLowFramerateInputs {
   String toValue() {
     switch (this) {
@@ -9030,7 +9037,7 @@ enum GlobalConfigurationOutputLockingMode {
   pipelineLocking,
 }
 
-extension GlobalConfigurationOutputLockingModeValue
+extension GlobalConfigurationOutputLockingModeValueExtension
     on GlobalConfigurationOutputLockingMode {
   String toValue() {
     switch (this) {
@@ -9062,7 +9069,7 @@ enum GlobalConfigurationOutputTimingSource {
   systemClock,
 }
 
-extension GlobalConfigurationOutputTimingSourceValue
+extension GlobalConfigurationOutputTimingSourceValueExtension
     on GlobalConfigurationOutputTimingSource {
   String toValue() {
     switch (this) {
@@ -9098,7 +9105,7 @@ enum H264AdaptiveQuantization {
   off,
 }
 
-extension H264AdaptiveQuantizationValue on H264AdaptiveQuantization {
+extension H264AdaptiveQuantizationValueExtension on H264AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264AdaptiveQuantization.high:
@@ -9143,7 +9150,7 @@ enum H264ColorMetadata {
   insert,
 }
 
-extension H264ColorMetadataValue on H264ColorMetadata {
+extension H264ColorMetadataValueExtension on H264ColorMetadata {
   String toValue() {
     switch (this) {
       case H264ColorMetadata.ignore:
@@ -9214,7 +9221,7 @@ enum H264EntropyEncoding {
   cavlc,
 }
 
-extension H264EntropyEncodingValue on H264EntropyEncoding {
+extension H264EntropyEncodingValueExtension on H264EntropyEncoding {
   String toValue() {
     switch (this) {
       case H264EntropyEncoding.cabac:
@@ -9268,7 +9275,7 @@ enum H264FlickerAq {
   enabled,
 }
 
-extension H264FlickerAqValue on H264FlickerAq {
+extension H264FlickerAqValueExtension on H264FlickerAq {
   String toValue() {
     switch (this) {
       case H264FlickerAq.disabled:
@@ -9297,7 +9304,7 @@ enum H264ForceFieldPictures {
   enabled,
 }
 
-extension H264ForceFieldPicturesValue on H264ForceFieldPictures {
+extension H264ForceFieldPicturesValueExtension on H264ForceFieldPictures {
   String toValue() {
     switch (this) {
       case H264ForceFieldPictures.disabled:
@@ -9326,7 +9333,7 @@ enum H264FramerateControl {
   specified,
 }
 
-extension H264FramerateControlValue on H264FramerateControl {
+extension H264FramerateControlValueExtension on H264FramerateControl {
   String toValue() {
     switch (this) {
       case H264FramerateControl.initializeFromSource:
@@ -9355,7 +9362,7 @@ enum H264GopBReference {
   enabled,
 }
 
-extension H264GopBReferenceValue on H264GopBReference {
+extension H264GopBReferenceValueExtension on H264GopBReference {
   String toValue() {
     switch (this) {
       case H264GopBReference.disabled:
@@ -9384,7 +9391,7 @@ enum H264GopSizeUnits {
   seconds,
 }
 
-extension H264GopSizeUnitsValue on H264GopSizeUnits {
+extension H264GopSizeUnitsValueExtension on H264GopSizeUnits {
   String toValue() {
     switch (this) {
       case H264GopSizeUnits.frames:
@@ -9428,7 +9435,7 @@ enum H264Level {
   h264LevelAuto,
 }
 
-extension H264LevelValue on H264Level {
+extension H264LevelValueExtension on H264Level {
   String toValue() {
     switch (this) {
       case H264Level.h264Level_1:
@@ -9518,7 +9525,7 @@ enum H264LookAheadRateControl {
   medium,
 }
 
-extension H264LookAheadRateControlValue on H264LookAheadRateControl {
+extension H264LookAheadRateControlValueExtension on H264LookAheadRateControl {
   String toValue() {
     switch (this) {
       case H264LookAheadRateControl.high:
@@ -9551,7 +9558,7 @@ enum H264ParControl {
   specified,
 }
 
-extension H264ParControlValue on H264ParControl {
+extension H264ParControlValueExtension on H264ParControl {
   String toValue() {
     switch (this) {
       case H264ParControl.initializeFromSource:
@@ -9584,7 +9591,7 @@ enum H264Profile {
   main,
 }
 
-extension H264ProfileValue on H264Profile {
+extension H264ProfileValueExtension on H264Profile {
   String toValue() {
     switch (this) {
       case H264Profile.baseline:
@@ -9629,7 +9636,7 @@ enum H264QualityLevel {
   standardQuality,
 }
 
-extension H264QualityLevelValue on H264QualityLevel {
+extension H264QualityLevelValueExtension on H264QualityLevel {
   String toValue() {
     switch (this) {
       case H264QualityLevel.enhancedQuality:
@@ -9660,7 +9667,7 @@ enum H264RateControlMode {
   vbr,
 }
 
-extension H264RateControlModeValue on H264RateControlMode {
+extension H264RateControlModeValueExtension on H264RateControlMode {
   String toValue() {
     switch (this) {
       case H264RateControlMode.cbr:
@@ -9697,7 +9704,7 @@ enum H264ScanType {
   progressive,
 }
 
-extension H264ScanTypeValue on H264ScanType {
+extension H264ScanTypeValueExtension on H264ScanType {
   String toValue() {
     switch (this) {
       case H264ScanType.interlaced:
@@ -9726,7 +9733,7 @@ enum H264SceneChangeDetect {
   enabled,
 }
 
-extension H264SceneChangeDetectValue on H264SceneChangeDetect {
+extension H264SceneChangeDetectValueExtension on H264SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H264SceneChangeDetect.disabled:
@@ -10173,7 +10180,7 @@ enum H264SpatialAq {
   enabled,
 }
 
-extension H264SpatialAqValue on H264SpatialAq {
+extension H264SpatialAqValueExtension on H264SpatialAq {
   String toValue() {
     switch (this) {
       case H264SpatialAq.disabled:
@@ -10202,7 +10209,7 @@ enum H264SubGopLength {
   fixed,
 }
 
-extension H264SubGopLengthValue on H264SubGopLength {
+extension H264SubGopLengthValueExtension on H264SubGopLength {
   String toValue() {
     switch (this) {
       case H264SubGopLength.dynamic:
@@ -10231,7 +10238,7 @@ enum H264Syntax {
   rp2027,
 }
 
-extension H264SyntaxValue on H264Syntax {
+extension H264SyntaxValueExtension on H264Syntax {
   String toValue() {
     switch (this) {
       case H264Syntax.$default:
@@ -10260,7 +10267,7 @@ enum H264TemporalAq {
   enabled,
 }
 
-extension H264TemporalAqValue on H264TemporalAq {
+extension H264TemporalAqValueExtension on H264TemporalAq {
   String toValue() {
     switch (this) {
       case H264TemporalAq.disabled:
@@ -10289,7 +10296,8 @@ enum H264TimecodeInsertionBehavior {
   picTimingSei,
 }
 
-extension H264TimecodeInsertionBehaviorValue on H264TimecodeInsertionBehavior {
+extension H264TimecodeInsertionBehaviorValueExtension
+    on H264TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
       case H264TimecodeInsertionBehavior.disabled:
@@ -10322,7 +10330,7 @@ enum H265AdaptiveQuantization {
   off,
 }
 
-extension H265AdaptiveQuantizationValue on H265AdaptiveQuantization {
+extension H265AdaptiveQuantizationValueExtension on H265AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265AdaptiveQuantization.high:
@@ -10367,7 +10375,7 @@ enum H265AlternativeTransferFunction {
   omit,
 }
 
-extension H265AlternativeTransferFunctionValue
+extension H265AlternativeTransferFunctionValueExtension
     on H265AlternativeTransferFunction {
   String toValue() {
     switch (this) {
@@ -10398,7 +10406,7 @@ enum H265ColorMetadata {
   insert,
 }
 
-extension H265ColorMetadataValue on H265ColorMetadata {
+extension H265ColorMetadataValueExtension on H265ColorMetadata {
   String toValue() {
     switch (this) {
       case H265ColorMetadata.ignore:
@@ -10502,7 +10510,7 @@ enum H265FlickerAq {
   enabled,
 }
 
-extension H265FlickerAqValue on H265FlickerAq {
+extension H265FlickerAqValueExtension on H265FlickerAq {
   String toValue() {
     switch (this) {
       case H265FlickerAq.disabled:
@@ -10531,7 +10539,7 @@ enum H265GopSizeUnits {
   seconds,
 }
 
-extension H265GopSizeUnitsValue on H265GopSizeUnits {
+extension H265GopSizeUnitsValueExtension on H265GopSizeUnits {
   String toValue() {
     switch (this) {
       case H265GopSizeUnits.frames:
@@ -10572,7 +10580,7 @@ enum H265Level {
   h265LevelAuto,
 }
 
-extension H265LevelValue on H265Level {
+extension H265LevelValueExtension on H265Level {
   String toValue() {
     switch (this) {
       case H265Level.h265Level_1:
@@ -10650,7 +10658,7 @@ enum H265LookAheadRateControl {
   medium,
 }
 
-extension H265LookAheadRateControlValue on H265LookAheadRateControl {
+extension H265LookAheadRateControlValueExtension on H265LookAheadRateControl {
   String toValue() {
     switch (this) {
       case H265LookAheadRateControl.high:
@@ -10683,7 +10691,7 @@ enum H265Profile {
   main_10bit,
 }
 
-extension H265ProfileValue on H265Profile {
+extension H265ProfileValueExtension on H265Profile {
   String toValue() {
     switch (this) {
       case H265Profile.main:
@@ -10713,7 +10721,7 @@ enum H265RateControlMode {
   qvbr,
 }
 
-extension H265RateControlModeValue on H265RateControlMode {
+extension H265RateControlModeValueExtension on H265RateControlMode {
   String toValue() {
     switch (this) {
       case H265RateControlMode.cbr:
@@ -10746,7 +10754,7 @@ enum H265ScanType {
   progressive,
 }
 
-extension H265ScanTypeValue on H265ScanType {
+extension H265ScanTypeValueExtension on H265ScanType {
   String toValue() {
     switch (this) {
       case H265ScanType.interlaced:
@@ -10775,7 +10783,7 @@ enum H265SceneChangeDetect {
   enabled,
 }
 
-extension H265SceneChangeDetectValue on H265SceneChangeDetect {
+extension H265SceneChangeDetectValueExtension on H265SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H265SceneChangeDetect.disabled:
@@ -11098,7 +11106,7 @@ enum H265Tier {
   main,
 }
 
-extension H265TierValue on H265Tier {
+extension H265TierValueExtension on H265Tier {
   String toValue() {
     switch (this) {
       case H265Tier.high:
@@ -11127,7 +11135,8 @@ enum H265TimecodeInsertionBehavior {
   picTimingSei,
 }
 
-extension H265TimecodeInsertionBehaviorValue on H265TimecodeInsertionBehavior {
+extension H265TimecodeInsertionBehaviorValueExtension
+    on H265TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
       case H265TimecodeInsertionBehavior.disabled:
@@ -11190,7 +11199,7 @@ enum HlsAdMarkers {
   elementalScte35,
 }
 
-extension HlsAdMarkersValue on HlsAdMarkers {
+extension HlsAdMarkersValueExtension on HlsAdMarkers {
   String toValue() {
     switch (this) {
       case HlsAdMarkers.adobe:
@@ -11223,7 +11232,7 @@ enum HlsAkamaiHttpTransferMode {
   nonChunked,
 }
 
-extension HlsAkamaiHttpTransferModeValue on HlsAkamaiHttpTransferMode {
+extension HlsAkamaiHttpTransferModeValueExtension on HlsAkamaiHttpTransferMode {
   String toValue() {
     switch (this) {
       case HlsAkamaiHttpTransferMode.chunked:
@@ -11371,7 +11380,7 @@ enum HlsCaptionLanguageSetting {
   omit,
 }
 
-extension HlsCaptionLanguageSettingValue on HlsCaptionLanguageSetting {
+extension HlsCaptionLanguageSettingValueExtension on HlsCaptionLanguageSetting {
   String toValue() {
     switch (this) {
       case HlsCaptionLanguageSetting.insert:
@@ -11454,7 +11463,7 @@ enum HlsClientCache {
   enabled,
 }
 
-extension HlsClientCacheValue on HlsClientCache {
+extension HlsClientCacheValueExtension on HlsClientCache {
   String toValue() {
     switch (this) {
       case HlsClientCache.disabled:
@@ -11483,7 +11492,7 @@ enum HlsCodecSpecification {
   rfc_6381,
 }
 
-extension HlsCodecSpecificationValue on HlsCodecSpecification {
+extension HlsCodecSpecificationValueExtension on HlsCodecSpecification {
   String toValue() {
     switch (this) {
       case HlsCodecSpecification.rfc_4281:
@@ -11512,7 +11521,7 @@ enum HlsDirectoryStructure {
   subdirectoryPerStream,
 }
 
-extension HlsDirectoryStructureValue on HlsDirectoryStructure {
+extension HlsDirectoryStructureValueExtension on HlsDirectoryStructure {
   String toValue() {
     switch (this) {
       case HlsDirectoryStructure.singleDirectory:
@@ -11541,7 +11550,7 @@ enum HlsDiscontinuityTags {
   neverInsert,
 }
 
-extension HlsDiscontinuityTagsValue on HlsDiscontinuityTags {
+extension HlsDiscontinuityTagsValueExtension on HlsDiscontinuityTags {
   String toValue() {
     switch (this) {
       case HlsDiscontinuityTags.insert:
@@ -11570,7 +11579,7 @@ enum HlsEncryptionType {
   sampleAes,
 }
 
-extension HlsEncryptionTypeValue on HlsEncryptionType {
+extension HlsEncryptionTypeValueExtension on HlsEncryptionType {
   String toValue() {
     switch (this) {
       case HlsEncryptionType.aes128:
@@ -12079,7 +12088,7 @@ enum HlsH265PackagingType {
   hvc1,
 }
 
-extension HlsH265PackagingTypeValue on HlsH265PackagingType {
+extension HlsH265PackagingTypeValueExtension on HlsH265PackagingType {
   String toValue() {
     switch (this) {
       case HlsH265PackagingType.hev1:
@@ -12133,7 +12142,7 @@ enum HlsId3SegmentTaggingState {
   enabled,
 }
 
-extension HlsId3SegmentTaggingStateValue on HlsId3SegmentTaggingState {
+extension HlsId3SegmentTaggingStateValueExtension on HlsId3SegmentTaggingState {
   String toValue() {
     switch (this) {
       case HlsId3SegmentTaggingState.disabled:
@@ -12162,7 +12171,8 @@ enum HlsIncompleteSegmentBehavior {
   suppress,
 }
 
-extension HlsIncompleteSegmentBehaviorValue on HlsIncompleteSegmentBehavior {
+extension HlsIncompleteSegmentBehaviorValueExtension
+    on HlsIncompleteSegmentBehavior {
   String toValue() {
     switch (this) {
       case HlsIncompleteSegmentBehavior.auto:
@@ -12241,7 +12251,7 @@ enum HlsIvInManifest {
   include,
 }
 
-extension HlsIvInManifestValue on HlsIvInManifest {
+extension HlsIvInManifestValueExtension on HlsIvInManifest {
   String toValue() {
     switch (this) {
       case HlsIvInManifest.exclude:
@@ -12270,7 +12280,7 @@ enum HlsIvSource {
   followsSegmentNumber,
 }
 
-extension HlsIvSourceValue on HlsIvSource {
+extension HlsIvSourceValueExtension on HlsIvSource {
   String toValue() {
     switch (this) {
       case HlsIvSource.explicit:
@@ -12299,7 +12309,7 @@ enum HlsManifestCompression {
   none,
 }
 
-extension HlsManifestCompressionValue on HlsManifestCompression {
+extension HlsManifestCompressionValueExtension on HlsManifestCompression {
   String toValue() {
     switch (this) {
       case HlsManifestCompression.gzip:
@@ -12328,7 +12338,7 @@ enum HlsManifestDurationFormat {
   integer,
 }
 
-extension HlsManifestDurationFormatValue on HlsManifestDurationFormat {
+extension HlsManifestDurationFormatValueExtension on HlsManifestDurationFormat {
   String toValue() {
     switch (this) {
       case HlsManifestDurationFormat.floatingPoint:
@@ -12413,7 +12423,7 @@ enum HlsMediaStoreStorageClass {
   temporal,
 }
 
-extension HlsMediaStoreStorageClassValue on HlsMediaStoreStorageClass {
+extension HlsMediaStoreStorageClassValueExtension on HlsMediaStoreStorageClass {
   String toValue() {
     switch (this) {
       case HlsMediaStoreStorageClass.temporal:
@@ -12438,7 +12448,7 @@ enum HlsMode {
   vod,
 }
 
-extension HlsModeValue on HlsMode {
+extension HlsModeValueExtension on HlsMode {
   String toValue() {
     switch (this) {
       case HlsMode.live:
@@ -12468,7 +12478,7 @@ enum HlsOutputSelection {
   variantManifestsAndSegments,
 }
 
-extension HlsOutputSelectionValue on HlsOutputSelection {
+extension HlsOutputSelectionValueExtension on HlsOutputSelection {
   String toValue() {
     switch (this) {
       case HlsOutputSelection.manifestsAndSegments:
@@ -12550,7 +12560,7 @@ enum HlsProgramDateTime {
   include,
 }
 
-extension HlsProgramDateTimeValue on HlsProgramDateTime {
+extension HlsProgramDateTimeValueExtension on HlsProgramDateTime {
   String toValue() {
     switch (this) {
       case HlsProgramDateTime.exclude:
@@ -12579,7 +12589,7 @@ enum HlsRedundantManifest {
   enabled,
 }
 
-extension HlsRedundantManifestValue on HlsRedundantManifest {
+extension HlsRedundantManifestValueExtension on HlsRedundantManifest {
   String toValue() {
     switch (this) {
       case HlsRedundantManifest.disabled:
@@ -12608,7 +12618,7 @@ enum HlsSegmentationMode {
   useSegmentDuration,
 }
 
-extension HlsSegmentationModeValue on HlsSegmentationMode {
+extension HlsSegmentationModeValueExtension on HlsSegmentationMode {
   String toValue() {
     switch (this) {
       case HlsSegmentationMode.useInputSegmentation:
@@ -12679,7 +12689,7 @@ enum HlsStreamInfResolution {
   include,
 }
 
-extension HlsStreamInfResolutionValue on HlsStreamInfResolution {
+extension HlsStreamInfResolutionValueExtension on HlsStreamInfResolution {
   String toValue() {
     switch (this) {
       case HlsStreamInfResolution.exclude:
@@ -12709,7 +12719,7 @@ enum HlsTimedMetadataId3Frame {
   tdrl,
 }
 
-extension HlsTimedMetadataId3FrameValue on HlsTimedMetadataId3Frame {
+extension HlsTimedMetadataId3FrameValueExtension on HlsTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case HlsTimedMetadataId3Frame.none:
@@ -12766,7 +12776,7 @@ enum HlsTsFileMode {
   singleFile,
 }
 
-extension HlsTsFileModeValue on HlsTsFileMode {
+extension HlsTsFileModeValueExtension on HlsTsFileMode {
   String toValue() {
     switch (this) {
       case HlsTsFileMode.segmentedFiles:
@@ -12795,7 +12805,7 @@ enum HlsWebdavHttpTransferMode {
   nonChunked,
 }
 
-extension HlsWebdavHttpTransferModeValue on HlsWebdavHttpTransferMode {
+extension HlsWebdavHttpTransferModeValueExtension on HlsWebdavHttpTransferMode {
   String toValue() {
     switch (this) {
       case HlsWebdavHttpTransferMode.chunked:
@@ -12882,7 +12892,7 @@ enum IFrameOnlyPlaylistType {
   standard,
 }
 
-extension IFrameOnlyPlaylistTypeValue on IFrameOnlyPlaylistType {
+extension IFrameOnlyPlaylistTypeValueExtension on IFrameOnlyPlaylistType {
   String toValue() {
     switch (this) {
       case IFrameOnlyPlaylistType.disabled:
@@ -13121,7 +13131,7 @@ enum InputClass {
   singlePipeline,
 }
 
-extension InputClassValue on InputClass {
+extension InputClassValueExtension on InputClass {
   String toValue() {
     switch (this) {
       case InputClass.standard:
@@ -13194,7 +13204,7 @@ enum InputCodec {
   hevc,
 }
 
-extension InputCodecValue on InputCodec {
+extension InputCodecValueExtension on InputCodec {
   String toValue() {
     switch (this) {
       case InputCodec.mpeg2:
@@ -13227,7 +13237,7 @@ enum InputDeblockFilter {
   enabled,
 }
 
-extension InputDeblockFilterValue on InputDeblockFilter {
+extension InputDeblockFilterValueExtension on InputDeblockFilter {
   String toValue() {
     switch (this) {
       case InputDeblockFilter.disabled:
@@ -13256,7 +13266,7 @@ enum InputDenoiseFilter {
   enabled,
 }
 
-extension InputDenoiseFilterValue on InputDenoiseFilter {
+extension InputDenoiseFilterValueExtension on InputDenoiseFilter {
   String toValue() {
     switch (this) {
       case InputDenoiseFilter.disabled:
@@ -13354,7 +13364,7 @@ enum InputDeviceActiveInput {
   sdi,
 }
 
-extension InputDeviceActiveInputValue on InputDeviceActiveInput {
+extension InputDeviceActiveInputValueExtension on InputDeviceActiveInput {
   String toValue() {
     switch (this) {
       case InputDeviceActiveInput.hdmi:
@@ -13410,7 +13420,8 @@ enum InputDeviceConfiguredInput {
   sdi,
 }
 
-extension InputDeviceConfiguredInputValue on InputDeviceConfiguredInput {
+extension InputDeviceConfiguredInputValueExtension
+    on InputDeviceConfiguredInput {
   String toValue() {
     switch (this) {
       case InputDeviceConfiguredInput.auto:
@@ -13443,7 +13454,8 @@ enum InputDeviceConnectionState {
   connected,
 }
 
-extension InputDeviceConnectionStateValue on InputDeviceConnectionState {
+extension InputDeviceConnectionStateValueExtension
+    on InputDeviceConnectionState {
   String toValue() {
     switch (this) {
       case InputDeviceConnectionState.disconnected:
@@ -13529,7 +13541,7 @@ enum InputDeviceIpScheme {
   dhcp,
 }
 
-extension InputDeviceIpSchemeValue on InputDeviceIpScheme {
+extension InputDeviceIpSchemeValueExtension on InputDeviceIpScheme {
   String toValue() {
     switch (this) {
       case InputDeviceIpScheme.static:
@@ -13614,7 +13626,7 @@ enum InputDeviceScanType {
   progressive,
 }
 
-extension InputDeviceScanTypeValue on InputDeviceScanType {
+extension InputDeviceScanTypeValueExtension on InputDeviceScanType {
   String toValue() {
     switch (this) {
       case InputDeviceScanType.interlaced:
@@ -13665,7 +13677,7 @@ enum InputDeviceState {
   streaming,
 }
 
-extension InputDeviceStateValue on InputDeviceState {
+extension InputDeviceStateValueExtension on InputDeviceState {
   String toValue() {
     switch (this) {
       case InputDeviceState.idle:
@@ -13782,7 +13794,7 @@ enum InputDeviceTransferType {
   incoming,
 }
 
-extension InputDeviceTransferTypeValue on InputDeviceTransferType {
+extension InputDeviceTransferTypeValueExtension on InputDeviceTransferType {
   String toValue() {
     switch (this) {
       case InputDeviceTransferType.outgoing:
@@ -13811,7 +13823,7 @@ enum InputDeviceType {
   hd,
 }
 
-extension InputDeviceTypeValue on InputDeviceType {
+extension InputDeviceTypeValueExtension on InputDeviceType {
   String toValue() {
     switch (this) {
       case InputDeviceType.hd:
@@ -13892,7 +13904,7 @@ enum InputFilter {
   forced,
 }
 
-extension InputFilterValue on InputFilter {
+extension InputFilterValueExtension on InputFilter {
   String toValue() {
     switch (this) {
       case InputFilter.auto:
@@ -13964,7 +13976,7 @@ enum InputLossActionForHlsOut {
   pauseOutput,
 }
 
-extension InputLossActionForHlsOutValue on InputLossActionForHlsOut {
+extension InputLossActionForHlsOutValueExtension on InputLossActionForHlsOut {
   String toValue() {
     switch (this) {
       case InputLossActionForHlsOut.emitOutput:
@@ -13993,7 +14005,8 @@ enum InputLossActionForMsSmoothOut {
   pauseOutput,
 }
 
-extension InputLossActionForMsSmoothOutValue on InputLossActionForMsSmoothOut {
+extension InputLossActionForMsSmoothOutValueExtension
+    on InputLossActionForMsSmoothOut {
   String toValue() {
     switch (this) {
       case InputLossActionForMsSmoothOut.emitOutput:
@@ -14022,7 +14035,7 @@ enum InputLossActionForRtmpOut {
   pauseOutput,
 }
 
-extension InputLossActionForRtmpOutValue on InputLossActionForRtmpOut {
+extension InputLossActionForRtmpOutValueExtension on InputLossActionForRtmpOut {
   String toValue() {
     switch (this) {
       case InputLossActionForRtmpOut.emitOutput:
@@ -14052,7 +14065,7 @@ enum InputLossActionForUdpOut {
   emitProgram,
 }
 
-extension InputLossActionForUdpOutValue on InputLossActionForUdpOut {
+extension InputLossActionForUdpOutValueExtension on InputLossActionForUdpOut {
   String toValue() {
     switch (this) {
       case InputLossActionForUdpOut.dropProgram:
@@ -14170,7 +14183,7 @@ enum InputLossImageType {
   slate,
 }
 
-extension InputLossImageTypeValue on InputLossImageType {
+extension InputLossImageTypeValueExtension on InputLossImageType {
   String toValue() {
     switch (this) {
       case InputLossImageType.color:
@@ -14201,7 +14214,7 @@ enum InputMaximumBitrate {
   max_50Mbps,
 }
 
-extension InputMaximumBitrateValue on InputMaximumBitrate {
+extension InputMaximumBitrateValueExtension on InputMaximumBitrate {
   String toValue() {
     switch (this) {
       case InputMaximumBitrate.max_10Mbps:
@@ -14239,7 +14252,7 @@ enum InputPreference {
   primaryInputPreferred,
 }
 
-extension InputPreferenceValue on InputPreference {
+extension InputPreferenceValueExtension on InputPreference {
   String toValue() {
     switch (this) {
       case InputPreference.equalInputPreference:
@@ -14322,7 +14335,7 @@ enum InputResolution {
   uhd,
 }
 
-extension InputResolutionValue on InputResolution {
+extension InputResolutionValueExtension on InputResolution {
   String toValue() {
     switch (this) {
       case InputResolution.sd:
@@ -14404,7 +14417,7 @@ enum InputSecurityGroupState {
   deleted,
 }
 
-extension InputSecurityGroupStateValue on InputSecurityGroupState {
+extension InputSecurityGroupStateValueExtension on InputSecurityGroupState {
   String toValue() {
     switch (this) {
       case InputSecurityGroupState.idle:
@@ -14583,7 +14596,7 @@ enum InputSourceEndBehavior {
   loop,
 }
 
-extension InputSourceEndBehaviorValue on InputSourceEndBehavior {
+extension InputSourceEndBehaviorValueExtension on InputSourceEndBehavior {
   String toValue() {
     switch (this) {
       case InputSourceEndBehavior.$continue:
@@ -14646,7 +14659,7 @@ enum InputSourceType {
   dynamic,
 }
 
-extension InputSourceTypeValue on InputSourceType {
+extension InputSourceTypeValueExtension on InputSourceType {
   String toValue() {
     switch (this) {
       case InputSourceType.static:
@@ -14715,7 +14728,7 @@ enum InputState {
   deleted,
 }
 
-extension InputStateValue on InputState {
+extension InputStateValueExtension on InputState {
   String toValue() {
     switch (this) {
       case InputState.creating:
@@ -14807,7 +14820,7 @@ enum InputTimecodeSource {
   embedded,
 }
 
-extension InputTimecodeSourceValue on InputTimecodeSource {
+extension InputTimecodeSourceValueExtension on InputTimecodeSource {
   String toValue() {
     switch (this) {
       case InputTimecodeSource.zerobased:
@@ -14843,7 +14856,7 @@ enum InputType {
   awsCdi,
 }
 
-extension InputTypeValue on InputType {
+extension InputTypeValueExtension on InputType {
   String toValue() {
     switch (this) {
       case InputType.udpPush:
@@ -14987,7 +15000,7 @@ enum LastFrameClippingBehavior {
   includeLastFrame,
 }
 
-extension LastFrameClippingBehaviorValue on LastFrameClippingBehavior {
+extension LastFrameClippingBehaviorValueExtension on LastFrameClippingBehavior {
   String toValue() {
     switch (this) {
       case LastFrameClippingBehavior.excludeLastFrame:
@@ -15236,7 +15249,7 @@ enum LogLevel {
   disabled,
 }
 
-extension LogLevelValue on LogLevel {
+extension LogLevelValueExtension on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.error:
@@ -15277,7 +15290,8 @@ enum M2tsAbsentInputAudioBehavior {
   encodeSilence,
 }
 
-extension M2tsAbsentInputAudioBehaviorValue on M2tsAbsentInputAudioBehavior {
+extension M2tsAbsentInputAudioBehaviorValueExtension
+    on M2tsAbsentInputAudioBehavior {
   String toValue() {
     switch (this) {
       case M2tsAbsentInputAudioBehavior.drop:
@@ -15306,7 +15320,7 @@ enum M2tsArib {
   enabled,
 }
 
-extension M2tsAribValue on M2tsArib {
+extension M2tsAribValueExtension on M2tsArib {
   String toValue() {
     switch (this) {
       case M2tsArib.disabled:
@@ -15335,7 +15349,8 @@ enum M2tsAribCaptionsPidControl {
   useConfigured,
 }
 
-extension M2tsAribCaptionsPidControlValue on M2tsAribCaptionsPidControl {
+extension M2tsAribCaptionsPidControlValueExtension
+    on M2tsAribCaptionsPidControl {
   String toValue() {
     switch (this) {
       case M2tsAribCaptionsPidControl.auto:
@@ -15364,7 +15379,7 @@ enum M2tsAudioBufferModel {
   dvb,
 }
 
-extension M2tsAudioBufferModelValue on M2tsAudioBufferModel {
+extension M2tsAudioBufferModelValueExtension on M2tsAudioBufferModel {
   String toValue() {
     switch (this) {
       case M2tsAudioBufferModel.atsc:
@@ -15393,7 +15408,7 @@ enum M2tsAudioInterval {
   videoInterval,
 }
 
-extension M2tsAudioIntervalValue on M2tsAudioInterval {
+extension M2tsAudioIntervalValueExtension on M2tsAudioInterval {
   String toValue() {
     switch (this) {
       case M2tsAudioInterval.videoAndFixedIntervals:
@@ -15422,7 +15437,7 @@ enum M2tsAudioStreamType {
   dvb,
 }
 
-extension M2tsAudioStreamTypeValue on M2tsAudioStreamType {
+extension M2tsAudioStreamTypeValueExtension on M2tsAudioStreamType {
   String toValue() {
     switch (this) {
       case M2tsAudioStreamType.atsc:
@@ -15451,7 +15466,7 @@ enum M2tsBufferModel {
   none,
 }
 
-extension M2tsBufferModelValue on M2tsBufferModel {
+extension M2tsBufferModelValueExtension on M2tsBufferModel {
   String toValue() {
     switch (this) {
       case M2tsBufferModel.multiplex:
@@ -15480,7 +15495,7 @@ enum M2tsCcDescriptor {
   enabled,
 }
 
-extension M2tsCcDescriptorValue on M2tsCcDescriptor {
+extension M2tsCcDescriptorValueExtension on M2tsCcDescriptor {
   String toValue() {
     switch (this) {
       case M2tsCcDescriptor.disabled:
@@ -15509,7 +15524,7 @@ enum M2tsEbifControl {
   passthrough,
 }
 
-extension M2tsEbifControlValue on M2tsEbifControl {
+extension M2tsEbifControlValueExtension on M2tsEbifControl {
   String toValue() {
     switch (this) {
       case M2tsEbifControl.none:
@@ -15538,7 +15553,7 @@ enum M2tsEbpPlacement {
   videoPid,
 }
 
-extension M2tsEbpPlacementValue on M2tsEbpPlacement {
+extension M2tsEbpPlacementValueExtension on M2tsEbpPlacement {
   String toValue() {
     switch (this) {
       case M2tsEbpPlacement.videoAndAudioPids:
@@ -15567,7 +15582,7 @@ enum M2tsEsRateInPes {
   include,
 }
 
-extension M2tsEsRateInPesValue on M2tsEsRateInPes {
+extension M2tsEsRateInPesValueExtension on M2tsEsRateInPes {
   String toValue() {
     switch (this) {
       case M2tsEsRateInPes.exclude:
@@ -15596,7 +15611,7 @@ enum M2tsKlv {
   passthrough,
 }
 
-extension M2tsKlvValue on M2tsKlv {
+extension M2tsKlvValueExtension on M2tsKlv {
   String toValue() {
     switch (this) {
       case M2tsKlv.none:
@@ -15625,7 +15640,7 @@ enum M2tsNielsenId3Behavior {
   passthrough,
 }
 
-extension M2tsNielsenId3BehaviorValue on M2tsNielsenId3Behavior {
+extension M2tsNielsenId3BehaviorValueExtension on M2tsNielsenId3Behavior {
   String toValue() {
     switch (this) {
       case M2tsNielsenId3Behavior.noPassthrough:
@@ -15654,7 +15669,7 @@ enum M2tsPcrControl {
   pcrEveryPesPacket,
 }
 
-extension M2tsPcrControlValue on M2tsPcrControl {
+extension M2tsPcrControlValueExtension on M2tsPcrControl {
   String toValue() {
     switch (this) {
       case M2tsPcrControl.configuredPcrPeriod:
@@ -15683,7 +15698,7 @@ enum M2tsRateMode {
   vbr,
 }
 
-extension M2tsRateModeValue on M2tsRateMode {
+extension M2tsRateModeValueExtension on M2tsRateMode {
   String toValue() {
     switch (this) {
       case M2tsRateMode.cbr:
@@ -15712,7 +15727,7 @@ enum M2tsScte35Control {
   passthrough,
 }
 
-extension M2tsScte35ControlValue on M2tsScte35Control {
+extension M2tsScte35ControlValueExtension on M2tsScte35Control {
   String toValue() {
     switch (this) {
       case M2tsScte35Control.none:
@@ -15745,7 +15760,7 @@ enum M2tsSegmentationMarkers {
   raiSegstart,
 }
 
-extension M2tsSegmentationMarkersValue on M2tsSegmentationMarkers {
+extension M2tsSegmentationMarkersValueExtension on M2tsSegmentationMarkers {
   String toValue() {
     switch (this) {
       case M2tsSegmentationMarkers.ebp:
@@ -15790,7 +15805,7 @@ enum M2tsSegmentationStyle {
   resetCadence,
 }
 
-extension M2tsSegmentationStyleValue on M2tsSegmentationStyle {
+extension M2tsSegmentationStyleValueExtension on M2tsSegmentationStyle {
   String toValue() {
     switch (this) {
       case M2tsSegmentationStyle.maintainCadence:
@@ -16285,7 +16300,7 @@ enum M2tsTimedMetadataBehavior {
   passthrough,
 }
 
-extension M2tsTimedMetadataBehaviorValue on M2tsTimedMetadataBehavior {
+extension M2tsTimedMetadataBehaviorValueExtension on M2tsTimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case M2tsTimedMetadataBehavior.noPassthrough:
@@ -16314,7 +16329,7 @@ enum M3u8NielsenId3Behavior {
   passthrough,
 }
 
-extension M3u8NielsenId3BehaviorValue on M3u8NielsenId3Behavior {
+extension M3u8NielsenId3BehaviorValueExtension on M3u8NielsenId3Behavior {
   String toValue() {
     switch (this) {
       case M3u8NielsenId3Behavior.noPassthrough:
@@ -16343,7 +16358,7 @@ enum M3u8PcrControl {
   pcrEveryPesPacket,
 }
 
-extension M3u8PcrControlValue on M3u8PcrControl {
+extension M3u8PcrControlValueExtension on M3u8PcrControl {
   String toValue() {
     switch (this) {
       case M3u8PcrControl.configuredPcrPeriod:
@@ -16372,7 +16387,7 @@ enum M3u8Scte35Behavior {
   passthrough,
 }
 
-extension M3u8Scte35BehaviorValue on M3u8Scte35Behavior {
+extension M3u8Scte35BehaviorValueExtension on M3u8Scte35Behavior {
   String toValue() {
     switch (this) {
       case M3u8Scte35Behavior.noPassthrough:
@@ -16559,7 +16574,7 @@ enum M3u8TimedMetadataBehavior {
   passthrough,
 }
 
-extension M3u8TimedMetadataBehaviorValue on M3u8TimedMetadataBehavior {
+extension M3u8TimedMetadataBehaviorValueExtension on M3u8TimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case M3u8TimedMetadataBehavior.noPassthrough:
@@ -16681,7 +16696,7 @@ enum Mp2CodingMode {
   codingMode_2_0,
 }
 
-extension Mp2CodingModeValue on Mp2CodingMode {
+extension Mp2CodingModeValueExtension on Mp2CodingMode {
   String toValue() {
     switch (this) {
       case Mp2CodingMode.codingMode_1_0:
@@ -16750,7 +16765,7 @@ enum Mpeg2AdaptiveQuantization {
   off,
 }
 
-extension Mpeg2AdaptiveQuantizationValue on Mpeg2AdaptiveQuantization {
+extension Mpeg2AdaptiveQuantizationValueExtension on Mpeg2AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2AdaptiveQuantization.auto:
@@ -16791,7 +16806,7 @@ enum Mpeg2ColorMetadata {
   insert,
 }
 
-extension Mpeg2ColorMetadataValue on Mpeg2ColorMetadata {
+extension Mpeg2ColorMetadataValueExtension on Mpeg2ColorMetadata {
   String toValue() {
     switch (this) {
       case Mpeg2ColorMetadata.ignore:
@@ -16820,7 +16835,7 @@ enum Mpeg2ColorSpace {
   passthrough,
 }
 
-extension Mpeg2ColorSpaceValue on Mpeg2ColorSpace {
+extension Mpeg2ColorSpaceValueExtension on Mpeg2ColorSpace {
   String toValue() {
     switch (this) {
       case Mpeg2ColorSpace.auto:
@@ -16849,7 +16864,7 @@ enum Mpeg2DisplayRatio {
   displayratio4x3,
 }
 
-extension Mpeg2DisplayRatioValue on Mpeg2DisplayRatio {
+extension Mpeg2DisplayRatioValueExtension on Mpeg2DisplayRatio {
   String toValue() {
     switch (this) {
       case Mpeg2DisplayRatio.displayratio16x9:
@@ -16903,7 +16918,7 @@ enum Mpeg2GopSizeUnits {
   seconds,
 }
 
-extension Mpeg2GopSizeUnitsValue on Mpeg2GopSizeUnits {
+extension Mpeg2GopSizeUnitsValueExtension on Mpeg2GopSizeUnits {
   String toValue() {
     switch (this) {
       case Mpeg2GopSizeUnits.frames:
@@ -16932,7 +16947,7 @@ enum Mpeg2ScanType {
   progressive,
 }
 
-extension Mpeg2ScanTypeValue on Mpeg2ScanType {
+extension Mpeg2ScanTypeValueExtension on Mpeg2ScanType {
   String toValue() {
     switch (this) {
       case Mpeg2ScanType.interlaced:
@@ -17148,7 +17163,7 @@ enum Mpeg2SubGopLength {
   fixed,
 }
 
-extension Mpeg2SubGopLengthValue on Mpeg2SubGopLength {
+extension Mpeg2SubGopLengthValueExtension on Mpeg2SubGopLength {
   String toValue() {
     switch (this) {
       case Mpeg2SubGopLength.dynamic:
@@ -17177,7 +17192,7 @@ enum Mpeg2TimecodeInsertionBehavior {
   gopTimecode,
 }
 
-extension Mpeg2TimecodeInsertionBehaviorValue
+extension Mpeg2TimecodeInsertionBehaviorValueExtension
     on Mpeg2TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
@@ -17403,7 +17418,7 @@ enum MsSmoothH265PackagingType {
   hvc1,
 }
 
-extension MsSmoothH265PackagingTypeValue on MsSmoothH265PackagingType {
+extension MsSmoothH265PackagingTypeValueExtension on MsSmoothH265PackagingType {
   String toValue() {
     switch (this) {
       case MsSmoothH265PackagingType.hev1:
@@ -17946,7 +17961,7 @@ enum MultiplexState {
   deleted,
 }
 
-extension MultiplexStateValue on MultiplexState {
+extension MultiplexStateValueExtension on MultiplexState {
   String toValue() {
     switch (this) {
       case MultiplexState.creating:
@@ -18139,7 +18154,8 @@ enum NetworkInputServerValidation {
   checkCryptographyOnly,
 }
 
-extension NetworkInputServerValidationValue on NetworkInputServerValidation {
+extension NetworkInputServerValidationValueExtension
+    on NetworkInputServerValidation {
   String toValue() {
     switch (this) {
       case NetworkInputServerValidation.checkCryptographyAndValidateName:
@@ -18239,7 +18255,8 @@ enum NielsenPcmToId3TaggingState {
   enabled,
 }
 
-extension NielsenPcmToId3TaggingStateValue on NielsenPcmToId3TaggingState {
+extension NielsenPcmToId3TaggingStateValueExtension
+    on NielsenPcmToId3TaggingState {
   String toValue() {
     switch (this) {
       case NielsenPcmToId3TaggingState.disabled:
@@ -18339,7 +18356,7 @@ enum OfferingDurationUnits {
   months,
 }
 
-extension OfferingDurationUnitsValue on OfferingDurationUnits {
+extension OfferingDurationUnitsValueExtension on OfferingDurationUnits {
   String toValue() {
     switch (this) {
       case OfferingDurationUnits.months:
@@ -18363,7 +18380,7 @@ enum OfferingType {
   noUpfront,
 }
 
-extension OfferingTypeValue on OfferingType {
+extension OfferingTypeValueExtension on OfferingType {
   String toValue() {
     switch (this) {
       case OfferingType.noUpfront:
@@ -18847,7 +18864,7 @@ enum PipelineId {
   pipeline_1,
 }
 
-extension PipelineIdValue on PipelineId {
+extension PipelineIdValueExtension on PipelineId {
   String toValue() {
     switch (this) {
       case PipelineId.pipeline_0:
@@ -18906,7 +18923,7 @@ enum PreferredChannelPipeline {
   pipeline_1,
 }
 
-extension PreferredChannelPipelineValue on PreferredChannelPipeline {
+extension PreferredChannelPipelineValueExtension on PreferredChannelPipeline {
   String toValue() {
     switch (this) {
       case PreferredChannelPipeline.currentlyActive:
@@ -19153,7 +19170,7 @@ enum ReservationCodec {
   link,
 }
 
-extension ReservationCodecValue on ReservationCodec {
+extension ReservationCodecValueExtension on ReservationCodec {
   String toValue() {
     switch (this) {
       case ReservationCodec.mpeg2:
@@ -19195,7 +19212,7 @@ enum ReservationMaximumBitrate {
   max_50Mbps,
 }
 
-extension ReservationMaximumBitrateValue on ReservationMaximumBitrate {
+extension ReservationMaximumBitrateValueExtension on ReservationMaximumBitrate {
   String toValue() {
     switch (this) {
       case ReservationMaximumBitrate.max_10Mbps:
@@ -19228,7 +19245,8 @@ enum ReservationMaximumFramerate {
   max_60Fps,
 }
 
-extension ReservationMaximumFramerateValue on ReservationMaximumFramerate {
+extension ReservationMaximumFramerateValueExtension
+    on ReservationMaximumFramerate {
   String toValue() {
     switch (this) {
       case ReservationMaximumFramerate.max_30Fps:
@@ -19260,7 +19278,7 @@ enum ReservationResolution {
   uhd,
 }
 
-extension ReservationResolutionValue on ReservationResolution {
+extension ReservationResolutionValueExtension on ReservationResolution {
   String toValue() {
     switch (this) {
       case ReservationResolution.sd:
@@ -19354,7 +19372,7 @@ enum ReservationResourceType {
   channel,
 }
 
-extension ReservationResourceTypeValue on ReservationResourceType {
+extension ReservationResourceTypeValueExtension on ReservationResourceType {
   String toValue() {
     switch (this) {
       case ReservationResourceType.input:
@@ -19391,7 +19409,7 @@ enum ReservationSpecialFeature {
   audioNormalization,
 }
 
-extension ReservationSpecialFeatureValue on ReservationSpecialFeature {
+extension ReservationSpecialFeatureValueExtension on ReservationSpecialFeature {
   String toValue() {
     switch (this) {
       case ReservationSpecialFeature.advancedAudio:
@@ -19422,7 +19440,7 @@ enum ReservationState {
   deleted,
 }
 
-extension ReservationStateValue on ReservationState {
+extension ReservationStateValueExtension on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.active:
@@ -19460,7 +19478,7 @@ enum ReservationVideoQuality {
   premium,
 }
 
-extension ReservationVideoQualityValue on ReservationVideoQuality {
+extension ReservationVideoQualityValueExtension on ReservationVideoQuality {
   String toValue() {
     switch (this) {
       case ReservationVideoQuality.standard:
@@ -19492,7 +19510,7 @@ enum RtmpAdMarkers {
   onCuePointScte35,
 }
 
-extension RtmpAdMarkersValue on RtmpAdMarkers {
+extension RtmpAdMarkersValueExtension on RtmpAdMarkers {
   String toValue() {
     switch (this) {
       case RtmpAdMarkers.onCuePointScte35:
@@ -19517,7 +19535,7 @@ enum RtmpCacheFullBehavior {
   waitForServer,
 }
 
-extension RtmpCacheFullBehaviorValue on RtmpCacheFullBehavior {
+extension RtmpCacheFullBehaviorValueExtension on RtmpCacheFullBehavior {
   String toValue() {
     switch (this) {
       case RtmpCacheFullBehavior.disconnectImmediately:
@@ -19547,7 +19565,7 @@ enum RtmpCaptionData {
   field1AndField2_608,
 }
 
-extension RtmpCaptionDataValue on RtmpCaptionData {
+extension RtmpCaptionDataValueExtension on RtmpCaptionData {
   String toValue() {
     switch (this) {
       case RtmpCaptionData.all:
@@ -19683,7 +19701,7 @@ enum RtmpOutputCertificateMode {
   verifyAuthenticity,
 }
 
-extension RtmpOutputCertificateModeValue on RtmpOutputCertificateMode {
+extension RtmpOutputCertificateModeValueExtension on RtmpOutputCertificateMode {
   String toValue() {
     switch (this) {
       case RtmpOutputCertificateMode.selfSigned:
@@ -19998,7 +20016,7 @@ enum Scte20Convert608To708 {
   upconvert,
 }
 
-extension Scte20Convert608To708Value on Scte20Convert608To708 {
+extension Scte20Convert608To708ValueExtension on Scte20Convert608To708 {
   String toValue() {
     switch (this) {
       case Scte20Convert608To708.disabled:
@@ -20116,7 +20134,7 @@ enum Scte35AposNoRegionalBlackoutBehavior {
   ignore,
 }
 
-extension Scte35AposNoRegionalBlackoutBehaviorValue
+extension Scte35AposNoRegionalBlackoutBehaviorValueExtension
     on Scte35AposNoRegionalBlackoutBehavior {
   String toValue() {
     switch (this) {
@@ -20148,7 +20166,7 @@ enum Scte35AposWebDeliveryAllowedBehavior {
   ignore,
 }
 
-extension Scte35AposWebDeliveryAllowedBehaviorValue
+extension Scte35AposWebDeliveryAllowedBehaviorValueExtension
     on Scte35AposWebDeliveryAllowedBehavior {
   String toValue() {
     switch (this) {
@@ -20182,7 +20200,7 @@ enum Scte35ArchiveAllowedFlag {
   archiveAllowed,
 }
 
-extension Scte35ArchiveAllowedFlagValue on Scte35ArchiveAllowedFlag {
+extension Scte35ArchiveAllowedFlagValueExtension on Scte35ArchiveAllowedFlag {
   String toValue() {
     switch (this) {
       case Scte35ArchiveAllowedFlag.archiveNotAllowed:
@@ -20315,7 +20333,7 @@ enum Scte35DeviceRestrictions {
   restrictGroup2,
 }
 
-extension Scte35DeviceRestrictionsValue on Scte35DeviceRestrictions {
+extension Scte35DeviceRestrictionsValueExtension on Scte35DeviceRestrictions {
   String toValue() {
     switch (this) {
       case Scte35DeviceRestrictions.none:
@@ -20355,7 +20373,8 @@ enum Scte35NoRegionalBlackoutFlag {
   noRegionalBlackout,
 }
 
-extension Scte35NoRegionalBlackoutFlagValue on Scte35NoRegionalBlackoutFlag {
+extension Scte35NoRegionalBlackoutFlagValueExtension
+    on Scte35NoRegionalBlackoutFlag {
   String toValue() {
     switch (this) {
       case Scte35NoRegionalBlackoutFlag.regionalBlackout:
@@ -20412,7 +20431,7 @@ enum Scte35SegmentationCancelIndicator {
   segmentationEventCanceled,
 }
 
-extension Scte35SegmentationCancelIndicatorValue
+extension Scte35SegmentationCancelIndicatorValueExtension
     on Scte35SegmentationCancelIndicator {
   String toValue() {
     switch (this) {
@@ -20607,7 +20626,7 @@ enum Scte35SpliceInsertNoRegionalBlackoutBehavior {
   ignore,
 }
 
-extension Scte35SpliceInsertNoRegionalBlackoutBehaviorValue
+extension Scte35SpliceInsertNoRegionalBlackoutBehaviorValueExtension
     on Scte35SpliceInsertNoRegionalBlackoutBehavior {
   String toValue() {
     switch (this) {
@@ -20674,7 +20693,7 @@ enum Scte35SpliceInsertWebDeliveryAllowedBehavior {
   ignore,
 }
 
-extension Scte35SpliceInsertWebDeliveryAllowedBehaviorValue
+extension Scte35SpliceInsertWebDeliveryAllowedBehaviorValueExtension
     on Scte35SpliceInsertWebDeliveryAllowedBehavior {
   String toValue() {
     switch (this) {
@@ -20779,7 +20798,8 @@ enum Scte35WebDeliveryAllowedFlag {
   webDeliveryAllowed,
 }
 
-extension Scte35WebDeliveryAllowedFlagValue on Scte35WebDeliveryAllowedFlag {
+extension Scte35WebDeliveryAllowedFlagValueExtension
+    on Scte35WebDeliveryAllowedFlag {
   String toValue() {
     switch (this) {
       case Scte35WebDeliveryAllowedFlag.webDeliveryNotAllowed:
@@ -20808,7 +20828,7 @@ enum SmoothGroupAudioOnlyTimecodeControl {
   useConfiguredClock,
 }
 
-extension SmoothGroupAudioOnlyTimecodeControlValue
+extension SmoothGroupAudioOnlyTimecodeControlValueExtension
     on SmoothGroupAudioOnlyTimecodeControl {
   String toValue() {
     switch (this) {
@@ -20839,7 +20859,8 @@ enum SmoothGroupCertificateMode {
   verifyAuthenticity,
 }
 
-extension SmoothGroupCertificateModeValue on SmoothGroupCertificateMode {
+extension SmoothGroupCertificateModeValueExtension
+    on SmoothGroupCertificateMode {
   String toValue() {
     switch (this) {
       case SmoothGroupCertificateMode.selfSigned:
@@ -20869,7 +20890,7 @@ enum SmoothGroupEventIdMode {
   useTimestamp,
 }
 
-extension SmoothGroupEventIdModeValue on SmoothGroupEventIdMode {
+extension SmoothGroupEventIdModeValueExtension on SmoothGroupEventIdMode {
   String toValue() {
     switch (this) {
       case SmoothGroupEventIdMode.noEventId:
@@ -20902,7 +20923,8 @@ enum SmoothGroupEventStopBehavior {
   sendEos,
 }
 
-extension SmoothGroupEventStopBehaviorValue on SmoothGroupEventStopBehavior {
+extension SmoothGroupEventStopBehaviorValueExtension
+    on SmoothGroupEventStopBehavior {
   String toValue() {
     switch (this) {
       case SmoothGroupEventStopBehavior.none:
@@ -20931,7 +20953,8 @@ enum SmoothGroupSegmentationMode {
   useSegmentDuration,
 }
 
-extension SmoothGroupSegmentationModeValue on SmoothGroupSegmentationMode {
+extension SmoothGroupSegmentationModeValueExtension
+    on SmoothGroupSegmentationMode {
   String toValue() {
     switch (this) {
       case SmoothGroupSegmentationMode.useInputSegmentation:
@@ -20961,7 +20984,8 @@ enum SmoothGroupSparseTrackType {
   scte_35WithoutSegmentation,
 }
 
-extension SmoothGroupSparseTrackTypeValue on SmoothGroupSparseTrackType {
+extension SmoothGroupSparseTrackTypeValueExtension
+    on SmoothGroupSparseTrackType {
   String toValue() {
     switch (this) {
       case SmoothGroupSparseTrackType.none:
@@ -20994,7 +21018,7 @@ enum SmoothGroupStreamManifestBehavior {
   send,
 }
 
-extension SmoothGroupStreamManifestBehaviorValue
+extension SmoothGroupStreamManifestBehaviorValueExtension
     on SmoothGroupStreamManifestBehavior {
   String toValue() {
     switch (this) {
@@ -21025,7 +21049,7 @@ enum SmoothGroupTimestampOffsetMode {
   useEventStartDate,
 }
 
-extension SmoothGroupTimestampOffsetModeValue
+extension SmoothGroupTimestampOffsetModeValueExtension
     on SmoothGroupTimestampOffsetMode {
   String toValue() {
     switch (this) {
@@ -21056,7 +21080,7 @@ enum Smpte2038DataPreference {
   prefer,
 }
 
-extension Smpte2038DataPreferenceValue on Smpte2038DataPreference {
+extension Smpte2038DataPreferenceValueExtension on Smpte2038DataPreference {
   String toValue() {
     switch (this) {
       case Smpte2038DataPreference.ignore:
@@ -21758,7 +21782,7 @@ enum TemporalFilterPostFilterSharpening {
   enabled,
 }
 
-extension TemporalFilterPostFilterSharpeningValue
+extension TemporalFilterPostFilterSharpeningValueExtension
     on TemporalFilterPostFilterSharpening {
   String toValue() {
     switch (this) {
@@ -21845,7 +21869,7 @@ enum TemporalFilterStrength {
   strength_16,
 }
 
-extension TemporalFilterStrengthValue on TemporalFilterStrength {
+extension TemporalFilterStrengthValueExtension on TemporalFilterStrength {
   String toValue() {
     switch (this) {
       case TemporalFilterStrength.auto:
@@ -21974,7 +21998,7 @@ enum TimecodeConfigSource {
   zerobased,
 }
 
-extension TimecodeConfigSourceValue on TimecodeConfigSource {
+extension TimecodeConfigSourceValueExtension on TimecodeConfigSource {
   String toValue() {
     switch (this) {
       case TimecodeConfigSource.embedded:
@@ -22071,7 +22095,8 @@ enum TtmlDestinationStyleControl {
   useConfigured,
 }
 
-extension TtmlDestinationStyleControlValue on TtmlDestinationStyleControl {
+extension TtmlDestinationStyleControlValueExtension
+    on TtmlDestinationStyleControl {
   String toValue() {
     switch (this) {
       case TtmlDestinationStyleControl.passthrough:
@@ -22222,7 +22247,7 @@ enum UdpTimedMetadataId3Frame {
   tdrl,
 }
 
-extension UdpTimedMetadataId3FrameValue on UdpTimedMetadataId3Frame {
+extension UdpTimedMetadataId3FrameValueExtension on UdpTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case UdpTimedMetadataId3Frame.none:
@@ -22637,7 +22662,8 @@ enum VideoDescriptionRespondToAfd {
   respond,
 }
 
-extension VideoDescriptionRespondToAfdValue on VideoDescriptionRespondToAfd {
+extension VideoDescriptionRespondToAfdValueExtension
+    on VideoDescriptionRespondToAfd {
   String toValue() {
     switch (this) {
       case VideoDescriptionRespondToAfd.none:
@@ -22670,7 +22696,7 @@ enum VideoDescriptionScalingBehavior {
   stretchToOutput,
 }
 
-extension VideoDescriptionScalingBehaviorValue
+extension VideoDescriptionScalingBehaviorValueExtension
     on VideoDescriptionScalingBehavior {
   String toValue() {
     switch (this) {
@@ -22752,7 +22778,7 @@ enum VideoSelectorColorSpace {
   rec_709,
 }
 
-extension VideoSelectorColorSpaceValue on VideoSelectorColorSpace {
+extension VideoSelectorColorSpaceValueExtension on VideoSelectorColorSpace {
   String toValue() {
     switch (this) {
       case VideoSelectorColorSpace.follow:
@@ -22785,7 +22811,8 @@ enum VideoSelectorColorSpaceUsage {
   force,
 }
 
-extension VideoSelectorColorSpaceUsageValue on VideoSelectorColorSpaceUsage {
+extension VideoSelectorColorSpaceUsageValueExtension
+    on VideoSelectorColorSpaceUsage {
   String toValue() {
     switch (this) {
       case VideoSelectorColorSpaceUsage.fallback:
@@ -22895,7 +22922,7 @@ enum WavCodingMode {
   codingMode_8_0,
 }
 
-extension WavCodingModeValue on WavCodingMode {
+extension WavCodingModeValueExtension on WavCodingMode {
   String toValue() {
     switch (this) {
       case WavCodingMode.codingMode_1_0:
@@ -22980,7 +23007,7 @@ enum AcceptHeader {
   imageJpeg,
 }
 
-extension AcceptHeaderValue on AcceptHeader {
+extension AcceptHeaderValueExtension on AcceptHeader {
   String toValue() {
     switch (this) {
       case AcceptHeader.imageJpeg:
@@ -23004,7 +23031,7 @@ enum ContentType {
   imageJpeg,
 }
 
-extension ContentTypeValue on ContentType {
+extension ContentTypeValueExtension on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.imageJpeg:

--- a/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
+++ b/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
@@ -2112,7 +2112,7 @@ enum AacCodingMode {
   codingMode_5_1,
 }
 
-extension on AacCodingMode {
+extension AacCodingModeValue on AacCodingMode {
   String toValue() {
     switch (this) {
       case AacCodingMode.adReceiverMix:
@@ -2129,7 +2129,7 @@ extension on AacCodingMode {
   }
 }
 
-extension on String {
+extension AacCodingModeFromString on String {
   AacCodingMode toAacCodingMode() {
     switch (this) {
       case 'AD_RECEIVER_MIX':
@@ -2153,7 +2153,7 @@ enum AacInputType {
   normal,
 }
 
-extension on AacInputType {
+extension AacInputTypeValue on AacInputType {
   String toValue() {
     switch (this) {
       case AacInputType.broadcasterMixedAd:
@@ -2164,7 +2164,7 @@ extension on AacInputType {
   }
 }
 
-extension on String {
+extension AacInputTypeFromString on String {
   AacInputType toAacInputType() {
     switch (this) {
       case 'BROADCASTER_MIXED_AD':
@@ -2183,7 +2183,7 @@ enum AacProfile {
   lc,
 }
 
-extension on AacProfile {
+extension AacProfileValue on AacProfile {
   String toValue() {
     switch (this) {
       case AacProfile.hev1:
@@ -2196,7 +2196,7 @@ extension on AacProfile {
   }
 }
 
-extension on String {
+extension AacProfileFromString on String {
   AacProfile toAacProfile() {
     switch (this) {
       case 'HEV1':
@@ -2216,7 +2216,7 @@ enum AacRateControlMode {
   vbr,
 }
 
-extension on AacRateControlMode {
+extension AacRateControlModeValue on AacRateControlMode {
   String toValue() {
     switch (this) {
       case AacRateControlMode.cbr:
@@ -2227,7 +2227,7 @@ extension on AacRateControlMode {
   }
 }
 
-extension on String {
+extension AacRateControlModeFromString on String {
   AacRateControlMode toAacRateControlMode() {
     switch (this) {
       case 'CBR':
@@ -2245,7 +2245,7 @@ enum AacRawFormat {
   none,
 }
 
-extension on AacRawFormat {
+extension AacRawFormatValue on AacRawFormat {
   String toValue() {
     switch (this) {
       case AacRawFormat.latmLoas:
@@ -2256,7 +2256,7 @@ extension on AacRawFormat {
   }
 }
 
-extension on String {
+extension AacRawFormatFromString on String {
   AacRawFormat toAacRawFormat() {
     switch (this) {
       case 'LATM_LOAS':
@@ -2366,7 +2366,7 @@ enum AacSpec {
   mpeg4,
 }
 
-extension on AacSpec {
+extension AacSpecValue on AacSpec {
   String toValue() {
     switch (this) {
       case AacSpec.mpeg2:
@@ -2377,7 +2377,7 @@ extension on AacSpec {
   }
 }
 
-extension on String {
+extension AacSpecFromString on String {
   AacSpec toAacSpec() {
     switch (this) {
       case 'MPEG2':
@@ -2397,7 +2397,7 @@ enum AacVbrQuality {
   mediumLow,
 }
 
-extension on AacVbrQuality {
+extension AacVbrQualityValue on AacVbrQuality {
   String toValue() {
     switch (this) {
       case AacVbrQuality.high:
@@ -2412,7 +2412,7 @@ extension on AacVbrQuality {
   }
 }
 
-extension on String {
+extension AacVbrQualityFromString on String {
   AacVbrQuality toAacVbrQuality() {
     switch (this) {
       case 'HIGH':
@@ -2440,7 +2440,7 @@ enum Ac3BitstreamMode {
   voiceOver,
 }
 
-extension on Ac3BitstreamMode {
+extension Ac3BitstreamModeValue on Ac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Ac3BitstreamMode.commentary:
@@ -2463,7 +2463,7 @@ extension on Ac3BitstreamMode {
   }
 }
 
-extension on String {
+extension Ac3BitstreamModeFromString on String {
   Ac3BitstreamMode toAc3BitstreamMode() {
     switch (this) {
       case 'COMMENTARY':
@@ -2495,7 +2495,7 @@ enum Ac3CodingMode {
   codingMode_3_2Lfe,
 }
 
-extension on Ac3CodingMode {
+extension Ac3CodingModeValue on Ac3CodingMode {
   String toValue() {
     switch (this) {
       case Ac3CodingMode.codingMode_1_0:
@@ -2510,7 +2510,7 @@ extension on Ac3CodingMode {
   }
 }
 
-extension on String {
+extension Ac3CodingModeFromString on String {
   Ac3CodingMode toAc3CodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -2532,7 +2532,7 @@ enum Ac3DrcProfile {
   none,
 }
 
-extension on Ac3DrcProfile {
+extension Ac3DrcProfileValue on Ac3DrcProfile {
   String toValue() {
     switch (this) {
       case Ac3DrcProfile.filmStandard:
@@ -2543,7 +2543,7 @@ extension on Ac3DrcProfile {
   }
 }
 
-extension on String {
+extension Ac3DrcProfileFromString on String {
   Ac3DrcProfile toAc3DrcProfile() {
     switch (this) {
       case 'FILM_STANDARD':
@@ -2561,7 +2561,7 @@ enum Ac3LfeFilter {
   enabled,
 }
 
-extension on Ac3LfeFilter {
+extension Ac3LfeFilterValue on Ac3LfeFilter {
   String toValue() {
     switch (this) {
       case Ac3LfeFilter.disabled:
@@ -2572,7 +2572,7 @@ extension on Ac3LfeFilter {
   }
 }
 
-extension on String {
+extension Ac3LfeFilterFromString on String {
   Ac3LfeFilter toAc3LfeFilter() {
     switch (this) {
       case 'DISABLED':
@@ -2590,7 +2590,7 @@ enum Ac3MetadataControl {
   useConfigured,
 }
 
-extension on Ac3MetadataControl {
+extension Ac3MetadataControlValue on Ac3MetadataControl {
   String toValue() {
     switch (this) {
       case Ac3MetadataControl.followInput:
@@ -2601,7 +2601,7 @@ extension on Ac3MetadataControl {
   }
 }
 
-extension on String {
+extension Ac3MetadataControlFromString on String {
   Ac3MetadataControl toAc3MetadataControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -2700,7 +2700,7 @@ enum AfdSignaling {
   none,
 }
 
-extension on AfdSignaling {
+extension AfdSignalingValue on AfdSignaling {
   String toValue() {
     switch (this) {
       case AfdSignaling.auto:
@@ -2713,7 +2713,7 @@ extension on AfdSignaling {
   }
 }
 
-extension on String {
+extension AfdSignalingFromString on String {
   AfdSignaling toAfdSignaling() {
     switch (this) {
       case 'AUTO':
@@ -3094,7 +3094,8 @@ enum AudioDescriptionAudioTypeControl {
   useConfigured,
 }
 
-extension on AudioDescriptionAudioTypeControl {
+extension AudioDescriptionAudioTypeControlValue
+    on AudioDescriptionAudioTypeControl {
   String toValue() {
     switch (this) {
       case AudioDescriptionAudioTypeControl.followInput:
@@ -3105,7 +3106,7 @@ extension on AudioDescriptionAudioTypeControl {
   }
 }
 
-extension on String {
+extension AudioDescriptionAudioTypeControlFromString on String {
   AudioDescriptionAudioTypeControl toAudioDescriptionAudioTypeControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -3124,7 +3125,8 @@ enum AudioDescriptionLanguageCodeControl {
   useConfigured,
 }
 
-extension on AudioDescriptionLanguageCodeControl {
+extension AudioDescriptionLanguageCodeControlValue
+    on AudioDescriptionLanguageCodeControl {
   String toValue() {
     switch (this) {
       case AudioDescriptionLanguageCodeControl.followInput:
@@ -3135,7 +3137,7 @@ extension on AudioDescriptionLanguageCodeControl {
   }
 }
 
-extension on String {
+extension AudioDescriptionLanguageCodeControlFromString on String {
   AudioDescriptionLanguageCodeControl toAudioDescriptionLanguageCodeControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -3190,7 +3192,7 @@ enum AudioLanguageSelectionPolicy {
   strict,
 }
 
-extension on AudioLanguageSelectionPolicy {
+extension AudioLanguageSelectionPolicyValue on AudioLanguageSelectionPolicy {
   String toValue() {
     switch (this) {
       case AudioLanguageSelectionPolicy.loose:
@@ -3201,7 +3203,7 @@ extension on AudioLanguageSelectionPolicy {
   }
 }
 
-extension on String {
+extension AudioLanguageSelectionPolicyFromString on String {
   AudioLanguageSelectionPolicy toAudioLanguageSelectionPolicy() {
     switch (this) {
       case 'LOOSE':
@@ -3219,7 +3221,7 @@ enum AudioNormalizationAlgorithm {
   itu_1770_2,
 }
 
-extension on AudioNormalizationAlgorithm {
+extension AudioNormalizationAlgorithmValue on AudioNormalizationAlgorithm {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithm.itu_1770_1:
@@ -3230,7 +3232,7 @@ extension on AudioNormalizationAlgorithm {
   }
 }
 
-extension on String {
+extension AudioNormalizationAlgorithmFromString on String {
   AudioNormalizationAlgorithm toAudioNormalizationAlgorithm() {
     switch (this) {
       case 'ITU_1770_1':
@@ -3247,7 +3249,8 @@ enum AudioNormalizationAlgorithmControl {
   correctAudio,
 }
 
-extension on AudioNormalizationAlgorithmControl {
+extension AudioNormalizationAlgorithmControlValue
+    on AudioNormalizationAlgorithmControl {
   String toValue() {
     switch (this) {
       case AudioNormalizationAlgorithmControl.correctAudio:
@@ -3256,7 +3259,7 @@ extension on AudioNormalizationAlgorithmControl {
   }
 }
 
-extension on String {
+extension AudioNormalizationAlgorithmControlFromString on String {
   AudioNormalizationAlgorithmControl toAudioNormalizationAlgorithmControl() {
     switch (this) {
       case 'CORRECT_AUDIO':
@@ -3318,7 +3321,7 @@ enum AudioOnlyHlsSegmentType {
   fmp4,
 }
 
-extension on AudioOnlyHlsSegmentType {
+extension AudioOnlyHlsSegmentTypeValue on AudioOnlyHlsSegmentType {
   String toValue() {
     switch (this) {
       case AudioOnlyHlsSegmentType.aac:
@@ -3329,7 +3332,7 @@ extension on AudioOnlyHlsSegmentType {
   }
 }
 
-extension on String {
+extension AudioOnlyHlsSegmentTypeFromString on String {
   AudioOnlyHlsSegmentType toAudioOnlyHlsSegmentType() {
     switch (this) {
       case 'AAC':
@@ -3422,7 +3425,7 @@ enum AudioOnlyHlsTrackType {
   audioOnlyVariantStream,
 }
 
-extension on AudioOnlyHlsTrackType {
+extension AudioOnlyHlsTrackTypeValue on AudioOnlyHlsTrackType {
   String toValue() {
     switch (this) {
       case AudioOnlyHlsTrackType.alternateAudioAutoSelect:
@@ -3437,7 +3440,7 @@ extension on AudioOnlyHlsTrackType {
   }
 }
 
-extension on String {
+extension AudioOnlyHlsTrackTypeFromString on String {
   AudioOnlyHlsTrackType toAudioOnlyHlsTrackType() {
     switch (this) {
       case 'ALTERNATE_AUDIO_AUTO_SELECT':
@@ -3639,7 +3642,7 @@ enum AudioType {
   visualImpairedCommentary,
 }
 
-extension on AudioType {
+extension AudioTypeValue on AudioType {
   String toValue() {
     switch (this) {
       case AudioType.cleanEffects:
@@ -3654,7 +3657,7 @@ extension on AudioType {
   }
 }
 
-extension on String {
+extension AudioTypeFromString on String {
   AudioType toAudioType() {
     switch (this) {
       case 'CLEAN_EFFECTS':
@@ -3676,7 +3679,7 @@ enum AuthenticationScheme {
   common,
 }
 
-extension on AuthenticationScheme {
+extension AuthenticationSchemeValue on AuthenticationScheme {
   String toValue() {
     switch (this) {
       case AuthenticationScheme.akamai:
@@ -3687,7 +3690,7 @@ extension on AuthenticationScheme {
   }
 }
 
-extension on String {
+extension AuthenticationSchemeFromString on String {
   AuthenticationScheme toAuthenticationScheme() {
     switch (this) {
       case 'AKAMAI':
@@ -3793,7 +3796,7 @@ enum AvailBlankingState {
   enabled,
 }
 
-extension on AvailBlankingState {
+extension AvailBlankingStateValue on AvailBlankingState {
   String toValue() {
     switch (this) {
       case AvailBlankingState.disabled:
@@ -3804,7 +3807,7 @@ extension on AvailBlankingState {
   }
 }
 
-extension on String {
+extension AvailBlankingStateFromString on String {
   AvailBlankingState toAvailBlankingState() {
     switch (this) {
       case 'DISABLED':
@@ -4182,7 +4185,8 @@ enum BlackoutSlateNetworkEndBlackout {
   enabled,
 }
 
-extension on BlackoutSlateNetworkEndBlackout {
+extension BlackoutSlateNetworkEndBlackoutValue
+    on BlackoutSlateNetworkEndBlackout {
   String toValue() {
     switch (this) {
       case BlackoutSlateNetworkEndBlackout.disabled:
@@ -4193,7 +4197,7 @@ extension on BlackoutSlateNetworkEndBlackout {
   }
 }
 
-extension on String {
+extension BlackoutSlateNetworkEndBlackoutFromString on String {
   BlackoutSlateNetworkEndBlackout toBlackoutSlateNetworkEndBlackout() {
     switch (this) {
       case 'DISABLED':
@@ -4212,7 +4216,7 @@ enum BlackoutSlateState {
   enabled,
 }
 
-extension on BlackoutSlateState {
+extension BlackoutSlateStateValue on BlackoutSlateState {
   String toValue() {
     switch (this) {
       case BlackoutSlateState.disabled:
@@ -4223,7 +4227,7 @@ extension on BlackoutSlateState {
   }
 }
 
-extension on String {
+extension BlackoutSlateStateFromString on String {
   BlackoutSlateState toBlackoutSlateState() {
     switch (this) {
       case 'DISABLED':
@@ -4242,7 +4246,7 @@ enum BurnInAlignment {
   smart,
 }
 
-extension on BurnInAlignment {
+extension BurnInAlignmentValue on BurnInAlignment {
   String toValue() {
     switch (this) {
       case BurnInAlignment.centered:
@@ -4255,7 +4259,7 @@ extension on BurnInAlignment {
   }
 }
 
-extension on String {
+extension BurnInAlignmentFromString on String {
   BurnInAlignment toBurnInAlignment() {
     switch (this) {
       case 'CENTERED':
@@ -4276,7 +4280,7 @@ enum BurnInBackgroundColor {
   white,
 }
 
-extension on BurnInBackgroundColor {
+extension BurnInBackgroundColorValue on BurnInBackgroundColor {
   String toValue() {
     switch (this) {
       case BurnInBackgroundColor.black:
@@ -4289,7 +4293,7 @@ extension on BurnInBackgroundColor {
   }
 }
 
-extension on String {
+extension BurnInBackgroundColorFromString on String {
   BurnInBackgroundColor toBurnInBackgroundColor() {
     switch (this) {
       case 'BLACK':
@@ -4497,7 +4501,7 @@ enum BurnInFontColor {
   yellow,
 }
 
-extension on BurnInFontColor {
+extension BurnInFontColorValue on BurnInFontColor {
   String toValue() {
     switch (this) {
       case BurnInFontColor.black:
@@ -4516,7 +4520,7 @@ extension on BurnInFontColor {
   }
 }
 
-extension on String {
+extension BurnInFontColorFromString on String {
   BurnInFontColor toBurnInFontColor() {
     switch (this) {
       case 'BLACK':
@@ -4546,7 +4550,7 @@ enum BurnInOutlineColor {
   yellow,
 }
 
-extension on BurnInOutlineColor {
+extension BurnInOutlineColorValue on BurnInOutlineColor {
   String toValue() {
     switch (this) {
       case BurnInOutlineColor.black:
@@ -4565,7 +4569,7 @@ extension on BurnInOutlineColor {
   }
 }
 
-extension on String {
+extension BurnInOutlineColorFromString on String {
   BurnInOutlineColor toBurnInOutlineColor() {
     switch (this) {
       case 'BLACK':
@@ -4592,7 +4596,7 @@ enum BurnInShadowColor {
   white,
 }
 
-extension on BurnInShadowColor {
+extension BurnInShadowColorValue on BurnInShadowColor {
   String toValue() {
     switch (this) {
       case BurnInShadowColor.black:
@@ -4605,7 +4609,7 @@ extension on BurnInShadowColor {
   }
 }
 
-extension on String {
+extension BurnInShadowColorFromString on String {
   BurnInShadowColor toBurnInShadowColor() {
     switch (this) {
       case 'BLACK':
@@ -4625,7 +4629,7 @@ enum BurnInTeletextGridControl {
   scaled,
 }
 
-extension on BurnInTeletextGridControl {
+extension BurnInTeletextGridControlValue on BurnInTeletextGridControl {
   String toValue() {
     switch (this) {
       case BurnInTeletextGridControl.fixed:
@@ -4636,7 +4640,7 @@ extension on BurnInTeletextGridControl {
   }
 }
 
-extension on String {
+extension BurnInTeletextGridControlFromString on String {
   BurnInTeletextGridControl toBurnInTeletextGridControl() {
     switch (this) {
       case 'FIXED':
@@ -5032,7 +5036,7 @@ enum CdiInputResolution {
   uhd,
 }
 
-extension on CdiInputResolution {
+extension CdiInputResolutionValue on CdiInputResolution {
   String toValue() {
     switch (this) {
       case CdiInputResolution.sd:
@@ -5047,7 +5051,7 @@ extension on CdiInputResolution {
   }
 }
 
-extension on String {
+extension CdiInputResolutionFromString on String {
   CdiInputResolution toCdiInputResolution() {
     switch (this) {
       case 'SD':
@@ -5203,7 +5207,7 @@ enum ChannelClass {
   singlePipeline,
 }
 
-extension on ChannelClass {
+extension ChannelClassValue on ChannelClass {
   String toValue() {
     switch (this) {
       case ChannelClass.standard:
@@ -5214,7 +5218,7 @@ extension on ChannelClass {
   }
 }
 
-extension on String {
+extension ChannelClassFromString on String {
   ChannelClass toChannelClass() {
     switch (this) {
       case 'STANDARD':
@@ -5256,7 +5260,7 @@ enum ChannelState {
   updateFailed,
 }
 
-extension on ChannelState {
+extension ChannelStateValue on ChannelState {
   String toValue() {
     switch (this) {
       case ChannelState.creating:
@@ -5285,7 +5289,7 @@ extension on ChannelState {
   }
 }
 
-extension on String {
+extension ChannelStateFromString on String {
   ChannelState toChannelState() {
     switch (this) {
       case 'CREATING':
@@ -6593,7 +6597,7 @@ enum DeviceSettingsSyncState {
   syncing,
 }
 
-extension on DeviceSettingsSyncState {
+extension DeviceSettingsSyncStateValue on DeviceSettingsSyncState {
   String toValue() {
     switch (this) {
       case DeviceSettingsSyncState.synced:
@@ -6604,7 +6608,7 @@ extension on DeviceSettingsSyncState {
   }
 }
 
-extension on String {
+extension DeviceSettingsSyncStateFromString on String {
   DeviceSettingsSyncState toDeviceSettingsSyncState() {
     switch (this) {
       case 'SYNCED':
@@ -6622,7 +6626,7 @@ enum DeviceUpdateStatus {
   notUpToDate,
 }
 
-extension on DeviceUpdateStatus {
+extension DeviceUpdateStatusValue on DeviceUpdateStatus {
   String toValue() {
     switch (this) {
       case DeviceUpdateStatus.upToDate:
@@ -6633,7 +6637,7 @@ extension on DeviceUpdateStatus {
   }
 }
 
-extension on String {
+extension DeviceUpdateStatusFromString on String {
   DeviceUpdateStatus toDeviceUpdateStatus() {
     switch (this) {
       case 'UP_TO_DATE':
@@ -6691,7 +6695,7 @@ enum DvbSdtOutputSdt {
   sdtNone,
 }
 
-extension on DvbSdtOutputSdt {
+extension DvbSdtOutputSdtValue on DvbSdtOutputSdt {
   String toValue() {
     switch (this) {
       case DvbSdtOutputSdt.sdtFollow:
@@ -6706,7 +6710,7 @@ extension on DvbSdtOutputSdt {
   }
 }
 
-extension on String {
+extension DvbSdtOutputSdtFromString on String {
   DvbSdtOutputSdt toDvbSdtOutputSdt() {
     switch (this) {
       case 'SDT_FOLLOW':
@@ -6782,7 +6786,7 @@ enum DvbSubDestinationAlignment {
   smart,
 }
 
-extension on DvbSubDestinationAlignment {
+extension DvbSubDestinationAlignmentValue on DvbSubDestinationAlignment {
   String toValue() {
     switch (this) {
       case DvbSubDestinationAlignment.centered:
@@ -6795,7 +6799,7 @@ extension on DvbSubDestinationAlignment {
   }
 }
 
-extension on String {
+extension DvbSubDestinationAlignmentFromString on String {
   DvbSubDestinationAlignment toDvbSubDestinationAlignment() {
     switch (this) {
       case 'CENTERED':
@@ -6816,7 +6820,8 @@ enum DvbSubDestinationBackgroundColor {
   white,
 }
 
-extension on DvbSubDestinationBackgroundColor {
+extension DvbSubDestinationBackgroundColorValue
+    on DvbSubDestinationBackgroundColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationBackgroundColor.black:
@@ -6829,7 +6834,7 @@ extension on DvbSubDestinationBackgroundColor {
   }
 }
 
-extension on String {
+extension DvbSubDestinationBackgroundColorFromString on String {
   DvbSubDestinationBackgroundColor toDvbSubDestinationBackgroundColor() {
     switch (this) {
       case 'BLACK':
@@ -6854,7 +6859,7 @@ enum DvbSubDestinationFontColor {
   yellow,
 }
 
-extension on DvbSubDestinationFontColor {
+extension DvbSubDestinationFontColorValue on DvbSubDestinationFontColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationFontColor.black:
@@ -6873,7 +6878,7 @@ extension on DvbSubDestinationFontColor {
   }
 }
 
-extension on String {
+extension DvbSubDestinationFontColorFromString on String {
   DvbSubDestinationFontColor toDvbSubDestinationFontColor() {
     switch (this) {
       case 'BLACK':
@@ -6903,7 +6908,7 @@ enum DvbSubDestinationOutlineColor {
   yellow,
 }
 
-extension on DvbSubDestinationOutlineColor {
+extension DvbSubDestinationOutlineColorValue on DvbSubDestinationOutlineColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationOutlineColor.black:
@@ -6922,7 +6927,7 @@ extension on DvbSubDestinationOutlineColor {
   }
 }
 
-extension on String {
+extension DvbSubDestinationOutlineColorFromString on String {
   DvbSubDestinationOutlineColor toDvbSubDestinationOutlineColor() {
     switch (this) {
       case 'BLACK':
@@ -7141,7 +7146,7 @@ enum DvbSubDestinationShadowColor {
   white,
 }
 
-extension on DvbSubDestinationShadowColor {
+extension DvbSubDestinationShadowColorValue on DvbSubDestinationShadowColor {
   String toValue() {
     switch (this) {
       case DvbSubDestinationShadowColor.black:
@@ -7154,7 +7159,7 @@ extension on DvbSubDestinationShadowColor {
   }
 }
 
-extension on String {
+extension DvbSubDestinationShadowColorFromString on String {
   DvbSubDestinationShadowColor toDvbSubDestinationShadowColor() {
     switch (this) {
       case 'BLACK':
@@ -7174,7 +7179,8 @@ enum DvbSubDestinationTeletextGridControl {
   scaled,
 }
 
-extension on DvbSubDestinationTeletextGridControl {
+extension DvbSubDestinationTeletextGridControlValue
+    on DvbSubDestinationTeletextGridControl {
   String toValue() {
     switch (this) {
       case DvbSubDestinationTeletextGridControl.fixed:
@@ -7185,7 +7191,7 @@ extension on DvbSubDestinationTeletextGridControl {
   }
 }
 
-extension on String {
+extension DvbSubDestinationTeletextGridControlFromString on String {
   DvbSubDestinationTeletextGridControl
       toDvbSubDestinationTeletextGridControl() {
     switch (this) {
@@ -7252,7 +7258,7 @@ enum Eac3AttenuationControl {
   none,
 }
 
-extension on Eac3AttenuationControl {
+extension Eac3AttenuationControlValue on Eac3AttenuationControl {
   String toValue() {
     switch (this) {
       case Eac3AttenuationControl.attenuate_3Db:
@@ -7263,7 +7269,7 @@ extension on Eac3AttenuationControl {
   }
 }
 
-extension on String {
+extension Eac3AttenuationControlFromString on String {
   Eac3AttenuationControl toEac3AttenuationControl() {
     switch (this) {
       case 'ATTENUATE_3_DB':
@@ -7284,7 +7290,7 @@ enum Eac3BitstreamMode {
   visuallyImpaired,
 }
 
-extension on Eac3BitstreamMode {
+extension Eac3BitstreamModeValue on Eac3BitstreamMode {
   String toValue() {
     switch (this) {
       case Eac3BitstreamMode.commentary:
@@ -7301,7 +7307,7 @@ extension on Eac3BitstreamMode {
   }
 }
 
-extension on String {
+extension Eac3BitstreamModeFromString on String {
   Eac3BitstreamMode toEac3BitstreamMode() {
     switch (this) {
       case 'COMMENTARY':
@@ -7326,7 +7332,7 @@ enum Eac3CodingMode {
   codingMode_3_2,
 }
 
-extension on Eac3CodingMode {
+extension Eac3CodingModeValue on Eac3CodingMode {
   String toValue() {
     switch (this) {
       case Eac3CodingMode.codingMode_1_0:
@@ -7339,7 +7345,7 @@ extension on Eac3CodingMode {
   }
 }
 
-extension on String {
+extension Eac3CodingModeFromString on String {
   Eac3CodingMode toEac3CodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -7359,7 +7365,7 @@ enum Eac3DcFilter {
   enabled,
 }
 
-extension on Eac3DcFilter {
+extension Eac3DcFilterValue on Eac3DcFilter {
   String toValue() {
     switch (this) {
       case Eac3DcFilter.disabled:
@@ -7370,7 +7376,7 @@ extension on Eac3DcFilter {
   }
 }
 
-extension on String {
+extension Eac3DcFilterFromString on String {
   Eac3DcFilter toEac3DcFilter() {
     switch (this) {
       case 'DISABLED':
@@ -7392,7 +7398,7 @@ enum Eac3DrcLine {
   speech,
 }
 
-extension on Eac3DrcLine {
+extension Eac3DrcLineValue on Eac3DrcLine {
   String toValue() {
     switch (this) {
       case Eac3DrcLine.filmLight:
@@ -7411,7 +7417,7 @@ extension on Eac3DrcLine {
   }
 }
 
-extension on String {
+extension Eac3DrcLineFromString on String {
   Eac3DrcLine toEac3DrcLine() {
     switch (this) {
       case 'FILM_LIGHT':
@@ -7441,7 +7447,7 @@ enum Eac3DrcRf {
   speech,
 }
 
-extension on Eac3DrcRf {
+extension Eac3DrcRfValue on Eac3DrcRf {
   String toValue() {
     switch (this) {
       case Eac3DrcRf.filmLight:
@@ -7460,7 +7466,7 @@ extension on Eac3DrcRf {
   }
 }
 
-extension on String {
+extension Eac3DrcRfFromString on String {
   Eac3DrcRf toEac3DrcRf() {
     switch (this) {
       case 'FILM_LIGHT':
@@ -7486,7 +7492,7 @@ enum Eac3LfeControl {
   noLfe,
 }
 
-extension on Eac3LfeControl {
+extension Eac3LfeControlValue on Eac3LfeControl {
   String toValue() {
     switch (this) {
       case Eac3LfeControl.lfe:
@@ -7497,7 +7503,7 @@ extension on Eac3LfeControl {
   }
 }
 
-extension on String {
+extension Eac3LfeControlFromString on String {
   Eac3LfeControl toEac3LfeControl() {
     switch (this) {
       case 'LFE':
@@ -7515,7 +7521,7 @@ enum Eac3LfeFilter {
   enabled,
 }
 
-extension on Eac3LfeFilter {
+extension Eac3LfeFilterValue on Eac3LfeFilter {
   String toValue() {
     switch (this) {
       case Eac3LfeFilter.disabled:
@@ -7526,7 +7532,7 @@ extension on Eac3LfeFilter {
   }
 }
 
-extension on String {
+extension Eac3LfeFilterFromString on String {
   Eac3LfeFilter toEac3LfeFilter() {
     switch (this) {
       case 'DISABLED':
@@ -7544,7 +7550,7 @@ enum Eac3MetadataControl {
   useConfigured,
 }
 
-extension on Eac3MetadataControl {
+extension Eac3MetadataControlValue on Eac3MetadataControl {
   String toValue() {
     switch (this) {
       case Eac3MetadataControl.followInput:
@@ -7555,7 +7561,7 @@ extension on Eac3MetadataControl {
   }
 }
 
-extension on String {
+extension Eac3MetadataControlFromString on String {
   Eac3MetadataControl toEac3MetadataControl() {
     switch (this) {
       case 'FOLLOW_INPUT':
@@ -7573,7 +7579,7 @@ enum Eac3PassthroughControl {
   whenPossible,
 }
 
-extension on Eac3PassthroughControl {
+extension Eac3PassthroughControlValue on Eac3PassthroughControl {
   String toValue() {
     switch (this) {
       case Eac3PassthroughControl.noPassthrough:
@@ -7584,7 +7590,7 @@ extension on Eac3PassthroughControl {
   }
 }
 
-extension on String {
+extension Eac3PassthroughControlFromString on String {
   Eac3PassthroughControl toEac3PassthroughControl() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -7602,7 +7608,7 @@ enum Eac3PhaseControl {
   shift_90Degrees,
 }
 
-extension on Eac3PhaseControl {
+extension Eac3PhaseControlValue on Eac3PhaseControl {
   String toValue() {
     switch (this) {
       case Eac3PhaseControl.noShift:
@@ -7613,7 +7619,7 @@ extension on Eac3PhaseControl {
   }
 }
 
-extension on String {
+extension Eac3PhaseControlFromString on String {
   Eac3PhaseControl toEac3PhaseControl() {
     switch (this) {
       case 'NO_SHIFT':
@@ -7810,7 +7816,7 @@ enum Eac3StereoDownmix {
   notIndicated,
 }
 
-extension on Eac3StereoDownmix {
+extension Eac3StereoDownmixValue on Eac3StereoDownmix {
   String toValue() {
     switch (this) {
       case Eac3StereoDownmix.dpl2:
@@ -7825,7 +7831,7 @@ extension on Eac3StereoDownmix {
   }
 }
 
-extension on String {
+extension Eac3StereoDownmixFromString on String {
   Eac3StereoDownmix toEac3StereoDownmix() {
     switch (this) {
       case 'DPL2':
@@ -7848,7 +7854,7 @@ enum Eac3SurroundExMode {
   notIndicated,
 }
 
-extension on Eac3SurroundExMode {
+extension Eac3SurroundExModeValue on Eac3SurroundExMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundExMode.disabled:
@@ -7861,7 +7867,7 @@ extension on Eac3SurroundExMode {
   }
 }
 
-extension on String {
+extension Eac3SurroundExModeFromString on String {
   Eac3SurroundExMode toEac3SurroundExMode() {
     switch (this) {
       case 'DISABLED':
@@ -7882,7 +7888,7 @@ enum Eac3SurroundMode {
   notIndicated,
 }
 
-extension on Eac3SurroundMode {
+extension Eac3SurroundModeValue on Eac3SurroundMode {
   String toValue() {
     switch (this) {
       case Eac3SurroundMode.disabled:
@@ -7895,7 +7901,7 @@ extension on Eac3SurroundMode {
   }
 }
 
-extension on String {
+extension Eac3SurroundModeFromString on String {
   Eac3SurroundMode toEac3SurroundMode() {
     switch (this) {
       case 'DISABLED':
@@ -7978,7 +7984,7 @@ enum EbuTtDDestinationStyleControl {
   include,
 }
 
-extension on EbuTtDDestinationStyleControl {
+extension EbuTtDDestinationStyleControlValue on EbuTtDDestinationStyleControl {
   String toValue() {
     switch (this) {
       case EbuTtDDestinationStyleControl.exclude:
@@ -7989,7 +7995,7 @@ extension on EbuTtDDestinationStyleControl {
   }
 }
 
-extension on String {
+extension EbuTtDDestinationStyleControlFromString on String {
   EbuTtDDestinationStyleControl toEbuTtDDestinationStyleControl() {
     switch (this) {
       case 'EXCLUDE':
@@ -8007,7 +8013,7 @@ enum EbuTtDFillLineGapControl {
   enabled,
 }
 
-extension on EbuTtDFillLineGapControl {
+extension EbuTtDFillLineGapControlValue on EbuTtDFillLineGapControl {
   String toValue() {
     switch (this) {
       case EbuTtDFillLineGapControl.disabled:
@@ -8018,7 +8024,7 @@ extension on EbuTtDFillLineGapControl {
   }
 }
 
-extension on String {
+extension EbuTtDFillLineGapControlFromString on String {
   EbuTtDFillLineGapControl toEbuTtDFillLineGapControl() {
     switch (this) {
       case 'DISABLED':
@@ -8036,7 +8042,7 @@ enum EmbeddedConvert608To708 {
   upconvert,
 }
 
-extension on EmbeddedConvert608To708 {
+extension EmbeddedConvert608To708Value on EmbeddedConvert608To708 {
   String toValue() {
     switch (this) {
       case EmbeddedConvert608To708.disabled:
@@ -8047,7 +8053,7 @@ extension on EmbeddedConvert608To708 {
   }
 }
 
-extension on String {
+extension EmbeddedConvert608To708FromString on String {
   EmbeddedConvert608To708 toEmbeddedConvert608To708() {
     switch (this) {
       case 'DISABLED':
@@ -8090,7 +8096,7 @@ enum EmbeddedScte20Detection {
   off,
 }
 
-extension on EmbeddedScte20Detection {
+extension EmbeddedScte20DetectionValue on EmbeddedScte20Detection {
   String toValue() {
     switch (this) {
       case EmbeddedScte20Detection.auto:
@@ -8101,7 +8107,7 @@ extension on EmbeddedScte20Detection {
   }
 }
 
-extension on String {
+extension EmbeddedScte20DetectionFromString on String {
   EmbeddedScte20Detection toEmbeddedScte20Detection() {
     switch (this) {
       case 'AUTO':
@@ -8397,7 +8403,8 @@ enum FeatureActivationsInputPrepareScheduleActions {
   enabled,
 }
 
-extension on FeatureActivationsInputPrepareScheduleActions {
+extension FeatureActivationsInputPrepareScheduleActionsValue
+    on FeatureActivationsInputPrepareScheduleActions {
   String toValue() {
     switch (this) {
       case FeatureActivationsInputPrepareScheduleActions.disabled:
@@ -8408,7 +8415,7 @@ extension on FeatureActivationsInputPrepareScheduleActions {
   }
 }
 
-extension on String {
+extension FeatureActivationsInputPrepareScheduleActionsFromString on String {
   FeatureActivationsInputPrepareScheduleActions
       toFeatureActivationsInputPrepareScheduleActions() {
     switch (this) {
@@ -8428,7 +8435,7 @@ enum FecOutputIncludeFec {
   columnAndRow,
 }
 
-extension on FecOutputIncludeFec {
+extension FecOutputIncludeFecValue on FecOutputIncludeFec {
   String toValue() {
     switch (this) {
       case FecOutputIncludeFec.column:
@@ -8439,7 +8446,7 @@ extension on FecOutputIncludeFec {
   }
 }
 
-extension on String {
+extension FecOutputIncludeFecFromString on String {
   FecOutputIncludeFec toFecOutputIncludeFec() {
     switch (this) {
       case 'COLUMN':
@@ -8509,7 +8516,7 @@ enum FixedAfd {
   afd_1111,
 }
 
-extension on FixedAfd {
+extension FixedAfdValue on FixedAfd {
   String toValue() {
     switch (this) {
       case FixedAfd.afd_0000:
@@ -8538,7 +8545,7 @@ extension on FixedAfd {
   }
 }
 
-extension on String {
+extension FixedAfdFromString on String {
   FixedAfd toFixedAfd() {
     switch (this) {
       case 'AFD_0000':
@@ -8645,7 +8652,7 @@ enum Fmp4NielsenId3Behavior {
   passthrough,
 }
 
-extension on Fmp4NielsenId3Behavior {
+extension Fmp4NielsenId3BehaviorValue on Fmp4NielsenId3Behavior {
   String toValue() {
     switch (this) {
       case Fmp4NielsenId3Behavior.noPassthrough:
@@ -8656,7 +8663,7 @@ extension on Fmp4NielsenId3Behavior {
   }
 }
 
-extension on String {
+extension Fmp4NielsenId3BehaviorFromString on String {
   Fmp4NielsenId3Behavior toFmp4NielsenId3Behavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -8674,7 +8681,7 @@ enum Fmp4TimedMetadataBehavior {
   passthrough,
 }
 
-extension on Fmp4TimedMetadataBehavior {
+extension Fmp4TimedMetadataBehaviorValue on Fmp4TimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case Fmp4TimedMetadataBehavior.noPassthrough:
@@ -8685,7 +8692,7 @@ extension on Fmp4TimedMetadataBehavior {
   }
 }
 
-extension on String {
+extension Fmp4TimedMetadataBehaviorFromString on String {
   Fmp4TimedMetadataBehavior toFmp4TimedMetadataBehavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -8734,7 +8741,7 @@ enum FollowPoint {
   start,
 }
 
-extension on FollowPoint {
+extension FollowPointValue on FollowPoint {
   String toValue() {
     switch (this) {
       case FollowPoint.end:
@@ -8745,7 +8752,7 @@ extension on FollowPoint {
   }
 }
 
-extension on String {
+extension FollowPointFromString on String {
   FollowPoint toFollowPoint() {
     switch (this) {
       case 'END':
@@ -8793,7 +8800,7 @@ enum FrameCaptureIntervalUnit {
   seconds,
 }
 
-extension on FrameCaptureIntervalUnit {
+extension FrameCaptureIntervalUnitValue on FrameCaptureIntervalUnit {
   String toValue() {
     switch (this) {
       case FrameCaptureIntervalUnit.milliseconds:
@@ -8804,7 +8811,7 @@ extension on FrameCaptureIntervalUnit {
   }
 }
 
-extension on String {
+extension FrameCaptureIntervalUnitFromString on String {
   FrameCaptureIntervalUnit toFrameCaptureIntervalUnit() {
     switch (this) {
       case 'MILLISECONDS':
@@ -8960,7 +8967,8 @@ enum GlobalConfigurationInputEndAction {
   switchAndLoopInputs,
 }
 
-extension on GlobalConfigurationInputEndAction {
+extension GlobalConfigurationInputEndActionValue
+    on GlobalConfigurationInputEndAction {
   String toValue() {
     switch (this) {
       case GlobalConfigurationInputEndAction.none:
@@ -8971,7 +8979,7 @@ extension on GlobalConfigurationInputEndAction {
   }
 }
 
-extension on String {
+extension GlobalConfigurationInputEndActionFromString on String {
   GlobalConfigurationInputEndAction toGlobalConfigurationInputEndAction() {
     switch (this) {
       case 'NONE':
@@ -8990,7 +8998,8 @@ enum GlobalConfigurationLowFramerateInputs {
   enabled,
 }
 
-extension on GlobalConfigurationLowFramerateInputs {
+extension GlobalConfigurationLowFramerateInputsValue
+    on GlobalConfigurationLowFramerateInputs {
   String toValue() {
     switch (this) {
       case GlobalConfigurationLowFramerateInputs.disabled:
@@ -9001,7 +9010,7 @@ extension on GlobalConfigurationLowFramerateInputs {
   }
 }
 
-extension on String {
+extension GlobalConfigurationLowFramerateInputsFromString on String {
   GlobalConfigurationLowFramerateInputs
       toGlobalConfigurationLowFramerateInputs() {
     switch (this) {
@@ -9021,7 +9030,8 @@ enum GlobalConfigurationOutputLockingMode {
   pipelineLocking,
 }
 
-extension on GlobalConfigurationOutputLockingMode {
+extension GlobalConfigurationOutputLockingModeValue
+    on GlobalConfigurationOutputLockingMode {
   String toValue() {
     switch (this) {
       case GlobalConfigurationOutputLockingMode.epochLocking:
@@ -9032,7 +9042,7 @@ extension on GlobalConfigurationOutputLockingMode {
   }
 }
 
-extension on String {
+extension GlobalConfigurationOutputLockingModeFromString on String {
   GlobalConfigurationOutputLockingMode
       toGlobalConfigurationOutputLockingMode() {
     switch (this) {
@@ -9052,7 +9062,8 @@ enum GlobalConfigurationOutputTimingSource {
   systemClock,
 }
 
-extension on GlobalConfigurationOutputTimingSource {
+extension GlobalConfigurationOutputTimingSourceValue
+    on GlobalConfigurationOutputTimingSource {
   String toValue() {
     switch (this) {
       case GlobalConfigurationOutputTimingSource.inputClock:
@@ -9063,7 +9074,7 @@ extension on GlobalConfigurationOutputTimingSource {
   }
 }
 
-extension on String {
+extension GlobalConfigurationOutputTimingSourceFromString on String {
   GlobalConfigurationOutputTimingSource
       toGlobalConfigurationOutputTimingSource() {
     switch (this) {
@@ -9087,7 +9098,7 @@ enum H264AdaptiveQuantization {
   off,
 }
 
-extension on H264AdaptiveQuantization {
+extension H264AdaptiveQuantizationValue on H264AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H264AdaptiveQuantization.high:
@@ -9106,7 +9117,7 @@ extension on H264AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H264AdaptiveQuantizationFromString on String {
   H264AdaptiveQuantization toH264AdaptiveQuantization() {
     switch (this) {
       case 'HIGH':
@@ -9132,7 +9143,7 @@ enum H264ColorMetadata {
   insert,
 }
 
-extension on H264ColorMetadata {
+extension H264ColorMetadataValue on H264ColorMetadata {
   String toValue() {
     switch (this) {
       case H264ColorMetadata.ignore:
@@ -9143,7 +9154,7 @@ extension on H264ColorMetadata {
   }
 }
 
-extension on String {
+extension H264ColorMetadataFromString on String {
   H264ColorMetadata toH264ColorMetadata() {
     switch (this) {
       case 'IGNORE':
@@ -9203,7 +9214,7 @@ enum H264EntropyEncoding {
   cavlc,
 }
 
-extension on H264EntropyEncoding {
+extension H264EntropyEncodingValue on H264EntropyEncoding {
   String toValue() {
     switch (this) {
       case H264EntropyEncoding.cabac:
@@ -9214,7 +9225,7 @@ extension on H264EntropyEncoding {
   }
 }
 
-extension on String {
+extension H264EntropyEncodingFromString on String {
   H264EntropyEncoding toH264EntropyEncoding() {
     switch (this) {
       case 'CABAC':
@@ -9257,7 +9268,7 @@ enum H264FlickerAq {
   enabled,
 }
 
-extension on H264FlickerAq {
+extension H264FlickerAqValue on H264FlickerAq {
   String toValue() {
     switch (this) {
       case H264FlickerAq.disabled:
@@ -9268,7 +9279,7 @@ extension on H264FlickerAq {
   }
 }
 
-extension on String {
+extension H264FlickerAqFromString on String {
   H264FlickerAq toH264FlickerAq() {
     switch (this) {
       case 'DISABLED':
@@ -9286,7 +9297,7 @@ enum H264ForceFieldPictures {
   enabled,
 }
 
-extension on H264ForceFieldPictures {
+extension H264ForceFieldPicturesValue on H264ForceFieldPictures {
   String toValue() {
     switch (this) {
       case H264ForceFieldPictures.disabled:
@@ -9297,7 +9308,7 @@ extension on H264ForceFieldPictures {
   }
 }
 
-extension on String {
+extension H264ForceFieldPicturesFromString on String {
   H264ForceFieldPictures toH264ForceFieldPictures() {
     switch (this) {
       case 'DISABLED':
@@ -9315,7 +9326,7 @@ enum H264FramerateControl {
   specified,
 }
 
-extension on H264FramerateControl {
+extension H264FramerateControlValue on H264FramerateControl {
   String toValue() {
     switch (this) {
       case H264FramerateControl.initializeFromSource:
@@ -9326,7 +9337,7 @@ extension on H264FramerateControl {
   }
 }
 
-extension on String {
+extension H264FramerateControlFromString on String {
   H264FramerateControl toH264FramerateControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -9344,7 +9355,7 @@ enum H264GopBReference {
   enabled,
 }
 
-extension on H264GopBReference {
+extension H264GopBReferenceValue on H264GopBReference {
   String toValue() {
     switch (this) {
       case H264GopBReference.disabled:
@@ -9355,7 +9366,7 @@ extension on H264GopBReference {
   }
 }
 
-extension on String {
+extension H264GopBReferenceFromString on String {
   H264GopBReference toH264GopBReference() {
     switch (this) {
       case 'DISABLED':
@@ -9373,7 +9384,7 @@ enum H264GopSizeUnits {
   seconds,
 }
 
-extension on H264GopSizeUnits {
+extension H264GopSizeUnitsValue on H264GopSizeUnits {
   String toValue() {
     switch (this) {
       case H264GopSizeUnits.frames:
@@ -9384,7 +9395,7 @@ extension on H264GopSizeUnits {
   }
 }
 
-extension on String {
+extension H264GopSizeUnitsFromString on String {
   H264GopSizeUnits toH264GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -9417,7 +9428,7 @@ enum H264Level {
   h264LevelAuto,
 }
 
-extension on H264Level {
+extension H264LevelValue on H264Level {
   String toValue() {
     switch (this) {
       case H264Level.h264Level_1:
@@ -9458,7 +9469,7 @@ extension on H264Level {
   }
 }
 
-extension on String {
+extension H264LevelFromString on String {
   H264Level toH264Level() {
     switch (this) {
       case 'H264_LEVEL_1':
@@ -9507,7 +9518,7 @@ enum H264LookAheadRateControl {
   medium,
 }
 
-extension on H264LookAheadRateControl {
+extension H264LookAheadRateControlValue on H264LookAheadRateControl {
   String toValue() {
     switch (this) {
       case H264LookAheadRateControl.high:
@@ -9520,7 +9531,7 @@ extension on H264LookAheadRateControl {
   }
 }
 
-extension on String {
+extension H264LookAheadRateControlFromString on String {
   H264LookAheadRateControl toH264LookAheadRateControl() {
     switch (this) {
       case 'HIGH':
@@ -9540,7 +9551,7 @@ enum H264ParControl {
   specified,
 }
 
-extension on H264ParControl {
+extension H264ParControlValue on H264ParControl {
   String toValue() {
     switch (this) {
       case H264ParControl.initializeFromSource:
@@ -9551,7 +9562,7 @@ extension on H264ParControl {
   }
 }
 
-extension on String {
+extension H264ParControlFromString on String {
   H264ParControl toH264ParControl() {
     switch (this) {
       case 'INITIALIZE_FROM_SOURCE':
@@ -9573,7 +9584,7 @@ enum H264Profile {
   main,
 }
 
-extension on H264Profile {
+extension H264ProfileValue on H264Profile {
   String toValue() {
     switch (this) {
       case H264Profile.baseline:
@@ -9592,7 +9603,7 @@ extension on H264Profile {
   }
 }
 
-extension on String {
+extension H264ProfileFromString on String {
   H264Profile toH264Profile() {
     switch (this) {
       case 'BASELINE':
@@ -9618,7 +9629,7 @@ enum H264QualityLevel {
   standardQuality,
 }
 
-extension on H264QualityLevel {
+extension H264QualityLevelValue on H264QualityLevel {
   String toValue() {
     switch (this) {
       case H264QualityLevel.enhancedQuality:
@@ -9629,7 +9640,7 @@ extension on H264QualityLevel {
   }
 }
 
-extension on String {
+extension H264QualityLevelFromString on String {
   H264QualityLevel toH264QualityLevel() {
     switch (this) {
       case 'ENHANCED_QUALITY':
@@ -9649,7 +9660,7 @@ enum H264RateControlMode {
   vbr,
 }
 
-extension on H264RateControlMode {
+extension H264RateControlModeValue on H264RateControlMode {
   String toValue() {
     switch (this) {
       case H264RateControlMode.cbr:
@@ -9664,7 +9675,7 @@ extension on H264RateControlMode {
   }
 }
 
-extension on String {
+extension H264RateControlModeFromString on String {
   H264RateControlMode toH264RateControlMode() {
     switch (this) {
       case 'CBR':
@@ -9686,7 +9697,7 @@ enum H264ScanType {
   progressive,
 }
 
-extension on H264ScanType {
+extension H264ScanTypeValue on H264ScanType {
   String toValue() {
     switch (this) {
       case H264ScanType.interlaced:
@@ -9697,7 +9708,7 @@ extension on H264ScanType {
   }
 }
 
-extension on String {
+extension H264ScanTypeFromString on String {
   H264ScanType toH264ScanType() {
     switch (this) {
       case 'INTERLACED':
@@ -9715,7 +9726,7 @@ enum H264SceneChangeDetect {
   enabled,
 }
 
-extension on H264SceneChangeDetect {
+extension H264SceneChangeDetectValue on H264SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H264SceneChangeDetect.disabled:
@@ -9726,7 +9737,7 @@ extension on H264SceneChangeDetect {
   }
 }
 
-extension on String {
+extension H264SceneChangeDetectFromString on String {
   H264SceneChangeDetect toH264SceneChangeDetect() {
     switch (this) {
       case 'DISABLED':
@@ -10162,7 +10173,7 @@ enum H264SpatialAq {
   enabled,
 }
 
-extension on H264SpatialAq {
+extension H264SpatialAqValue on H264SpatialAq {
   String toValue() {
     switch (this) {
       case H264SpatialAq.disabled:
@@ -10173,7 +10184,7 @@ extension on H264SpatialAq {
   }
 }
 
-extension on String {
+extension H264SpatialAqFromString on String {
   H264SpatialAq toH264SpatialAq() {
     switch (this) {
       case 'DISABLED':
@@ -10191,7 +10202,7 @@ enum H264SubGopLength {
   fixed,
 }
 
-extension on H264SubGopLength {
+extension H264SubGopLengthValue on H264SubGopLength {
   String toValue() {
     switch (this) {
       case H264SubGopLength.dynamic:
@@ -10202,7 +10213,7 @@ extension on H264SubGopLength {
   }
 }
 
-extension on String {
+extension H264SubGopLengthFromString on String {
   H264SubGopLength toH264SubGopLength() {
     switch (this) {
       case 'DYNAMIC':
@@ -10220,7 +10231,7 @@ enum H264Syntax {
   rp2027,
 }
 
-extension on H264Syntax {
+extension H264SyntaxValue on H264Syntax {
   String toValue() {
     switch (this) {
       case H264Syntax.$default:
@@ -10231,7 +10242,7 @@ extension on H264Syntax {
   }
 }
 
-extension on String {
+extension H264SyntaxFromString on String {
   H264Syntax toH264Syntax() {
     switch (this) {
       case 'DEFAULT':
@@ -10249,7 +10260,7 @@ enum H264TemporalAq {
   enabled,
 }
 
-extension on H264TemporalAq {
+extension H264TemporalAqValue on H264TemporalAq {
   String toValue() {
     switch (this) {
       case H264TemporalAq.disabled:
@@ -10260,7 +10271,7 @@ extension on H264TemporalAq {
   }
 }
 
-extension on String {
+extension H264TemporalAqFromString on String {
   H264TemporalAq toH264TemporalAq() {
     switch (this) {
       case 'DISABLED':
@@ -10278,7 +10289,7 @@ enum H264TimecodeInsertionBehavior {
   picTimingSei,
 }
 
-extension on H264TimecodeInsertionBehavior {
+extension H264TimecodeInsertionBehaviorValue on H264TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
       case H264TimecodeInsertionBehavior.disabled:
@@ -10289,7 +10300,7 @@ extension on H264TimecodeInsertionBehavior {
   }
 }
 
-extension on String {
+extension H264TimecodeInsertionBehaviorFromString on String {
   H264TimecodeInsertionBehavior toH264TimecodeInsertionBehavior() {
     switch (this) {
       case 'DISABLED':
@@ -10311,7 +10322,7 @@ enum H265AdaptiveQuantization {
   off,
 }
 
-extension on H265AdaptiveQuantization {
+extension H265AdaptiveQuantizationValue on H265AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case H265AdaptiveQuantization.high:
@@ -10330,7 +10341,7 @@ extension on H265AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension H265AdaptiveQuantizationFromString on String {
   H265AdaptiveQuantization toH265AdaptiveQuantization() {
     switch (this) {
       case 'HIGH':
@@ -10356,7 +10367,8 @@ enum H265AlternativeTransferFunction {
   omit,
 }
 
-extension on H265AlternativeTransferFunction {
+extension H265AlternativeTransferFunctionValue
+    on H265AlternativeTransferFunction {
   String toValue() {
     switch (this) {
       case H265AlternativeTransferFunction.insert:
@@ -10367,7 +10379,7 @@ extension on H265AlternativeTransferFunction {
   }
 }
 
-extension on String {
+extension H265AlternativeTransferFunctionFromString on String {
   H265AlternativeTransferFunction toH265AlternativeTransferFunction() {
     switch (this) {
       case 'INSERT':
@@ -10386,7 +10398,7 @@ enum H265ColorMetadata {
   insert,
 }
 
-extension on H265ColorMetadata {
+extension H265ColorMetadataValue on H265ColorMetadata {
   String toValue() {
     switch (this) {
       case H265ColorMetadata.ignore:
@@ -10397,7 +10409,7 @@ extension on H265ColorMetadata {
   }
 }
 
-extension on String {
+extension H265ColorMetadataFromString on String {
   H265ColorMetadata toH265ColorMetadata() {
     switch (this) {
       case 'IGNORE':
@@ -10490,7 +10502,7 @@ enum H265FlickerAq {
   enabled,
 }
 
-extension on H265FlickerAq {
+extension H265FlickerAqValue on H265FlickerAq {
   String toValue() {
     switch (this) {
       case H265FlickerAq.disabled:
@@ -10501,7 +10513,7 @@ extension on H265FlickerAq {
   }
 }
 
-extension on String {
+extension H265FlickerAqFromString on String {
   H265FlickerAq toH265FlickerAq() {
     switch (this) {
       case 'DISABLED':
@@ -10519,7 +10531,7 @@ enum H265GopSizeUnits {
   seconds,
 }
 
-extension on H265GopSizeUnits {
+extension H265GopSizeUnitsValue on H265GopSizeUnits {
   String toValue() {
     switch (this) {
       case H265GopSizeUnits.frames:
@@ -10530,7 +10542,7 @@ extension on H265GopSizeUnits {
   }
 }
 
-extension on String {
+extension H265GopSizeUnitsFromString on String {
   H265GopSizeUnits toH265GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -10560,7 +10572,7 @@ enum H265Level {
   h265LevelAuto,
 }
 
-extension on H265Level {
+extension H265LevelValue on H265Level {
   String toValue() {
     switch (this) {
       case H265Level.h265Level_1:
@@ -10595,7 +10607,7 @@ extension on H265Level {
   }
 }
 
-extension on String {
+extension H265LevelFromString on String {
   H265Level toH265Level() {
     switch (this) {
       case 'H265_LEVEL_1':
@@ -10638,7 +10650,7 @@ enum H265LookAheadRateControl {
   medium,
 }
 
-extension on H265LookAheadRateControl {
+extension H265LookAheadRateControlValue on H265LookAheadRateControl {
   String toValue() {
     switch (this) {
       case H265LookAheadRateControl.high:
@@ -10651,7 +10663,7 @@ extension on H265LookAheadRateControl {
   }
 }
 
-extension on String {
+extension H265LookAheadRateControlFromString on String {
   H265LookAheadRateControl toH265LookAheadRateControl() {
     switch (this) {
       case 'HIGH':
@@ -10671,7 +10683,7 @@ enum H265Profile {
   main_10bit,
 }
 
-extension on H265Profile {
+extension H265ProfileValue on H265Profile {
   String toValue() {
     switch (this) {
       case H265Profile.main:
@@ -10682,7 +10694,7 @@ extension on H265Profile {
   }
 }
 
-extension on String {
+extension H265ProfileFromString on String {
   H265Profile toH265Profile() {
     switch (this) {
       case 'MAIN':
@@ -10701,7 +10713,7 @@ enum H265RateControlMode {
   qvbr,
 }
 
-extension on H265RateControlMode {
+extension H265RateControlModeValue on H265RateControlMode {
   String toValue() {
     switch (this) {
       case H265RateControlMode.cbr:
@@ -10714,7 +10726,7 @@ extension on H265RateControlMode {
   }
 }
 
-extension on String {
+extension H265RateControlModeFromString on String {
   H265RateControlMode toH265RateControlMode() {
     switch (this) {
       case 'CBR':
@@ -10734,7 +10746,7 @@ enum H265ScanType {
   progressive,
 }
 
-extension on H265ScanType {
+extension H265ScanTypeValue on H265ScanType {
   String toValue() {
     switch (this) {
       case H265ScanType.interlaced:
@@ -10745,7 +10757,7 @@ extension on H265ScanType {
   }
 }
 
-extension on String {
+extension H265ScanTypeFromString on String {
   H265ScanType toH265ScanType() {
     switch (this) {
       case 'INTERLACED':
@@ -10763,7 +10775,7 @@ enum H265SceneChangeDetect {
   enabled,
 }
 
-extension on H265SceneChangeDetect {
+extension H265SceneChangeDetectValue on H265SceneChangeDetect {
   String toValue() {
     switch (this) {
       case H265SceneChangeDetect.disabled:
@@ -10774,7 +10786,7 @@ extension on H265SceneChangeDetect {
   }
 }
 
-extension on String {
+extension H265SceneChangeDetectFromString on String {
   H265SceneChangeDetect toH265SceneChangeDetect() {
     switch (this) {
       case 'DISABLED':
@@ -11086,7 +11098,7 @@ enum H265Tier {
   main,
 }
 
-extension on H265Tier {
+extension H265TierValue on H265Tier {
   String toValue() {
     switch (this) {
       case H265Tier.high:
@@ -11097,7 +11109,7 @@ extension on H265Tier {
   }
 }
 
-extension on String {
+extension H265TierFromString on String {
   H265Tier toH265Tier() {
     switch (this) {
       case 'HIGH':
@@ -11115,7 +11127,7 @@ enum H265TimecodeInsertionBehavior {
   picTimingSei,
 }
 
-extension on H265TimecodeInsertionBehavior {
+extension H265TimecodeInsertionBehaviorValue on H265TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
       case H265TimecodeInsertionBehavior.disabled:
@@ -11126,7 +11138,7 @@ extension on H265TimecodeInsertionBehavior {
   }
 }
 
-extension on String {
+extension H265TimecodeInsertionBehaviorFromString on String {
   H265TimecodeInsertionBehavior toH265TimecodeInsertionBehavior() {
     switch (this) {
       case 'DISABLED':
@@ -11178,7 +11190,7 @@ enum HlsAdMarkers {
   elementalScte35,
 }
 
-extension on HlsAdMarkers {
+extension HlsAdMarkersValue on HlsAdMarkers {
   String toValue() {
     switch (this) {
       case HlsAdMarkers.adobe:
@@ -11191,7 +11203,7 @@ extension on HlsAdMarkers {
   }
 }
 
-extension on String {
+extension HlsAdMarkersFromString on String {
   HlsAdMarkers toHlsAdMarkers() {
     switch (this) {
       case 'ADOBE':
@@ -11211,7 +11223,7 @@ enum HlsAkamaiHttpTransferMode {
   nonChunked,
 }
 
-extension on HlsAkamaiHttpTransferMode {
+extension HlsAkamaiHttpTransferModeValue on HlsAkamaiHttpTransferMode {
   String toValue() {
     switch (this) {
       case HlsAkamaiHttpTransferMode.chunked:
@@ -11222,7 +11234,7 @@ extension on HlsAkamaiHttpTransferMode {
   }
 }
 
-extension on String {
+extension HlsAkamaiHttpTransferModeFromString on String {
   HlsAkamaiHttpTransferMode toHlsAkamaiHttpTransferMode() {
     switch (this) {
       case 'CHUNKED':
@@ -11359,7 +11371,7 @@ enum HlsCaptionLanguageSetting {
   omit,
 }
 
-extension on HlsCaptionLanguageSetting {
+extension HlsCaptionLanguageSettingValue on HlsCaptionLanguageSetting {
   String toValue() {
     switch (this) {
       case HlsCaptionLanguageSetting.insert:
@@ -11372,7 +11384,7 @@ extension on HlsCaptionLanguageSetting {
   }
 }
 
-extension on String {
+extension HlsCaptionLanguageSettingFromString on String {
   HlsCaptionLanguageSetting toHlsCaptionLanguageSetting() {
     switch (this) {
       case 'INSERT':
@@ -11442,7 +11454,7 @@ enum HlsClientCache {
   enabled,
 }
 
-extension on HlsClientCache {
+extension HlsClientCacheValue on HlsClientCache {
   String toValue() {
     switch (this) {
       case HlsClientCache.disabled:
@@ -11453,7 +11465,7 @@ extension on HlsClientCache {
   }
 }
 
-extension on String {
+extension HlsClientCacheFromString on String {
   HlsClientCache toHlsClientCache() {
     switch (this) {
       case 'DISABLED':
@@ -11471,7 +11483,7 @@ enum HlsCodecSpecification {
   rfc_6381,
 }
 
-extension on HlsCodecSpecification {
+extension HlsCodecSpecificationValue on HlsCodecSpecification {
   String toValue() {
     switch (this) {
       case HlsCodecSpecification.rfc_4281:
@@ -11482,7 +11494,7 @@ extension on HlsCodecSpecification {
   }
 }
 
-extension on String {
+extension HlsCodecSpecificationFromString on String {
   HlsCodecSpecification toHlsCodecSpecification() {
     switch (this) {
       case 'RFC_4281':
@@ -11500,7 +11512,7 @@ enum HlsDirectoryStructure {
   subdirectoryPerStream,
 }
 
-extension on HlsDirectoryStructure {
+extension HlsDirectoryStructureValue on HlsDirectoryStructure {
   String toValue() {
     switch (this) {
       case HlsDirectoryStructure.singleDirectory:
@@ -11511,7 +11523,7 @@ extension on HlsDirectoryStructure {
   }
 }
 
-extension on String {
+extension HlsDirectoryStructureFromString on String {
   HlsDirectoryStructure toHlsDirectoryStructure() {
     switch (this) {
       case 'SINGLE_DIRECTORY':
@@ -11529,7 +11541,7 @@ enum HlsDiscontinuityTags {
   neverInsert,
 }
 
-extension on HlsDiscontinuityTags {
+extension HlsDiscontinuityTagsValue on HlsDiscontinuityTags {
   String toValue() {
     switch (this) {
       case HlsDiscontinuityTags.insert:
@@ -11540,7 +11552,7 @@ extension on HlsDiscontinuityTags {
   }
 }
 
-extension on String {
+extension HlsDiscontinuityTagsFromString on String {
   HlsDiscontinuityTags toHlsDiscontinuityTags() {
     switch (this) {
       case 'INSERT':
@@ -11558,7 +11570,7 @@ enum HlsEncryptionType {
   sampleAes,
 }
 
-extension on HlsEncryptionType {
+extension HlsEncryptionTypeValue on HlsEncryptionType {
   String toValue() {
     switch (this) {
       case HlsEncryptionType.aes128:
@@ -11569,7 +11581,7 @@ extension on HlsEncryptionType {
   }
 }
 
-extension on String {
+extension HlsEncryptionTypeFromString on String {
   HlsEncryptionType toHlsEncryptionType() {
     switch (this) {
       case 'AES128':
@@ -12067,7 +12079,7 @@ enum HlsH265PackagingType {
   hvc1,
 }
 
-extension on HlsH265PackagingType {
+extension HlsH265PackagingTypeValue on HlsH265PackagingType {
   String toValue() {
     switch (this) {
       case HlsH265PackagingType.hev1:
@@ -12078,7 +12090,7 @@ extension on HlsH265PackagingType {
   }
 }
 
-extension on String {
+extension HlsH265PackagingTypeFromString on String {
   HlsH265PackagingType toHlsH265PackagingType() {
     switch (this) {
       case 'HEV1':
@@ -12121,7 +12133,7 @@ enum HlsId3SegmentTaggingState {
   enabled,
 }
 
-extension on HlsId3SegmentTaggingState {
+extension HlsId3SegmentTaggingStateValue on HlsId3SegmentTaggingState {
   String toValue() {
     switch (this) {
       case HlsId3SegmentTaggingState.disabled:
@@ -12132,7 +12144,7 @@ extension on HlsId3SegmentTaggingState {
   }
 }
 
-extension on String {
+extension HlsId3SegmentTaggingStateFromString on String {
   HlsId3SegmentTaggingState toHlsId3SegmentTaggingState() {
     switch (this) {
       case 'DISABLED':
@@ -12150,7 +12162,7 @@ enum HlsIncompleteSegmentBehavior {
   suppress,
 }
 
-extension on HlsIncompleteSegmentBehavior {
+extension HlsIncompleteSegmentBehaviorValue on HlsIncompleteSegmentBehavior {
   String toValue() {
     switch (this) {
       case HlsIncompleteSegmentBehavior.auto:
@@ -12161,7 +12173,7 @@ extension on HlsIncompleteSegmentBehavior {
   }
 }
 
-extension on String {
+extension HlsIncompleteSegmentBehaviorFromString on String {
   HlsIncompleteSegmentBehavior toHlsIncompleteSegmentBehavior() {
     switch (this) {
       case 'AUTO':
@@ -12229,7 +12241,7 @@ enum HlsIvInManifest {
   include,
 }
 
-extension on HlsIvInManifest {
+extension HlsIvInManifestValue on HlsIvInManifest {
   String toValue() {
     switch (this) {
       case HlsIvInManifest.exclude:
@@ -12240,7 +12252,7 @@ extension on HlsIvInManifest {
   }
 }
 
-extension on String {
+extension HlsIvInManifestFromString on String {
   HlsIvInManifest toHlsIvInManifest() {
     switch (this) {
       case 'EXCLUDE':
@@ -12258,7 +12270,7 @@ enum HlsIvSource {
   followsSegmentNumber,
 }
 
-extension on HlsIvSource {
+extension HlsIvSourceValue on HlsIvSource {
   String toValue() {
     switch (this) {
       case HlsIvSource.explicit:
@@ -12269,7 +12281,7 @@ extension on HlsIvSource {
   }
 }
 
-extension on String {
+extension HlsIvSourceFromString on String {
   HlsIvSource toHlsIvSource() {
     switch (this) {
       case 'EXPLICIT':
@@ -12287,7 +12299,7 @@ enum HlsManifestCompression {
   none,
 }
 
-extension on HlsManifestCompression {
+extension HlsManifestCompressionValue on HlsManifestCompression {
   String toValue() {
     switch (this) {
       case HlsManifestCompression.gzip:
@@ -12298,7 +12310,7 @@ extension on HlsManifestCompression {
   }
 }
 
-extension on String {
+extension HlsManifestCompressionFromString on String {
   HlsManifestCompression toHlsManifestCompression() {
     switch (this) {
       case 'GZIP':
@@ -12316,7 +12328,7 @@ enum HlsManifestDurationFormat {
   integer,
 }
 
-extension on HlsManifestDurationFormat {
+extension HlsManifestDurationFormatValue on HlsManifestDurationFormat {
   String toValue() {
     switch (this) {
       case HlsManifestDurationFormat.floatingPoint:
@@ -12327,7 +12339,7 @@ extension on HlsManifestDurationFormat {
   }
 }
 
-extension on String {
+extension HlsManifestDurationFormatFromString on String {
   HlsManifestDurationFormat toHlsManifestDurationFormat() {
     switch (this) {
       case 'FLOATING_POINT':
@@ -12401,7 +12413,7 @@ enum HlsMediaStoreStorageClass {
   temporal,
 }
 
-extension on HlsMediaStoreStorageClass {
+extension HlsMediaStoreStorageClassValue on HlsMediaStoreStorageClass {
   String toValue() {
     switch (this) {
       case HlsMediaStoreStorageClass.temporal:
@@ -12410,7 +12422,7 @@ extension on HlsMediaStoreStorageClass {
   }
 }
 
-extension on String {
+extension HlsMediaStoreStorageClassFromString on String {
   HlsMediaStoreStorageClass toHlsMediaStoreStorageClass() {
     switch (this) {
       case 'TEMPORAL':
@@ -12426,7 +12438,7 @@ enum HlsMode {
   vod,
 }
 
-extension on HlsMode {
+extension HlsModeValue on HlsMode {
   String toValue() {
     switch (this) {
       case HlsMode.live:
@@ -12437,7 +12449,7 @@ extension on HlsMode {
   }
 }
 
-extension on String {
+extension HlsModeFromString on String {
   HlsMode toHlsMode() {
     switch (this) {
       case 'LIVE':
@@ -12456,7 +12468,7 @@ enum HlsOutputSelection {
   variantManifestsAndSegments,
 }
 
-extension on HlsOutputSelection {
+extension HlsOutputSelectionValue on HlsOutputSelection {
   String toValue() {
     switch (this) {
       case HlsOutputSelection.manifestsAndSegments:
@@ -12469,7 +12481,7 @@ extension on HlsOutputSelection {
   }
 }
 
-extension on String {
+extension HlsOutputSelectionFromString on String {
   HlsOutputSelection toHlsOutputSelection() {
     switch (this) {
       case 'MANIFESTS_AND_SEGMENTS':
@@ -12538,7 +12550,7 @@ enum HlsProgramDateTime {
   include,
 }
 
-extension on HlsProgramDateTime {
+extension HlsProgramDateTimeValue on HlsProgramDateTime {
   String toValue() {
     switch (this) {
       case HlsProgramDateTime.exclude:
@@ -12549,7 +12561,7 @@ extension on HlsProgramDateTime {
   }
 }
 
-extension on String {
+extension HlsProgramDateTimeFromString on String {
   HlsProgramDateTime toHlsProgramDateTime() {
     switch (this) {
       case 'EXCLUDE':
@@ -12567,7 +12579,7 @@ enum HlsRedundantManifest {
   enabled,
 }
 
-extension on HlsRedundantManifest {
+extension HlsRedundantManifestValue on HlsRedundantManifest {
   String toValue() {
     switch (this) {
       case HlsRedundantManifest.disabled:
@@ -12578,7 +12590,7 @@ extension on HlsRedundantManifest {
   }
 }
 
-extension on String {
+extension HlsRedundantManifestFromString on String {
   HlsRedundantManifest toHlsRedundantManifest() {
     switch (this) {
       case 'DISABLED':
@@ -12596,7 +12608,7 @@ enum HlsSegmentationMode {
   useSegmentDuration,
 }
 
-extension on HlsSegmentationMode {
+extension HlsSegmentationModeValue on HlsSegmentationMode {
   String toValue() {
     switch (this) {
       case HlsSegmentationMode.useInputSegmentation:
@@ -12607,7 +12619,7 @@ extension on HlsSegmentationMode {
   }
 }
 
-extension on String {
+extension HlsSegmentationModeFromString on String {
   HlsSegmentationMode toHlsSegmentationMode() {
     switch (this) {
       case 'USE_INPUT_SEGMENTATION':
@@ -12667,7 +12679,7 @@ enum HlsStreamInfResolution {
   include,
 }
 
-extension on HlsStreamInfResolution {
+extension HlsStreamInfResolutionValue on HlsStreamInfResolution {
   String toValue() {
     switch (this) {
       case HlsStreamInfResolution.exclude:
@@ -12678,7 +12690,7 @@ extension on HlsStreamInfResolution {
   }
 }
 
-extension on String {
+extension HlsStreamInfResolutionFromString on String {
   HlsStreamInfResolution toHlsStreamInfResolution() {
     switch (this) {
       case 'EXCLUDE':
@@ -12697,7 +12709,7 @@ enum HlsTimedMetadataId3Frame {
   tdrl,
 }
 
-extension on HlsTimedMetadataId3Frame {
+extension HlsTimedMetadataId3FrameValue on HlsTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case HlsTimedMetadataId3Frame.none:
@@ -12710,7 +12722,7 @@ extension on HlsTimedMetadataId3Frame {
   }
 }
 
-extension on String {
+extension HlsTimedMetadataId3FrameFromString on String {
   HlsTimedMetadataId3Frame toHlsTimedMetadataId3Frame() {
     switch (this) {
       case 'NONE':
@@ -12754,7 +12766,7 @@ enum HlsTsFileMode {
   singleFile,
 }
 
-extension on HlsTsFileMode {
+extension HlsTsFileModeValue on HlsTsFileMode {
   String toValue() {
     switch (this) {
       case HlsTsFileMode.segmentedFiles:
@@ -12765,7 +12777,7 @@ extension on HlsTsFileMode {
   }
 }
 
-extension on String {
+extension HlsTsFileModeFromString on String {
   HlsTsFileMode toHlsTsFileMode() {
     switch (this) {
       case 'SEGMENTED_FILES':
@@ -12783,7 +12795,7 @@ enum HlsWebdavHttpTransferMode {
   nonChunked,
 }
 
-extension on HlsWebdavHttpTransferMode {
+extension HlsWebdavHttpTransferModeValue on HlsWebdavHttpTransferMode {
   String toValue() {
     switch (this) {
       case HlsWebdavHttpTransferMode.chunked:
@@ -12794,7 +12806,7 @@ extension on HlsWebdavHttpTransferMode {
   }
 }
 
-extension on String {
+extension HlsWebdavHttpTransferModeFromString on String {
   HlsWebdavHttpTransferMode toHlsWebdavHttpTransferMode() {
     switch (this) {
       case 'CHUNKED':
@@ -12870,7 +12882,7 @@ enum IFrameOnlyPlaylistType {
   standard,
 }
 
-extension on IFrameOnlyPlaylistType {
+extension IFrameOnlyPlaylistTypeValue on IFrameOnlyPlaylistType {
   String toValue() {
     switch (this) {
       case IFrameOnlyPlaylistType.disabled:
@@ -12881,7 +12893,7 @@ extension on IFrameOnlyPlaylistType {
   }
 }
 
-extension on String {
+extension IFrameOnlyPlaylistTypeFromString on String {
   IFrameOnlyPlaylistType toIFrameOnlyPlaylistType() {
     switch (this) {
       case 'DISABLED':
@@ -13109,7 +13121,7 @@ enum InputClass {
   singlePipeline,
 }
 
-extension on InputClass {
+extension InputClassValue on InputClass {
   String toValue() {
     switch (this) {
       case InputClass.standard:
@@ -13120,7 +13132,7 @@ extension on InputClass {
   }
 }
 
-extension on String {
+extension InputClassFromString on String {
   InputClass toInputClass() {
     switch (this) {
       case 'STANDARD':
@@ -13182,7 +13194,7 @@ enum InputCodec {
   hevc,
 }
 
-extension on InputCodec {
+extension InputCodecValue on InputCodec {
   String toValue() {
     switch (this) {
       case InputCodec.mpeg2:
@@ -13195,7 +13207,7 @@ extension on InputCodec {
   }
 }
 
-extension on String {
+extension InputCodecFromString on String {
   InputCodec toInputCodec() {
     switch (this) {
       case 'MPEG2':
@@ -13215,7 +13227,7 @@ enum InputDeblockFilter {
   enabled,
 }
 
-extension on InputDeblockFilter {
+extension InputDeblockFilterValue on InputDeblockFilter {
   String toValue() {
     switch (this) {
       case InputDeblockFilter.disabled:
@@ -13226,7 +13238,7 @@ extension on InputDeblockFilter {
   }
 }
 
-extension on String {
+extension InputDeblockFilterFromString on String {
   InputDeblockFilter toInputDeblockFilter() {
     switch (this) {
       case 'DISABLED':
@@ -13244,7 +13256,7 @@ enum InputDenoiseFilter {
   enabled,
 }
 
-extension on InputDenoiseFilter {
+extension InputDenoiseFilterValue on InputDenoiseFilter {
   String toValue() {
     switch (this) {
       case InputDenoiseFilter.disabled:
@@ -13255,7 +13267,7 @@ extension on InputDenoiseFilter {
   }
 }
 
-extension on String {
+extension InputDenoiseFilterFromString on String {
   InputDenoiseFilter toInputDenoiseFilter() {
     switch (this) {
       case 'DISABLED':
@@ -13342,7 +13354,7 @@ enum InputDeviceActiveInput {
   sdi,
 }
 
-extension on InputDeviceActiveInput {
+extension InputDeviceActiveInputValue on InputDeviceActiveInput {
   String toValue() {
     switch (this) {
       case InputDeviceActiveInput.hdmi:
@@ -13353,7 +13365,7 @@ extension on InputDeviceActiveInput {
   }
 }
 
-extension on String {
+extension InputDeviceActiveInputFromString on String {
   InputDeviceActiveInput toInputDeviceActiveInput() {
     switch (this) {
       case 'HDMI':
@@ -13398,7 +13410,7 @@ enum InputDeviceConfiguredInput {
   sdi,
 }
 
-extension on InputDeviceConfiguredInput {
+extension InputDeviceConfiguredInputValue on InputDeviceConfiguredInput {
   String toValue() {
     switch (this) {
       case InputDeviceConfiguredInput.auto:
@@ -13411,7 +13423,7 @@ extension on InputDeviceConfiguredInput {
   }
 }
 
-extension on String {
+extension InputDeviceConfiguredInputFromString on String {
   InputDeviceConfiguredInput toInputDeviceConfiguredInput() {
     switch (this) {
       case 'AUTO':
@@ -13431,7 +13443,7 @@ enum InputDeviceConnectionState {
   connected,
 }
 
-extension on InputDeviceConnectionState {
+extension InputDeviceConnectionStateValue on InputDeviceConnectionState {
   String toValue() {
     switch (this) {
       case InputDeviceConnectionState.disconnected:
@@ -13442,7 +13454,7 @@ extension on InputDeviceConnectionState {
   }
 }
 
-extension on String {
+extension InputDeviceConnectionStateFromString on String {
   InputDeviceConnectionState toInputDeviceConnectionState() {
     switch (this) {
       case 'DISCONNECTED':
@@ -13517,7 +13529,7 @@ enum InputDeviceIpScheme {
   dhcp,
 }
 
-extension on InputDeviceIpScheme {
+extension InputDeviceIpSchemeValue on InputDeviceIpScheme {
   String toValue() {
     switch (this) {
       case InputDeviceIpScheme.static:
@@ -13528,7 +13540,7 @@ extension on InputDeviceIpScheme {
   }
 }
 
-extension on String {
+extension InputDeviceIpSchemeFromString on String {
   InputDeviceIpScheme toInputDeviceIpScheme() {
     switch (this) {
       case 'STATIC':
@@ -13602,7 +13614,7 @@ enum InputDeviceScanType {
   progressive,
 }
 
-extension on InputDeviceScanType {
+extension InputDeviceScanTypeValue on InputDeviceScanType {
   String toValue() {
     switch (this) {
       case InputDeviceScanType.interlaced:
@@ -13613,7 +13625,7 @@ extension on InputDeviceScanType {
   }
 }
 
-extension on String {
+extension InputDeviceScanTypeFromString on String {
   InputDeviceScanType toInputDeviceScanType() {
     switch (this) {
       case 'INTERLACED':
@@ -13653,7 +13665,7 @@ enum InputDeviceState {
   streaming,
 }
 
-extension on InputDeviceState {
+extension InputDeviceStateValue on InputDeviceState {
   String toValue() {
     switch (this) {
       case InputDeviceState.idle:
@@ -13664,7 +13676,7 @@ extension on InputDeviceState {
   }
 }
 
-extension on String {
+extension InputDeviceStateFromString on String {
   InputDeviceState toInputDeviceState() {
     switch (this) {
       case 'IDLE':
@@ -13770,7 +13782,7 @@ enum InputDeviceTransferType {
   incoming,
 }
 
-extension on InputDeviceTransferType {
+extension InputDeviceTransferTypeValue on InputDeviceTransferType {
   String toValue() {
     switch (this) {
       case InputDeviceTransferType.outgoing:
@@ -13781,7 +13793,7 @@ extension on InputDeviceTransferType {
   }
 }
 
-extension on String {
+extension InputDeviceTransferTypeFromString on String {
   InputDeviceTransferType toInputDeviceTransferType() {
     switch (this) {
       case 'OUTGOING':
@@ -13799,7 +13811,7 @@ enum InputDeviceType {
   hd,
 }
 
-extension on InputDeviceType {
+extension InputDeviceTypeValue on InputDeviceType {
   String toValue() {
     switch (this) {
       case InputDeviceType.hd:
@@ -13808,7 +13820,7 @@ extension on InputDeviceType {
   }
 }
 
-extension on String {
+extension InputDeviceTypeFromString on String {
   InputDeviceType toInputDeviceType() {
     switch (this) {
       case 'HD':
@@ -13880,7 +13892,7 @@ enum InputFilter {
   forced,
 }
 
-extension on InputFilter {
+extension InputFilterValue on InputFilter {
   String toValue() {
     switch (this) {
       case InputFilter.auto:
@@ -13893,7 +13905,7 @@ extension on InputFilter {
   }
 }
 
-extension on String {
+extension InputFilterFromString on String {
   InputFilter toInputFilter() {
     switch (this) {
       case 'AUTO':
@@ -13952,7 +13964,7 @@ enum InputLossActionForHlsOut {
   pauseOutput,
 }
 
-extension on InputLossActionForHlsOut {
+extension InputLossActionForHlsOutValue on InputLossActionForHlsOut {
   String toValue() {
     switch (this) {
       case InputLossActionForHlsOut.emitOutput:
@@ -13963,7 +13975,7 @@ extension on InputLossActionForHlsOut {
   }
 }
 
-extension on String {
+extension InputLossActionForHlsOutFromString on String {
   InputLossActionForHlsOut toInputLossActionForHlsOut() {
     switch (this) {
       case 'EMIT_OUTPUT':
@@ -13981,7 +13993,7 @@ enum InputLossActionForMsSmoothOut {
   pauseOutput,
 }
 
-extension on InputLossActionForMsSmoothOut {
+extension InputLossActionForMsSmoothOutValue on InputLossActionForMsSmoothOut {
   String toValue() {
     switch (this) {
       case InputLossActionForMsSmoothOut.emitOutput:
@@ -13992,7 +14004,7 @@ extension on InputLossActionForMsSmoothOut {
   }
 }
 
-extension on String {
+extension InputLossActionForMsSmoothOutFromString on String {
   InputLossActionForMsSmoothOut toInputLossActionForMsSmoothOut() {
     switch (this) {
       case 'EMIT_OUTPUT':
@@ -14010,7 +14022,7 @@ enum InputLossActionForRtmpOut {
   pauseOutput,
 }
 
-extension on InputLossActionForRtmpOut {
+extension InputLossActionForRtmpOutValue on InputLossActionForRtmpOut {
   String toValue() {
     switch (this) {
       case InputLossActionForRtmpOut.emitOutput:
@@ -14021,7 +14033,7 @@ extension on InputLossActionForRtmpOut {
   }
 }
 
-extension on String {
+extension InputLossActionForRtmpOutFromString on String {
   InputLossActionForRtmpOut toInputLossActionForRtmpOut() {
     switch (this) {
       case 'EMIT_OUTPUT':
@@ -14040,7 +14052,7 @@ enum InputLossActionForUdpOut {
   emitProgram,
 }
 
-extension on InputLossActionForUdpOut {
+extension InputLossActionForUdpOutValue on InputLossActionForUdpOut {
   String toValue() {
     switch (this) {
       case InputLossActionForUdpOut.dropProgram:
@@ -14053,7 +14065,7 @@ extension on InputLossActionForUdpOut {
   }
 }
 
-extension on String {
+extension InputLossActionForUdpOutFromString on String {
   InputLossActionForUdpOut toInputLossActionForUdpOut() {
     switch (this) {
       case 'DROP_PROGRAM':
@@ -14158,7 +14170,7 @@ enum InputLossImageType {
   slate,
 }
 
-extension on InputLossImageType {
+extension InputLossImageTypeValue on InputLossImageType {
   String toValue() {
     switch (this) {
       case InputLossImageType.color:
@@ -14169,7 +14181,7 @@ extension on InputLossImageType {
   }
 }
 
-extension on String {
+extension InputLossImageTypeFromString on String {
   InputLossImageType toInputLossImageType() {
     switch (this) {
       case 'COLOR':
@@ -14189,7 +14201,7 @@ enum InputMaximumBitrate {
   max_50Mbps,
 }
 
-extension on InputMaximumBitrate {
+extension InputMaximumBitrateValue on InputMaximumBitrate {
   String toValue() {
     switch (this) {
       case InputMaximumBitrate.max_10Mbps:
@@ -14202,7 +14214,7 @@ extension on InputMaximumBitrate {
   }
 }
 
-extension on String {
+extension InputMaximumBitrateFromString on String {
   InputMaximumBitrate toInputMaximumBitrate() {
     switch (this) {
       case 'MAX_10_MBPS':
@@ -14227,7 +14239,7 @@ enum InputPreference {
   primaryInputPreferred,
 }
 
-extension on InputPreference {
+extension InputPreferenceValue on InputPreference {
   String toValue() {
     switch (this) {
       case InputPreference.equalInputPreference:
@@ -14238,7 +14250,7 @@ extension on InputPreference {
   }
 }
 
-extension on String {
+extension InputPreferenceFromString on String {
   InputPreference toInputPreference() {
     switch (this) {
       case 'EQUAL_INPUT_PREFERENCE':
@@ -14310,7 +14322,7 @@ enum InputResolution {
   uhd,
 }
 
-extension on InputResolution {
+extension InputResolutionValue on InputResolution {
   String toValue() {
     switch (this) {
       case InputResolution.sd:
@@ -14323,7 +14335,7 @@ extension on InputResolution {
   }
 }
 
-extension on String {
+extension InputResolutionFromString on String {
   InputResolution toInputResolution() {
     switch (this) {
       case 'SD':
@@ -14392,7 +14404,7 @@ enum InputSecurityGroupState {
   deleted,
 }
 
-extension on InputSecurityGroupState {
+extension InputSecurityGroupStateValue on InputSecurityGroupState {
   String toValue() {
     switch (this) {
       case InputSecurityGroupState.idle:
@@ -14407,7 +14419,7 @@ extension on InputSecurityGroupState {
   }
 }
 
-extension on String {
+extension InputSecurityGroupStateFromString on String {
   InputSecurityGroupState toInputSecurityGroupState() {
     switch (this) {
       case 'IDLE':
@@ -14571,7 +14583,7 @@ enum InputSourceEndBehavior {
   loop,
 }
 
-extension on InputSourceEndBehavior {
+extension InputSourceEndBehaviorValue on InputSourceEndBehavior {
   String toValue() {
     switch (this) {
       case InputSourceEndBehavior.$continue:
@@ -14582,7 +14594,7 @@ extension on InputSourceEndBehavior {
   }
 }
 
-extension on String {
+extension InputSourceEndBehaviorFromString on String {
   InputSourceEndBehavior toInputSourceEndBehavior() {
     switch (this) {
       case 'CONTINUE':
@@ -14634,7 +14646,7 @@ enum InputSourceType {
   dynamic,
 }
 
-extension on InputSourceType {
+extension InputSourceTypeValue on InputSourceType {
   String toValue() {
     switch (this) {
       case InputSourceType.static:
@@ -14645,7 +14657,7 @@ extension on InputSourceType {
   }
 }
 
-extension on String {
+extension InputSourceTypeFromString on String {
   InputSourceType toInputSourceType() {
     switch (this) {
       case 'STATIC':
@@ -14703,7 +14715,7 @@ enum InputState {
   deleted,
 }
 
-extension on InputState {
+extension InputStateValue on InputState {
   String toValue() {
     switch (this) {
       case InputState.creating:
@@ -14720,7 +14732,7 @@ extension on InputState {
   }
 }
 
-extension on String {
+extension InputStateFromString on String {
   InputState toInputState() {
     switch (this) {
       case 'CREATING':
@@ -14795,7 +14807,7 @@ enum InputTimecodeSource {
   embedded,
 }
 
-extension on InputTimecodeSource {
+extension InputTimecodeSourceValue on InputTimecodeSource {
   String toValue() {
     switch (this) {
       case InputTimecodeSource.zerobased:
@@ -14806,7 +14818,7 @@ extension on InputTimecodeSource {
   }
 }
 
-extension on String {
+extension InputTimecodeSourceFromString on String {
   InputTimecodeSource toInputTimecodeSource() {
     switch (this) {
       case 'ZEROBASED':
@@ -14831,7 +14843,7 @@ enum InputType {
   awsCdi,
 }
 
-extension on InputType {
+extension InputTypeValue on InputType {
   String toValue() {
     switch (this) {
       case InputType.udpPush:
@@ -14856,7 +14868,7 @@ extension on InputType {
   }
 }
 
-extension on String {
+extension InputTypeFromString on String {
   InputType toInputType() {
     switch (this) {
       case 'UDP_PUSH':
@@ -14975,7 +14987,7 @@ enum LastFrameClippingBehavior {
   includeLastFrame,
 }
 
-extension on LastFrameClippingBehavior {
+extension LastFrameClippingBehaviorValue on LastFrameClippingBehavior {
   String toValue() {
     switch (this) {
       case LastFrameClippingBehavior.excludeLastFrame:
@@ -14986,7 +14998,7 @@ extension on LastFrameClippingBehavior {
   }
 }
 
-extension on String {
+extension LastFrameClippingBehaviorFromString on String {
   LastFrameClippingBehavior toLastFrameClippingBehavior() {
     switch (this) {
       case 'EXCLUDE_LAST_FRAME':
@@ -15224,7 +15236,7 @@ enum LogLevel {
   disabled,
 }
 
-extension on LogLevel {
+extension LogLevelValue on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.error:
@@ -15241,7 +15253,7 @@ extension on LogLevel {
   }
 }
 
-extension on String {
+extension LogLevelFromString on String {
   LogLevel toLogLevel() {
     switch (this) {
       case 'ERROR':
@@ -15265,7 +15277,7 @@ enum M2tsAbsentInputAudioBehavior {
   encodeSilence,
 }
 
-extension on M2tsAbsentInputAudioBehavior {
+extension M2tsAbsentInputAudioBehaviorValue on M2tsAbsentInputAudioBehavior {
   String toValue() {
     switch (this) {
       case M2tsAbsentInputAudioBehavior.drop:
@@ -15276,7 +15288,7 @@ extension on M2tsAbsentInputAudioBehavior {
   }
 }
 
-extension on String {
+extension M2tsAbsentInputAudioBehaviorFromString on String {
   M2tsAbsentInputAudioBehavior toM2tsAbsentInputAudioBehavior() {
     switch (this) {
       case 'DROP':
@@ -15294,7 +15306,7 @@ enum M2tsArib {
   enabled,
 }
 
-extension on M2tsArib {
+extension M2tsAribValue on M2tsArib {
   String toValue() {
     switch (this) {
       case M2tsArib.disabled:
@@ -15305,7 +15317,7 @@ extension on M2tsArib {
   }
 }
 
-extension on String {
+extension M2tsAribFromString on String {
   M2tsArib toM2tsArib() {
     switch (this) {
       case 'DISABLED':
@@ -15323,7 +15335,7 @@ enum M2tsAribCaptionsPidControl {
   useConfigured,
 }
 
-extension on M2tsAribCaptionsPidControl {
+extension M2tsAribCaptionsPidControlValue on M2tsAribCaptionsPidControl {
   String toValue() {
     switch (this) {
       case M2tsAribCaptionsPidControl.auto:
@@ -15334,7 +15346,7 @@ extension on M2tsAribCaptionsPidControl {
   }
 }
 
-extension on String {
+extension M2tsAribCaptionsPidControlFromString on String {
   M2tsAribCaptionsPidControl toM2tsAribCaptionsPidControl() {
     switch (this) {
       case 'AUTO':
@@ -15352,7 +15364,7 @@ enum M2tsAudioBufferModel {
   dvb,
 }
 
-extension on M2tsAudioBufferModel {
+extension M2tsAudioBufferModelValue on M2tsAudioBufferModel {
   String toValue() {
     switch (this) {
       case M2tsAudioBufferModel.atsc:
@@ -15363,7 +15375,7 @@ extension on M2tsAudioBufferModel {
   }
 }
 
-extension on String {
+extension M2tsAudioBufferModelFromString on String {
   M2tsAudioBufferModel toM2tsAudioBufferModel() {
     switch (this) {
       case 'ATSC':
@@ -15381,7 +15393,7 @@ enum M2tsAudioInterval {
   videoInterval,
 }
 
-extension on M2tsAudioInterval {
+extension M2tsAudioIntervalValue on M2tsAudioInterval {
   String toValue() {
     switch (this) {
       case M2tsAudioInterval.videoAndFixedIntervals:
@@ -15392,7 +15404,7 @@ extension on M2tsAudioInterval {
   }
 }
 
-extension on String {
+extension M2tsAudioIntervalFromString on String {
   M2tsAudioInterval toM2tsAudioInterval() {
     switch (this) {
       case 'VIDEO_AND_FIXED_INTERVALS':
@@ -15410,7 +15422,7 @@ enum M2tsAudioStreamType {
   dvb,
 }
 
-extension on M2tsAudioStreamType {
+extension M2tsAudioStreamTypeValue on M2tsAudioStreamType {
   String toValue() {
     switch (this) {
       case M2tsAudioStreamType.atsc:
@@ -15421,7 +15433,7 @@ extension on M2tsAudioStreamType {
   }
 }
 
-extension on String {
+extension M2tsAudioStreamTypeFromString on String {
   M2tsAudioStreamType toM2tsAudioStreamType() {
     switch (this) {
       case 'ATSC':
@@ -15439,7 +15451,7 @@ enum M2tsBufferModel {
   none,
 }
 
-extension on M2tsBufferModel {
+extension M2tsBufferModelValue on M2tsBufferModel {
   String toValue() {
     switch (this) {
       case M2tsBufferModel.multiplex:
@@ -15450,7 +15462,7 @@ extension on M2tsBufferModel {
   }
 }
 
-extension on String {
+extension M2tsBufferModelFromString on String {
   M2tsBufferModel toM2tsBufferModel() {
     switch (this) {
       case 'MULTIPLEX':
@@ -15468,7 +15480,7 @@ enum M2tsCcDescriptor {
   enabled,
 }
 
-extension on M2tsCcDescriptor {
+extension M2tsCcDescriptorValue on M2tsCcDescriptor {
   String toValue() {
     switch (this) {
       case M2tsCcDescriptor.disabled:
@@ -15479,7 +15491,7 @@ extension on M2tsCcDescriptor {
   }
 }
 
-extension on String {
+extension M2tsCcDescriptorFromString on String {
   M2tsCcDescriptor toM2tsCcDescriptor() {
     switch (this) {
       case 'DISABLED':
@@ -15497,7 +15509,7 @@ enum M2tsEbifControl {
   passthrough,
 }
 
-extension on M2tsEbifControl {
+extension M2tsEbifControlValue on M2tsEbifControl {
   String toValue() {
     switch (this) {
       case M2tsEbifControl.none:
@@ -15508,7 +15520,7 @@ extension on M2tsEbifControl {
   }
 }
 
-extension on String {
+extension M2tsEbifControlFromString on String {
   M2tsEbifControl toM2tsEbifControl() {
     switch (this) {
       case 'NONE':
@@ -15526,7 +15538,7 @@ enum M2tsEbpPlacement {
   videoPid,
 }
 
-extension on M2tsEbpPlacement {
+extension M2tsEbpPlacementValue on M2tsEbpPlacement {
   String toValue() {
     switch (this) {
       case M2tsEbpPlacement.videoAndAudioPids:
@@ -15537,7 +15549,7 @@ extension on M2tsEbpPlacement {
   }
 }
 
-extension on String {
+extension M2tsEbpPlacementFromString on String {
   M2tsEbpPlacement toM2tsEbpPlacement() {
     switch (this) {
       case 'VIDEO_AND_AUDIO_PIDS':
@@ -15555,7 +15567,7 @@ enum M2tsEsRateInPes {
   include,
 }
 
-extension on M2tsEsRateInPes {
+extension M2tsEsRateInPesValue on M2tsEsRateInPes {
   String toValue() {
     switch (this) {
       case M2tsEsRateInPes.exclude:
@@ -15566,7 +15578,7 @@ extension on M2tsEsRateInPes {
   }
 }
 
-extension on String {
+extension M2tsEsRateInPesFromString on String {
   M2tsEsRateInPes toM2tsEsRateInPes() {
     switch (this) {
       case 'EXCLUDE':
@@ -15584,7 +15596,7 @@ enum M2tsKlv {
   passthrough,
 }
 
-extension on M2tsKlv {
+extension M2tsKlvValue on M2tsKlv {
   String toValue() {
     switch (this) {
       case M2tsKlv.none:
@@ -15595,7 +15607,7 @@ extension on M2tsKlv {
   }
 }
 
-extension on String {
+extension M2tsKlvFromString on String {
   M2tsKlv toM2tsKlv() {
     switch (this) {
       case 'NONE':
@@ -15613,7 +15625,7 @@ enum M2tsNielsenId3Behavior {
   passthrough,
 }
 
-extension on M2tsNielsenId3Behavior {
+extension M2tsNielsenId3BehaviorValue on M2tsNielsenId3Behavior {
   String toValue() {
     switch (this) {
       case M2tsNielsenId3Behavior.noPassthrough:
@@ -15624,7 +15636,7 @@ extension on M2tsNielsenId3Behavior {
   }
 }
 
-extension on String {
+extension M2tsNielsenId3BehaviorFromString on String {
   M2tsNielsenId3Behavior toM2tsNielsenId3Behavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -15642,7 +15654,7 @@ enum M2tsPcrControl {
   pcrEveryPesPacket,
 }
 
-extension on M2tsPcrControl {
+extension M2tsPcrControlValue on M2tsPcrControl {
   String toValue() {
     switch (this) {
       case M2tsPcrControl.configuredPcrPeriod:
@@ -15653,7 +15665,7 @@ extension on M2tsPcrControl {
   }
 }
 
-extension on String {
+extension M2tsPcrControlFromString on String {
   M2tsPcrControl toM2tsPcrControl() {
     switch (this) {
       case 'CONFIGURED_PCR_PERIOD':
@@ -15671,7 +15683,7 @@ enum M2tsRateMode {
   vbr,
 }
 
-extension on M2tsRateMode {
+extension M2tsRateModeValue on M2tsRateMode {
   String toValue() {
     switch (this) {
       case M2tsRateMode.cbr:
@@ -15682,7 +15694,7 @@ extension on M2tsRateMode {
   }
 }
 
-extension on String {
+extension M2tsRateModeFromString on String {
   M2tsRateMode toM2tsRateMode() {
     switch (this) {
       case 'CBR':
@@ -15700,7 +15712,7 @@ enum M2tsScte35Control {
   passthrough,
 }
 
-extension on M2tsScte35Control {
+extension M2tsScte35ControlValue on M2tsScte35Control {
   String toValue() {
     switch (this) {
       case M2tsScte35Control.none:
@@ -15711,7 +15723,7 @@ extension on M2tsScte35Control {
   }
 }
 
-extension on String {
+extension M2tsScte35ControlFromString on String {
   M2tsScte35Control toM2tsScte35Control() {
     switch (this) {
       case 'NONE':
@@ -15733,7 +15745,7 @@ enum M2tsSegmentationMarkers {
   raiSegstart,
 }
 
-extension on M2tsSegmentationMarkers {
+extension M2tsSegmentationMarkersValue on M2tsSegmentationMarkers {
   String toValue() {
     switch (this) {
       case M2tsSegmentationMarkers.ebp:
@@ -15752,7 +15764,7 @@ extension on M2tsSegmentationMarkers {
   }
 }
 
-extension on String {
+extension M2tsSegmentationMarkersFromString on String {
   M2tsSegmentationMarkers toM2tsSegmentationMarkers() {
     switch (this) {
       case 'EBP':
@@ -15778,7 +15790,7 @@ enum M2tsSegmentationStyle {
   resetCadence,
 }
 
-extension on M2tsSegmentationStyle {
+extension M2tsSegmentationStyleValue on M2tsSegmentationStyle {
   String toValue() {
     switch (this) {
       case M2tsSegmentationStyle.maintainCadence:
@@ -15789,7 +15801,7 @@ extension on M2tsSegmentationStyle {
   }
 }
 
-extension on String {
+extension M2tsSegmentationStyleFromString on String {
   M2tsSegmentationStyle toM2tsSegmentationStyle() {
     switch (this) {
       case 'MAINTAIN_CADENCE':
@@ -16273,7 +16285,7 @@ enum M2tsTimedMetadataBehavior {
   passthrough,
 }
 
-extension on M2tsTimedMetadataBehavior {
+extension M2tsTimedMetadataBehaviorValue on M2tsTimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case M2tsTimedMetadataBehavior.noPassthrough:
@@ -16284,7 +16296,7 @@ extension on M2tsTimedMetadataBehavior {
   }
 }
 
-extension on String {
+extension M2tsTimedMetadataBehaviorFromString on String {
   M2tsTimedMetadataBehavior toM2tsTimedMetadataBehavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -16302,7 +16314,7 @@ enum M3u8NielsenId3Behavior {
   passthrough,
 }
 
-extension on M3u8NielsenId3Behavior {
+extension M3u8NielsenId3BehaviorValue on M3u8NielsenId3Behavior {
   String toValue() {
     switch (this) {
       case M3u8NielsenId3Behavior.noPassthrough:
@@ -16313,7 +16325,7 @@ extension on M3u8NielsenId3Behavior {
   }
 }
 
-extension on String {
+extension M3u8NielsenId3BehaviorFromString on String {
   M3u8NielsenId3Behavior toM3u8NielsenId3Behavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -16331,7 +16343,7 @@ enum M3u8PcrControl {
   pcrEveryPesPacket,
 }
 
-extension on M3u8PcrControl {
+extension M3u8PcrControlValue on M3u8PcrControl {
   String toValue() {
     switch (this) {
       case M3u8PcrControl.configuredPcrPeriod:
@@ -16342,7 +16354,7 @@ extension on M3u8PcrControl {
   }
 }
 
-extension on String {
+extension M3u8PcrControlFromString on String {
   M3u8PcrControl toM3u8PcrControl() {
     switch (this) {
       case 'CONFIGURED_PCR_PERIOD':
@@ -16360,7 +16372,7 @@ enum M3u8Scte35Behavior {
   passthrough,
 }
 
-extension on M3u8Scte35Behavior {
+extension M3u8Scte35BehaviorValue on M3u8Scte35Behavior {
   String toValue() {
     switch (this) {
       case M3u8Scte35Behavior.noPassthrough:
@@ -16371,7 +16383,7 @@ extension on M3u8Scte35Behavior {
   }
 }
 
-extension on String {
+extension M3u8Scte35BehaviorFromString on String {
   M3u8Scte35Behavior toM3u8Scte35Behavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -16547,7 +16559,7 @@ enum M3u8TimedMetadataBehavior {
   passthrough,
 }
 
-extension on M3u8TimedMetadataBehavior {
+extension M3u8TimedMetadataBehaviorValue on M3u8TimedMetadataBehavior {
   String toValue() {
     switch (this) {
       case M3u8TimedMetadataBehavior.noPassthrough:
@@ -16558,7 +16570,7 @@ extension on M3u8TimedMetadataBehavior {
   }
 }
 
-extension on String {
+extension M3u8TimedMetadataBehaviorFromString on String {
   M3u8TimedMetadataBehavior toM3u8TimedMetadataBehavior() {
     switch (this) {
       case 'NO_PASSTHROUGH':
@@ -16669,7 +16681,7 @@ enum Mp2CodingMode {
   codingMode_2_0,
 }
 
-extension on Mp2CodingMode {
+extension Mp2CodingModeValue on Mp2CodingMode {
   String toValue() {
     switch (this) {
       case Mp2CodingMode.codingMode_1_0:
@@ -16680,7 +16692,7 @@ extension on Mp2CodingMode {
   }
 }
 
-extension on String {
+extension Mp2CodingModeFromString on String {
   Mp2CodingMode toMp2CodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -16738,7 +16750,7 @@ enum Mpeg2AdaptiveQuantization {
   off,
 }
 
-extension on Mpeg2AdaptiveQuantization {
+extension Mpeg2AdaptiveQuantizationValue on Mpeg2AdaptiveQuantization {
   String toValue() {
     switch (this) {
       case Mpeg2AdaptiveQuantization.auto:
@@ -16755,7 +16767,7 @@ extension on Mpeg2AdaptiveQuantization {
   }
 }
 
-extension on String {
+extension Mpeg2AdaptiveQuantizationFromString on String {
   Mpeg2AdaptiveQuantization toMpeg2AdaptiveQuantization() {
     switch (this) {
       case 'AUTO':
@@ -16779,7 +16791,7 @@ enum Mpeg2ColorMetadata {
   insert,
 }
 
-extension on Mpeg2ColorMetadata {
+extension Mpeg2ColorMetadataValue on Mpeg2ColorMetadata {
   String toValue() {
     switch (this) {
       case Mpeg2ColorMetadata.ignore:
@@ -16790,7 +16802,7 @@ extension on Mpeg2ColorMetadata {
   }
 }
 
-extension on String {
+extension Mpeg2ColorMetadataFromString on String {
   Mpeg2ColorMetadata toMpeg2ColorMetadata() {
     switch (this) {
       case 'IGNORE':
@@ -16808,7 +16820,7 @@ enum Mpeg2ColorSpace {
   passthrough,
 }
 
-extension on Mpeg2ColorSpace {
+extension Mpeg2ColorSpaceValue on Mpeg2ColorSpace {
   String toValue() {
     switch (this) {
       case Mpeg2ColorSpace.auto:
@@ -16819,7 +16831,7 @@ extension on Mpeg2ColorSpace {
   }
 }
 
-extension on String {
+extension Mpeg2ColorSpaceFromString on String {
   Mpeg2ColorSpace toMpeg2ColorSpace() {
     switch (this) {
       case 'AUTO':
@@ -16837,7 +16849,7 @@ enum Mpeg2DisplayRatio {
   displayratio4x3,
 }
 
-extension on Mpeg2DisplayRatio {
+extension Mpeg2DisplayRatioValue on Mpeg2DisplayRatio {
   String toValue() {
     switch (this) {
       case Mpeg2DisplayRatio.displayratio16x9:
@@ -16848,7 +16860,7 @@ extension on Mpeg2DisplayRatio {
   }
 }
 
-extension on String {
+extension Mpeg2DisplayRatioFromString on String {
   Mpeg2DisplayRatio toMpeg2DisplayRatio() {
     switch (this) {
       case 'DISPLAYRATIO16X9':
@@ -16891,7 +16903,7 @@ enum Mpeg2GopSizeUnits {
   seconds,
 }
 
-extension on Mpeg2GopSizeUnits {
+extension Mpeg2GopSizeUnitsValue on Mpeg2GopSizeUnits {
   String toValue() {
     switch (this) {
       case Mpeg2GopSizeUnits.frames:
@@ -16902,7 +16914,7 @@ extension on Mpeg2GopSizeUnits {
   }
 }
 
-extension on String {
+extension Mpeg2GopSizeUnitsFromString on String {
   Mpeg2GopSizeUnits toMpeg2GopSizeUnits() {
     switch (this) {
       case 'FRAMES':
@@ -16920,7 +16932,7 @@ enum Mpeg2ScanType {
   progressive,
 }
 
-extension on Mpeg2ScanType {
+extension Mpeg2ScanTypeValue on Mpeg2ScanType {
   String toValue() {
     switch (this) {
       case Mpeg2ScanType.interlaced:
@@ -16931,7 +16943,7 @@ extension on Mpeg2ScanType {
   }
 }
 
-extension on String {
+extension Mpeg2ScanTypeFromString on String {
   Mpeg2ScanType toMpeg2ScanType() {
     switch (this) {
       case 'INTERLACED':
@@ -17136,7 +17148,7 @@ enum Mpeg2SubGopLength {
   fixed,
 }
 
-extension on Mpeg2SubGopLength {
+extension Mpeg2SubGopLengthValue on Mpeg2SubGopLength {
   String toValue() {
     switch (this) {
       case Mpeg2SubGopLength.dynamic:
@@ -17147,7 +17159,7 @@ extension on Mpeg2SubGopLength {
   }
 }
 
-extension on String {
+extension Mpeg2SubGopLengthFromString on String {
   Mpeg2SubGopLength toMpeg2SubGopLength() {
     switch (this) {
       case 'DYNAMIC':
@@ -17165,7 +17177,8 @@ enum Mpeg2TimecodeInsertionBehavior {
   gopTimecode,
 }
 
-extension on Mpeg2TimecodeInsertionBehavior {
+extension Mpeg2TimecodeInsertionBehaviorValue
+    on Mpeg2TimecodeInsertionBehavior {
   String toValue() {
     switch (this) {
       case Mpeg2TimecodeInsertionBehavior.disabled:
@@ -17176,7 +17189,7 @@ extension on Mpeg2TimecodeInsertionBehavior {
   }
 }
 
-extension on String {
+extension Mpeg2TimecodeInsertionBehaviorFromString on String {
   Mpeg2TimecodeInsertionBehavior toMpeg2TimecodeInsertionBehavior() {
     switch (this) {
       case 'DISABLED':
@@ -17390,7 +17403,7 @@ enum MsSmoothH265PackagingType {
   hvc1,
 }
 
-extension on MsSmoothH265PackagingType {
+extension MsSmoothH265PackagingTypeValue on MsSmoothH265PackagingType {
   String toValue() {
     switch (this) {
       case MsSmoothH265PackagingType.hev1:
@@ -17401,7 +17414,7 @@ extension on MsSmoothH265PackagingType {
   }
 }
 
-extension on String {
+extension MsSmoothH265PackagingTypeFromString on String {
   MsSmoothH265PackagingType toMsSmoothH265PackagingType() {
     switch (this) {
       case 'HEV1':
@@ -17933,7 +17946,7 @@ enum MultiplexState {
   deleted,
 }
 
-extension on MultiplexState {
+extension MultiplexStateValue on MultiplexState {
   String toValue() {
     switch (this) {
       case MultiplexState.creating:
@@ -17958,7 +17971,7 @@ extension on MultiplexState {
   }
 }
 
-extension on String {
+extension MultiplexStateFromString on String {
   MultiplexState toMultiplexState() {
     switch (this) {
       case 'CREATING':
@@ -18126,7 +18139,7 @@ enum NetworkInputServerValidation {
   checkCryptographyOnly,
 }
 
-extension on NetworkInputServerValidation {
+extension NetworkInputServerValidationValue on NetworkInputServerValidation {
   String toValue() {
     switch (this) {
       case NetworkInputServerValidation.checkCryptographyAndValidateName:
@@ -18137,7 +18150,7 @@ extension on NetworkInputServerValidation {
   }
 }
 
-extension on String {
+extension NetworkInputServerValidationFromString on String {
   NetworkInputServerValidation toNetworkInputServerValidation() {
     switch (this) {
       case 'CHECK_CRYPTOGRAPHY_AND_VALIDATE_NAME':
@@ -18226,7 +18239,7 @@ enum NielsenPcmToId3TaggingState {
   enabled,
 }
 
-extension on NielsenPcmToId3TaggingState {
+extension NielsenPcmToId3TaggingStateValue on NielsenPcmToId3TaggingState {
   String toValue() {
     switch (this) {
       case NielsenPcmToId3TaggingState.disabled:
@@ -18237,7 +18250,7 @@ extension on NielsenPcmToId3TaggingState {
   }
 }
 
-extension on String {
+extension NielsenPcmToId3TaggingStateFromString on String {
   NielsenPcmToId3TaggingState toNielsenPcmToId3TaggingState() {
     switch (this) {
       case 'DISABLED':
@@ -18326,7 +18339,7 @@ enum OfferingDurationUnits {
   months,
 }
 
-extension on OfferingDurationUnits {
+extension OfferingDurationUnitsValue on OfferingDurationUnits {
   String toValue() {
     switch (this) {
       case OfferingDurationUnits.months:
@@ -18335,7 +18348,7 @@ extension on OfferingDurationUnits {
   }
 }
 
-extension on String {
+extension OfferingDurationUnitsFromString on String {
   OfferingDurationUnits toOfferingDurationUnits() {
     switch (this) {
       case 'MONTHS':
@@ -18350,7 +18363,7 @@ enum OfferingType {
   noUpfront,
 }
 
-extension on OfferingType {
+extension OfferingTypeValue on OfferingType {
   String toValue() {
     switch (this) {
       case OfferingType.noUpfront:
@@ -18359,7 +18372,7 @@ extension on OfferingType {
   }
 }
 
-extension on String {
+extension OfferingTypeFromString on String {
   OfferingType toOfferingType() {
     switch (this) {
       case 'NO_UPFRONT':
@@ -18834,7 +18847,7 @@ enum PipelineId {
   pipeline_1,
 }
 
-extension on PipelineId {
+extension PipelineIdValue on PipelineId {
   String toValue() {
     switch (this) {
       case PipelineId.pipeline_0:
@@ -18845,7 +18858,7 @@ extension on PipelineId {
   }
 }
 
-extension on String {
+extension PipelineIdFromString on String {
   PipelineId toPipelineId() {
     switch (this) {
       case 'PIPELINE_0':
@@ -18893,7 +18906,7 @@ enum PreferredChannelPipeline {
   pipeline_1,
 }
 
-extension on PreferredChannelPipeline {
+extension PreferredChannelPipelineValue on PreferredChannelPipeline {
   String toValue() {
     switch (this) {
       case PreferredChannelPipeline.currentlyActive:
@@ -18906,7 +18919,7 @@ extension on PreferredChannelPipeline {
   }
 }
 
-extension on String {
+extension PreferredChannelPipelineFromString on String {
   PreferredChannelPipeline toPreferredChannelPipeline() {
     switch (this) {
       case 'CURRENTLY_ACTIVE':
@@ -19140,7 +19153,7 @@ enum ReservationCodec {
   link,
 }
 
-extension on ReservationCodec {
+extension ReservationCodecValue on ReservationCodec {
   String toValue() {
     switch (this) {
       case ReservationCodec.mpeg2:
@@ -19157,7 +19170,7 @@ extension on ReservationCodec {
   }
 }
 
-extension on String {
+extension ReservationCodecFromString on String {
   ReservationCodec toReservationCodec() {
     switch (this) {
       case 'MPEG2':
@@ -19182,7 +19195,7 @@ enum ReservationMaximumBitrate {
   max_50Mbps,
 }
 
-extension on ReservationMaximumBitrate {
+extension ReservationMaximumBitrateValue on ReservationMaximumBitrate {
   String toValue() {
     switch (this) {
       case ReservationMaximumBitrate.max_10Mbps:
@@ -19195,7 +19208,7 @@ extension on ReservationMaximumBitrate {
   }
 }
 
-extension on String {
+extension ReservationMaximumBitrateFromString on String {
   ReservationMaximumBitrate toReservationMaximumBitrate() {
     switch (this) {
       case 'MAX_10_MBPS':
@@ -19215,7 +19228,7 @@ enum ReservationMaximumFramerate {
   max_60Fps,
 }
 
-extension on ReservationMaximumFramerate {
+extension ReservationMaximumFramerateValue on ReservationMaximumFramerate {
   String toValue() {
     switch (this) {
       case ReservationMaximumFramerate.max_30Fps:
@@ -19226,7 +19239,7 @@ extension on ReservationMaximumFramerate {
   }
 }
 
-extension on String {
+extension ReservationMaximumFramerateFromString on String {
   ReservationMaximumFramerate toReservationMaximumFramerate() {
     switch (this) {
       case 'MAX_30_FPS':
@@ -19247,7 +19260,7 @@ enum ReservationResolution {
   uhd,
 }
 
-extension on ReservationResolution {
+extension ReservationResolutionValue on ReservationResolution {
   String toValue() {
     switch (this) {
       case ReservationResolution.sd:
@@ -19262,7 +19275,7 @@ extension on ReservationResolution {
   }
 }
 
-extension on String {
+extension ReservationResolutionFromString on String {
   ReservationResolution toReservationResolution() {
     switch (this) {
       case 'SD':
@@ -19341,7 +19354,7 @@ enum ReservationResourceType {
   channel,
 }
 
-extension on ReservationResourceType {
+extension ReservationResourceTypeValue on ReservationResourceType {
   String toValue() {
     switch (this) {
       case ReservationResourceType.input:
@@ -19356,7 +19369,7 @@ extension on ReservationResourceType {
   }
 }
 
-extension on String {
+extension ReservationResourceTypeFromString on String {
   ReservationResourceType toReservationResourceType() {
     switch (this) {
       case 'INPUT':
@@ -19378,7 +19391,7 @@ enum ReservationSpecialFeature {
   audioNormalization,
 }
 
-extension on ReservationSpecialFeature {
+extension ReservationSpecialFeatureValue on ReservationSpecialFeature {
   String toValue() {
     switch (this) {
       case ReservationSpecialFeature.advancedAudio:
@@ -19389,7 +19402,7 @@ extension on ReservationSpecialFeature {
   }
 }
 
-extension on String {
+extension ReservationSpecialFeatureFromString on String {
   ReservationSpecialFeature toReservationSpecialFeature() {
     switch (this) {
       case 'ADVANCED_AUDIO':
@@ -19409,7 +19422,7 @@ enum ReservationState {
   deleted,
 }
 
-extension on ReservationState {
+extension ReservationStateValue on ReservationState {
   String toValue() {
     switch (this) {
       case ReservationState.active:
@@ -19424,7 +19437,7 @@ extension on ReservationState {
   }
 }
 
-extension on String {
+extension ReservationStateFromString on String {
   ReservationState toReservationState() {
     switch (this) {
       case 'ACTIVE':
@@ -19447,7 +19460,7 @@ enum ReservationVideoQuality {
   premium,
 }
 
-extension on ReservationVideoQuality {
+extension ReservationVideoQualityValue on ReservationVideoQuality {
   String toValue() {
     switch (this) {
       case ReservationVideoQuality.standard:
@@ -19460,7 +19473,7 @@ extension on ReservationVideoQuality {
   }
 }
 
-extension on String {
+extension ReservationVideoQualityFromString on String {
   ReservationVideoQuality toReservationVideoQuality() {
     switch (this) {
       case 'STANDARD':
@@ -19479,7 +19492,7 @@ enum RtmpAdMarkers {
   onCuePointScte35,
 }
 
-extension on RtmpAdMarkers {
+extension RtmpAdMarkersValue on RtmpAdMarkers {
   String toValue() {
     switch (this) {
       case RtmpAdMarkers.onCuePointScte35:
@@ -19488,7 +19501,7 @@ extension on RtmpAdMarkers {
   }
 }
 
-extension on String {
+extension RtmpAdMarkersFromString on String {
   RtmpAdMarkers toRtmpAdMarkers() {
     switch (this) {
       case 'ON_CUE_POINT_SCTE35':
@@ -19504,7 +19517,7 @@ enum RtmpCacheFullBehavior {
   waitForServer,
 }
 
-extension on RtmpCacheFullBehavior {
+extension RtmpCacheFullBehaviorValue on RtmpCacheFullBehavior {
   String toValue() {
     switch (this) {
       case RtmpCacheFullBehavior.disconnectImmediately:
@@ -19515,7 +19528,7 @@ extension on RtmpCacheFullBehavior {
   }
 }
 
-extension on String {
+extension RtmpCacheFullBehaviorFromString on String {
   RtmpCacheFullBehavior toRtmpCacheFullBehavior() {
     switch (this) {
       case 'DISCONNECT_IMMEDIATELY':
@@ -19534,7 +19547,7 @@ enum RtmpCaptionData {
   field1AndField2_608,
 }
 
-extension on RtmpCaptionData {
+extension RtmpCaptionDataValue on RtmpCaptionData {
   String toValue() {
     switch (this) {
       case RtmpCaptionData.all:
@@ -19547,7 +19560,7 @@ extension on RtmpCaptionData {
   }
 }
 
-extension on String {
+extension RtmpCaptionDataFromString on String {
   RtmpCaptionData toRtmpCaptionData() {
     switch (this) {
       case 'ALL':
@@ -19670,7 +19683,7 @@ enum RtmpOutputCertificateMode {
   verifyAuthenticity,
 }
 
-extension on RtmpOutputCertificateMode {
+extension RtmpOutputCertificateModeValue on RtmpOutputCertificateMode {
   String toValue() {
     switch (this) {
       case RtmpOutputCertificateMode.selfSigned:
@@ -19681,7 +19694,7 @@ extension on RtmpOutputCertificateMode {
   }
 }
 
-extension on String {
+extension RtmpOutputCertificateModeFromString on String {
   RtmpOutputCertificateMode toRtmpOutputCertificateMode() {
     switch (this) {
       case 'SELF_SIGNED':
@@ -19985,7 +19998,7 @@ enum Scte20Convert608To708 {
   upconvert,
 }
 
-extension on Scte20Convert608To708 {
+extension Scte20Convert608To708Value on Scte20Convert608To708 {
   String toValue() {
     switch (this) {
       case Scte20Convert608To708.disabled:
@@ -19996,7 +20009,7 @@ extension on Scte20Convert608To708 {
   }
 }
 
-extension on String {
+extension Scte20Convert608To708FromString on String {
   Scte20Convert608To708 toScte20Convert608To708() {
     switch (this) {
       case 'DISABLED':
@@ -20103,7 +20116,8 @@ enum Scte35AposNoRegionalBlackoutBehavior {
   ignore,
 }
 
-extension on Scte35AposNoRegionalBlackoutBehavior {
+extension Scte35AposNoRegionalBlackoutBehaviorValue
+    on Scte35AposNoRegionalBlackoutBehavior {
   String toValue() {
     switch (this) {
       case Scte35AposNoRegionalBlackoutBehavior.follow:
@@ -20114,7 +20128,7 @@ extension on Scte35AposNoRegionalBlackoutBehavior {
   }
 }
 
-extension on String {
+extension Scte35AposNoRegionalBlackoutBehaviorFromString on String {
   Scte35AposNoRegionalBlackoutBehavior
       toScte35AposNoRegionalBlackoutBehavior() {
     switch (this) {
@@ -20134,7 +20148,8 @@ enum Scte35AposWebDeliveryAllowedBehavior {
   ignore,
 }
 
-extension on Scte35AposWebDeliveryAllowedBehavior {
+extension Scte35AposWebDeliveryAllowedBehaviorValue
+    on Scte35AposWebDeliveryAllowedBehavior {
   String toValue() {
     switch (this) {
       case Scte35AposWebDeliveryAllowedBehavior.follow:
@@ -20145,7 +20160,7 @@ extension on Scte35AposWebDeliveryAllowedBehavior {
   }
 }
 
-extension on String {
+extension Scte35AposWebDeliveryAllowedBehaviorFromString on String {
   Scte35AposWebDeliveryAllowedBehavior
       toScte35AposWebDeliveryAllowedBehavior() {
     switch (this) {
@@ -20167,7 +20182,7 @@ enum Scte35ArchiveAllowedFlag {
   archiveAllowed,
 }
 
-extension on Scte35ArchiveAllowedFlag {
+extension Scte35ArchiveAllowedFlagValue on Scte35ArchiveAllowedFlag {
   String toValue() {
     switch (this) {
       case Scte35ArchiveAllowedFlag.archiveNotAllowed:
@@ -20178,7 +20193,7 @@ extension on Scte35ArchiveAllowedFlag {
   }
 }
 
-extension on String {
+extension Scte35ArchiveAllowedFlagFromString on String {
   Scte35ArchiveAllowedFlag toScte35ArchiveAllowedFlag() {
     switch (this) {
       case 'ARCHIVE_NOT_ALLOWED':
@@ -20300,7 +20315,7 @@ enum Scte35DeviceRestrictions {
   restrictGroup2,
 }
 
-extension on Scte35DeviceRestrictions {
+extension Scte35DeviceRestrictionsValue on Scte35DeviceRestrictions {
   String toValue() {
     switch (this) {
       case Scte35DeviceRestrictions.none:
@@ -20315,7 +20330,7 @@ extension on Scte35DeviceRestrictions {
   }
 }
 
-extension on String {
+extension Scte35DeviceRestrictionsFromString on String {
   Scte35DeviceRestrictions toScte35DeviceRestrictions() {
     switch (this) {
       case 'NONE':
@@ -20340,7 +20355,7 @@ enum Scte35NoRegionalBlackoutFlag {
   noRegionalBlackout,
 }
 
-extension on Scte35NoRegionalBlackoutFlag {
+extension Scte35NoRegionalBlackoutFlagValue on Scte35NoRegionalBlackoutFlag {
   String toValue() {
     switch (this) {
       case Scte35NoRegionalBlackoutFlag.regionalBlackout:
@@ -20351,7 +20366,7 @@ extension on Scte35NoRegionalBlackoutFlag {
   }
 }
 
-extension on String {
+extension Scte35NoRegionalBlackoutFlagFromString on String {
   Scte35NoRegionalBlackoutFlag toScte35NoRegionalBlackoutFlag() {
     switch (this) {
       case 'REGIONAL_BLACKOUT':
@@ -20397,7 +20412,8 @@ enum Scte35SegmentationCancelIndicator {
   segmentationEventCanceled,
 }
 
-extension on Scte35SegmentationCancelIndicator {
+extension Scte35SegmentationCancelIndicatorValue
+    on Scte35SegmentationCancelIndicator {
   String toValue() {
     switch (this) {
       case Scte35SegmentationCancelIndicator.segmentationEventNotCanceled:
@@ -20408,7 +20424,7 @@ extension on Scte35SegmentationCancelIndicator {
   }
 }
 
-extension on String {
+extension Scte35SegmentationCancelIndicatorFromString on String {
   Scte35SegmentationCancelIndicator toScte35SegmentationCancelIndicator() {
     switch (this) {
       case 'SEGMENTATION_EVENT_NOT_CANCELED':
@@ -20591,7 +20607,8 @@ enum Scte35SpliceInsertNoRegionalBlackoutBehavior {
   ignore,
 }
 
-extension on Scte35SpliceInsertNoRegionalBlackoutBehavior {
+extension Scte35SpliceInsertNoRegionalBlackoutBehaviorValue
+    on Scte35SpliceInsertNoRegionalBlackoutBehavior {
   String toValue() {
     switch (this) {
       case Scte35SpliceInsertNoRegionalBlackoutBehavior.follow:
@@ -20602,7 +20619,7 @@ extension on Scte35SpliceInsertNoRegionalBlackoutBehavior {
   }
 }
 
-extension on String {
+extension Scte35SpliceInsertNoRegionalBlackoutBehaviorFromString on String {
   Scte35SpliceInsertNoRegionalBlackoutBehavior
       toScte35SpliceInsertNoRegionalBlackoutBehavior() {
     switch (this) {
@@ -20657,7 +20674,8 @@ enum Scte35SpliceInsertWebDeliveryAllowedBehavior {
   ignore,
 }
 
-extension on Scte35SpliceInsertWebDeliveryAllowedBehavior {
+extension Scte35SpliceInsertWebDeliveryAllowedBehaviorValue
+    on Scte35SpliceInsertWebDeliveryAllowedBehavior {
   String toValue() {
     switch (this) {
       case Scte35SpliceInsertWebDeliveryAllowedBehavior.follow:
@@ -20668,7 +20686,7 @@ extension on Scte35SpliceInsertWebDeliveryAllowedBehavior {
   }
 }
 
-extension on String {
+extension Scte35SpliceInsertWebDeliveryAllowedBehaviorFromString on String {
   Scte35SpliceInsertWebDeliveryAllowedBehavior
       toScte35SpliceInsertWebDeliveryAllowedBehavior() {
     switch (this) {
@@ -20761,7 +20779,7 @@ enum Scte35WebDeliveryAllowedFlag {
   webDeliveryAllowed,
 }
 
-extension on Scte35WebDeliveryAllowedFlag {
+extension Scte35WebDeliveryAllowedFlagValue on Scte35WebDeliveryAllowedFlag {
   String toValue() {
     switch (this) {
       case Scte35WebDeliveryAllowedFlag.webDeliveryNotAllowed:
@@ -20772,7 +20790,7 @@ extension on Scte35WebDeliveryAllowedFlag {
   }
 }
 
-extension on String {
+extension Scte35WebDeliveryAllowedFlagFromString on String {
   Scte35WebDeliveryAllowedFlag toScte35WebDeliveryAllowedFlag() {
     switch (this) {
       case 'WEB_DELIVERY_NOT_ALLOWED':
@@ -20790,7 +20808,8 @@ enum SmoothGroupAudioOnlyTimecodeControl {
   useConfiguredClock,
 }
 
-extension on SmoothGroupAudioOnlyTimecodeControl {
+extension SmoothGroupAudioOnlyTimecodeControlValue
+    on SmoothGroupAudioOnlyTimecodeControl {
   String toValue() {
     switch (this) {
       case SmoothGroupAudioOnlyTimecodeControl.passthrough:
@@ -20801,7 +20820,7 @@ extension on SmoothGroupAudioOnlyTimecodeControl {
   }
 }
 
-extension on String {
+extension SmoothGroupAudioOnlyTimecodeControlFromString on String {
   SmoothGroupAudioOnlyTimecodeControl toSmoothGroupAudioOnlyTimecodeControl() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -20820,7 +20839,7 @@ enum SmoothGroupCertificateMode {
   verifyAuthenticity,
 }
 
-extension on SmoothGroupCertificateMode {
+extension SmoothGroupCertificateModeValue on SmoothGroupCertificateMode {
   String toValue() {
     switch (this) {
       case SmoothGroupCertificateMode.selfSigned:
@@ -20831,7 +20850,7 @@ extension on SmoothGroupCertificateMode {
   }
 }
 
-extension on String {
+extension SmoothGroupCertificateModeFromString on String {
   SmoothGroupCertificateMode toSmoothGroupCertificateMode() {
     switch (this) {
       case 'SELF_SIGNED':
@@ -20850,7 +20869,7 @@ enum SmoothGroupEventIdMode {
   useTimestamp,
 }
 
-extension on SmoothGroupEventIdMode {
+extension SmoothGroupEventIdModeValue on SmoothGroupEventIdMode {
   String toValue() {
     switch (this) {
       case SmoothGroupEventIdMode.noEventId:
@@ -20863,7 +20882,7 @@ extension on SmoothGroupEventIdMode {
   }
 }
 
-extension on String {
+extension SmoothGroupEventIdModeFromString on String {
   SmoothGroupEventIdMode toSmoothGroupEventIdMode() {
     switch (this) {
       case 'NO_EVENT_ID':
@@ -20883,7 +20902,7 @@ enum SmoothGroupEventStopBehavior {
   sendEos,
 }
 
-extension on SmoothGroupEventStopBehavior {
+extension SmoothGroupEventStopBehaviorValue on SmoothGroupEventStopBehavior {
   String toValue() {
     switch (this) {
       case SmoothGroupEventStopBehavior.none:
@@ -20894,7 +20913,7 @@ extension on SmoothGroupEventStopBehavior {
   }
 }
 
-extension on String {
+extension SmoothGroupEventStopBehaviorFromString on String {
   SmoothGroupEventStopBehavior toSmoothGroupEventStopBehavior() {
     switch (this) {
       case 'NONE':
@@ -20912,7 +20931,7 @@ enum SmoothGroupSegmentationMode {
   useSegmentDuration,
 }
 
-extension on SmoothGroupSegmentationMode {
+extension SmoothGroupSegmentationModeValue on SmoothGroupSegmentationMode {
   String toValue() {
     switch (this) {
       case SmoothGroupSegmentationMode.useInputSegmentation:
@@ -20923,7 +20942,7 @@ extension on SmoothGroupSegmentationMode {
   }
 }
 
-extension on String {
+extension SmoothGroupSegmentationModeFromString on String {
   SmoothGroupSegmentationMode toSmoothGroupSegmentationMode() {
     switch (this) {
       case 'USE_INPUT_SEGMENTATION':
@@ -20942,7 +20961,7 @@ enum SmoothGroupSparseTrackType {
   scte_35WithoutSegmentation,
 }
 
-extension on SmoothGroupSparseTrackType {
+extension SmoothGroupSparseTrackTypeValue on SmoothGroupSparseTrackType {
   String toValue() {
     switch (this) {
       case SmoothGroupSparseTrackType.none:
@@ -20955,7 +20974,7 @@ extension on SmoothGroupSparseTrackType {
   }
 }
 
-extension on String {
+extension SmoothGroupSparseTrackTypeFromString on String {
   SmoothGroupSparseTrackType toSmoothGroupSparseTrackType() {
     switch (this) {
       case 'NONE':
@@ -20975,7 +20994,8 @@ enum SmoothGroupStreamManifestBehavior {
   send,
 }
 
-extension on SmoothGroupStreamManifestBehavior {
+extension SmoothGroupStreamManifestBehaviorValue
+    on SmoothGroupStreamManifestBehavior {
   String toValue() {
     switch (this) {
       case SmoothGroupStreamManifestBehavior.doNotSend:
@@ -20986,7 +21006,7 @@ extension on SmoothGroupStreamManifestBehavior {
   }
 }
 
-extension on String {
+extension SmoothGroupStreamManifestBehaviorFromString on String {
   SmoothGroupStreamManifestBehavior toSmoothGroupStreamManifestBehavior() {
     switch (this) {
       case 'DO_NOT_SEND':
@@ -21005,7 +21025,8 @@ enum SmoothGroupTimestampOffsetMode {
   useEventStartDate,
 }
 
-extension on SmoothGroupTimestampOffsetMode {
+extension SmoothGroupTimestampOffsetModeValue
+    on SmoothGroupTimestampOffsetMode {
   String toValue() {
     switch (this) {
       case SmoothGroupTimestampOffsetMode.useConfiguredOffset:
@@ -21016,7 +21037,7 @@ extension on SmoothGroupTimestampOffsetMode {
   }
 }
 
-extension on String {
+extension SmoothGroupTimestampOffsetModeFromString on String {
   SmoothGroupTimestampOffsetMode toSmoothGroupTimestampOffsetMode() {
     switch (this) {
       case 'USE_CONFIGURED_OFFSET':
@@ -21035,7 +21056,7 @@ enum Smpte2038DataPreference {
   prefer,
 }
 
-extension on Smpte2038DataPreference {
+extension Smpte2038DataPreferenceValue on Smpte2038DataPreference {
   String toValue() {
     switch (this) {
       case Smpte2038DataPreference.ignore:
@@ -21046,7 +21067,7 @@ extension on Smpte2038DataPreference {
   }
 }
 
-extension on String {
+extension Smpte2038DataPreferenceFromString on String {
   Smpte2038DataPreference toSmpte2038DataPreference() {
     switch (this) {
       case 'IGNORE':
@@ -21737,7 +21758,8 @@ enum TemporalFilterPostFilterSharpening {
   enabled,
 }
 
-extension on TemporalFilterPostFilterSharpening {
+extension TemporalFilterPostFilterSharpeningValue
+    on TemporalFilterPostFilterSharpening {
   String toValue() {
     switch (this) {
       case TemporalFilterPostFilterSharpening.auto:
@@ -21750,7 +21772,7 @@ extension on TemporalFilterPostFilterSharpening {
   }
 }
 
-extension on String {
+extension TemporalFilterPostFilterSharpeningFromString on String {
   TemporalFilterPostFilterSharpening toTemporalFilterPostFilterSharpening() {
     switch (this) {
       case 'AUTO':
@@ -21823,7 +21845,7 @@ enum TemporalFilterStrength {
   strength_16,
 }
 
-extension on TemporalFilterStrength {
+extension TemporalFilterStrengthValue on TemporalFilterStrength {
   String toValue() {
     switch (this) {
       case TemporalFilterStrength.auto:
@@ -21864,7 +21886,7 @@ extension on TemporalFilterStrength {
   }
 }
 
-extension on String {
+extension TemporalFilterStrengthFromString on String {
   TemporalFilterStrength toTemporalFilterStrength() {
     switch (this) {
       case 'AUTO':
@@ -21952,7 +21974,7 @@ enum TimecodeConfigSource {
   zerobased,
 }
 
-extension on TimecodeConfigSource {
+extension TimecodeConfigSourceValue on TimecodeConfigSource {
   String toValue() {
     switch (this) {
       case TimecodeConfigSource.embedded:
@@ -21965,7 +21987,7 @@ extension on TimecodeConfigSource {
   }
 }
 
-extension on String {
+extension TimecodeConfigSourceFromString on String {
   TimecodeConfigSource toTimecodeConfigSource() {
     switch (this) {
       case 'EMBEDDED':
@@ -22049,7 +22071,7 @@ enum TtmlDestinationStyleControl {
   useConfigured,
 }
 
-extension on TtmlDestinationStyleControl {
+extension TtmlDestinationStyleControlValue on TtmlDestinationStyleControl {
   String toValue() {
     switch (this) {
       case TtmlDestinationStyleControl.passthrough:
@@ -22060,7 +22082,7 @@ extension on TtmlDestinationStyleControl {
   }
 }
 
-extension on String {
+extension TtmlDestinationStyleControlFromString on String {
   TtmlDestinationStyleControl toTtmlDestinationStyleControl() {
     switch (this) {
       case 'PASSTHROUGH':
@@ -22200,7 +22222,7 @@ enum UdpTimedMetadataId3Frame {
   tdrl,
 }
 
-extension on UdpTimedMetadataId3Frame {
+extension UdpTimedMetadataId3FrameValue on UdpTimedMetadataId3Frame {
   String toValue() {
     switch (this) {
       case UdpTimedMetadataId3Frame.none:
@@ -22213,7 +22235,7 @@ extension on UdpTimedMetadataId3Frame {
   }
 }
 
-extension on String {
+extension UdpTimedMetadataId3FrameFromString on String {
   UdpTimedMetadataId3Frame toUdpTimedMetadataId3Frame() {
     switch (this) {
       case 'NONE':
@@ -22615,7 +22637,7 @@ enum VideoDescriptionRespondToAfd {
   respond,
 }
 
-extension on VideoDescriptionRespondToAfd {
+extension VideoDescriptionRespondToAfdValue on VideoDescriptionRespondToAfd {
   String toValue() {
     switch (this) {
       case VideoDescriptionRespondToAfd.none:
@@ -22628,7 +22650,7 @@ extension on VideoDescriptionRespondToAfd {
   }
 }
 
-extension on String {
+extension VideoDescriptionRespondToAfdFromString on String {
   VideoDescriptionRespondToAfd toVideoDescriptionRespondToAfd() {
     switch (this) {
       case 'NONE':
@@ -22648,7 +22670,8 @@ enum VideoDescriptionScalingBehavior {
   stretchToOutput,
 }
 
-extension on VideoDescriptionScalingBehavior {
+extension VideoDescriptionScalingBehaviorValue
+    on VideoDescriptionScalingBehavior {
   String toValue() {
     switch (this) {
       case VideoDescriptionScalingBehavior.$default:
@@ -22659,7 +22682,7 @@ extension on VideoDescriptionScalingBehavior {
   }
 }
 
-extension on String {
+extension VideoDescriptionScalingBehaviorFromString on String {
   VideoDescriptionScalingBehavior toVideoDescriptionScalingBehavior() {
     switch (this) {
       case 'DEFAULT':
@@ -22729,7 +22752,7 @@ enum VideoSelectorColorSpace {
   rec_709,
 }
 
-extension on VideoSelectorColorSpace {
+extension VideoSelectorColorSpaceValue on VideoSelectorColorSpace {
   String toValue() {
     switch (this) {
       case VideoSelectorColorSpace.follow:
@@ -22742,7 +22765,7 @@ extension on VideoSelectorColorSpace {
   }
 }
 
-extension on String {
+extension VideoSelectorColorSpaceFromString on String {
   VideoSelectorColorSpace toVideoSelectorColorSpace() {
     switch (this) {
       case 'FOLLOW':
@@ -22762,7 +22785,7 @@ enum VideoSelectorColorSpaceUsage {
   force,
 }
 
-extension on VideoSelectorColorSpaceUsage {
+extension VideoSelectorColorSpaceUsageValue on VideoSelectorColorSpaceUsage {
   String toValue() {
     switch (this) {
       case VideoSelectorColorSpaceUsage.fallback:
@@ -22773,7 +22796,7 @@ extension on VideoSelectorColorSpaceUsage {
   }
 }
 
-extension on String {
+extension VideoSelectorColorSpaceUsageFromString on String {
   VideoSelectorColorSpaceUsage toVideoSelectorColorSpaceUsage() {
     switch (this) {
       case 'FALLBACK':
@@ -22872,7 +22895,7 @@ enum WavCodingMode {
   codingMode_8_0,
 }
 
-extension on WavCodingMode {
+extension WavCodingModeValue on WavCodingMode {
   String toValue() {
     switch (this) {
       case WavCodingMode.codingMode_1_0:
@@ -22887,7 +22910,7 @@ extension on WavCodingMode {
   }
 }
 
-extension on String {
+extension WavCodingModeFromString on String {
   WavCodingMode toWavCodingMode() {
     switch (this) {
       case 'CODING_MODE_1_0':
@@ -22957,7 +22980,7 @@ enum AcceptHeader {
   imageJpeg,
 }
 
-extension on AcceptHeader {
+extension AcceptHeaderValue on AcceptHeader {
   String toValue() {
     switch (this) {
       case AcceptHeader.imageJpeg:
@@ -22966,7 +22989,7 @@ extension on AcceptHeader {
   }
 }
 
-extension on String {
+extension AcceptHeaderFromString on String {
   AcceptHeader toAcceptHeader() {
     switch (this) {
       case 'image/jpeg':
@@ -22981,7 +23004,7 @@ enum ContentType {
   imageJpeg,
 }
 
-extension on ContentType {
+extension ContentTypeValue on ContentType {
   String toValue() {
     switch (this) {
       case ContentType.imageJpeg:
@@ -22990,7 +23013,7 @@ extension on ContentType {
   }
 }
 
-extension on String {
+extension ContentTypeFromString on String {
   ContentType toContentType() {
     switch (this) {
       case 'image/jpeg':

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -728,7 +728,7 @@ enum AdMarkers {
   daterange,
 }
 
-extension on AdMarkers {
+extension AdMarkersValue on AdMarkers {
   String toValue() {
     switch (this) {
       case AdMarkers.none:
@@ -743,7 +743,7 @@ extension on AdMarkers {
   }
 }
 
-extension on String {
+extension AdMarkersFromString on String {
   AdMarkers toAdMarkers() {
     switch (this) {
       case 'NONE':
@@ -781,7 +781,7 @@ enum AdsOnDeliveryRestrictions {
   both,
 }
 
-extension on AdsOnDeliveryRestrictions {
+extension AdsOnDeliveryRestrictionsValue on AdsOnDeliveryRestrictions {
   String toValue() {
     switch (this) {
       case AdsOnDeliveryRestrictions.none:
@@ -796,7 +796,7 @@ extension on AdsOnDeliveryRestrictions {
   }
 }
 
-extension on String {
+extension AdsOnDeliveryRestrictionsFromString on String {
   AdsOnDeliveryRestrictions toAdsOnDeliveryRestrictions() {
     switch (this) {
       case 'NONE':
@@ -1691,7 +1691,7 @@ enum EncryptionMethod {
   sampleAes,
 }
 
-extension on EncryptionMethod {
+extension EncryptionMethodValue on EncryptionMethod {
   String toValue() {
     switch (this) {
       case EncryptionMethod.aes_128:
@@ -1702,7 +1702,7 @@ extension on EncryptionMethod {
   }
 }
 
-extension on String {
+extension EncryptionMethodFromString on String {
   EncryptionMethod toEncryptionMethod() {
     switch (this) {
       case 'AES_128':
@@ -2285,7 +2285,7 @@ enum ManifestLayout {
   compact,
 }
 
-extension on ManifestLayout {
+extension ManifestLayoutValue on ManifestLayout {
   String toValue() {
     switch (this) {
       case ManifestLayout.full:
@@ -2296,7 +2296,7 @@ extension on ManifestLayout {
   }
 }
 
-extension on String {
+extension ManifestLayoutFromString on String {
   ManifestLayout toManifestLayout() {
     switch (this) {
       case 'FULL':
@@ -2485,7 +2485,7 @@ enum Origination {
   deny,
 }
 
-extension on Origination {
+extension OriginationValue on Origination {
   String toValue() {
     switch (this) {
       case Origination.allow:
@@ -2496,7 +2496,7 @@ extension on Origination {
   }
 }
 
-extension on String {
+extension OriginationFromString on String {
   Origination toOrigination() {
     switch (this) {
       case 'ALLOW':
@@ -2514,7 +2514,7 @@ enum PlaylistType {
   vod,
 }
 
-extension on PlaylistType {
+extension PlaylistTypeValue on PlaylistType {
   String toValue() {
     switch (this) {
       case PlaylistType.none:
@@ -2527,7 +2527,7 @@ extension on PlaylistType {
   }
 }
 
-extension on String {
+extension PlaylistTypeFromString on String {
   PlaylistType toPlaylistType() {
     switch (this) {
       case 'NONE':
@@ -2546,7 +2546,7 @@ enum Profile {
   hbbtv_1_5,
 }
 
-extension on Profile {
+extension ProfileValue on Profile {
   String toValue() {
     switch (this) {
       case Profile.none:
@@ -2557,7 +2557,7 @@ extension on Profile {
   }
 }
 
-extension on String {
+extension ProfileFromString on String {
   Profile toProfile() {
     switch (this) {
       case 'NONE':
@@ -2705,7 +2705,7 @@ enum SegmentTemplateFormat {
   numberWithDuration,
 }
 
-extension on SegmentTemplateFormat {
+extension SegmentTemplateFormatValue on SegmentTemplateFormat {
   String toValue() {
     switch (this) {
       case SegmentTemplateFormat.numberWithTimeline:
@@ -2718,7 +2718,7 @@ extension on SegmentTemplateFormat {
   }
 }
 
-extension on String {
+extension SegmentTemplateFormatFromString on String {
   SegmentTemplateFormat toSegmentTemplateFormat() {
     switch (this) {
       case 'NUMBER_WITH_TIMELINE':
@@ -2795,7 +2795,7 @@ enum Status {
   failed,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.inProgress:
@@ -2808,7 +2808,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -2828,7 +2828,7 @@ enum StreamOrder {
   videoBitrateDescending,
 }
 
-extension on StreamOrder {
+extension StreamOrderValue on StreamOrder {
   String toValue() {
     switch (this) {
       case StreamOrder.original:
@@ -2841,7 +2841,7 @@ extension on StreamOrder {
   }
 }
 
-extension on String {
+extension StreamOrderFromString on String {
   StreamOrder toStreamOrder() {
     switch (this) {
       case 'ORIGINAL':
@@ -3046,7 +3046,7 @@ enum UtcTiming {
   httpIso,
 }
 
-extension on UtcTiming {
+extension UtcTimingValue on UtcTiming {
   String toValue() {
     switch (this) {
       case UtcTiming.none:
@@ -3059,7 +3059,7 @@ extension on UtcTiming {
   }
 }
 
-extension on String {
+extension UtcTimingFromString on String {
   UtcTiming toUtcTiming() {
     switch (this) {
       case 'NONE':
@@ -3084,7 +3084,7 @@ enum AdTriggersElement {
   distributorOverlayPlacementOpportunity,
 }
 
-extension on AdTriggersElement {
+extension AdTriggersElementValue on AdTriggersElement {
   String toValue() {
     switch (this) {
       case AdTriggersElement.spliceInsert:
@@ -3107,7 +3107,7 @@ extension on AdTriggersElement {
   }
 }
 
-extension on String {
+extension AdTriggersElementFromString on String {
   AdTriggersElement toAdTriggersElement() {
     switch (this) {
       case 'SPLICE_INSERT':
@@ -3135,7 +3135,7 @@ enum PeriodTriggersElement {
   ads,
 }
 
-extension on PeriodTriggersElement {
+extension PeriodTriggersElementValue on PeriodTriggersElement {
   String toValue() {
     switch (this) {
       case PeriodTriggersElement.ads:
@@ -3144,7 +3144,7 @@ extension on PeriodTriggersElement {
   }
 }
 
-extension on String {
+extension PeriodTriggersElementFromString on String {
   PeriodTriggersElement toPeriodTriggersElement() {
     switch (this) {
       case 'ADS':

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -728,7 +728,7 @@ enum AdMarkers {
   daterange,
 }
 
-extension AdMarkersValue on AdMarkers {
+extension AdMarkersValueExtension on AdMarkers {
   String toValue() {
     switch (this) {
       case AdMarkers.none:
@@ -781,7 +781,7 @@ enum AdsOnDeliveryRestrictions {
   both,
 }
 
-extension AdsOnDeliveryRestrictionsValue on AdsOnDeliveryRestrictions {
+extension AdsOnDeliveryRestrictionsValueExtension on AdsOnDeliveryRestrictions {
   String toValue() {
     switch (this) {
       case AdsOnDeliveryRestrictions.none:
@@ -1691,7 +1691,7 @@ enum EncryptionMethod {
   sampleAes,
 }
 
-extension EncryptionMethodValue on EncryptionMethod {
+extension EncryptionMethodValueExtension on EncryptionMethod {
   String toValue() {
     switch (this) {
       case EncryptionMethod.aes_128:
@@ -2285,7 +2285,7 @@ enum ManifestLayout {
   compact,
 }
 
-extension ManifestLayoutValue on ManifestLayout {
+extension ManifestLayoutValueExtension on ManifestLayout {
   String toValue() {
     switch (this) {
       case ManifestLayout.full:
@@ -2485,7 +2485,7 @@ enum Origination {
   deny,
 }
 
-extension OriginationValue on Origination {
+extension OriginationValueExtension on Origination {
   String toValue() {
     switch (this) {
       case Origination.allow:
@@ -2514,7 +2514,7 @@ enum PlaylistType {
   vod,
 }
 
-extension PlaylistTypeValue on PlaylistType {
+extension PlaylistTypeValueExtension on PlaylistType {
   String toValue() {
     switch (this) {
       case PlaylistType.none:
@@ -2546,7 +2546,7 @@ enum Profile {
   hbbtv_1_5,
 }
 
-extension ProfileValue on Profile {
+extension ProfileValueExtension on Profile {
   String toValue() {
     switch (this) {
       case Profile.none:
@@ -2705,7 +2705,7 @@ enum SegmentTemplateFormat {
   numberWithDuration,
 }
 
-extension SegmentTemplateFormatValue on SegmentTemplateFormat {
+extension SegmentTemplateFormatValueExtension on SegmentTemplateFormat {
   String toValue() {
     switch (this) {
       case SegmentTemplateFormat.numberWithTimeline:
@@ -2795,7 +2795,7 @@ enum Status {
   failed,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.inProgress:
@@ -2828,7 +2828,7 @@ enum StreamOrder {
   videoBitrateDescending,
 }
 
-extension StreamOrderValue on StreamOrder {
+extension StreamOrderValueExtension on StreamOrder {
   String toValue() {
     switch (this) {
       case StreamOrder.original:
@@ -3046,7 +3046,7 @@ enum UtcTiming {
   httpIso,
 }
 
-extension UtcTimingValue on UtcTiming {
+extension UtcTimingValueExtension on UtcTiming {
   String toValue() {
     switch (this) {
       case UtcTiming.none:
@@ -3084,7 +3084,7 @@ enum AdTriggersElement {
   distributorOverlayPlacementOpportunity,
 }
 
-extension AdTriggersElementValue on AdTriggersElement {
+extension AdTriggersElementValueExtension on AdTriggersElement {
   String toValue() {
     switch (this) {
       case AdTriggersElement.spliceInsert:
@@ -3135,7 +3135,7 @@ enum PeriodTriggersElement {
   ads,
 }
 
-extension PeriodTriggersElementValue on PeriodTriggersElement {
+extension PeriodTriggersElementValueExtension on PeriodTriggersElement {
   String toValue() {
     switch (this) {
       case PeriodTriggersElement.ads:

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -549,7 +549,7 @@ enum AdMarkers {
   passthrough,
 }
 
-extension AdMarkersValue on AdMarkers {
+extension AdMarkersValueExtension on AdMarkers {
   String toValue() {
     switch (this) {
       case AdMarkers.none:
@@ -1195,7 +1195,7 @@ enum EncryptionMethod {
   sampleAes,
 }
 
-extension EncryptionMethodValue on EncryptionMethod {
+extension EncryptionMethodValueExtension on EncryptionMethod {
   String toValue() {
     switch (this) {
       case EncryptionMethod.aes_128:
@@ -1477,7 +1477,7 @@ enum ManifestLayout {
   compact,
 }
 
-extension ManifestLayoutValue on ManifestLayout {
+extension ManifestLayoutValueExtension on ManifestLayout {
   String toValue() {
     switch (this) {
       case ManifestLayout.full:
@@ -1681,7 +1681,7 @@ enum Profile {
   hbbtv_1_5,
 }
 
-extension ProfileValue on Profile {
+extension ProfileValueExtension on Profile {
   String toValue() {
     switch (this) {
       case Profile.none:
@@ -1710,7 +1710,7 @@ enum SegmentTemplateFormat {
   numberWithDuration,
 }
 
-extension SegmentTemplateFormatValue on SegmentTemplateFormat {
+extension SegmentTemplateFormatValueExtension on SegmentTemplateFormat {
   String toValue() {
     switch (this) {
       case SegmentTemplateFormat.numberWithTimeline:
@@ -1784,7 +1784,7 @@ enum StreamOrder {
   videoBitrateDescending,
 }
 
-extension StreamOrderValue on StreamOrder {
+extension StreamOrderValueExtension on StreamOrder {
   String toValue() {
     switch (this) {
       case StreamOrder.original:
@@ -1887,7 +1887,7 @@ enum PeriodTriggersElement {
   ads,
 }
 
-extension PeriodTriggersElementValue on PeriodTriggersElement {
+extension PeriodTriggersElementValueExtension on PeriodTriggersElement {
   String toValue() {
     switch (this) {
       case PeriodTriggersElement.ads:

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -549,7 +549,7 @@ enum AdMarkers {
   passthrough,
 }
 
-extension on AdMarkers {
+extension AdMarkersValue on AdMarkers {
   String toValue() {
     switch (this) {
       case AdMarkers.none:
@@ -562,7 +562,7 @@ extension on AdMarkers {
   }
 }
 
-extension on String {
+extension AdMarkersFromString on String {
   AdMarkers toAdMarkers() {
     switch (this) {
       case 'NONE':
@@ -1195,7 +1195,7 @@ enum EncryptionMethod {
   sampleAes,
 }
 
-extension on EncryptionMethod {
+extension EncryptionMethodValue on EncryptionMethod {
   String toValue() {
     switch (this) {
       case EncryptionMethod.aes_128:
@@ -1206,7 +1206,7 @@ extension on EncryptionMethod {
   }
 }
 
-extension on String {
+extension EncryptionMethodFromString on String {
   EncryptionMethod toEncryptionMethod() {
     switch (this) {
       case 'AES_128':
@@ -1477,7 +1477,7 @@ enum ManifestLayout {
   compact,
 }
 
-extension on ManifestLayout {
+extension ManifestLayoutValue on ManifestLayout {
   String toValue() {
     switch (this) {
       case ManifestLayout.full:
@@ -1488,7 +1488,7 @@ extension on ManifestLayout {
   }
 }
 
-extension on String {
+extension ManifestLayoutFromString on String {
   ManifestLayout toManifestLayout() {
     switch (this) {
       case 'FULL':
@@ -1681,7 +1681,7 @@ enum Profile {
   hbbtv_1_5,
 }
 
-extension on Profile {
+extension ProfileValue on Profile {
   String toValue() {
     switch (this) {
       case Profile.none:
@@ -1692,7 +1692,7 @@ extension on Profile {
   }
 }
 
-extension on String {
+extension ProfileFromString on String {
   Profile toProfile() {
     switch (this) {
       case 'NONE':
@@ -1710,7 +1710,7 @@ enum SegmentTemplateFormat {
   numberWithDuration,
 }
 
-extension on SegmentTemplateFormat {
+extension SegmentTemplateFormatValue on SegmentTemplateFormat {
   String toValue() {
     switch (this) {
       case SegmentTemplateFormat.numberWithTimeline:
@@ -1723,7 +1723,7 @@ extension on SegmentTemplateFormat {
   }
 }
 
-extension on String {
+extension SegmentTemplateFormatFromString on String {
   SegmentTemplateFormat toSegmentTemplateFormat() {
     switch (this) {
       case 'NUMBER_WITH_TIMELINE':
@@ -1784,7 +1784,7 @@ enum StreamOrder {
   videoBitrateDescending,
 }
 
-extension on StreamOrder {
+extension StreamOrderValue on StreamOrder {
   String toValue() {
     switch (this) {
       case StreamOrder.original:
@@ -1797,7 +1797,7 @@ extension on StreamOrder {
   }
 }
 
-extension on String {
+extension StreamOrderFromString on String {
   StreamOrder toStreamOrder() {
     switch (this) {
       case 'ORIGINAL':
@@ -1887,7 +1887,7 @@ enum PeriodTriggersElement {
   ads,
 }
 
-extension on PeriodTriggersElement {
+extension PeriodTriggersElementValue on PeriodTriggersElement {
   String toValue() {
     switch (this) {
       case PeriodTriggersElement.ads:
@@ -1896,7 +1896,7 @@ extension on PeriodTriggersElement {
   }
 }
 
-extension on String {
+extension PeriodTriggersElementFromString on String {
   PeriodTriggersElement toPeriodTriggersElement() {
     switch (this) {
       case 'ADS':

--- a/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
+++ b/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
@@ -1069,7 +1069,7 @@ enum ContainerLevelMetrics {
   disabled,
 }
 
-extension on ContainerLevelMetrics {
+extension ContainerLevelMetricsValue on ContainerLevelMetrics {
   String toValue() {
     switch (this) {
       case ContainerLevelMetrics.enabled:
@@ -1080,7 +1080,7 @@ extension on ContainerLevelMetrics {
   }
 }
 
-extension on String {
+extension ContainerLevelMetricsFromString on String {
   ContainerLevelMetrics toContainerLevelMetrics() {
     switch (this) {
       case 'ENABLED':
@@ -1098,7 +1098,7 @@ enum ContainerStatus {
   deleting,
 }
 
-extension on ContainerStatus {
+extension ContainerStatusValue on ContainerStatus {
   String toValue() {
     switch (this) {
       case ContainerStatus.active:
@@ -1111,7 +1111,7 @@ extension on ContainerStatus {
   }
 }
 
-extension on String {
+extension ContainerStatusFromString on String {
   ContainerStatus toContainerStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -1405,7 +1405,7 @@ enum MethodName {
   head,
 }
 
-extension on MethodName {
+extension MethodNameValue on MethodName {
   String toValue() {
     switch (this) {
       case MethodName.put:
@@ -1420,7 +1420,7 @@ extension on MethodName {
   }
 }
 
-extension on String {
+extension MethodNameFromString on String {
   MethodName toMethodName() {
     switch (this) {
       case 'PUT':

--- a/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
+++ b/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
@@ -1069,7 +1069,7 @@ enum ContainerLevelMetrics {
   disabled,
 }
 
-extension ContainerLevelMetricsValue on ContainerLevelMetrics {
+extension ContainerLevelMetricsValueExtension on ContainerLevelMetrics {
   String toValue() {
     switch (this) {
       case ContainerLevelMetrics.enabled:
@@ -1098,7 +1098,7 @@ enum ContainerStatus {
   deleting,
 }
 
-extension ContainerStatusValue on ContainerStatus {
+extension ContainerStatusValueExtension on ContainerStatus {
   String toValue() {
     switch (this) {
       case ContainerStatus.active:
@@ -1405,7 +1405,7 @@ enum MethodName {
   head,
 }
 
-extension MethodNameValue on MethodName {
+extension MethodNameValueExtension on MethodName {
   String toValue() {
     switch (this) {
       case MethodName.put:

--- a/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
+++ b/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
@@ -494,7 +494,7 @@ enum ItemType {
   folder,
 }
 
-extension ItemTypeValue on ItemType {
+extension ItemTypeValueExtension on ItemType {
   String toValue() {
     switch (this) {
       case ItemType.object:
@@ -572,7 +572,7 @@ enum StorageClass {
   temporal,
 }
 
-extension StorageClassValue on StorageClass {
+extension StorageClassValueExtension on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.temporal:
@@ -596,7 +596,7 @@ enum UploadAvailability {
   streaming,
 }
 
-extension UploadAvailabilityValue on UploadAvailability {
+extension UploadAvailabilityValueExtension on UploadAvailability {
   String toValue() {
     switch (this) {
       case UploadAvailability.standard:

--- a/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
+++ b/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
@@ -494,7 +494,7 @@ enum ItemType {
   folder,
 }
 
-extension on ItemType {
+extension ItemTypeValue on ItemType {
   String toValue() {
     switch (this) {
       case ItemType.object:
@@ -505,7 +505,7 @@ extension on ItemType {
   }
 }
 
-extension on String {
+extension ItemTypeFromString on String {
   ItemType toItemType() {
     switch (this) {
       case 'OBJECT':
@@ -572,7 +572,7 @@ enum StorageClass {
   temporal,
 }
 
-extension on StorageClass {
+extension StorageClassValue on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.temporal:
@@ -581,7 +581,7 @@ extension on StorageClass {
   }
 }
 
-extension on String {
+extension StorageClassFromString on String {
   StorageClass toStorageClass() {
     switch (this) {
       case 'TEMPORAL':
@@ -596,7 +596,7 @@ enum UploadAvailability {
   streaming,
 }
 
-extension on UploadAvailability {
+extension UploadAvailabilityValue on UploadAvailability {
   String toValue() {
     switch (this) {
       case UploadAvailability.standard:
@@ -607,7 +607,7 @@ extension on UploadAvailability {
   }
 }
 
-extension on String {
+extension UploadAvailabilityFromString on String {
   UploadAvailability toUploadAvailability() {
     switch (this) {
       case 'STANDARD':

--- a/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
+++ b/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
@@ -740,7 +740,7 @@ enum OriginManifestType {
   multiPeriod,
 }
 
-extension on OriginManifestType {
+extension OriginManifestTypeValue on OriginManifestType {
   String toValue() {
     switch (this) {
       case OriginManifestType.singlePeriod:
@@ -751,7 +751,7 @@ extension on OriginManifestType {
   }
 }
 
-extension on String {
+extension OriginManifestTypeFromString on String {
   OriginManifestType toOriginManifestType() {
     switch (this) {
       case 'SINGLE_PERIOD':
@@ -794,7 +794,7 @@ enum Mode {
   behindLiveEdge,
 }
 
-extension on Mode {
+extension ModeValue on Mode {
   String toValue() {
     switch (this) {
       case Mode.off:
@@ -805,7 +805,7 @@ extension on Mode {
   }
 }
 
-extension on String {
+extension ModeFromString on String {
   Mode toMode() {
     switch (this) {
       case 'OFF':

--- a/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
+++ b/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
@@ -740,7 +740,7 @@ enum OriginManifestType {
   multiPeriod,
 }
 
-extension OriginManifestTypeValue on OriginManifestType {
+extension OriginManifestTypeValueExtension on OriginManifestType {
   String toValue() {
     switch (this) {
       case OriginManifestType.singlePeriod:
@@ -794,7 +794,7 @@ enum Mode {
   behindLiveEdge,
 }
 
-extension ModeValue on Mode {
+extension ModeValueExtension on Mode {
   String toValue() {
     switch (this) {
       case Mode.off:

--- a/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
+++ b/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
@@ -643,7 +643,7 @@ enum UsageRecordResultStatus {
   duplicateRecord,
 }
 
-extension on UsageRecordResultStatus {
+extension UsageRecordResultStatusValue on UsageRecordResultStatus {
   String toValue() {
     switch (this) {
       case UsageRecordResultStatus.success:
@@ -656,7 +656,7 @@ extension on UsageRecordResultStatus {
   }
 }
 
-extension on String {
+extension UsageRecordResultStatusFromString on String {
   UsageRecordResultStatus toUsageRecordResultStatus() {
     switch (this) {
       case 'Success':

--- a/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
+++ b/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
@@ -643,7 +643,7 @@ enum UsageRecordResultStatus {
   duplicateRecord,
 }
 
-extension UsageRecordResultStatusValue on UsageRecordResultStatus {
+extension UsageRecordResultStatusValueExtension on UsageRecordResultStatus {
   String toValue() {
     switch (this) {
       case UsageRecordResultStatus.success:

--- a/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
+++ b/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
@@ -1358,7 +1358,7 @@ enum ApplicationStatus {
   completed,
 }
 
-extension on ApplicationStatus {
+extension ApplicationStatusValue on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.notStarted:
@@ -1371,7 +1371,7 @@ extension on ApplicationStatus {
   }
 }
 
-extension on String {
+extension ApplicationStatusFromString on String {
   ApplicationStatus toApplicationStatus() {
     switch (this) {
       case 'NOT_STARTED':
@@ -1840,7 +1840,7 @@ enum ResourceAttributeType {
   motherboardSerialNumber,
 }
 
-extension on ResourceAttributeType {
+extension ResourceAttributeTypeValue on ResourceAttributeType {
   String toValue() {
     switch (this) {
       case ResourceAttributeType.ipv4Address:
@@ -1867,7 +1867,7 @@ extension on ResourceAttributeType {
   }
 }
 
-extension on String {
+extension ResourceAttributeTypeFromString on String {
   ResourceAttributeType toResourceAttributeType() {
     switch (this) {
       case 'IPV4_ADDRESS':
@@ -1902,7 +1902,7 @@ enum Status {
   completed,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.notStarted:
@@ -1917,7 +1917,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'NOT_STARTED':

--- a/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
+++ b/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
@@ -1358,7 +1358,7 @@ enum ApplicationStatus {
   completed,
 }
 
-extension ApplicationStatusValue on ApplicationStatus {
+extension ApplicationStatusValueExtension on ApplicationStatus {
   String toValue() {
     switch (this) {
       case ApplicationStatus.notStarted:
@@ -1840,7 +1840,7 @@ enum ResourceAttributeType {
   motherboardSerialNumber,
 }
 
-extension ResourceAttributeTypeValue on ResourceAttributeType {
+extension ResourceAttributeTypeValueExtension on ResourceAttributeType {
   String toValue() {
     switch (this) {
       case ResourceAttributeType.ipv4Address:
@@ -1902,7 +1902,7 @@ enum Status {
   completed,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.notStarted:

--- a/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
+++ b/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
@@ -373,7 +373,7 @@ enum TargetType {
   account,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:
@@ -382,7 +382,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'ACCOUNT':

--- a/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
+++ b/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
@@ -373,7 +373,7 @@ enum TargetType {
   account,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:

--- a/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
+++ b/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
@@ -640,7 +640,7 @@ enum Platform {
   javascript,
 }
 
-extension PlatformValue on Platform {
+extension PlatformValueExtension on Platform {
   String toValue() {
     switch (this) {
       case Platform.osx:
@@ -733,7 +733,7 @@ enum ProjectState {
   importing,
 }
 
-extension ProjectStateValue on ProjectState {
+extension ProjectStateValueExtension on ProjectState {
   String toValue() {
     switch (this) {
       case ProjectState.normal:

--- a/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
+++ b/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
@@ -640,7 +640,7 @@ enum Platform {
   javascript,
 }
 
-extension on Platform {
+extension PlatformValue on Platform {
   String toValue() {
     switch (this) {
       case Platform.osx:
@@ -661,7 +661,7 @@ extension on Platform {
   }
 }
 
-extension on String {
+extension PlatformFromString on String {
   Platform toPlatform() {
     switch (this) {
       case 'OSX':
@@ -733,7 +733,7 @@ enum ProjectState {
   importing,
 }
 
-extension on ProjectState {
+extension ProjectStateValue on ProjectState {
   String toValue() {
     switch (this) {
       case ProjectState.normal:
@@ -746,7 +746,7 @@ extension on ProjectState {
   }
 }
 
-extension on String {
+extension ProjectStateFromString on String {
   ProjectState toProjectState() {
     switch (this) {
       case 'NORMAL':

--- a/generated/aws_mq_api/lib/mq-2017-11-27.dart
+++ b/generated/aws_mq_api/lib/mq-2017-11-27.dart
@@ -980,7 +980,7 @@ enum AuthenticationStrategy {
   ldap,
 }
 
-extension AuthenticationStrategyValue on AuthenticationStrategy {
+extension AuthenticationStrategyValueExtension on AuthenticationStrategy {
   String toValue() {
     switch (this) {
       case AuthenticationStrategy.simple:
@@ -1128,7 +1128,7 @@ enum BrokerState {
   rebootInProgress,
 }
 
-extension BrokerStateValue on BrokerState {
+extension BrokerStateValueExtension on BrokerState {
   String toValue() {
     switch (this) {
       case BrokerState.creationInProgress:
@@ -1170,7 +1170,7 @@ enum BrokerStorageType {
   efs,
 }
 
-extension BrokerStorageTypeValue on BrokerStorageType {
+extension BrokerStorageTypeValueExtension on BrokerStorageType {
   String toValue() {
     switch (this) {
       case BrokerStorageType.ebs:
@@ -1253,7 +1253,7 @@ enum ChangeType {
   delete,
 }
 
-extension ChangeTypeValue on ChangeType {
+extension ChangeTypeValueExtension on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.create:
@@ -1518,7 +1518,7 @@ enum DayOfWeek {
   sunday,
 }
 
-extension DayOfWeekValue on DayOfWeek {
+extension DayOfWeekValueExtension on DayOfWeek {
   String toValue() {
     switch (this) {
       case DayOfWeek.monday:
@@ -1589,7 +1589,7 @@ enum DeploymentMode {
   clusterMultiAz,
 }
 
-extension DeploymentModeValue on DeploymentMode {
+extension DeploymentModeValueExtension on DeploymentMode {
   String toValue() {
     switch (this) {
       case DeploymentMode.singleInstance:
@@ -2065,7 +2065,7 @@ enum EngineType {
   rabbitmq,
 }
 
-extension EngineTypeValue on EngineType {
+extension EngineTypeValueExtension on EngineType {
   String toValue() {
     switch (this) {
       case EngineType.activemq:
@@ -2520,7 +2520,7 @@ enum SanitizationWarningReason {
   invalidAttributeValueRemoved,
 }
 
-extension SanitizationWarningReasonValue on SanitizationWarningReason {
+extension SanitizationWarningReasonValueExtension on SanitizationWarningReason {
   String toValue() {
     switch (this) {
       case SanitizationWarningReason.disallowedElementRemoved:

--- a/generated/aws_mq_api/lib/mq-2017-11-27.dart
+++ b/generated/aws_mq_api/lib/mq-2017-11-27.dart
@@ -980,7 +980,7 @@ enum AuthenticationStrategy {
   ldap,
 }
 
-extension on AuthenticationStrategy {
+extension AuthenticationStrategyValue on AuthenticationStrategy {
   String toValue() {
     switch (this) {
       case AuthenticationStrategy.simple:
@@ -991,7 +991,7 @@ extension on AuthenticationStrategy {
   }
 }
 
-extension on String {
+extension AuthenticationStrategyFromString on String {
   AuthenticationStrategy toAuthenticationStrategy() {
     switch (this) {
       case 'SIMPLE':
@@ -1128,7 +1128,7 @@ enum BrokerState {
   rebootInProgress,
 }
 
-extension on BrokerState {
+extension BrokerStateValue on BrokerState {
   String toValue() {
     switch (this) {
       case BrokerState.creationInProgress:
@@ -1145,7 +1145,7 @@ extension on BrokerState {
   }
 }
 
-extension on String {
+extension BrokerStateFromString on String {
   BrokerState toBrokerState() {
     switch (this) {
       case 'CREATION_IN_PROGRESS':
@@ -1170,7 +1170,7 @@ enum BrokerStorageType {
   efs,
 }
 
-extension on BrokerStorageType {
+extension BrokerStorageTypeValue on BrokerStorageType {
   String toValue() {
     switch (this) {
       case BrokerStorageType.ebs:
@@ -1181,7 +1181,7 @@ extension on BrokerStorageType {
   }
 }
 
-extension on String {
+extension BrokerStorageTypeFromString on String {
   BrokerStorageType toBrokerStorageType() {
     switch (this) {
       case 'EBS':
@@ -1253,7 +1253,7 @@ enum ChangeType {
   delete,
 }
 
-extension on ChangeType {
+extension ChangeTypeValue on ChangeType {
   String toValue() {
     switch (this) {
       case ChangeType.create:
@@ -1266,7 +1266,7 @@ extension on ChangeType {
   }
 }
 
-extension on String {
+extension ChangeTypeFromString on String {
   ChangeType toChangeType() {
     switch (this) {
       case 'CREATE':
@@ -1518,7 +1518,7 @@ enum DayOfWeek {
   sunday,
 }
 
-extension on DayOfWeek {
+extension DayOfWeekValue on DayOfWeek {
   String toValue() {
     switch (this) {
       case DayOfWeek.monday:
@@ -1539,7 +1539,7 @@ extension on DayOfWeek {
   }
 }
 
-extension on String {
+extension DayOfWeekFromString on String {
   DayOfWeek toDayOfWeek() {
     switch (this) {
       case 'MONDAY':
@@ -1589,7 +1589,7 @@ enum DeploymentMode {
   clusterMultiAz,
 }
 
-extension on DeploymentMode {
+extension DeploymentModeValue on DeploymentMode {
   String toValue() {
     switch (this) {
       case DeploymentMode.singleInstance:
@@ -1602,7 +1602,7 @@ extension on DeploymentMode {
   }
 }
 
-extension on String {
+extension DeploymentModeFromString on String {
   DeploymentMode toDeploymentMode() {
     switch (this) {
       case 'SINGLE_INSTANCE':
@@ -2065,7 +2065,7 @@ enum EngineType {
   rabbitmq,
 }
 
-extension on EngineType {
+extension EngineTypeValue on EngineType {
   String toValue() {
     switch (this) {
       case EngineType.activemq:
@@ -2076,7 +2076,7 @@ extension on EngineType {
   }
 }
 
-extension on String {
+extension EngineTypeFromString on String {
   EngineType toEngineType() {
     switch (this) {
       case 'ACTIVEMQ':
@@ -2520,7 +2520,7 @@ enum SanitizationWarningReason {
   invalidAttributeValueRemoved,
 }
 
-extension on SanitizationWarningReason {
+extension SanitizationWarningReasonValue on SanitizationWarningReason {
   String toValue() {
     switch (this) {
       case SanitizationWarningReason.disallowedElementRemoved:
@@ -2533,7 +2533,7 @@ extension on SanitizationWarningReason {
   }
 }
 
-extension on String {
+extension SanitizationWarningReasonFromString on String {
   SanitizationWarningReason toSanitizationWarningReason() {
     switch (this) {
       case 'DISALLOWED_ELEMENT_REMOVED':

--- a/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
+++ b/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
@@ -2761,7 +2761,7 @@ enum AssignmentStatus {
   rejected,
 }
 
-extension AssignmentStatusValue on AssignmentStatus {
+extension AssignmentStatusValueExtension on AssignmentStatus {
   String toValue() {
     switch (this) {
       case AssignmentStatus.submitted:
@@ -2842,7 +2842,7 @@ enum Comparator {
   notIn,
 }
 
-extension ComparatorValue on Comparator {
+extension ComparatorValueExtension on Comparator {
   String toValue() {
     switch (this) {
       case Comparator.lessThan:
@@ -3024,7 +3024,7 @@ enum EventType {
   ping,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.assignmentAccepted:
@@ -3340,7 +3340,7 @@ enum HITAccessActions {
   discoverPreviewAndAccept,
 }
 
-extension HITAccessActionsValue on HITAccessActions {
+extension HITAccessActionsValueExtension on HITAccessActions {
   String toValue() {
     switch (this) {
       case HITAccessActions.accept:
@@ -3398,7 +3398,7 @@ enum HITReviewStatus {
   reviewedInappropriate,
 }
 
-extension HITReviewStatusValue on HITReviewStatus {
+extension HITReviewStatusValueExtension on HITReviewStatus {
   String toValue() {
     switch (this) {
       case HITReviewStatus.notReviewed:
@@ -3437,7 +3437,7 @@ enum HITStatus {
   disposed,
 }
 
-extension HITStatusValue on HITStatus {
+extension HITStatusValueExtension on HITStatus {
   String toValue() {
     switch (this) {
       case HITStatus.assignable:
@@ -3859,7 +3859,7 @@ enum NotificationTransport {
   sns,
 }
 
-extension NotificationTransportValue on NotificationTransport {
+extension NotificationTransportValueExtension on NotificationTransport {
   String toValue() {
     switch (this) {
       case NotificationTransport.email:
@@ -3891,7 +3891,7 @@ enum NotifyWorkersFailureCode {
   hardFailure,
 }
 
-extension NotifyWorkersFailureCodeValue on NotifyWorkersFailureCode {
+extension NotifyWorkersFailureCodeValueExtension on NotifyWorkersFailureCode {
   String toValue() {
     switch (this) {
       case NotifyWorkersFailureCode.softFailure:
@@ -4255,7 +4255,7 @@ enum QualificationStatus {
   revoked,
 }
 
-extension QualificationStatusValue on QualificationStatus {
+extension QualificationStatusValueExtension on QualificationStatus {
   String toValue() {
     switch (this) {
       case QualificationStatus.granted:
@@ -4387,7 +4387,7 @@ enum QualificationTypeStatus {
   inactive,
 }
 
-extension QualificationTypeStatusValue on QualificationTypeStatus {
+extension QualificationTypeStatusValueExtension on QualificationTypeStatus {
   String toValue() {
     switch (this) {
       case QualificationTypeStatus.active:
@@ -4503,7 +4503,7 @@ enum ReviewActionStatus {
   cancelled,
 }
 
-extension ReviewActionStatusValue on ReviewActionStatus {
+extension ReviewActionStatusValueExtension on ReviewActionStatus {
   String toValue() {
     switch (this) {
       case ReviewActionStatus.intended:
@@ -4573,7 +4573,7 @@ enum ReviewPolicyLevel {
   hit,
 }
 
-extension ReviewPolicyLevelValue on ReviewPolicyLevel {
+extension ReviewPolicyLevelValueExtension on ReviewPolicyLevel {
   String toValue() {
     switch (this) {
       case ReviewPolicyLevel.assignment:
@@ -4678,7 +4678,7 @@ enum ReviewableHITStatus {
   reviewing,
 }
 
-extension ReviewableHITStatusValue on ReviewableHITStatus {
+extension ReviewableHITStatusValueExtension on ReviewableHITStatus {
   String toValue() {
     switch (this) {
       case ReviewableHITStatus.reviewable:

--- a/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
+++ b/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
@@ -2761,7 +2761,7 @@ enum AssignmentStatus {
   rejected,
 }
 
-extension on AssignmentStatus {
+extension AssignmentStatusValue on AssignmentStatus {
   String toValue() {
     switch (this) {
       case AssignmentStatus.submitted:
@@ -2774,7 +2774,7 @@ extension on AssignmentStatus {
   }
 }
 
-extension on String {
+extension AssignmentStatusFromString on String {
   AssignmentStatus toAssignmentStatus() {
     switch (this) {
       case 'Submitted':
@@ -2842,7 +2842,7 @@ enum Comparator {
   notIn,
 }
 
-extension on Comparator {
+extension ComparatorValue on Comparator {
   String toValue() {
     switch (this) {
       case Comparator.lessThan:
@@ -2869,7 +2869,7 @@ extension on Comparator {
   }
 }
 
-extension on String {
+extension ComparatorFromString on String {
   Comparator toComparator() {
     switch (this) {
       case 'LessThan':
@@ -3024,7 +3024,7 @@ enum EventType {
   ping,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.assignmentAccepted:
@@ -3055,7 +3055,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'AssignmentAccepted':
@@ -3340,7 +3340,7 @@ enum HITAccessActions {
   discoverPreviewAndAccept,
 }
 
-extension on HITAccessActions {
+extension HITAccessActionsValue on HITAccessActions {
   String toValue() {
     switch (this) {
       case HITAccessActions.accept:
@@ -3353,7 +3353,7 @@ extension on HITAccessActions {
   }
 }
 
-extension on String {
+extension HITAccessActionsFromString on String {
   HITAccessActions toHITAccessActions() {
     switch (this) {
       case 'Accept':
@@ -3398,7 +3398,7 @@ enum HITReviewStatus {
   reviewedInappropriate,
 }
 
-extension on HITReviewStatus {
+extension HITReviewStatusValue on HITReviewStatus {
   String toValue() {
     switch (this) {
       case HITReviewStatus.notReviewed:
@@ -3413,7 +3413,7 @@ extension on HITReviewStatus {
   }
 }
 
-extension on String {
+extension HITReviewStatusFromString on String {
   HITReviewStatus toHITReviewStatus() {
     switch (this) {
       case 'NotReviewed':
@@ -3437,7 +3437,7 @@ enum HITStatus {
   disposed,
 }
 
-extension on HITStatus {
+extension HITStatusValue on HITStatus {
   String toValue() {
     switch (this) {
       case HITStatus.assignable:
@@ -3454,7 +3454,7 @@ extension on HITStatus {
   }
 }
 
-extension on String {
+extension HITStatusFromString on String {
   HITStatus toHITStatus() {
     switch (this) {
       case 'Assignable':
@@ -3859,7 +3859,7 @@ enum NotificationTransport {
   sns,
 }
 
-extension on NotificationTransport {
+extension NotificationTransportValue on NotificationTransport {
   String toValue() {
     switch (this) {
       case NotificationTransport.email:
@@ -3872,7 +3872,7 @@ extension on NotificationTransport {
   }
 }
 
-extension on String {
+extension NotificationTransportFromString on String {
   NotificationTransport toNotificationTransport() {
     switch (this) {
       case 'Email':
@@ -3891,7 +3891,7 @@ enum NotifyWorkersFailureCode {
   hardFailure,
 }
 
-extension on NotifyWorkersFailureCode {
+extension NotifyWorkersFailureCodeValue on NotifyWorkersFailureCode {
   String toValue() {
     switch (this) {
       case NotifyWorkersFailureCode.softFailure:
@@ -3902,7 +3902,7 @@ extension on NotifyWorkersFailureCode {
   }
 }
 
-extension on String {
+extension NotifyWorkersFailureCodeFromString on String {
   NotifyWorkersFailureCode toNotifyWorkersFailureCode() {
     switch (this) {
       case 'SoftFailure':
@@ -4255,7 +4255,7 @@ enum QualificationStatus {
   revoked,
 }
 
-extension on QualificationStatus {
+extension QualificationStatusValue on QualificationStatus {
   String toValue() {
     switch (this) {
       case QualificationStatus.granted:
@@ -4266,7 +4266,7 @@ extension on QualificationStatus {
   }
 }
 
-extension on String {
+extension QualificationStatusFromString on String {
   QualificationStatus toQualificationStatus() {
     switch (this) {
       case 'Granted':
@@ -4387,7 +4387,7 @@ enum QualificationTypeStatus {
   inactive,
 }
 
-extension on QualificationTypeStatus {
+extension QualificationTypeStatusValue on QualificationTypeStatus {
   String toValue() {
     switch (this) {
       case QualificationTypeStatus.active:
@@ -4398,7 +4398,7 @@ extension on QualificationTypeStatus {
   }
 }
 
-extension on String {
+extension QualificationTypeStatusFromString on String {
   QualificationTypeStatus toQualificationTypeStatus() {
     switch (this) {
       case 'Active':
@@ -4503,7 +4503,7 @@ enum ReviewActionStatus {
   cancelled,
 }
 
-extension on ReviewActionStatus {
+extension ReviewActionStatusValue on ReviewActionStatus {
   String toValue() {
     switch (this) {
       case ReviewActionStatus.intended:
@@ -4518,7 +4518,7 @@ extension on ReviewActionStatus {
   }
 }
 
-extension on String {
+extension ReviewActionStatusFromString on String {
   ReviewActionStatus toReviewActionStatus() {
     switch (this) {
       case 'Intended':
@@ -4573,7 +4573,7 @@ enum ReviewPolicyLevel {
   hit,
 }
 
-extension on ReviewPolicyLevel {
+extension ReviewPolicyLevelValue on ReviewPolicyLevel {
   String toValue() {
     switch (this) {
       case ReviewPolicyLevel.assignment:
@@ -4584,7 +4584,7 @@ extension on ReviewPolicyLevel {
   }
 }
 
-extension on String {
+extension ReviewPolicyLevelFromString on String {
   ReviewPolicyLevel toReviewPolicyLevel() {
     switch (this) {
       case 'Assignment':
@@ -4678,7 +4678,7 @@ enum ReviewableHITStatus {
   reviewing,
 }
 
-extension on ReviewableHITStatus {
+extension ReviewableHITStatusValue on ReviewableHITStatus {
   String toValue() {
     switch (this) {
       case ReviewableHITStatus.reviewable:
@@ -4689,7 +4689,7 @@ extension on ReviewableHITStatus {
   }
 }
 
-extension on String {
+extension ReviewableHITStatusFromString on String {
   ReviewableHITStatus toReviewableHITStatus() {
     switch (this) {
       case 'Reviewable':

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -5467,7 +5467,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -5478,7 +5478,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -8829,7 +8829,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -8848,7 +8848,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -5467,7 +5467,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -8829,7 +8829,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
+++ b/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
@@ -1882,7 +1882,7 @@ enum ConnectionState {
   updating,
 }
 
-extension ConnectionStateValue on ConnectionState {
+extension ConnectionStateValueExtension on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.pending:
@@ -2036,7 +2036,7 @@ enum CustomerGatewayAssociationState {
   deleted,
 }
 
-extension CustomerGatewayAssociationStateValue
+extension CustomerGatewayAssociationStateValueExtension
     on CustomerGatewayAssociationState {
   String toValue() {
     switch (this) {
@@ -2283,7 +2283,7 @@ enum DeviceState {
   updating,
 }
 
-extension DeviceStateValue on DeviceState {
+extension DeviceStateValueExtension on DeviceState {
   String toValue() {
     switch (this) {
       case DeviceState.pending:
@@ -2606,7 +2606,7 @@ enum GlobalNetworkState {
   updating,
 }
 
-extension GlobalNetworkStateValue on GlobalNetworkState {
+extension GlobalNetworkStateValueExtension on GlobalNetworkState {
   String toValue() {
     switch (this) {
       case GlobalNetworkState.pending:
@@ -2745,7 +2745,7 @@ enum LinkAssociationState {
   deleted,
 }
 
-extension LinkAssociationStateValue on LinkAssociationState {
+extension LinkAssociationStateValueExtension on LinkAssociationState {
   String toValue() {
     switch (this) {
       case LinkAssociationState.pending:
@@ -2783,7 +2783,7 @@ enum LinkState {
   updating,
 }
 
-extension LinkStateValue on LinkState {
+extension LinkStateValueExtension on LinkState {
   String toValue() {
     switch (this) {
       case LinkState.pending:
@@ -2946,7 +2946,7 @@ enum SiteState {
   updating,
 }
 
-extension SiteStateValue on SiteState {
+extension SiteStateValueExtension on SiteState {
   String toValue() {
     switch (this) {
       case SiteState.pending:
@@ -3062,7 +3062,7 @@ enum TransitGatewayConnectPeerAssociationState {
   deleted,
 }
 
-extension TransitGatewayConnectPeerAssociationStateValue
+extension TransitGatewayConnectPeerAssociationStateValueExtension
     on TransitGatewayConnectPeerAssociationState {
   String toValue() {
     switch (this) {
@@ -3132,7 +3132,7 @@ enum TransitGatewayRegistrationState {
   failed,
 }
 
-extension TransitGatewayRegistrationStateValue
+extension TransitGatewayRegistrationStateValueExtension
     on TransitGatewayRegistrationState {
   String toValue() {
     switch (this) {

--- a/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
+++ b/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
@@ -1882,7 +1882,7 @@ enum ConnectionState {
   updating,
 }
 
-extension on ConnectionState {
+extension ConnectionStateValue on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.pending:
@@ -1897,7 +1897,7 @@ extension on ConnectionState {
   }
 }
 
-extension on String {
+extension ConnectionStateFromString on String {
   ConnectionState toConnectionState() {
     switch (this) {
       case 'PENDING':
@@ -2036,7 +2036,8 @@ enum CustomerGatewayAssociationState {
   deleted,
 }
 
-extension on CustomerGatewayAssociationState {
+extension CustomerGatewayAssociationStateValue
+    on CustomerGatewayAssociationState {
   String toValue() {
     switch (this) {
       case CustomerGatewayAssociationState.pending:
@@ -2051,7 +2052,7 @@ extension on CustomerGatewayAssociationState {
   }
 }
 
-extension on String {
+extension CustomerGatewayAssociationStateFromString on String {
   CustomerGatewayAssociationState toCustomerGatewayAssociationState() {
     switch (this) {
       case 'PENDING':
@@ -2282,7 +2283,7 @@ enum DeviceState {
   updating,
 }
 
-extension on DeviceState {
+extension DeviceStateValue on DeviceState {
   String toValue() {
     switch (this) {
       case DeviceState.pending:
@@ -2297,7 +2298,7 @@ extension on DeviceState {
   }
 }
 
-extension on String {
+extension DeviceStateFromString on String {
   DeviceState toDeviceState() {
     switch (this) {
       case 'PENDING':
@@ -2605,7 +2606,7 @@ enum GlobalNetworkState {
   updating,
 }
 
-extension on GlobalNetworkState {
+extension GlobalNetworkStateValue on GlobalNetworkState {
   String toValue() {
     switch (this) {
       case GlobalNetworkState.pending:
@@ -2620,7 +2621,7 @@ extension on GlobalNetworkState {
   }
 }
 
-extension on String {
+extension GlobalNetworkStateFromString on String {
   GlobalNetworkState toGlobalNetworkState() {
     switch (this) {
       case 'PENDING':
@@ -2744,7 +2745,7 @@ enum LinkAssociationState {
   deleted,
 }
 
-extension on LinkAssociationState {
+extension LinkAssociationStateValue on LinkAssociationState {
   String toValue() {
     switch (this) {
       case LinkAssociationState.pending:
@@ -2759,7 +2760,7 @@ extension on LinkAssociationState {
   }
 }
 
-extension on String {
+extension LinkAssociationStateFromString on String {
   LinkAssociationState toLinkAssociationState() {
     switch (this) {
       case 'PENDING':
@@ -2782,7 +2783,7 @@ enum LinkState {
   updating,
 }
 
-extension on LinkState {
+extension LinkStateValue on LinkState {
   String toValue() {
     switch (this) {
       case LinkState.pending:
@@ -2797,7 +2798,7 @@ extension on LinkState {
   }
 }
 
-extension on String {
+extension LinkStateFromString on String {
   LinkState toLinkState() {
     switch (this) {
       case 'PENDING':
@@ -2945,7 +2946,7 @@ enum SiteState {
   updating,
 }
 
-extension on SiteState {
+extension SiteStateValue on SiteState {
   String toValue() {
     switch (this) {
       case SiteState.pending:
@@ -2960,7 +2961,7 @@ extension on SiteState {
   }
 }
 
-extension on String {
+extension SiteStateFromString on String {
   SiteState toSiteState() {
     switch (this) {
       case 'PENDING':
@@ -3061,7 +3062,8 @@ enum TransitGatewayConnectPeerAssociationState {
   deleted,
 }
 
-extension on TransitGatewayConnectPeerAssociationState {
+extension TransitGatewayConnectPeerAssociationStateValue
+    on TransitGatewayConnectPeerAssociationState {
   String toValue() {
     switch (this) {
       case TransitGatewayConnectPeerAssociationState.pending:
@@ -3076,7 +3078,7 @@ extension on TransitGatewayConnectPeerAssociationState {
   }
 }
 
-extension on String {
+extension TransitGatewayConnectPeerAssociationStateFromString on String {
   TransitGatewayConnectPeerAssociationState
       toTransitGatewayConnectPeerAssociationState() {
     switch (this) {
@@ -3130,7 +3132,8 @@ enum TransitGatewayRegistrationState {
   failed,
 }
 
-extension on TransitGatewayRegistrationState {
+extension TransitGatewayRegistrationStateValue
+    on TransitGatewayRegistrationState {
   String toValue() {
     switch (this) {
       case TransitGatewayRegistrationState.pending:
@@ -3147,7 +3150,7 @@ extension on TransitGatewayRegistrationState {
   }
 }
 
-extension on String {
+extension TransitGatewayRegistrationStateFromString on String {
   TransitGatewayRegistrationState toTransitGatewayRegistrationState() {
     switch (this) {
       case 'PENDING':

--- a/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
+++ b/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
@@ -5184,7 +5184,7 @@ enum AppAttributesKeys {
   awsFlowRubySettings,
 }
 
-extension on AppAttributesKeys {
+extension AppAttributesKeysValue on AppAttributesKeys {
   String toValue() {
     switch (this) {
       case AppAttributesKeys.documentRoot:
@@ -5199,7 +5199,7 @@ extension on AppAttributesKeys {
   }
 }
 
-extension on String {
+extension AppAttributesKeysFromString on String {
   AppAttributesKeys toAppAttributesKeys() {
     switch (this) {
       case 'DocumentRoot':
@@ -5225,7 +5225,7 @@ enum AppType {
   other,
 }
 
-extension on AppType {
+extension AppTypeValue on AppType {
   String toValue() {
     switch (this) {
       case AppType.awsFlowRuby:
@@ -5246,7 +5246,7 @@ extension on AppType {
   }
 }
 
-extension on String {
+extension AppTypeFromString on String {
   AppType toAppType() {
     switch (this) {
       case 'aws-flow-ruby':
@@ -5273,7 +5273,7 @@ enum Architecture {
   i386,
 }
 
-extension on Architecture {
+extension ArchitectureValue on Architecture {
   String toValue() {
     switch (this) {
       case Architecture.x86_64:
@@ -5284,7 +5284,7 @@ extension on Architecture {
   }
 }
 
-extension on String {
+extension ArchitectureFromString on String {
   Architecture toArchitecture() {
     switch (this) {
       case 'x86_64':
@@ -5393,7 +5393,7 @@ enum AutoScalingType {
   timer,
 }
 
-extension on AutoScalingType {
+extension AutoScalingTypeValue on AutoScalingType {
   String toValue() {
     switch (this) {
       case AutoScalingType.load:
@@ -5404,7 +5404,7 @@ extension on AutoScalingType {
   }
 }
 
-extension on String {
+extension AutoScalingTypeFromString on String {
   AutoScalingType toAutoScalingType() {
     switch (this) {
       case 'load':
@@ -5644,7 +5644,7 @@ enum CloudWatchLogsEncoding {
   utf_8Sig,
 }
 
-extension on CloudWatchLogsEncoding {
+extension CloudWatchLogsEncodingValue on CloudWatchLogsEncoding {
   String toValue() {
     switch (this) {
       case CloudWatchLogsEncoding.ascii:
@@ -5835,7 +5835,7 @@ extension on CloudWatchLogsEncoding {
   }
 }
 
-extension on String {
+extension CloudWatchLogsEncodingFromString on String {
   CloudWatchLogsEncoding toCloudWatchLogsEncoding() {
     switch (this) {
       case 'ascii':
@@ -6035,7 +6035,7 @@ enum CloudWatchLogsInitialPosition {
   endOfFile,
 }
 
-extension on CloudWatchLogsInitialPosition {
+extension CloudWatchLogsInitialPositionValue on CloudWatchLogsInitialPosition {
   String toValue() {
     switch (this) {
       case CloudWatchLogsInitialPosition.startOfFile:
@@ -6046,7 +6046,7 @@ extension on CloudWatchLogsInitialPosition {
   }
 }
 
-extension on String {
+extension CloudWatchLogsInitialPositionFromString on String {
   CloudWatchLogsInitialPosition toCloudWatchLogsInitialPosition() {
     switch (this) {
       case 'start_of_file':
@@ -6195,7 +6195,7 @@ enum CloudWatchLogsTimeZone {
   utc,
 }
 
-extension on CloudWatchLogsTimeZone {
+extension CloudWatchLogsTimeZoneValue on CloudWatchLogsTimeZone {
   String toValue() {
     switch (this) {
       case CloudWatchLogsTimeZone.local:
@@ -6206,7 +6206,7 @@ extension on CloudWatchLogsTimeZone {
   }
 }
 
-extension on String {
+extension CloudWatchLogsTimeZoneFromString on String {
   CloudWatchLogsTimeZone toCloudWatchLogsTimeZone() {
     switch (this) {
       case 'LOCAL':
@@ -6681,7 +6681,7 @@ enum DeploymentCommandName {
   undeploy,
 }
 
-extension on DeploymentCommandName {
+extension DeploymentCommandNameValue on DeploymentCommandName {
   String toValue() {
     switch (this) {
       case DeploymentCommandName.installDependencies:
@@ -6712,7 +6712,7 @@ extension on DeploymentCommandName {
   }
 }
 
-extension on String {
+extension DeploymentCommandNameFromString on String {
   DeploymentCommandName toDeploymentCommandName() {
     switch (this) {
       case 'install_dependencies':
@@ -8135,7 +8135,7 @@ enum LayerAttributesKeys {
   javaAppServerVersion,
 }
 
-extension on LayerAttributesKeys {
+extension LayerAttributesKeysValue on LayerAttributesKeys {
   String toValue() {
     switch (this) {
       case LayerAttributesKeys.ecsClusterArn:
@@ -8192,7 +8192,7 @@ extension on LayerAttributesKeys {
   }
 }
 
-extension on String {
+extension LayerAttributesKeysFromString on String {
   LayerAttributesKeys toLayerAttributesKeys() {
     switch (this) {
       case 'EcsClusterArn':
@@ -8265,7 +8265,7 @@ enum LayerType {
   custom,
 }
 
-extension on LayerType {
+extension LayerTypeValue on LayerType {
   String toValue() {
     switch (this) {
       case LayerType.awsFlowRuby:
@@ -8296,7 +8296,7 @@ extension on LayerType {
   }
 }
 
-extension on String {
+extension LayerTypeFromString on String {
   LayerType toLayerType() {
     switch (this) {
       case 'aws-flow-ruby':
@@ -8865,7 +8865,7 @@ enum RootDeviceType {
   instanceStore,
 }
 
-extension on RootDeviceType {
+extension RootDeviceTypeValue on RootDeviceType {
   String toValue() {
     switch (this) {
       case RootDeviceType.ebs:
@@ -8876,7 +8876,7 @@ extension on RootDeviceType {
   }
 }
 
-extension on String {
+extension RootDeviceTypeFromString on String {
   RootDeviceType toRootDeviceType() {
     switch (this) {
       case 'ebs':
@@ -9097,7 +9097,7 @@ enum SourceType {
   s3,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.git:
@@ -9112,7 +9112,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'git':
@@ -9332,7 +9332,7 @@ enum StackAttributesKeys {
   color,
 }
 
-extension on StackAttributesKeys {
+extension StackAttributesKeysValue on StackAttributesKeys {
   String toValue() {
     switch (this) {
       case StackAttributesKeys.color:
@@ -9341,7 +9341,7 @@ extension on StackAttributesKeys {
   }
 }
 
-extension on String {
+extension StackAttributesKeysFromString on String {
   StackAttributesKeys toStackAttributesKeys() {
     switch (this) {
       case 'Color':
@@ -9527,7 +9527,7 @@ enum VirtualizationType {
   hvm,
 }
 
-extension on VirtualizationType {
+extension VirtualizationTypeValue on VirtualizationType {
   String toValue() {
     switch (this) {
       case VirtualizationType.paravirtual:
@@ -9538,7 +9538,7 @@ extension on VirtualizationType {
   }
 }
 
-extension on String {
+extension VirtualizationTypeFromString on String {
   VirtualizationType toVirtualizationType() {
     switch (this) {
       case 'paravirtual':
@@ -9764,7 +9764,7 @@ enum VolumeType {
   standard,
 }
 
-extension on VolumeType {
+extension VolumeTypeValue on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.gp2:
@@ -9777,7 +9777,7 @@ extension on VolumeType {
   }
 }
 
-extension on String {
+extension VolumeTypeFromString on String {
   VolumeType toVolumeType() {
     switch (this) {
       case 'gp2':

--- a/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
+++ b/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
@@ -5184,7 +5184,7 @@ enum AppAttributesKeys {
   awsFlowRubySettings,
 }
 
-extension AppAttributesKeysValue on AppAttributesKeys {
+extension AppAttributesKeysValueExtension on AppAttributesKeys {
   String toValue() {
     switch (this) {
       case AppAttributesKeys.documentRoot:
@@ -5225,7 +5225,7 @@ enum AppType {
   other,
 }
 
-extension AppTypeValue on AppType {
+extension AppTypeValueExtension on AppType {
   String toValue() {
     switch (this) {
       case AppType.awsFlowRuby:
@@ -5273,7 +5273,7 @@ enum Architecture {
   i386,
 }
 
-extension ArchitectureValue on Architecture {
+extension ArchitectureValueExtension on Architecture {
   String toValue() {
     switch (this) {
       case Architecture.x86_64:
@@ -5393,7 +5393,7 @@ enum AutoScalingType {
   timer,
 }
 
-extension AutoScalingTypeValue on AutoScalingType {
+extension AutoScalingTypeValueExtension on AutoScalingType {
   String toValue() {
     switch (this) {
       case AutoScalingType.load:
@@ -5644,7 +5644,7 @@ enum CloudWatchLogsEncoding {
   utf_8Sig,
 }
 
-extension CloudWatchLogsEncodingValue on CloudWatchLogsEncoding {
+extension CloudWatchLogsEncodingValueExtension on CloudWatchLogsEncoding {
   String toValue() {
     switch (this) {
       case CloudWatchLogsEncoding.ascii:
@@ -6035,7 +6035,8 @@ enum CloudWatchLogsInitialPosition {
   endOfFile,
 }
 
-extension CloudWatchLogsInitialPositionValue on CloudWatchLogsInitialPosition {
+extension CloudWatchLogsInitialPositionValueExtension
+    on CloudWatchLogsInitialPosition {
   String toValue() {
     switch (this) {
       case CloudWatchLogsInitialPosition.startOfFile:
@@ -6195,7 +6196,7 @@ enum CloudWatchLogsTimeZone {
   utc,
 }
 
-extension CloudWatchLogsTimeZoneValue on CloudWatchLogsTimeZone {
+extension CloudWatchLogsTimeZoneValueExtension on CloudWatchLogsTimeZone {
   String toValue() {
     switch (this) {
       case CloudWatchLogsTimeZone.local:
@@ -6681,7 +6682,7 @@ enum DeploymentCommandName {
   undeploy,
 }
 
-extension DeploymentCommandNameValue on DeploymentCommandName {
+extension DeploymentCommandNameValueExtension on DeploymentCommandName {
   String toValue() {
     switch (this) {
       case DeploymentCommandName.installDependencies:
@@ -8135,7 +8136,7 @@ enum LayerAttributesKeys {
   javaAppServerVersion,
 }
 
-extension LayerAttributesKeysValue on LayerAttributesKeys {
+extension LayerAttributesKeysValueExtension on LayerAttributesKeys {
   String toValue() {
     switch (this) {
       case LayerAttributesKeys.ecsClusterArn:
@@ -8265,7 +8266,7 @@ enum LayerType {
   custom,
 }
 
-extension LayerTypeValue on LayerType {
+extension LayerTypeValueExtension on LayerType {
   String toValue() {
     switch (this) {
       case LayerType.awsFlowRuby:
@@ -8865,7 +8866,7 @@ enum RootDeviceType {
   instanceStore,
 }
 
-extension RootDeviceTypeValue on RootDeviceType {
+extension RootDeviceTypeValueExtension on RootDeviceType {
   String toValue() {
     switch (this) {
       case RootDeviceType.ebs:
@@ -9097,7 +9098,7 @@ enum SourceType {
   s3,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.git:
@@ -9332,7 +9333,7 @@ enum StackAttributesKeys {
   color,
 }
 
-extension StackAttributesKeysValue on StackAttributesKeys {
+extension StackAttributesKeysValueExtension on StackAttributesKeys {
   String toValue() {
     switch (this) {
       case StackAttributesKeys.color:
@@ -9527,7 +9528,7 @@ enum VirtualizationType {
   hvm,
 }
 
-extension VirtualizationTypeValue on VirtualizationType {
+extension VirtualizationTypeValueExtension on VirtualizationType {
   String toValue() {
     switch (this) {
       case VirtualizationType.paravirtual:
@@ -9764,7 +9765,7 @@ enum VolumeType {
   standard,
 }
 
-extension VolumeTypeValue on VolumeType {
+extension VolumeTypeValueExtension on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.gp2:

--- a/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
+++ b/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
@@ -1940,7 +1940,7 @@ enum BackupStatus {
   deleting,
 }
 
-extension BackupStatusValue on BackupStatus {
+extension BackupStatusValueExtension on BackupStatus {
   String toValue() {
     switch (this) {
       case BackupStatus.inProgress:
@@ -1976,7 +1976,7 @@ enum BackupType {
   manual,
 }
 
-extension BackupTypeValue on BackupType {
+extension BackupTypeValueExtension on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.automated:
@@ -2285,7 +2285,7 @@ enum MaintenanceStatus {
   failed,
 }
 
-extension MaintenanceStatusValue on MaintenanceStatus {
+extension MaintenanceStatusValueExtension on MaintenanceStatus {
   String toValue() {
     switch (this) {
       case MaintenanceStatus.success:
@@ -2329,7 +2329,7 @@ enum NodeAssociationStatus {
   inProgress,
 }
 
-extension NodeAssociationStatusValue on NodeAssociationStatus {
+extension NodeAssociationStatusValueExtension on NodeAssociationStatus {
   String toValue() {
     switch (this) {
       case NodeAssociationStatus.success:
@@ -2603,7 +2603,7 @@ enum ServerStatus {
   terminated,
 }
 
-extension ServerStatusValue on ServerStatus {
+extension ServerStatusValueExtension on ServerStatus {
   String toValue() {
     switch (this) {
       case ServerStatus.backingUp:

--- a/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
+++ b/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
@@ -1940,7 +1940,7 @@ enum BackupStatus {
   deleting,
 }
 
-extension on BackupStatus {
+extension BackupStatusValue on BackupStatus {
   String toValue() {
     switch (this) {
       case BackupStatus.inProgress:
@@ -1955,7 +1955,7 @@ extension on BackupStatus {
   }
 }
 
-extension on String {
+extension BackupStatusFromString on String {
   BackupStatus toBackupStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -1976,7 +1976,7 @@ enum BackupType {
   manual,
 }
 
-extension on BackupType {
+extension BackupTypeValue on BackupType {
   String toValue() {
     switch (this) {
       case BackupType.automated:
@@ -1987,7 +1987,7 @@ extension on BackupType {
   }
 }
 
-extension on String {
+extension BackupTypeFromString on String {
   BackupType toBackupType() {
     switch (this) {
       case 'AUTOMATED':
@@ -2285,7 +2285,7 @@ enum MaintenanceStatus {
   failed,
 }
 
-extension on MaintenanceStatus {
+extension MaintenanceStatusValue on MaintenanceStatus {
   String toValue() {
     switch (this) {
       case MaintenanceStatus.success:
@@ -2296,7 +2296,7 @@ extension on MaintenanceStatus {
   }
 }
 
-extension on String {
+extension MaintenanceStatusFromString on String {
   MaintenanceStatus toMaintenanceStatus() {
     switch (this) {
       case 'SUCCESS':
@@ -2329,7 +2329,7 @@ enum NodeAssociationStatus {
   inProgress,
 }
 
-extension on NodeAssociationStatus {
+extension NodeAssociationStatusValue on NodeAssociationStatus {
   String toValue() {
     switch (this) {
       case NodeAssociationStatus.success:
@@ -2342,7 +2342,7 @@ extension on NodeAssociationStatus {
   }
 }
 
-extension on String {
+extension NodeAssociationStatusFromString on String {
   NodeAssociationStatus toNodeAssociationStatus() {
     switch (this) {
       case 'SUCCESS':
@@ -2603,7 +2603,7 @@ enum ServerStatus {
   terminated,
 }
 
-extension on ServerStatus {
+extension ServerStatusValue on ServerStatus {
   String toValue() {
     switch (this) {
       case ServerStatus.backingUp:
@@ -2636,7 +2636,7 @@ extension on ServerStatus {
   }
 }
 
-extension on String {
+extension ServerStatusFromString on String {
   ServerStatus toServerStatus() {
     switch (this) {
       case 'BACKING_UP':

--- a/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
+++ b/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
@@ -4636,7 +4636,7 @@ enum AccountJoinedMethod {
   created,
 }
 
-extension AccountJoinedMethodValue on AccountJoinedMethod {
+extension AccountJoinedMethodValueExtension on AccountJoinedMethod {
   String toValue() {
     switch (this) {
       case AccountJoinedMethod.invited:
@@ -4664,7 +4664,7 @@ enum AccountStatus {
   suspended,
 }
 
-extension AccountStatusValue on AccountStatus {
+extension AccountStatusValueExtension on AccountStatus {
   String toValue() {
     switch (this) {
       case AccountStatus.active:
@@ -4694,7 +4694,7 @@ enum ActionType {
   addOrganizationsServiceLinkedRole,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.invite:
@@ -4781,7 +4781,7 @@ enum ChildType {
   organizationalUnit,
 }
 
-extension ChildTypeValue on ChildType {
+extension ChildTypeValueExtension on ChildType {
   String toValue() {
     switch (this) {
       case ChildType.account:
@@ -4816,7 +4816,8 @@ enum CreateAccountFailureReason {
   missingPaymentInstrument,
 }
 
-extension CreateAccountFailureReasonValue on CreateAccountFailureReason {
+extension CreateAccountFailureReasonValueExtension
+    on CreateAccountFailureReason {
   String toValue() {
     switch (this) {
       case CreateAccountFailureReason.accountLimitExceeded:
@@ -4899,7 +4900,7 @@ enum CreateAccountState {
   failed,
 }
 
-extension CreateAccountStateValue on CreateAccountState {
+extension CreateAccountStateValueExtension on CreateAccountState {
   String toValue() {
     switch (this) {
       case CreateAccountState.inProgress:
@@ -5367,7 +5368,7 @@ enum EffectivePolicyType {
   aiservicesOptOutPolicy,
 }
 
-extension EffectivePolicyTypeValue on EffectivePolicyType {
+extension EffectivePolicyTypeValueExtension on EffectivePolicyType {
   String toValue() {
     switch (this) {
       case EffectivePolicyType.tagPolicy:
@@ -5656,7 +5657,7 @@ enum HandshakePartyType {
   email,
 }
 
-extension HandshakePartyTypeValue on HandshakePartyType {
+extension HandshakePartyTypeValueExtension on HandshakePartyType {
   String toValue() {
     switch (this) {
       case HandshakePartyType.account:
@@ -5751,7 +5752,7 @@ enum HandshakeResourceType {
   parentHandshake,
 }
 
-extension HandshakeResourceTypeValue on HandshakeResourceType {
+extension HandshakeResourceTypeValueExtension on HandshakeResourceType {
   String toValue() {
     switch (this) {
       case HandshakeResourceType.account:
@@ -5807,7 +5808,7 @@ enum HandshakeState {
   expired,
 }
 
-extension HandshakeStateValue on HandshakeState {
+extension HandshakeStateValueExtension on HandshakeState {
   String toValue() {
     switch (this) {
       case HandshakeState.requested:
@@ -5851,7 +5852,7 @@ enum IAMUserAccessToBilling {
   deny,
 }
 
-extension IAMUserAccessToBillingValue on IAMUserAccessToBilling {
+extension IAMUserAccessToBillingValueExtension on IAMUserAccessToBilling {
   String toValue() {
     switch (this) {
       case IAMUserAccessToBilling.allow:
@@ -6412,7 +6413,7 @@ enum OrganizationFeatureSet {
   consolidatedBilling,
 }
 
-extension OrganizationFeatureSetValue on OrganizationFeatureSet {
+extension OrganizationFeatureSetValueExtension on OrganizationFeatureSet {
   String toValue() {
     switch (this) {
       case OrganizationFeatureSet.all:
@@ -6519,7 +6520,7 @@ enum ParentType {
   organizationalUnit,
 }
 
-extension ParentTypeValue on ParentType {
+extension ParentTypeValueExtension on ParentType {
   String toValue() {
     switch (this) {
       case ParentType.root:
@@ -6689,7 +6690,7 @@ enum PolicyType {
   aiservicesOptOutPolicy,
 }
 
-extension PolicyTypeValue on PolicyType {
+extension PolicyTypeValueExtension on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.serviceControlPolicy:
@@ -6726,7 +6727,7 @@ enum PolicyTypeStatus {
   pendingDisable,
 }
 
-extension PolicyTypeStatusValue on PolicyTypeStatus {
+extension PolicyTypeStatusValueExtension on PolicyTypeStatus {
   String toValue() {
     switch (this) {
       case PolicyTypeStatus.enabled:
@@ -6887,7 +6888,7 @@ enum TargetType {
   root,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:

--- a/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
+++ b/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
@@ -4636,7 +4636,7 @@ enum AccountJoinedMethod {
   created,
 }
 
-extension on AccountJoinedMethod {
+extension AccountJoinedMethodValue on AccountJoinedMethod {
   String toValue() {
     switch (this) {
       case AccountJoinedMethod.invited:
@@ -4647,7 +4647,7 @@ extension on AccountJoinedMethod {
   }
 }
 
-extension on String {
+extension AccountJoinedMethodFromString on String {
   AccountJoinedMethod toAccountJoinedMethod() {
     switch (this) {
       case 'INVITED':
@@ -4664,7 +4664,7 @@ enum AccountStatus {
   suspended,
 }
 
-extension on AccountStatus {
+extension AccountStatusValue on AccountStatus {
   String toValue() {
     switch (this) {
       case AccountStatus.active:
@@ -4675,7 +4675,7 @@ extension on AccountStatus {
   }
 }
 
-extension on String {
+extension AccountStatusFromString on String {
   AccountStatus toAccountStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -4694,7 +4694,7 @@ enum ActionType {
   addOrganizationsServiceLinkedRole,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.invite:
@@ -4709,7 +4709,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'INVITE':
@@ -4781,7 +4781,7 @@ enum ChildType {
   organizationalUnit,
 }
 
-extension on ChildType {
+extension ChildTypeValue on ChildType {
   String toValue() {
     switch (this) {
       case ChildType.account:
@@ -4792,7 +4792,7 @@ extension on ChildType {
   }
 }
 
-extension on String {
+extension ChildTypeFromString on String {
   ChildType toChildType() {
     switch (this) {
       case 'ACCOUNT':
@@ -4816,7 +4816,7 @@ enum CreateAccountFailureReason {
   missingPaymentInstrument,
 }
 
-extension on CreateAccountFailureReason {
+extension CreateAccountFailureReasonValue on CreateAccountFailureReason {
   String toValue() {
     switch (this) {
       case CreateAccountFailureReason.accountLimitExceeded:
@@ -4841,7 +4841,7 @@ extension on CreateAccountFailureReason {
   }
 }
 
-extension on String {
+extension CreateAccountFailureReasonFromString on String {
   CreateAccountFailureReason toCreateAccountFailureReason() {
     switch (this) {
       case 'ACCOUNT_LIMIT_EXCEEDED':
@@ -4899,7 +4899,7 @@ enum CreateAccountState {
   failed,
 }
 
-extension on CreateAccountState {
+extension CreateAccountStateValue on CreateAccountState {
   String toValue() {
     switch (this) {
       case CreateAccountState.inProgress:
@@ -4912,7 +4912,7 @@ extension on CreateAccountState {
   }
 }
 
-extension on String {
+extension CreateAccountStateFromString on String {
   CreateAccountState toCreateAccountState() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -5367,7 +5367,7 @@ enum EffectivePolicyType {
   aiservicesOptOutPolicy,
 }
 
-extension on EffectivePolicyType {
+extension EffectivePolicyTypeValue on EffectivePolicyType {
   String toValue() {
     switch (this) {
       case EffectivePolicyType.tagPolicy:
@@ -5380,7 +5380,7 @@ extension on EffectivePolicyType {
   }
 }
 
-extension on String {
+extension EffectivePolicyTypeFromString on String {
   EffectivePolicyType toEffectivePolicyType() {
     switch (this) {
       case 'TAG_POLICY':
@@ -5656,7 +5656,7 @@ enum HandshakePartyType {
   email,
 }
 
-extension on HandshakePartyType {
+extension HandshakePartyTypeValue on HandshakePartyType {
   String toValue() {
     switch (this) {
       case HandshakePartyType.account:
@@ -5669,7 +5669,7 @@ extension on HandshakePartyType {
   }
 }
 
-extension on String {
+extension HandshakePartyTypeFromString on String {
   HandshakePartyType toHandshakePartyType() {
     switch (this) {
       case 'ACCOUNT':
@@ -5751,7 +5751,7 @@ enum HandshakeResourceType {
   parentHandshake,
 }
 
-extension on HandshakeResourceType {
+extension HandshakeResourceTypeValue on HandshakeResourceType {
   String toValue() {
     switch (this) {
       case HandshakeResourceType.account:
@@ -5774,7 +5774,7 @@ extension on HandshakeResourceType {
   }
 }
 
-extension on String {
+extension HandshakeResourceTypeFromString on String {
   HandshakeResourceType toHandshakeResourceType() {
     switch (this) {
       case 'ACCOUNT':
@@ -5807,7 +5807,7 @@ enum HandshakeState {
   expired,
 }
 
-extension on HandshakeState {
+extension HandshakeStateValue on HandshakeState {
   String toValue() {
     switch (this) {
       case HandshakeState.requested:
@@ -5826,7 +5826,7 @@ extension on HandshakeState {
   }
 }
 
-extension on String {
+extension HandshakeStateFromString on String {
   HandshakeState toHandshakeState() {
     switch (this) {
       case 'REQUESTED':
@@ -5851,7 +5851,7 @@ enum IAMUserAccessToBilling {
   deny,
 }
 
-extension on IAMUserAccessToBilling {
+extension IAMUserAccessToBillingValue on IAMUserAccessToBilling {
   String toValue() {
     switch (this) {
       case IAMUserAccessToBilling.allow:
@@ -5862,7 +5862,7 @@ extension on IAMUserAccessToBilling {
   }
 }
 
-extension on String {
+extension IAMUserAccessToBillingFromString on String {
   IAMUserAccessToBilling toIAMUserAccessToBilling() {
     switch (this) {
       case 'ALLOW':
@@ -6412,7 +6412,7 @@ enum OrganizationFeatureSet {
   consolidatedBilling,
 }
 
-extension on OrganizationFeatureSet {
+extension OrganizationFeatureSetValue on OrganizationFeatureSet {
   String toValue() {
     switch (this) {
       case OrganizationFeatureSet.all:
@@ -6423,7 +6423,7 @@ extension on OrganizationFeatureSet {
   }
 }
 
-extension on String {
+extension OrganizationFeatureSetFromString on String {
   OrganizationFeatureSet toOrganizationFeatureSet() {
     switch (this) {
       case 'ALL':
@@ -6519,7 +6519,7 @@ enum ParentType {
   organizationalUnit,
 }
 
-extension on ParentType {
+extension ParentTypeValue on ParentType {
   String toValue() {
     switch (this) {
       case ParentType.root:
@@ -6530,7 +6530,7 @@ extension on ParentType {
   }
 }
 
-extension on String {
+extension ParentTypeFromString on String {
   ParentType toParentType() {
     switch (this) {
       case 'ROOT':
@@ -6689,7 +6689,7 @@ enum PolicyType {
   aiservicesOptOutPolicy,
 }
 
-extension on PolicyType {
+extension PolicyTypeValue on PolicyType {
   String toValue() {
     switch (this) {
       case PolicyType.serviceControlPolicy:
@@ -6704,7 +6704,7 @@ extension on PolicyType {
   }
 }
 
-extension on String {
+extension PolicyTypeFromString on String {
   PolicyType toPolicyType() {
     switch (this) {
       case 'SERVICE_CONTROL_POLICY':
@@ -6726,7 +6726,7 @@ enum PolicyTypeStatus {
   pendingDisable,
 }
 
-extension on PolicyTypeStatus {
+extension PolicyTypeStatusValue on PolicyTypeStatus {
   String toValue() {
     switch (this) {
       case PolicyTypeStatus.enabled:
@@ -6739,7 +6739,7 @@ extension on PolicyTypeStatus {
   }
 }
 
-extension on String {
+extension PolicyTypeStatusFromString on String {
   PolicyTypeStatus toPolicyTypeStatus() {
     switch (this) {
       case 'ENABLED':
@@ -6887,7 +6887,7 @@ enum TargetType {
   root,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.account:
@@ -6900,7 +6900,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'ACCOUNT':

--- a/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
+++ b/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
@@ -5184,7 +5184,7 @@ enum RecipeProvider {
   service,
 }
 
-extension on RecipeProvider {
+extension RecipeProviderValue on RecipeProvider {
   String toValue() {
     switch (this) {
       case RecipeProvider.service:
@@ -5193,7 +5193,7 @@ extension on RecipeProvider {
   }
 }
 
-extension on String {
+extension RecipeProviderFromString on String {
   RecipeProvider toRecipeProvider() {
     switch (this) {
       case 'SERVICE':
@@ -5661,7 +5661,7 @@ enum TrainingMode {
   update,
 }
 
-extension on TrainingMode {
+extension TrainingModeValue on TrainingMode {
   String toValue() {
     switch (this) {
       case TrainingMode.full:
@@ -5672,7 +5672,7 @@ extension on TrainingMode {
   }
 }
 
-extension on String {
+extension TrainingModeFromString on String {
   TrainingMode toTrainingMode() {
     switch (this) {
       case 'FULL':

--- a/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
+++ b/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
@@ -5184,7 +5184,7 @@ enum RecipeProvider {
   service,
 }
 
-extension RecipeProviderValue on RecipeProvider {
+extension RecipeProviderValueExtension on RecipeProvider {
   String toValue() {
     switch (this) {
       case RecipeProvider.service:
@@ -5661,7 +5661,7 @@ enum TrainingMode {
   update,
 }
 
-extension TrainingModeValue on TrainingMode {
+extension TrainingModeValueExtension on TrainingMode {
   String toValue() {
     switch (this) {
       case TrainingMode.full:

--- a/generated/aws_pi_api/lib/pi-2018-02-27.dart
+++ b/generated/aws_pi_api/lib/pi-2018-02-27.dart
@@ -815,7 +815,7 @@ enum ServiceType {
   rds,
 }
 
-extension on ServiceType {
+extension ServiceTypeValue on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.rds:
@@ -824,7 +824,7 @@ extension on ServiceType {
   }
 }
 
-extension on String {
+extension ServiceTypeFromString on String {
   ServiceType toServiceType() {
     switch (this) {
       case 'RDS':

--- a/generated/aws_pi_api/lib/pi-2018-02-27.dart
+++ b/generated/aws_pi_api/lib/pi-2018-02-27.dart
@@ -815,7 +815,7 @@ enum ServiceType {
   rds,
 }
 
-extension ServiceTypeValue on ServiceType {
+extension ServiceTypeValueExtension on ServiceType {
   String toValue() {
     switch (this) {
       case ServiceType.rds:

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -5793,7 +5793,7 @@ enum Action {
   url,
 }
 
-extension on Action {
+extension ActionValue on Action {
   String toValue() {
     switch (this) {
       case Action.openApp:
@@ -5806,7 +5806,7 @@ extension on Action {
   }
 }
 
-extension on String {
+extension ActionFromString on String {
   Action toAction() {
     switch (this) {
       case 'OPEN_APP':
@@ -6437,7 +6437,7 @@ enum AttributeType {
   exclusive,
 }
 
-extension on AttributeType {
+extension AttributeTypeValue on AttributeType {
   String toValue() {
     switch (this) {
       case AttributeType.inclusive:
@@ -6448,7 +6448,7 @@ extension on AttributeType {
   }
 }
 
-extension on String {
+extension AttributeTypeFromString on String {
   AttributeType toAttributeType() {
     switch (this) {
       case 'INCLUSIVE':
@@ -7262,7 +7262,7 @@ enum CampaignStatus {
   invalid,
 }
 
-extension on CampaignStatus {
+extension CampaignStatusValue on CampaignStatus {
   String toValue() {
     switch (this) {
       case CampaignStatus.scheduled:
@@ -7283,7 +7283,7 @@ extension on CampaignStatus {
   }
 }
 
-extension on String {
+extension CampaignStatusFromString on String {
   CampaignStatus toCampaignStatus() {
     switch (this) {
       case 'SCHEDULED':
@@ -7403,7 +7403,7 @@ enum ChannelType {
   custom,
 }
 
-extension on ChannelType {
+extension ChannelTypeValue on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.push:
@@ -7434,7 +7434,7 @@ extension on ChannelType {
   }
 }
 
-extension on String {
+extension ChannelTypeFromString on String {
   ChannelType toChannelType() {
     switch (this) {
       case 'PUSH':
@@ -8378,7 +8378,7 @@ enum DeliveryStatus {
   duplicate,
 }
 
-extension on DeliveryStatus {
+extension DeliveryStatusValue on DeliveryStatus {
   String toValue() {
     switch (this) {
       case DeliveryStatus.successful:
@@ -8399,7 +8399,7 @@ extension on DeliveryStatus {
   }
 }
 
-extension on String {
+extension DeliveryStatusFromString on String {
   DeliveryStatus toDeliveryStatus() {
     switch (this) {
       case 'SUCCESSFUL':
@@ -8426,7 +8426,7 @@ enum DimensionType {
   exclusive,
 }
 
-extension on DimensionType {
+extension DimensionTypeValue on DimensionType {
   String toValue() {
     switch (this) {
       case DimensionType.inclusive:
@@ -8437,7 +8437,7 @@ extension on DimensionType {
   }
 }
 
-extension on String {
+extension DimensionTypeFromString on String {
   DimensionType toDimensionType() {
     switch (this) {
       case 'INCLUSIVE':
@@ -8534,7 +8534,7 @@ enum Duration {
   day_30,
 }
 
-extension on Duration {
+extension DurationValue on Duration {
   String toValue() {
     switch (this) {
       case Duration.hr_24:
@@ -8549,7 +8549,7 @@ extension on Duration {
   }
 }
 
-extension on String {
+extension DurationFromString on String {
   Duration toDuration() {
     switch (this) {
       case 'HR_24':
@@ -10276,7 +10276,7 @@ enum FilterType {
   endpoint,
 }
 
-extension on FilterType {
+extension FilterTypeValue on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.system:
@@ -10287,7 +10287,7 @@ extension on FilterType {
   }
 }
 
-extension on String {
+extension FilterTypeFromString on String {
   FilterType toFilterType() {
     switch (this) {
       case 'SYSTEM':
@@ -10304,7 +10304,7 @@ enum Format {
   json,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.csv:
@@ -10315,7 +10315,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'CSV':
@@ -10336,7 +10336,7 @@ enum Frequency {
   event,
 }
 
-extension on Frequency {
+extension FrequencyValue on Frequency {
   String toValue() {
     switch (this) {
       case Frequency.once:
@@ -10355,7 +10355,7 @@ extension on Frequency {
   }
 }
 
-extension on String {
+extension FrequencyFromString on String {
   Frequency toFrequency() {
     switch (this) {
       case 'ONCE':
@@ -11382,7 +11382,7 @@ enum Include {
   none,
 }
 
-extension on Include {
+extension IncludeValue on Include {
   String toValue() {
     switch (this) {
       case Include.all:
@@ -11395,7 +11395,7 @@ extension on Include {
   }
 }
 
-extension on String {
+extension IncludeFromString on String {
   Include toInclude() {
     switch (this) {
       case 'ALL':
@@ -11449,7 +11449,7 @@ enum JobStatus {
   failed,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -11474,7 +11474,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'CREATED':
@@ -12575,7 +12575,7 @@ enum MessageType {
   promotional,
 }
 
-extension on MessageType {
+extension MessageTypeValue on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.transactional:
@@ -12586,7 +12586,7 @@ extension on MessageType {
   }
 }
 
-extension on String {
+extension MessageTypeFromString on String {
   MessageType toMessageType() {
     switch (this) {
       case 'TRANSACTIONAL':
@@ -12636,7 +12636,7 @@ enum Mode {
   filter,
 }
 
-extension on Mode {
+extension ModeValue on Mode {
   String toValue() {
     switch (this) {
       case Mode.delivery:
@@ -12647,7 +12647,7 @@ extension on Mode {
   }
 }
 
-extension on String {
+extension ModeFromString on String {
   Mode toMode() {
     switch (this) {
       case 'DELIVERY':
@@ -12873,7 +12873,7 @@ enum Operator {
   any,
 }
 
-extension on Operator {
+extension OperatorValue on Operator {
   String toValue() {
     switch (this) {
       case Operator.all:
@@ -12884,7 +12884,7 @@ extension on Operator {
   }
 }
 
-extension on String {
+extension OperatorFromString on String {
   Operator toOperator() {
     switch (this) {
       case 'ALL':
@@ -13440,7 +13440,7 @@ enum RecencyType {
   inactive,
 }
 
-extension on RecencyType {
+extension RecencyTypeValue on RecencyType {
   String toValue() {
     switch (this) {
       case RecencyType.active:
@@ -13451,7 +13451,7 @@ extension on RecencyType {
   }
 }
 
-extension on String {
+extension RecencyTypeFromString on String {
   RecencyType toRecencyType() {
     switch (this) {
       case 'ACTIVE':
@@ -14634,7 +14634,7 @@ enum SegmentType {
   import,
 }
 
-extension on SegmentType {
+extension SegmentTypeValue on SegmentType {
   String toValue() {
     switch (this) {
       case SegmentType.dimensional:
@@ -14645,7 +14645,7 @@ extension on SegmentType {
   }
 }
 
-extension on String {
+extension SegmentTypeFromString on String {
   SegmentType toSegmentType() {
     switch (this) {
       case 'DIMENSIONAL':
@@ -14960,7 +14960,7 @@ enum SourceType {
   none,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.all:
@@ -14973,7 +14973,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'ALL':
@@ -15039,7 +15039,7 @@ enum State {
   closed,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.draft:
@@ -15056,7 +15056,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'DRAFT':
@@ -15306,7 +15306,7 @@ enum TemplateType {
   push,
 }
 
-extension on TemplateType {
+extension TemplateTypeValue on TemplateType {
   String toValue() {
     switch (this) {
       case TemplateType.email:
@@ -15321,7 +15321,7 @@ extension on TemplateType {
   }
 }
 
-extension on String {
+extension TemplateTypeFromString on String {
   TemplateType toTemplateType() {
     switch (this) {
       case 'EMAIL':
@@ -15532,7 +15532,7 @@ enum Type {
   none,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.all:
@@ -15545,7 +15545,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'ALL':
@@ -16741,7 +16741,7 @@ enum EndpointTypesElement {
   custom,
 }
 
-extension on EndpointTypesElement {
+extension EndpointTypesElementValue on EndpointTypesElement {
   String toValue() {
     switch (this) {
       case EndpointTypesElement.push:
@@ -16772,7 +16772,7 @@ extension on EndpointTypesElement {
   }
 }
 
-extension on String {
+extension EndpointTypesElementFromString on String {
   EndpointTypesElement toEndpointTypesElement() {
     switch (this) {
       case 'PUSH':

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -5793,7 +5793,7 @@ enum Action {
   url,
 }
 
-extension ActionValue on Action {
+extension ActionValueExtension on Action {
   String toValue() {
     switch (this) {
       case Action.openApp:
@@ -6437,7 +6437,7 @@ enum AttributeType {
   exclusive,
 }
 
-extension AttributeTypeValue on AttributeType {
+extension AttributeTypeValueExtension on AttributeType {
   String toValue() {
     switch (this) {
       case AttributeType.inclusive:
@@ -7262,7 +7262,7 @@ enum CampaignStatus {
   invalid,
 }
 
-extension CampaignStatusValue on CampaignStatus {
+extension CampaignStatusValueExtension on CampaignStatus {
   String toValue() {
     switch (this) {
       case CampaignStatus.scheduled:
@@ -7403,7 +7403,7 @@ enum ChannelType {
   custom,
 }
 
-extension ChannelTypeValue on ChannelType {
+extension ChannelTypeValueExtension on ChannelType {
   String toValue() {
     switch (this) {
       case ChannelType.push:
@@ -8378,7 +8378,7 @@ enum DeliveryStatus {
   duplicate,
 }
 
-extension DeliveryStatusValue on DeliveryStatus {
+extension DeliveryStatusValueExtension on DeliveryStatus {
   String toValue() {
     switch (this) {
       case DeliveryStatus.successful:
@@ -8426,7 +8426,7 @@ enum DimensionType {
   exclusive,
 }
 
-extension DimensionTypeValue on DimensionType {
+extension DimensionTypeValueExtension on DimensionType {
   String toValue() {
     switch (this) {
       case DimensionType.inclusive:
@@ -8534,7 +8534,7 @@ enum Duration {
   day_30,
 }
 
-extension DurationValue on Duration {
+extension DurationValueExtension on Duration {
   String toValue() {
     switch (this) {
       case Duration.hr_24:
@@ -10276,7 +10276,7 @@ enum FilterType {
   endpoint,
 }
 
-extension FilterTypeValue on FilterType {
+extension FilterTypeValueExtension on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.system:
@@ -10304,7 +10304,7 @@ enum Format {
   json,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.csv:
@@ -10336,7 +10336,7 @@ enum Frequency {
   event,
 }
 
-extension FrequencyValue on Frequency {
+extension FrequencyValueExtension on Frequency {
   String toValue() {
     switch (this) {
       case Frequency.once:
@@ -11382,7 +11382,7 @@ enum Include {
   none,
 }
 
-extension IncludeValue on Include {
+extension IncludeValueExtension on Include {
   String toValue() {
     switch (this) {
       case Include.all:
@@ -11449,7 +11449,7 @@ enum JobStatus {
   failed,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -12575,7 +12575,7 @@ enum MessageType {
   promotional,
 }
 
-extension MessageTypeValue on MessageType {
+extension MessageTypeValueExtension on MessageType {
   String toValue() {
     switch (this) {
       case MessageType.transactional:
@@ -12636,7 +12636,7 @@ enum Mode {
   filter,
 }
 
-extension ModeValue on Mode {
+extension ModeValueExtension on Mode {
   String toValue() {
     switch (this) {
       case Mode.delivery:
@@ -12873,7 +12873,7 @@ enum Operator {
   any,
 }
 
-extension OperatorValue on Operator {
+extension OperatorValueExtension on Operator {
   String toValue() {
     switch (this) {
       case Operator.all:
@@ -13440,7 +13440,7 @@ enum RecencyType {
   inactive,
 }
 
-extension RecencyTypeValue on RecencyType {
+extension RecencyTypeValueExtension on RecencyType {
   String toValue() {
     switch (this) {
       case RecencyType.active:
@@ -14634,7 +14634,7 @@ enum SegmentType {
   import,
 }
 
-extension SegmentTypeValue on SegmentType {
+extension SegmentTypeValueExtension on SegmentType {
   String toValue() {
     switch (this) {
       case SegmentType.dimensional:
@@ -14960,7 +14960,7 @@ enum SourceType {
   none,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.all:
@@ -15039,7 +15039,7 @@ enum State {
   closed,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.draft:
@@ -15306,7 +15306,7 @@ enum TemplateType {
   push,
 }
 
-extension TemplateTypeValue on TemplateType {
+extension TemplateTypeValueExtension on TemplateType {
   String toValue() {
     switch (this) {
       case TemplateType.email:
@@ -15532,7 +15532,7 @@ enum Type {
   none,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.all:
@@ -16741,7 +16741,7 @@ enum EndpointTypesElement {
   custom,
 }
 
-extension EndpointTypesElementValue on EndpointTypesElement {
+extension EndpointTypesElementValueExtension on EndpointTypesElement {
   String toValue() {
     switch (this) {
       case EndpointTypesElement.push:

--- a/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
+++ b/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
@@ -1638,7 +1638,7 @@ enum BehaviorOnMxFailure {
   rejectMessage,
 }
 
-extension on BehaviorOnMxFailure {
+extension BehaviorOnMxFailureValue on BehaviorOnMxFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMxFailure.useDefaultValue:
@@ -1649,7 +1649,7 @@ extension on BehaviorOnMxFailure {
   }
 }
 
-extension on String {
+extension BehaviorOnMxFailureFromString on String {
   BehaviorOnMxFailure toBehaviorOnMxFailure() {
     switch (this) {
       case 'USE_DEFAULT_VALUE':
@@ -2056,7 +2056,8 @@ enum DeliverabilityDashboardAccountStatus {
   disabled,
 }
 
-extension on DeliverabilityDashboardAccountStatus {
+extension DeliverabilityDashboardAccountStatusValue
+    on DeliverabilityDashboardAccountStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityDashboardAccountStatus.active:
@@ -2069,7 +2070,7 @@ extension on DeliverabilityDashboardAccountStatus {
   }
 }
 
-extension on String {
+extension DeliverabilityDashboardAccountStatusFromString on String {
   DeliverabilityDashboardAccountStatus
       toDeliverabilityDashboardAccountStatus() {
     switch (this) {
@@ -2147,7 +2148,7 @@ enum DeliverabilityTestStatus {
   completed,
 }
 
-extension on DeliverabilityTestStatus {
+extension DeliverabilityTestStatusValue on DeliverabilityTestStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityTestStatus.inProgress:
@@ -2158,7 +2159,7 @@ extension on DeliverabilityTestStatus {
   }
 }
 
-extension on String {
+extension DeliverabilityTestStatusFromString on String {
   DeliverabilityTestStatus toDeliverabilityTestStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -2248,7 +2249,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension on DimensionValueSource {
+extension DimensionValueSourceValue on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -2261,7 +2262,7 @@ extension on DimensionValueSource {
   }
 }
 
-extension on String {
+extension DimensionValueSourceFromString on String {
   DimensionValueSource toDimensionValueSource() {
     switch (this) {
       case 'MESSAGE_TAG':
@@ -2374,7 +2375,7 @@ enum DkimStatus {
   notStarted,
 }
 
-extension on DkimStatus {
+extension DkimStatusValue on DkimStatus {
   String toValue() {
     switch (this) {
       case DkimStatus.pending:
@@ -2391,7 +2392,7 @@ extension on DkimStatus {
   }
 }
 
-extension on String {
+extension DkimStatusFromString on String {
   DkimStatus toDkimStatus() {
     switch (this) {
       case 'PENDING':
@@ -2830,7 +2831,7 @@ enum EventType {
   renderingFailure,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -2853,7 +2854,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'SEND':
@@ -3385,7 +3386,7 @@ enum IdentityType {
   managedDomain,
 }
 
-extension on IdentityType {
+extension IdentityTypeValue on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -3398,7 +3399,7 @@ extension on IdentityType {
   }
 }
 
-extension on String {
+extension IdentityTypeFromString on String {
   IdentityType toIdentityType() {
     switch (this) {
       case 'EMAIL_ADDRESS':
@@ -3757,7 +3758,7 @@ enum MailFromDomainStatus {
   temporaryFailure,
 }
 
-extension on MailFromDomainStatus {
+extension MailFromDomainStatusValue on MailFromDomainStatus {
   String toValue() {
     switch (this) {
       case MailFromDomainStatus.pending:
@@ -3772,7 +3773,7 @@ extension on MailFromDomainStatus {
   }
 }
 
-extension on String {
+extension MailFromDomainStatusFromString on String {
   MailFromDomainStatus toMailFromDomainStatus() {
     switch (this) {
       case 'PENDING':
@@ -4372,7 +4373,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension on TlsPolicy {
+extension TlsPolicyValue on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -4383,7 +4384,7 @@ extension on TlsPolicy {
   }
 }
 
-extension on String {
+extension TlsPolicyFromString on String {
   TlsPolicy toTlsPolicy() {
     switch (this) {
       case 'REQUIRE':
@@ -4482,7 +4483,7 @@ enum WarmupStatus {
   done,
 }
 
-extension on WarmupStatus {
+extension WarmupStatusValue on WarmupStatus {
   String toValue() {
     switch (this) {
       case WarmupStatus.inProgress:
@@ -4493,7 +4494,7 @@ extension on WarmupStatus {
   }
 }
 
-extension on String {
+extension WarmupStatusFromString on String {
   WarmupStatus toWarmupStatus() {
     switch (this) {
       case 'IN_PROGRESS':

--- a/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
+++ b/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
@@ -1638,7 +1638,7 @@ enum BehaviorOnMxFailure {
   rejectMessage,
 }
 
-extension BehaviorOnMxFailureValue on BehaviorOnMxFailure {
+extension BehaviorOnMxFailureValueExtension on BehaviorOnMxFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMxFailure.useDefaultValue:
@@ -2056,7 +2056,7 @@ enum DeliverabilityDashboardAccountStatus {
   disabled,
 }
 
-extension DeliverabilityDashboardAccountStatusValue
+extension DeliverabilityDashboardAccountStatusValueExtension
     on DeliverabilityDashboardAccountStatus {
   String toValue() {
     switch (this) {
@@ -2148,7 +2148,7 @@ enum DeliverabilityTestStatus {
   completed,
 }
 
-extension DeliverabilityTestStatusValue on DeliverabilityTestStatus {
+extension DeliverabilityTestStatusValueExtension on DeliverabilityTestStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityTestStatus.inProgress:
@@ -2249,7 +2249,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension DimensionValueSourceValue on DimensionValueSource {
+extension DimensionValueSourceValueExtension on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -2375,7 +2375,7 @@ enum DkimStatus {
   notStarted,
 }
 
-extension DkimStatusValue on DkimStatus {
+extension DkimStatusValueExtension on DkimStatus {
   String toValue() {
     switch (this) {
       case DkimStatus.pending:
@@ -2831,7 +2831,7 @@ enum EventType {
   renderingFailure,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -3386,7 +3386,7 @@ enum IdentityType {
   managedDomain,
 }
 
-extension IdentityTypeValue on IdentityType {
+extension IdentityTypeValueExtension on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -3758,7 +3758,7 @@ enum MailFromDomainStatus {
   temporaryFailure,
 }
 
-extension MailFromDomainStatusValue on MailFromDomainStatus {
+extension MailFromDomainStatusValueExtension on MailFromDomainStatus {
   String toValue() {
     switch (this) {
       case MailFromDomainStatus.pending:
@@ -4373,7 +4373,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension TlsPolicyValue on TlsPolicy {
+extension TlsPolicyValueExtension on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -4483,7 +4483,7 @@ enum WarmupStatus {
   done,
 }
 
-extension WarmupStatusValue on WarmupStatus {
+extension WarmupStatusValueExtension on WarmupStatus {
   String toValue() {
     switch (this) {
       case WarmupStatus.inProgress:

--- a/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
+++ b/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
@@ -484,7 +484,7 @@ enum EventType {
   noAnswer,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.initiatedCall:
@@ -505,7 +505,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'INITIATED_CALL':

--- a/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
+++ b/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
@@ -484,7 +484,7 @@ enum EventType {
   noAnswer,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.initiatedCall:

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -629,7 +629,7 @@ enum Engine {
   neural,
 }
 
-extension on Engine {
+extension EngineValue on Engine {
   String toValue() {
     switch (this) {
       case Engine.standard:
@@ -640,7 +640,7 @@ extension on Engine {
   }
 }
 
-extension on String {
+extension EngineFromString on String {
   Engine toEngine() {
     switch (this) {
       case 'standard':
@@ -657,7 +657,7 @@ enum Gender {
   male,
 }
 
-extension on Gender {
+extension GenderValue on Gender {
   String toValue() {
     switch (this) {
       case Gender.female:
@@ -668,7 +668,7 @@ extension on Gender {
   }
 }
 
-extension on String {
+extension GenderFromString on String {
   Gender toGender() {
     switch (this) {
       case 'Female':
@@ -756,7 +756,7 @@ enum LanguageCode {
   trTr,
 }
 
-extension on LanguageCode {
+extension LanguageCodeValue on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.arb:
@@ -821,7 +821,7 @@ extension on LanguageCode {
   }
 }
 
-extension on String {
+extension LanguageCodeFromString on String {
   LanguageCode toLanguageCode() {
     switch (this) {
       case 'arb':
@@ -1036,7 +1036,7 @@ enum OutputFormat {
   pcm,
 }
 
-extension on OutputFormat {
+extension OutputFormatValue on OutputFormat {
   String toValue() {
     switch (this) {
       case OutputFormat.json:
@@ -1051,7 +1051,7 @@ extension on OutputFormat {
   }
 }
 
-extension on String {
+extension OutputFormatFromString on String {
   OutputFormat toOutputFormat() {
     switch (this) {
       case 'json':
@@ -1081,7 +1081,7 @@ enum SpeechMarkType {
   word,
 }
 
-extension on SpeechMarkType {
+extension SpeechMarkTypeValue on SpeechMarkType {
   String toValue() {
     switch (this) {
       case SpeechMarkType.sentence:
@@ -1096,7 +1096,7 @@ extension on SpeechMarkType {
   }
 }
 
-extension on String {
+extension SpeechMarkTypeFromString on String {
   SpeechMarkType toSpeechMarkType() {
     switch (this) {
       case 'sentence':
@@ -1291,7 +1291,7 @@ enum TaskStatus {
   failed,
 }
 
-extension on TaskStatus {
+extension TaskStatusValue on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.scheduled:
@@ -1306,7 +1306,7 @@ extension on TaskStatus {
   }
 }
 
-extension on String {
+extension TaskStatusFromString on String {
   TaskStatus toTaskStatus() {
     switch (this) {
       case 'scheduled':
@@ -1327,7 +1327,7 @@ enum TextType {
   text,
 }
 
-extension on TextType {
+extension TextTypeValue on TextType {
   String toValue() {
     switch (this) {
       case TextType.ssml:
@@ -1338,7 +1338,7 @@ extension on TextType {
   }
 }
 
-extension on String {
+extension TextTypeFromString on String {
   TextType toTextType() {
     switch (this) {
       case 'ssml':
@@ -1475,7 +1475,7 @@ enum VoiceId {
   zhiyu,
 }
 
-extension on VoiceId {
+extension VoiceIdValue on VoiceId {
   String toValue() {
     switch (this) {
       case VoiceId.aditi:
@@ -1606,7 +1606,7 @@ extension on VoiceId {
   }
 }
 
-extension on String {
+extension VoiceIdFromString on String {
   VoiceId toVoiceId() {
     switch (this) {
       case 'Aditi':

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -629,7 +629,7 @@ enum Engine {
   neural,
 }
 
-extension EngineValue on Engine {
+extension EngineValueExtension on Engine {
   String toValue() {
     switch (this) {
       case Engine.standard:
@@ -657,7 +657,7 @@ enum Gender {
   male,
 }
 
-extension GenderValue on Gender {
+extension GenderValueExtension on Gender {
   String toValue() {
     switch (this) {
       case Gender.female:
@@ -756,7 +756,7 @@ enum LanguageCode {
   trTr,
 }
 
-extension LanguageCodeValue on LanguageCode {
+extension LanguageCodeValueExtension on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.arb:
@@ -1036,7 +1036,7 @@ enum OutputFormat {
   pcm,
 }
 
-extension OutputFormatValue on OutputFormat {
+extension OutputFormatValueExtension on OutputFormat {
   String toValue() {
     switch (this) {
       case OutputFormat.json:
@@ -1081,7 +1081,7 @@ enum SpeechMarkType {
   word,
 }
 
-extension SpeechMarkTypeValue on SpeechMarkType {
+extension SpeechMarkTypeValueExtension on SpeechMarkType {
   String toValue() {
     switch (this) {
       case SpeechMarkType.sentence:
@@ -1291,7 +1291,7 @@ enum TaskStatus {
   failed,
 }
 
-extension TaskStatusValue on TaskStatus {
+extension TaskStatusValueExtension on TaskStatus {
   String toValue() {
     switch (this) {
       case TaskStatus.scheduled:
@@ -1327,7 +1327,7 @@ enum TextType {
   text,
 }
 
-extension TextTypeValue on TextType {
+extension TextTypeValueExtension on TextType {
   String toValue() {
     switch (this) {
       case TextType.ssml:
@@ -1475,7 +1475,7 @@ enum VoiceId {
   zhiyu,
 }
 
-extension VoiceIdValue on VoiceId {
+extension VoiceIdValueExtension on VoiceId {
   String toValue() {
     switch (this) {
       case VoiceId.aditi:

--- a/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
+++ b/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
@@ -376,7 +376,7 @@ enum FilterType {
   termMatch,
 }
 
-extension on FilterType {
+extension FilterTypeValue on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.termMatch:
@@ -385,7 +385,7 @@ extension on FilterType {
   }
 }
 
-extension on String {
+extension FilterTypeFromString on String {
   FilterType toFilterType() {
     switch (this) {
       case 'TERM_MATCH':

--- a/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
+++ b/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
@@ -376,7 +376,7 @@ enum FilterType {
   termMatch,
 }
 
-extension FilterTypeValue on FilterType {
+extension FilterTypeValueExtension on FilterType {
   String toValue() {
     switch (this) {
       case FilterType.termMatch:

--- a/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
+++ b/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
@@ -1217,7 +1217,7 @@ enum ErrorCause {
   iamPermissionRevoked,
 }
 
-extension ErrorCauseValue on ErrorCause {
+extension ErrorCauseValueExtension on ErrorCause {
   String toValue() {
     switch (this) {
       case ErrorCause.kinesisStreamNotFound:
@@ -1263,7 +1263,7 @@ enum ExportStatus {
   cancelled,
 }
 
-extension ExportStatusValue on ExportStatus {
+extension ExportStatusValueExtension on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -1546,7 +1546,7 @@ enum LedgerState {
   deleted,
 }
 
-extension LedgerStateValue on LedgerState {
+extension LedgerStateValueExtension on LedgerState {
   String toValue() {
     switch (this) {
       case LedgerState.creating:
@@ -1767,7 +1767,7 @@ enum PermissionsMode {
   allowAll,
 }
 
-extension PermissionsModeValue on PermissionsMode {
+extension PermissionsModeValueExtension on PermissionsMode {
   String toValue() {
     switch (this) {
       case PermissionsMode.allowAll:
@@ -1901,7 +1901,7 @@ enum S3ObjectEncryptionType {
   noEncryption,
 }
 
-extension S3ObjectEncryptionTypeValue on S3ObjectEncryptionType {
+extension S3ObjectEncryptionTypeValueExtension on S3ObjectEncryptionType {
   String toValue() {
     switch (this) {
       case S3ObjectEncryptionType.sseKms:
@@ -1950,7 +1950,7 @@ enum StreamStatus {
   impaired,
 }
 
-extension StreamStatusValue on StreamStatus {
+extension StreamStatusValueExtension on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.active:

--- a/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
+++ b/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
@@ -1217,7 +1217,7 @@ enum ErrorCause {
   iamPermissionRevoked,
 }
 
-extension on ErrorCause {
+extension ErrorCauseValue on ErrorCause {
   String toValue() {
     switch (this) {
       case ErrorCause.kinesisStreamNotFound:
@@ -1228,7 +1228,7 @@ extension on ErrorCause {
   }
 }
 
-extension on String {
+extension ErrorCauseFromString on String {
   ErrorCause toErrorCause() {
     switch (this) {
       case 'KINESIS_STREAM_NOT_FOUND':
@@ -1263,7 +1263,7 @@ enum ExportStatus {
   cancelled,
 }
 
-extension on ExportStatus {
+extension ExportStatusValue on ExportStatus {
   String toValue() {
     switch (this) {
       case ExportStatus.inProgress:
@@ -1276,7 +1276,7 @@ extension on ExportStatus {
   }
 }
 
-extension on String {
+extension ExportStatusFromString on String {
   ExportStatus toExportStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -1546,7 +1546,7 @@ enum LedgerState {
   deleted,
 }
 
-extension on LedgerState {
+extension LedgerStateValue on LedgerState {
   String toValue() {
     switch (this) {
       case LedgerState.creating:
@@ -1561,7 +1561,7 @@ extension on LedgerState {
   }
 }
 
-extension on String {
+extension LedgerStateFromString on String {
   LedgerState toLedgerState() {
     switch (this) {
       case 'CREATING':
@@ -1767,7 +1767,7 @@ enum PermissionsMode {
   allowAll,
 }
 
-extension on PermissionsMode {
+extension PermissionsModeValue on PermissionsMode {
   String toValue() {
     switch (this) {
       case PermissionsMode.allowAll:
@@ -1776,7 +1776,7 @@ extension on PermissionsMode {
   }
 }
 
-extension on String {
+extension PermissionsModeFromString on String {
   PermissionsMode toPermissionsMode() {
     switch (this) {
       case 'ALLOW_ALL':
@@ -1901,7 +1901,7 @@ enum S3ObjectEncryptionType {
   noEncryption,
 }
 
-extension on S3ObjectEncryptionType {
+extension S3ObjectEncryptionTypeValue on S3ObjectEncryptionType {
   String toValue() {
     switch (this) {
       case S3ObjectEncryptionType.sseKms:
@@ -1914,7 +1914,7 @@ extension on S3ObjectEncryptionType {
   }
 }
 
-extension on String {
+extension S3ObjectEncryptionTypeFromString on String {
   S3ObjectEncryptionType toS3ObjectEncryptionType() {
     switch (this) {
       case 'SSE_KMS':
@@ -1950,7 +1950,7 @@ enum StreamStatus {
   impaired,
 }
 
-extension on StreamStatus {
+extension StreamStatusValue on StreamStatus {
   String toValue() {
     switch (this) {
       case StreamStatus.active:
@@ -1967,7 +1967,7 @@ extension on StreamStatus {
   }
 }
 
-extension on String {
+extension StreamStatusFromString on String {
   StreamStatus toStreamStatus() {
     switch (this) {
       case 'ACTIVE':

--- a/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
+++ b/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
@@ -7196,7 +7196,7 @@ enum AnalysisErrorType {
   columnReplacementMissing,
 }
 
-extension on AnalysisErrorType {
+extension AnalysisErrorTypeValue on AnalysisErrorType {
   String toValue() {
     switch (this) {
       case AnalysisErrorType.accessDenied:
@@ -7223,7 +7223,7 @@ extension on AnalysisErrorType {
   }
 }
 
-extension on String {
+extension AnalysisErrorTypeFromString on String {
   AnalysisErrorType toAnalysisErrorType() {
     switch (this) {
       case 'ACCESS_DENIED':
@@ -7255,7 +7255,7 @@ enum AnalysisFilterAttribute {
   quicksightUser,
 }
 
-extension on AnalysisFilterAttribute {
+extension AnalysisFilterAttributeValue on AnalysisFilterAttribute {
   String toValue() {
     switch (this) {
       case AnalysisFilterAttribute.quicksightUser:
@@ -7264,7 +7264,7 @@ extension on AnalysisFilterAttribute {
   }
 }
 
-extension on String {
+extension AnalysisFilterAttributeFromString on String {
   AnalysisFilterAttribute toAnalysisFilterAttribute() {
     switch (this) {
       case 'QUICKSIGHT_USER':
@@ -7390,7 +7390,7 @@ enum AssignmentStatus {
   disabled,
 }
 
-extension on AssignmentStatus {
+extension AssignmentStatusValue on AssignmentStatus {
   String toValue() {
     switch (this) {
       case AssignmentStatus.enabled:
@@ -7403,7 +7403,7 @@ extension on AssignmentStatus {
   }
 }
 
-extension on String {
+extension AssignmentStatusFromString on String {
   AssignmentStatus toAssignmentStatus() {
     switch (this) {
       case 'ENABLED':
@@ -7665,7 +7665,7 @@ enum ColumnDataType {
   datetime,
 }
 
-extension on ColumnDataType {
+extension ColumnDataTypeValue on ColumnDataType {
   String toValue() {
     switch (this) {
       case ColumnDataType.string:
@@ -7680,7 +7680,7 @@ extension on ColumnDataType {
   }
 }
 
-extension on String {
+extension ColumnDataTypeFromString on String {
   ColumnDataType toColumnDataType() {
     switch (this) {
       case 'STRING':
@@ -8564,7 +8564,7 @@ enum DashboardBehavior {
   disabled,
 }
 
-extension on DashboardBehavior {
+extension DashboardBehaviorValue on DashboardBehavior {
   String toValue() {
     switch (this) {
       case DashboardBehavior.enabled:
@@ -8575,7 +8575,7 @@ extension on DashboardBehavior {
   }
 }
 
-extension on String {
+extension DashboardBehaviorFromString on String {
   DashboardBehavior toDashboardBehavior() {
     switch (this) {
       case 'ENABLED':
@@ -8620,7 +8620,7 @@ enum DashboardErrorType {
   columnReplacementMissing,
 }
 
-extension on DashboardErrorType {
+extension DashboardErrorTypeValue on DashboardErrorType {
   String toValue() {
     switch (this) {
       case DashboardErrorType.accessDenied:
@@ -8647,7 +8647,7 @@ extension on DashboardErrorType {
   }
 }
 
-extension on String {
+extension DashboardErrorTypeFromString on String {
   DashboardErrorType toDashboardErrorType() {
     switch (this) {
       case 'ACCESS_DENIED':
@@ -8679,7 +8679,7 @@ enum DashboardFilterAttribute {
   quicksightUser,
 }
 
-extension on DashboardFilterAttribute {
+extension DashboardFilterAttributeValue on DashboardFilterAttribute {
   String toValue() {
     switch (this) {
       case DashboardFilterAttribute.quicksightUser:
@@ -8688,7 +8688,7 @@ extension on DashboardFilterAttribute {
   }
 }
 
-extension on String {
+extension DashboardFilterAttributeFromString on String {
   DashboardFilterAttribute toDashboardFilterAttribute() {
     switch (this) {
       case 'QUICKSIGHT_USER':
@@ -8848,7 +8848,7 @@ enum DashboardUIState {
   collapsed,
 }
 
-extension on DashboardUIState {
+extension DashboardUIStateValue on DashboardUIState {
   String toValue() {
     switch (this) {
       case DashboardUIState.expanded:
@@ -8859,7 +8859,7 @@ extension on DashboardUIState {
   }
 }
 
-extension on String {
+extension DashboardUIStateFromString on String {
   DashboardUIState toDashboardUIState() {
     switch (this) {
       case 'EXPANDED':
@@ -9162,7 +9162,7 @@ enum DataSetImportMode {
   directQuery,
 }
 
-extension on DataSetImportMode {
+extension DataSetImportModeValue on DataSetImportMode {
   String toValue() {
     switch (this) {
       case DataSetImportMode.spice:
@@ -9173,7 +9173,7 @@ extension on DataSetImportMode {
   }
 }
 
-extension on String {
+extension DataSetImportModeFromString on String {
   DataSetImportMode toDataSetImportMode() {
     switch (this) {
       case 'SPICE':
@@ -9440,7 +9440,7 @@ enum DataSourceErrorInfoType {
   unknown,
 }
 
-extension on DataSourceErrorInfoType {
+extension DataSourceErrorInfoTypeValue on DataSourceErrorInfoType {
   String toValue() {
     switch (this) {
       case DataSourceErrorInfoType.accessDenied:
@@ -9463,7 +9463,7 @@ extension on DataSourceErrorInfoType {
   }
 }
 
-extension on String {
+extension DataSourceErrorInfoTypeFromString on String {
   DataSourceErrorInfoType toDataSourceErrorInfoType() {
     switch (this) {
       case 'ACCESS_DENIED':
@@ -9737,7 +9737,7 @@ enum DataSourceType {
   timestream,
 }
 
-extension on DataSourceType {
+extension DataSourceTypeValue on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.adobeAnalytics:
@@ -9790,7 +9790,7 @@ extension on DataSourceType {
   }
 }
 
-extension on String {
+extension DataSourceTypeFromString on String {
   DataSourceType toDataSourceType() {
     switch (this) {
       case 'ADOBE_ANALYTICS':
@@ -10903,7 +10903,7 @@ enum Edition {
   enterprise,
 }
 
-extension on Edition {
+extension EditionValue on Edition {
   String toValue() {
     switch (this) {
       case Edition.standard:
@@ -10914,7 +10914,7 @@ extension on Edition {
   }
 }
 
-extension on String {
+extension EditionFromString on String {
   Edition toEdition() {
     switch (this) {
       case 'STANDARD':
@@ -10932,7 +10932,7 @@ enum EmbeddingIdentityType {
   anonymous,
 }
 
-extension on EmbeddingIdentityType {
+extension EmbeddingIdentityTypeValue on EmbeddingIdentityType {
   String toValue() {
     switch (this) {
       case EmbeddingIdentityType.iam:
@@ -10945,7 +10945,7 @@ extension on EmbeddingIdentityType {
   }
 }
 
-extension on String {
+extension EmbeddingIdentityTypeFromString on String {
   EmbeddingIdentityType toEmbeddingIdentityType() {
     switch (this) {
       case 'IAM':
@@ -11005,7 +11005,7 @@ enum FileFormat {
   json,
 }
 
-extension on FileFormat {
+extension FileFormatValue on FileFormat {
   String toValue() {
     switch (this) {
       case FileFormat.csv:
@@ -11024,7 +11024,7 @@ extension on FileFormat {
   }
 }
 
-extension on String {
+extension FileFormatFromString on String {
   FileFormat toFileFormat() {
     switch (this) {
       case 'CSV':
@@ -11071,7 +11071,7 @@ enum FilterOperator {
   stringEquals,
 }
 
-extension on FilterOperator {
+extension FilterOperatorValue on FilterOperator {
   String toValue() {
     switch (this) {
       case FilterOperator.stringEquals:
@@ -11080,7 +11080,7 @@ extension on FilterOperator {
   }
 }
 
-extension on String {
+extension FilterOperatorFromString on String {
   FilterOperator toFilterOperator() {
     switch (this) {
       case 'StringEquals':
@@ -11133,7 +11133,7 @@ enum GeoSpatialCountryCode {
   us,
 }
 
-extension on GeoSpatialCountryCode {
+extension GeoSpatialCountryCodeValue on GeoSpatialCountryCode {
   String toValue() {
     switch (this) {
       case GeoSpatialCountryCode.us:
@@ -11142,7 +11142,7 @@ extension on GeoSpatialCountryCode {
   }
 }
 
-extension on String {
+extension GeoSpatialCountryCodeFromString on String {
   GeoSpatialCountryCode toGeoSpatialCountryCode() {
     switch (this) {
       case 'US':
@@ -11162,7 +11162,7 @@ enum GeoSpatialDataRole {
   latitude,
 }
 
-extension on GeoSpatialDataRole {
+extension GeoSpatialDataRoleValue on GeoSpatialDataRole {
   String toValue() {
     switch (this) {
       case GeoSpatialDataRole.country:
@@ -11183,7 +11183,7 @@ extension on GeoSpatialDataRole {
   }
 }
 
-extension on String {
+extension GeoSpatialDataRoleFromString on String {
   GeoSpatialDataRole toGeoSpatialDataRole() {
     switch (this) {
       case 'COUNTRY':
@@ -11401,7 +11401,7 @@ enum IdentityStore {
   quicksight,
 }
 
-extension on IdentityStore {
+extension IdentityStoreValue on IdentityStore {
   String toValue() {
     switch (this) {
       case IdentityStore.quicksight:
@@ -11410,7 +11410,7 @@ extension on IdentityStore {
   }
 }
 
-extension on String {
+extension IdentityStoreFromString on String {
   IdentityStore toIdentityStore() {
     switch (this) {
       case 'QUICKSIGHT':
@@ -11425,7 +11425,7 @@ enum IdentityType {
   quicksight,
 }
 
-extension on IdentityType {
+extension IdentityTypeValue on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.iam:
@@ -11436,7 +11436,7 @@ extension on IdentityType {
   }
 }
 
-extension on String {
+extension IdentityTypeFromString on String {
   IdentityType toIdentityType() {
     switch (this) {
       case 'IAM':
@@ -11559,7 +11559,7 @@ enum IngestionErrorType {
   internalServiceError,
 }
 
-extension on IngestionErrorType {
+extension IngestionErrorTypeValue on IngestionErrorType {
   String toValue() {
     switch (this) {
       case IngestionErrorType.failureToAssumeRole:
@@ -11646,7 +11646,7 @@ extension on IngestionErrorType {
   }
 }
 
-extension on String {
+extension IngestionErrorTypeFromString on String {
   IngestionErrorType toIngestionErrorType() {
     switch (this) {
       case 'FAILURE_TO_ASSUME_ROLE':
@@ -11739,7 +11739,7 @@ enum IngestionRequestSource {
   scheduled,
 }
 
-extension on IngestionRequestSource {
+extension IngestionRequestSourceValue on IngestionRequestSource {
   String toValue() {
     switch (this) {
       case IngestionRequestSource.manual:
@@ -11750,7 +11750,7 @@ extension on IngestionRequestSource {
   }
 }
 
-extension on String {
+extension IngestionRequestSourceFromString on String {
   IngestionRequestSource toIngestionRequestSource() {
     switch (this) {
       case 'MANUAL':
@@ -11769,7 +11769,7 @@ enum IngestionRequestType {
   fullRefresh,
 }
 
-extension on IngestionRequestType {
+extension IngestionRequestTypeValue on IngestionRequestType {
   String toValue() {
     switch (this) {
       case IngestionRequestType.initialIngestion:
@@ -11784,7 +11784,7 @@ extension on IngestionRequestType {
   }
 }
 
-extension on String {
+extension IngestionRequestTypeFromString on String {
   IngestionRequestType toIngestionRequestType() {
     switch (this) {
       case 'INITIAL_INGESTION':
@@ -11809,7 +11809,7 @@ enum IngestionStatus {
   cancelled,
 }
 
-extension on IngestionStatus {
+extension IngestionStatusValue on IngestionStatus {
   String toValue() {
     switch (this) {
       case IngestionStatus.initialized:
@@ -11828,7 +11828,7 @@ extension on IngestionStatus {
   }
 }
 
-extension on String {
+extension IngestionStatusFromString on String {
   IngestionStatus toIngestionStatus() {
     switch (this) {
       case 'INITIALIZED':
@@ -11887,7 +11887,7 @@ enum InputColumnDataType {
   json,
 }
 
-extension on InputColumnDataType {
+extension InputColumnDataTypeValue on InputColumnDataType {
   String toValue() {
     switch (this) {
       case InputColumnDataType.string:
@@ -11908,7 +11908,7 @@ extension on InputColumnDataType {
   }
 }
 
-extension on String {
+extension InputColumnDataTypeFromString on String {
   InputColumnDataType toInputColumnDataType() {
     switch (this) {
       case 'STRING':
@@ -12070,7 +12070,7 @@ enum JoinType {
   right,
 }
 
-extension on JoinType {
+extension JoinTypeValue on JoinType {
   String toValue() {
     switch (this) {
       case JoinType.inner:
@@ -12085,7 +12085,7 @@ extension on JoinType {
   }
 }
 
-extension on String {
+extension JoinTypeFromString on String {
   JoinType toJoinType() {
     switch (this) {
       case 'INNER':
@@ -12952,7 +12952,7 @@ enum NamespaceErrorType {
   internalServiceError,
 }
 
-extension on NamespaceErrorType {
+extension NamespaceErrorTypeValue on NamespaceErrorType {
   String toValue() {
     switch (this) {
       case NamespaceErrorType.permissionDenied:
@@ -12963,7 +12963,7 @@ extension on NamespaceErrorType {
   }
 }
 
-extension on String {
+extension NamespaceErrorTypeFromString on String {
   NamespaceErrorType toNamespaceErrorType() {
     switch (this) {
       case 'PERMISSION_DENIED':
@@ -13026,7 +13026,7 @@ enum NamespaceStatus {
   nonRetryableFailure,
 }
 
-extension on NamespaceStatus {
+extension NamespaceStatusValue on NamespaceStatus {
   String toValue() {
     switch (this) {
       case NamespaceStatus.created:
@@ -13043,7 +13043,7 @@ extension on NamespaceStatus {
   }
 }
 
-extension on String {
+extension NamespaceStatusFromString on String {
   NamespaceStatus toNamespaceStatus() {
     switch (this) {
       case 'CREATED':
@@ -13569,7 +13569,7 @@ enum ResourceStatus {
   deleted,
 }
 
-extension on ResourceStatus {
+extension ResourceStatusValue on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.creationInProgress:
@@ -13590,7 +13590,7 @@ extension on ResourceStatus {
   }
 }
 
-extension on String {
+extension ResourceStatusFromString on String {
   ResourceStatus toResourceStatus() {
     switch (this) {
       case 'CREATION_IN_PROGRESS':
@@ -13702,7 +13702,7 @@ enum RowLevelPermissionPolicy {
   denyAccess,
 }
 
-extension on RowLevelPermissionPolicy {
+extension RowLevelPermissionPolicyValue on RowLevelPermissionPolicy {
   String toValue() {
     switch (this) {
       case RowLevelPermissionPolicy.grantAccess:
@@ -13713,7 +13713,7 @@ extension on RowLevelPermissionPolicy {
   }
 }
 
-extension on String {
+extension RowLevelPermissionPolicyFromString on String {
   RowLevelPermissionPolicy toRowLevelPermissionPolicy() {
     switch (this) {
       case 'GRANT_ACCESS':
@@ -14283,7 +14283,7 @@ enum TemplateErrorType {
   accessDenied,
 }
 
-extension on TemplateErrorType {
+extension TemplateErrorTypeValue on TemplateErrorType {
   String toValue() {
     switch (this) {
       case TemplateErrorType.sourceNotFound:
@@ -14298,7 +14298,7 @@ extension on TemplateErrorType {
   }
 }
 
-extension on String {
+extension TemplateErrorTypeFromString on String {
   TemplateErrorType toTemplateErrorType() {
     switch (this) {
       case 'SOURCE_NOT_FOUND':
@@ -14560,7 +14560,7 @@ enum TextQualifier {
   singleQuote,
 }
 
-extension on TextQualifier {
+extension TextQualifierValue on TextQualifier {
   String toValue() {
     switch (this) {
       case TextQualifier.doubleQuote:
@@ -14571,7 +14571,7 @@ extension on TextQualifier {
   }
 }
 
-extension on String {
+extension TextQualifierFromString on String {
   TextQualifier toTextQualifier() {
     switch (this) {
       case 'DOUBLE_QUOTE':
@@ -14724,7 +14724,7 @@ enum ThemeErrorType {
   internalFailure,
 }
 
-extension on ThemeErrorType {
+extension ThemeErrorTypeValue on ThemeErrorType {
   String toValue() {
     switch (this) {
       case ThemeErrorType.internalFailure:
@@ -14733,7 +14733,7 @@ extension on ThemeErrorType {
   }
 }
 
-extension on String {
+extension ThemeErrorTypeFromString on String {
   ThemeErrorType toThemeErrorType() {
     switch (this) {
       case 'INTERNAL_FAILURE':
@@ -14789,7 +14789,7 @@ enum ThemeType {
   all,
 }
 
-extension on ThemeType {
+extension ThemeTypeValue on ThemeType {
   String toValue() {
     switch (this) {
       case ThemeType.quicksight:
@@ -14802,7 +14802,7 @@ extension on ThemeType {
   }
 }
 
-extension on String {
+extension ThemeTypeFromString on String {
   ThemeType toThemeType() {
     switch (this) {
       case 'QUICKSIGHT':
@@ -16058,7 +16058,7 @@ enum UserRole {
   restrictedReader,
 }
 
-extension on UserRole {
+extension UserRoleValue on UserRole {
   String toValue() {
     switch (this) {
       case UserRole.admin:
@@ -16075,7 +16075,7 @@ extension on UserRole {
   }
 }
 
-extension on String {
+extension UserRoleFromString on String {
   UserRole toUserRole() {
     switch (this) {
       case 'ADMIN':

--- a/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
+++ b/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
@@ -7196,7 +7196,7 @@ enum AnalysisErrorType {
   columnReplacementMissing,
 }
 
-extension AnalysisErrorTypeValue on AnalysisErrorType {
+extension AnalysisErrorTypeValueExtension on AnalysisErrorType {
   String toValue() {
     switch (this) {
       case AnalysisErrorType.accessDenied:
@@ -7255,7 +7255,7 @@ enum AnalysisFilterAttribute {
   quicksightUser,
 }
 
-extension AnalysisFilterAttributeValue on AnalysisFilterAttribute {
+extension AnalysisFilterAttributeValueExtension on AnalysisFilterAttribute {
   String toValue() {
     switch (this) {
       case AnalysisFilterAttribute.quicksightUser:
@@ -7390,7 +7390,7 @@ enum AssignmentStatus {
   disabled,
 }
 
-extension AssignmentStatusValue on AssignmentStatus {
+extension AssignmentStatusValueExtension on AssignmentStatus {
   String toValue() {
     switch (this) {
       case AssignmentStatus.enabled:
@@ -7665,7 +7665,7 @@ enum ColumnDataType {
   datetime,
 }
 
-extension ColumnDataTypeValue on ColumnDataType {
+extension ColumnDataTypeValueExtension on ColumnDataType {
   String toValue() {
     switch (this) {
       case ColumnDataType.string:
@@ -8564,7 +8564,7 @@ enum DashboardBehavior {
   disabled,
 }
 
-extension DashboardBehaviorValue on DashboardBehavior {
+extension DashboardBehaviorValueExtension on DashboardBehavior {
   String toValue() {
     switch (this) {
       case DashboardBehavior.enabled:
@@ -8620,7 +8620,7 @@ enum DashboardErrorType {
   columnReplacementMissing,
 }
 
-extension DashboardErrorTypeValue on DashboardErrorType {
+extension DashboardErrorTypeValueExtension on DashboardErrorType {
   String toValue() {
     switch (this) {
       case DashboardErrorType.accessDenied:
@@ -8679,7 +8679,7 @@ enum DashboardFilterAttribute {
   quicksightUser,
 }
 
-extension DashboardFilterAttributeValue on DashboardFilterAttribute {
+extension DashboardFilterAttributeValueExtension on DashboardFilterAttribute {
   String toValue() {
     switch (this) {
       case DashboardFilterAttribute.quicksightUser:
@@ -8848,7 +8848,7 @@ enum DashboardUIState {
   collapsed,
 }
 
-extension DashboardUIStateValue on DashboardUIState {
+extension DashboardUIStateValueExtension on DashboardUIState {
   String toValue() {
     switch (this) {
       case DashboardUIState.expanded:
@@ -9162,7 +9162,7 @@ enum DataSetImportMode {
   directQuery,
 }
 
-extension DataSetImportModeValue on DataSetImportMode {
+extension DataSetImportModeValueExtension on DataSetImportMode {
   String toValue() {
     switch (this) {
       case DataSetImportMode.spice:
@@ -9440,7 +9440,7 @@ enum DataSourceErrorInfoType {
   unknown,
 }
 
-extension DataSourceErrorInfoTypeValue on DataSourceErrorInfoType {
+extension DataSourceErrorInfoTypeValueExtension on DataSourceErrorInfoType {
   String toValue() {
     switch (this) {
       case DataSourceErrorInfoType.accessDenied:
@@ -9737,7 +9737,7 @@ enum DataSourceType {
   timestream,
 }
 
-extension DataSourceTypeValue on DataSourceType {
+extension DataSourceTypeValueExtension on DataSourceType {
   String toValue() {
     switch (this) {
       case DataSourceType.adobeAnalytics:
@@ -10903,7 +10903,7 @@ enum Edition {
   enterprise,
 }
 
-extension EditionValue on Edition {
+extension EditionValueExtension on Edition {
   String toValue() {
     switch (this) {
       case Edition.standard:
@@ -10932,7 +10932,7 @@ enum EmbeddingIdentityType {
   anonymous,
 }
 
-extension EmbeddingIdentityTypeValue on EmbeddingIdentityType {
+extension EmbeddingIdentityTypeValueExtension on EmbeddingIdentityType {
   String toValue() {
     switch (this) {
       case EmbeddingIdentityType.iam:
@@ -11005,7 +11005,7 @@ enum FileFormat {
   json,
 }
 
-extension FileFormatValue on FileFormat {
+extension FileFormatValueExtension on FileFormat {
   String toValue() {
     switch (this) {
       case FileFormat.csv:
@@ -11071,7 +11071,7 @@ enum FilterOperator {
   stringEquals,
 }
 
-extension FilterOperatorValue on FilterOperator {
+extension FilterOperatorValueExtension on FilterOperator {
   String toValue() {
     switch (this) {
       case FilterOperator.stringEquals:
@@ -11133,7 +11133,7 @@ enum GeoSpatialCountryCode {
   us,
 }
 
-extension GeoSpatialCountryCodeValue on GeoSpatialCountryCode {
+extension GeoSpatialCountryCodeValueExtension on GeoSpatialCountryCode {
   String toValue() {
     switch (this) {
       case GeoSpatialCountryCode.us:
@@ -11162,7 +11162,7 @@ enum GeoSpatialDataRole {
   latitude,
 }
 
-extension GeoSpatialDataRoleValue on GeoSpatialDataRole {
+extension GeoSpatialDataRoleValueExtension on GeoSpatialDataRole {
   String toValue() {
     switch (this) {
       case GeoSpatialDataRole.country:
@@ -11401,7 +11401,7 @@ enum IdentityStore {
   quicksight,
 }
 
-extension IdentityStoreValue on IdentityStore {
+extension IdentityStoreValueExtension on IdentityStore {
   String toValue() {
     switch (this) {
       case IdentityStore.quicksight:
@@ -11425,7 +11425,7 @@ enum IdentityType {
   quicksight,
 }
 
-extension IdentityTypeValue on IdentityType {
+extension IdentityTypeValueExtension on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.iam:
@@ -11559,7 +11559,7 @@ enum IngestionErrorType {
   internalServiceError,
 }
 
-extension IngestionErrorTypeValue on IngestionErrorType {
+extension IngestionErrorTypeValueExtension on IngestionErrorType {
   String toValue() {
     switch (this) {
       case IngestionErrorType.failureToAssumeRole:
@@ -11739,7 +11739,7 @@ enum IngestionRequestSource {
   scheduled,
 }
 
-extension IngestionRequestSourceValue on IngestionRequestSource {
+extension IngestionRequestSourceValueExtension on IngestionRequestSource {
   String toValue() {
     switch (this) {
       case IngestionRequestSource.manual:
@@ -11769,7 +11769,7 @@ enum IngestionRequestType {
   fullRefresh,
 }
 
-extension IngestionRequestTypeValue on IngestionRequestType {
+extension IngestionRequestTypeValueExtension on IngestionRequestType {
   String toValue() {
     switch (this) {
       case IngestionRequestType.initialIngestion:
@@ -11809,7 +11809,7 @@ enum IngestionStatus {
   cancelled,
 }
 
-extension IngestionStatusValue on IngestionStatus {
+extension IngestionStatusValueExtension on IngestionStatus {
   String toValue() {
     switch (this) {
       case IngestionStatus.initialized:
@@ -11887,7 +11887,7 @@ enum InputColumnDataType {
   json,
 }
 
-extension InputColumnDataTypeValue on InputColumnDataType {
+extension InputColumnDataTypeValueExtension on InputColumnDataType {
   String toValue() {
     switch (this) {
       case InputColumnDataType.string:
@@ -12070,7 +12070,7 @@ enum JoinType {
   right,
 }
 
-extension JoinTypeValue on JoinType {
+extension JoinTypeValueExtension on JoinType {
   String toValue() {
     switch (this) {
       case JoinType.inner:
@@ -12952,7 +12952,7 @@ enum NamespaceErrorType {
   internalServiceError,
 }
 
-extension NamespaceErrorTypeValue on NamespaceErrorType {
+extension NamespaceErrorTypeValueExtension on NamespaceErrorType {
   String toValue() {
     switch (this) {
       case NamespaceErrorType.permissionDenied:
@@ -13026,7 +13026,7 @@ enum NamespaceStatus {
   nonRetryableFailure,
 }
 
-extension NamespaceStatusValue on NamespaceStatus {
+extension NamespaceStatusValueExtension on NamespaceStatus {
   String toValue() {
     switch (this) {
       case NamespaceStatus.created:
@@ -13569,7 +13569,7 @@ enum ResourceStatus {
   deleted,
 }
 
-extension ResourceStatusValue on ResourceStatus {
+extension ResourceStatusValueExtension on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.creationInProgress:
@@ -13702,7 +13702,7 @@ enum RowLevelPermissionPolicy {
   denyAccess,
 }
 
-extension RowLevelPermissionPolicyValue on RowLevelPermissionPolicy {
+extension RowLevelPermissionPolicyValueExtension on RowLevelPermissionPolicy {
   String toValue() {
     switch (this) {
       case RowLevelPermissionPolicy.grantAccess:
@@ -14283,7 +14283,7 @@ enum TemplateErrorType {
   accessDenied,
 }
 
-extension TemplateErrorTypeValue on TemplateErrorType {
+extension TemplateErrorTypeValueExtension on TemplateErrorType {
   String toValue() {
     switch (this) {
       case TemplateErrorType.sourceNotFound:
@@ -14560,7 +14560,7 @@ enum TextQualifier {
   singleQuote,
 }
 
-extension TextQualifierValue on TextQualifier {
+extension TextQualifierValueExtension on TextQualifier {
   String toValue() {
     switch (this) {
       case TextQualifier.doubleQuote:
@@ -14724,7 +14724,7 @@ enum ThemeErrorType {
   internalFailure,
 }
 
-extension ThemeErrorTypeValue on ThemeErrorType {
+extension ThemeErrorTypeValueExtension on ThemeErrorType {
   String toValue() {
     switch (this) {
       case ThemeErrorType.internalFailure:
@@ -14789,7 +14789,7 @@ enum ThemeType {
   all,
 }
 
-extension ThemeTypeValue on ThemeType {
+extension ThemeTypeValueExtension on ThemeType {
   String toValue() {
     switch (this) {
       case ThemeType.quicksight:
@@ -16058,7 +16058,7 @@ enum UserRole {
   restrictedReader,
 }
 
-extension UserRoleValue on UserRole {
+extension UserRoleValueExtension on UserRole {
   String toValue() {
     switch (this) {
       case UserRole.admin:

--- a/generated/aws_ram_api/lib/ram-2018-01-04.dart
+++ b/generated/aws_ram_api/lib/ram-2018-01-04.dart
@@ -1766,7 +1766,7 @@ enum ResourceOwner {
   otherAccounts,
 }
 
-extension on ResourceOwner {
+extension ResourceOwnerValue on ResourceOwner {
   String toValue() {
     switch (this) {
       case ResourceOwner.self:
@@ -1777,7 +1777,7 @@ extension on ResourceOwner {
   }
 }
 
-extension on String {
+extension ResourceOwnerFromString on String {
   ResourceOwner toResourceOwner() {
     switch (this) {
       case 'SELF':
@@ -1939,7 +1939,8 @@ enum ResourceShareAssociationStatus {
   disassociated,
 }
 
-extension on ResourceShareAssociationStatus {
+extension ResourceShareAssociationStatusValue
+    on ResourceShareAssociationStatus {
   String toValue() {
     switch (this) {
       case ResourceShareAssociationStatus.associating:
@@ -1956,7 +1957,7 @@ extension on ResourceShareAssociationStatus {
   }
 }
 
-extension on String {
+extension ResourceShareAssociationStatusFromString on String {
   ResourceShareAssociationStatus toResourceShareAssociationStatus() {
     switch (this) {
       case 'ASSOCIATING':
@@ -1980,7 +1981,7 @@ enum ResourceShareAssociationType {
   resource,
 }
 
-extension on ResourceShareAssociationType {
+extension ResourceShareAssociationTypeValue on ResourceShareAssociationType {
   String toValue() {
     switch (this) {
       case ResourceShareAssociationType.principal:
@@ -1991,7 +1992,7 @@ extension on ResourceShareAssociationType {
   }
 }
 
-extension on String {
+extension ResourceShareAssociationTypeFromString on String {
   ResourceShareAssociationType toResourceShareAssociationType() {
     switch (this) {
       case 'PRINCIPAL':
@@ -2009,7 +2010,7 @@ enum ResourceShareFeatureSet {
   standard,
 }
 
-extension on ResourceShareFeatureSet {
+extension ResourceShareFeatureSetValue on ResourceShareFeatureSet {
   String toValue() {
     switch (this) {
       case ResourceShareFeatureSet.createdFromPolicy:
@@ -2022,7 +2023,7 @@ extension on ResourceShareFeatureSet {
   }
 }
 
-extension on String {
+extension ResourceShareFeatureSetFromString on String {
   ResourceShareFeatureSet toResourceShareFeatureSet() {
     switch (this) {
       case 'CREATED_FROM_POLICY':
@@ -2100,7 +2101,7 @@ enum ResourceShareInvitationStatus {
   expired,
 }
 
-extension on ResourceShareInvitationStatus {
+extension ResourceShareInvitationStatusValue on ResourceShareInvitationStatus {
   String toValue() {
     switch (this) {
       case ResourceShareInvitationStatus.pending:
@@ -2115,7 +2116,7 @@ extension on ResourceShareInvitationStatus {
   }
 }
 
-extension on String {
+extension ResourceShareInvitationStatusFromString on String {
   ResourceShareInvitationStatus toResourceShareInvitationStatus() {
     switch (this) {
       case 'PENDING':
@@ -2244,7 +2245,7 @@ enum ResourceShareStatus {
   deleted,
 }
 
-extension on ResourceShareStatus {
+extension ResourceShareStatusValue on ResourceShareStatus {
   String toValue() {
     switch (this) {
       case ResourceShareStatus.pending:
@@ -2261,7 +2262,7 @@ extension on ResourceShareStatus {
   }
 }
 
-extension on String {
+extension ResourceShareStatusFromString on String {
   ResourceShareStatus toResourceShareStatus() {
     switch (this) {
       case 'PENDING':
@@ -2287,7 +2288,7 @@ enum ResourceStatus {
   pending,
 }
 
-extension on ResourceStatus {
+extension ResourceStatusValue on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.available:
@@ -2304,7 +2305,7 @@ extension on ResourceStatus {
   }
 }
 
-extension on String {
+extension ResourceStatusFromString on String {
   ResourceStatus toResourceStatus() {
     switch (this) {
       case 'AVAILABLE':

--- a/generated/aws_ram_api/lib/ram-2018-01-04.dart
+++ b/generated/aws_ram_api/lib/ram-2018-01-04.dart
@@ -1766,7 +1766,7 @@ enum ResourceOwner {
   otherAccounts,
 }
 
-extension ResourceOwnerValue on ResourceOwner {
+extension ResourceOwnerValueExtension on ResourceOwner {
   String toValue() {
     switch (this) {
       case ResourceOwner.self:
@@ -1939,7 +1939,7 @@ enum ResourceShareAssociationStatus {
   disassociated,
 }
 
-extension ResourceShareAssociationStatusValue
+extension ResourceShareAssociationStatusValueExtension
     on ResourceShareAssociationStatus {
   String toValue() {
     switch (this) {
@@ -1981,7 +1981,8 @@ enum ResourceShareAssociationType {
   resource,
 }
 
-extension ResourceShareAssociationTypeValue on ResourceShareAssociationType {
+extension ResourceShareAssociationTypeValueExtension
+    on ResourceShareAssociationType {
   String toValue() {
     switch (this) {
       case ResourceShareAssociationType.principal:
@@ -2010,7 +2011,7 @@ enum ResourceShareFeatureSet {
   standard,
 }
 
-extension ResourceShareFeatureSetValue on ResourceShareFeatureSet {
+extension ResourceShareFeatureSetValueExtension on ResourceShareFeatureSet {
   String toValue() {
     switch (this) {
       case ResourceShareFeatureSet.createdFromPolicy:
@@ -2101,7 +2102,8 @@ enum ResourceShareInvitationStatus {
   expired,
 }
 
-extension ResourceShareInvitationStatusValue on ResourceShareInvitationStatus {
+extension ResourceShareInvitationStatusValueExtension
+    on ResourceShareInvitationStatus {
   String toValue() {
     switch (this) {
       case ResourceShareInvitationStatus.pending:
@@ -2245,7 +2247,7 @@ enum ResourceShareStatus {
   deleted,
 }
 
-extension ResourceShareStatusValue on ResourceShareStatus {
+extension ResourceShareStatusValueExtension on ResourceShareStatus {
   String toValue() {
     switch (this) {
       case ResourceShareStatus.pending:
@@ -2288,7 +2290,7 @@ enum ResourceStatus {
   pending,
 }
 
-extension ResourceStatusValue on ResourceStatus {
+extension ResourceStatusValueExtension on ResourceStatus {
   String toValue() {
     switch (this) {
       case ResourceStatus.available:

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -1683,7 +1683,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -3367,7 +3367,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -1683,7 +1683,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -1694,7 +1694,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -3367,7 +3367,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -3382,7 +3382,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -1745,7 +1745,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -1756,7 +1756,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -3604,7 +3604,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -3619,7 +3619,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -1745,7 +1745,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -3604,7 +3604,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -1809,7 +1809,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -1820,7 +1820,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -3726,7 +3726,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -3741,7 +3741,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -1809,7 +1809,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -3726,7 +3726,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -1921,7 +1921,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -3885,7 +3885,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -1921,7 +1921,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -1932,7 +1932,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -3885,7 +3885,7 @@ enum SourceType {
   dbSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -3900,7 +3900,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -14378,7 +14378,7 @@ enum ActivityStreamMode {
   async,
 }
 
-extension on ActivityStreamMode {
+extension ActivityStreamModeValue on ActivityStreamMode {
   String toValue() {
     switch (this) {
       case ActivityStreamMode.sync:
@@ -14389,7 +14389,7 @@ extension on ActivityStreamMode {
   }
 }
 
-extension on String {
+extension ActivityStreamModeFromString on String {
   ActivityStreamMode toActivityStreamMode() {
     switch (this) {
       case 'sync':
@@ -14408,7 +14408,7 @@ enum ActivityStreamStatus {
   stopping,
 }
 
-extension on ActivityStreamStatus {
+extension ActivityStreamStatusValue on ActivityStreamStatus {
   String toValue() {
     switch (this) {
       case ActivityStreamStatus.stopped:
@@ -14423,7 +14423,7 @@ extension on ActivityStreamStatus {
   }
 }
 
-extension on String {
+extension ActivityStreamStatusFromString on String {
   ActivityStreamStatus toActivityStreamStatus() {
     switch (this) {
       case 'stopped':
@@ -14459,7 +14459,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension on ApplyMethod {
+extension ApplyMethodValue on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -14470,7 +14470,7 @@ extension on ApplyMethod {
   }
 }
 
-extension on String {
+extension ApplyMethodFromString on String {
   ApplyMethod toApplyMethod() {
     switch (this) {
       case 'immediate':
@@ -14501,7 +14501,7 @@ enum AuthScheme {
   secrets,
 }
 
-extension on AuthScheme {
+extension AuthSchemeValue on AuthScheme {
   String toValue() {
     switch (this) {
       case AuthScheme.secrets:
@@ -14510,7 +14510,7 @@ extension on AuthScheme {
   }
 }
 
-extension on String {
+extension AuthSchemeFromString on String {
   AuthScheme toAuthScheme() {
     switch (this) {
       case 'SECRETS':
@@ -17770,7 +17770,7 @@ enum DBProxyStatus {
   reactivating,
 }
 
-extension on DBProxyStatus {
+extension DBProxyStatusValue on DBProxyStatus {
   String toValue() {
     switch (this) {
       case DBProxyStatus.available:
@@ -17795,7 +17795,7 @@ extension on DBProxyStatus {
   }
 }
 
-extension on String {
+extension DBProxyStatusFromString on String {
   DBProxyStatus toDBProxyStatus() {
     switch (this) {
       case 'available':
@@ -18959,7 +18959,7 @@ enum EngineFamily {
   postgresql,
 }
 
-extension on EngineFamily {
+extension EngineFamilyValue on EngineFamily {
   String toValue() {
     switch (this) {
       case EngineFamily.mysql:
@@ -18970,7 +18970,7 @@ extension on EngineFamily {
   }
 }
 
-extension on String {
+extension EngineFamilyFromString on String {
   EngineFamily toEngineFamily() {
     switch (this) {
       case 'MYSQL':
@@ -19546,7 +19546,7 @@ enum IAMAuthMode {
   required,
 }
 
-extension on IAMAuthMode {
+extension IAMAuthModeValue on IAMAuthMode {
   String toValue() {
     switch (this) {
       case IAMAuthMode.disabled:
@@ -19557,7 +19557,7 @@ extension on IAMAuthMode {
   }
 }
 
-extension on String {
+extension IAMAuthModeFromString on String {
   IAMAuthMode toIAMAuthMode() {
     switch (this) {
       case 'DISABLED':
@@ -21240,7 +21240,7 @@ enum ReplicaMode {
   mounted,
 }
 
-extension on ReplicaMode {
+extension ReplicaModeValue on ReplicaMode {
   String toValue() {
     switch (this) {
       case ReplicaMode.openReadOnly:
@@ -21251,7 +21251,7 @@ extension on ReplicaMode {
   }
 }
 
-extension on String {
+extension ReplicaModeFromString on String {
   ReplicaMode toReplicaMode() {
     switch (this) {
       case 'open-read-only':
@@ -21851,7 +21851,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -21870,7 +21870,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'db-instance':
@@ -22182,7 +22182,7 @@ enum TargetHealthReason {
   pendingProxyCapacity,
 }
 
-extension on TargetHealthReason {
+extension TargetHealthReasonValue on TargetHealthReason {
   String toValue() {
     switch (this) {
       case TargetHealthReason.unreachable:
@@ -22197,7 +22197,7 @@ extension on TargetHealthReason {
   }
 }
 
-extension on String {
+extension TargetHealthReasonFromString on String {
   TargetHealthReason toTargetHealthReason() {
     switch (this) {
       case 'UNREACHABLE':
@@ -22219,7 +22219,7 @@ enum TargetState {
   unavailable,
 }
 
-extension on TargetState {
+extension TargetStateValue on TargetState {
   String toValue() {
     switch (this) {
       case TargetState.registering:
@@ -22232,7 +22232,7 @@ extension on TargetState {
   }
 }
 
-extension on String {
+extension TargetStateFromString on String {
   TargetState toTargetState() {
     switch (this) {
       case 'REGISTERING':
@@ -22252,7 +22252,7 @@ enum TargetType {
   trackedCluster,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.rdsInstance:
@@ -22265,7 +22265,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'RDS_INSTANCE':
@@ -22577,7 +22577,7 @@ enum WriteForwardingStatus {
   unknown,
 }
 
-extension on WriteForwardingStatus {
+extension WriteForwardingStatusValue on WriteForwardingStatus {
   String toValue() {
     switch (this) {
       case WriteForwardingStatus.enabled:
@@ -22594,7 +22594,7 @@ extension on WriteForwardingStatus {
   }
 }
 
-extension on String {
+extension WriteForwardingStatusFromString on String {
   WriteForwardingStatus toWriteForwardingStatus() {
     switch (this) {
       case 'enabled':

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -14378,7 +14378,7 @@ enum ActivityStreamMode {
   async,
 }
 
-extension ActivityStreamModeValue on ActivityStreamMode {
+extension ActivityStreamModeValueExtension on ActivityStreamMode {
   String toValue() {
     switch (this) {
       case ActivityStreamMode.sync:
@@ -14408,7 +14408,7 @@ enum ActivityStreamStatus {
   stopping,
 }
 
-extension ActivityStreamStatusValue on ActivityStreamStatus {
+extension ActivityStreamStatusValueExtension on ActivityStreamStatus {
   String toValue() {
     switch (this) {
       case ActivityStreamStatus.stopped:
@@ -14459,7 +14459,7 @@ enum ApplyMethod {
   pendingReboot,
 }
 
-extension ApplyMethodValue on ApplyMethod {
+extension ApplyMethodValueExtension on ApplyMethod {
   String toValue() {
     switch (this) {
       case ApplyMethod.immediate:
@@ -14501,7 +14501,7 @@ enum AuthScheme {
   secrets,
 }
 
-extension AuthSchemeValue on AuthScheme {
+extension AuthSchemeValueExtension on AuthScheme {
   String toValue() {
     switch (this) {
       case AuthScheme.secrets:
@@ -17770,7 +17770,7 @@ enum DBProxyStatus {
   reactivating,
 }
 
-extension DBProxyStatusValue on DBProxyStatus {
+extension DBProxyStatusValueExtension on DBProxyStatus {
   String toValue() {
     switch (this) {
       case DBProxyStatus.available:
@@ -18959,7 +18959,7 @@ enum EngineFamily {
   postgresql,
 }
 
-extension EngineFamilyValue on EngineFamily {
+extension EngineFamilyValueExtension on EngineFamily {
   String toValue() {
     switch (this) {
       case EngineFamily.mysql:
@@ -19546,7 +19546,7 @@ enum IAMAuthMode {
   required,
 }
 
-extension IAMAuthModeValue on IAMAuthMode {
+extension IAMAuthModeValueExtension on IAMAuthMode {
   String toValue() {
     switch (this) {
       case IAMAuthMode.disabled:
@@ -21240,7 +21240,7 @@ enum ReplicaMode {
   mounted,
 }
 
-extension ReplicaModeValue on ReplicaMode {
+extension ReplicaModeValueExtension on ReplicaMode {
   String toValue() {
     switch (this) {
       case ReplicaMode.openReadOnly:
@@ -21851,7 +21851,7 @@ enum SourceType {
   dbClusterSnapshot,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.dbInstance:
@@ -22182,7 +22182,7 @@ enum TargetHealthReason {
   pendingProxyCapacity,
 }
 
-extension TargetHealthReasonValue on TargetHealthReason {
+extension TargetHealthReasonValueExtension on TargetHealthReason {
   String toValue() {
     switch (this) {
       case TargetHealthReason.unreachable:
@@ -22219,7 +22219,7 @@ enum TargetState {
   unavailable,
 }
 
-extension TargetStateValue on TargetState {
+extension TargetStateValueExtension on TargetState {
   String toValue() {
     switch (this) {
       case TargetState.registering:
@@ -22252,7 +22252,7 @@ enum TargetType {
   trackedCluster,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.rdsInstance:
@@ -22577,7 +22577,7 @@ enum WriteForwardingStatus {
   unknown,
 }
 
-extension WriteForwardingStatusValue on WriteForwardingStatus {
+extension WriteForwardingStatusValueExtension on WriteForwardingStatus {
   String toValue() {
     switch (this) {
       case WriteForwardingStatus.enabled:

--- a/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
+++ b/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
@@ -806,7 +806,7 @@ enum DecimalReturnType {
   string,
 }
 
-extension DecimalReturnTypeValue on DecimalReturnType {
+extension DecimalReturnTypeValueExtension on DecimalReturnType {
   String toValue() {
     switch (this) {
       case DecimalReturnType.doubleOrLong:
@@ -1174,7 +1174,7 @@ enum TypeHint {
   timestamp,
 }
 
-extension TypeHintValue on TypeHint {
+extension TypeHintValueExtension on TypeHint {
   String toValue() {
     switch (this) {
       case TypeHint.date:

--- a/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
+++ b/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
@@ -806,7 +806,7 @@ enum DecimalReturnType {
   string,
 }
 
-extension on DecimalReturnType {
+extension DecimalReturnTypeValue on DecimalReturnType {
   String toValue() {
     switch (this) {
       case DecimalReturnType.doubleOrLong:
@@ -817,7 +817,7 @@ extension on DecimalReturnType {
   }
 }
 
-extension on String {
+extension DecimalReturnTypeFromString on String {
   DecimalReturnType toDecimalReturnType() {
     switch (this) {
       case 'DOUBLE_OR_LONG':
@@ -1174,7 +1174,7 @@ enum TypeHint {
   timestamp,
 }
 
-extension on TypeHint {
+extension TypeHintValue on TypeHint {
   String toValue() {
     switch (this) {
       case TypeHint.date:
@@ -1189,7 +1189,7 @@ extension on TypeHint {
   }
 }
 
-extension on String {
+extension TypeHintFromString on String {
   TypeHint toTypeHint() {
     switch (this) {
       case 'DATE':

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -8310,7 +8310,7 @@ enum ActionType {
   resizeCluster,
 }
 
-extension ActionTypeValue on ActionType {
+extension ActionTypeValueExtension on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.restoreCluster:
@@ -10671,7 +10671,7 @@ enum Mode {
   highPerformance,
 }
 
-extension ModeValue on Mode {
+extension ModeValueExtension on Mode {
   String toValue() {
     switch (this) {
       case Mode.standard:
@@ -10880,7 +10880,7 @@ enum NodeConfigurationOptionsFilterName {
   mode,
 }
 
-extension NodeConfigurationOptionsFilterNameValue
+extension NodeConfigurationOptionsFilterNameValueExtension
     on NodeConfigurationOptionsFilterName {
   String toValue() {
     switch (this) {
@@ -10953,7 +10953,7 @@ enum OperatorType {
   between,
 }
 
-extension OperatorTypeValue on OperatorType {
+extension OperatorTypeValueExtension on OperatorType {
   String toValue() {
     switch (this) {
       case OperatorType.eq:
@@ -11154,7 +11154,7 @@ enum ParameterApplyType {
   dynamic,
 }
 
-extension ParameterApplyTypeValue on ParameterApplyType {
+extension ParameterApplyTypeValueExtension on ParameterApplyType {
   String toValue() {
     switch (this) {
       case ParameterApplyType.static:
@@ -11526,7 +11526,7 @@ enum ReservedNodeOfferingType {
   upgradable,
 }
 
-extension ReservedNodeOfferingTypeValue on ReservedNodeOfferingType {
+extension ReservedNodeOfferingTypeValueExtension on ReservedNodeOfferingType {
   String toValue() {
     switch (this) {
       case ReservedNodeOfferingType.regular:
@@ -12024,7 +12024,7 @@ enum ScheduleState {
   failed,
 }
 
-extension ScheduleStateValue on ScheduleState {
+extension ScheduleStateValueExtension on ScheduleState {
   String toValue() {
     switch (this) {
       case ScheduleState.modifying:
@@ -12165,7 +12165,7 @@ enum ScheduledActionFilterName {
   iamRole,
 }
 
-extension ScheduledActionFilterNameValue on ScheduledActionFilterName {
+extension ScheduledActionFilterNameValueExtension on ScheduledActionFilterName {
   String toValue() {
     switch (this) {
       case ScheduledActionFilterName.clusterIdentifier:
@@ -12193,7 +12193,7 @@ enum ScheduledActionState {
   disabled,
 }
 
-extension ScheduledActionStateValue on ScheduledActionState {
+extension ScheduledActionStateValueExtension on ScheduledActionState {
   String toValue() {
     switch (this) {
       case ScheduledActionState.active:
@@ -12265,7 +12265,7 @@ enum ScheduledActionTypeValues {
   resumeCluster,
 }
 
-extension ScheduledActionTypeValuesValue on ScheduledActionTypeValues {
+extension ScheduledActionTypeValuesValueExtension on ScheduledActionTypeValues {
   String toValue() {
     switch (this) {
       case ScheduledActionTypeValues.resizeCluster:
@@ -12565,7 +12565,7 @@ enum SnapshotAttributeToSortBy {
   createTime,
 }
 
-extension SnapshotAttributeToSortByValue on SnapshotAttributeToSortBy {
+extension SnapshotAttributeToSortByValueExtension on SnapshotAttributeToSortBy {
   String toValue() {
     switch (this) {
       case SnapshotAttributeToSortBy.sourceType:
@@ -12802,7 +12802,7 @@ enum SortByOrder {
   desc,
 }
 
-extension SortByOrderValue on SortByOrder {
+extension SortByOrderValueExtension on SortByOrder {
   String toValue() {
     switch (this) {
       case SortByOrder.asc:
@@ -12833,7 +12833,7 @@ enum SourceType {
   scheduledAction,
 }
 
-extension SourceTypeValue on SourceType {
+extension SourceTypeValueExtension on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cluster:
@@ -13065,7 +13065,7 @@ enum TableRestoreStatusType {
   canceled,
 }
 
-extension TableRestoreStatusTypeValue on TableRestoreStatusType {
+extension TableRestoreStatusTypeValueExtension on TableRestoreStatusType {
   String toValue() {
     switch (this) {
       case TableRestoreStatusType.pending:
@@ -13354,7 +13354,7 @@ enum UsageLimitBreachAction {
   disable,
 }
 
-extension UsageLimitBreachActionValue on UsageLimitBreachAction {
+extension UsageLimitBreachActionValueExtension on UsageLimitBreachAction {
   String toValue() {
     switch (this) {
       case UsageLimitBreachAction.log:
@@ -13386,7 +13386,7 @@ enum UsageLimitFeatureType {
   concurrencyScaling,
 }
 
-extension UsageLimitFeatureTypeValue on UsageLimitFeatureType {
+extension UsageLimitFeatureTypeValueExtension on UsageLimitFeatureType {
   String toValue() {
     switch (this) {
       case UsageLimitFeatureType.spectrum:
@@ -13414,7 +13414,7 @@ enum UsageLimitLimitType {
   dataScanned,
 }
 
-extension UsageLimitLimitTypeValue on UsageLimitLimitType {
+extension UsageLimitLimitTypeValueExtension on UsageLimitLimitType {
   String toValue() {
     switch (this) {
       case UsageLimitLimitType.time:
@@ -13470,7 +13470,7 @@ enum UsageLimitPeriod {
   monthly,
 }
 
-extension UsageLimitPeriodValue on UsageLimitPeriod {
+extension UsageLimitPeriodValueExtension on UsageLimitPeriod {
   String toValue() {
     switch (this) {
       case UsageLimitPeriod.daily:

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -8310,7 +8310,7 @@ enum ActionType {
   resizeCluster,
 }
 
-extension on ActionType {
+extension ActionTypeValue on ActionType {
   String toValue() {
     switch (this) {
       case ActionType.restoreCluster:
@@ -8323,7 +8323,7 @@ extension on ActionType {
   }
 }
 
-extension on String {
+extension ActionTypeFromString on String {
   ActionType toActionType() {
     switch (this) {
       case 'restore-cluster':
@@ -10671,7 +10671,7 @@ enum Mode {
   highPerformance,
 }
 
-extension on Mode {
+extension ModeValue on Mode {
   String toValue() {
     switch (this) {
       case Mode.standard:
@@ -10682,7 +10682,7 @@ extension on Mode {
   }
 }
 
-extension on String {
+extension ModeFromString on String {
   Mode toMode() {
     switch (this) {
       case 'standard':
@@ -10880,7 +10880,8 @@ enum NodeConfigurationOptionsFilterName {
   mode,
 }
 
-extension on NodeConfigurationOptionsFilterName {
+extension NodeConfigurationOptionsFilterNameValue
+    on NodeConfigurationOptionsFilterName {
   String toValue() {
     switch (this) {
       case NodeConfigurationOptionsFilterName.nodeType:
@@ -10895,7 +10896,7 @@ extension on NodeConfigurationOptionsFilterName {
   }
 }
 
-extension on String {
+extension NodeConfigurationOptionsFilterNameFromString on String {
   NodeConfigurationOptionsFilterName toNodeConfigurationOptionsFilterName() {
     switch (this) {
       case 'NodeType':
@@ -10952,7 +10953,7 @@ enum OperatorType {
   between,
 }
 
-extension on OperatorType {
+extension OperatorTypeValue on OperatorType {
   String toValue() {
     switch (this) {
       case OperatorType.eq:
@@ -10973,7 +10974,7 @@ extension on OperatorType {
   }
 }
 
-extension on String {
+extension OperatorTypeFromString on String {
   OperatorType toOperatorType() {
     switch (this) {
       case 'eq':
@@ -11153,7 +11154,7 @@ enum ParameterApplyType {
   dynamic,
 }
 
-extension on ParameterApplyType {
+extension ParameterApplyTypeValue on ParameterApplyType {
   String toValue() {
     switch (this) {
       case ParameterApplyType.static:
@@ -11164,7 +11165,7 @@ extension on ParameterApplyType {
   }
 }
 
-extension on String {
+extension ParameterApplyTypeFromString on String {
   ParameterApplyType toParameterApplyType() {
     switch (this) {
       case 'static':
@@ -11525,7 +11526,7 @@ enum ReservedNodeOfferingType {
   upgradable,
 }
 
-extension on ReservedNodeOfferingType {
+extension ReservedNodeOfferingTypeValue on ReservedNodeOfferingType {
   String toValue() {
     switch (this) {
       case ReservedNodeOfferingType.regular:
@@ -11536,7 +11537,7 @@ extension on ReservedNodeOfferingType {
   }
 }
 
-extension on String {
+extension ReservedNodeOfferingTypeFromString on String {
   ReservedNodeOfferingType toReservedNodeOfferingType() {
     switch (this) {
       case 'Regular':
@@ -12023,7 +12024,7 @@ enum ScheduleState {
   failed,
 }
 
-extension on ScheduleState {
+extension ScheduleStateValue on ScheduleState {
   String toValue() {
     switch (this) {
       case ScheduleState.modifying:
@@ -12036,7 +12037,7 @@ extension on ScheduleState {
   }
 }
 
-extension on String {
+extension ScheduleStateFromString on String {
   ScheduleState toScheduleState() {
     switch (this) {
       case 'MODIFYING':
@@ -12164,7 +12165,7 @@ enum ScheduledActionFilterName {
   iamRole,
 }
 
-extension on ScheduledActionFilterName {
+extension ScheduledActionFilterNameValue on ScheduledActionFilterName {
   String toValue() {
     switch (this) {
       case ScheduledActionFilterName.clusterIdentifier:
@@ -12175,7 +12176,7 @@ extension on ScheduledActionFilterName {
   }
 }
 
-extension on String {
+extension ScheduledActionFilterNameFromString on String {
   ScheduledActionFilterName toScheduledActionFilterName() {
     switch (this) {
       case 'cluster-identifier':
@@ -12192,7 +12193,7 @@ enum ScheduledActionState {
   disabled,
 }
 
-extension on ScheduledActionState {
+extension ScheduledActionStateValue on ScheduledActionState {
   String toValue() {
     switch (this) {
       case ScheduledActionState.active:
@@ -12203,7 +12204,7 @@ extension on ScheduledActionState {
   }
 }
 
-extension on String {
+extension ScheduledActionStateFromString on String {
   ScheduledActionState toScheduledActionState() {
     switch (this) {
       case 'ACTIVE':
@@ -12264,7 +12265,7 @@ enum ScheduledActionTypeValues {
   resumeCluster,
 }
 
-extension on ScheduledActionTypeValues {
+extension ScheduledActionTypeValuesValue on ScheduledActionTypeValues {
   String toValue() {
     switch (this) {
       case ScheduledActionTypeValues.resizeCluster:
@@ -12277,7 +12278,7 @@ extension on ScheduledActionTypeValues {
   }
 }
 
-extension on String {
+extension ScheduledActionTypeValuesFromString on String {
   ScheduledActionTypeValues toScheduledActionTypeValues() {
     switch (this) {
       case 'ResizeCluster':
@@ -12564,7 +12565,7 @@ enum SnapshotAttributeToSortBy {
   createTime,
 }
 
-extension on SnapshotAttributeToSortBy {
+extension SnapshotAttributeToSortByValue on SnapshotAttributeToSortBy {
   String toValue() {
     switch (this) {
       case SnapshotAttributeToSortBy.sourceType:
@@ -12577,7 +12578,7 @@ extension on SnapshotAttributeToSortBy {
   }
 }
 
-extension on String {
+extension SnapshotAttributeToSortByFromString on String {
   SnapshotAttributeToSortBy toSnapshotAttributeToSortBy() {
     switch (this) {
       case 'SOURCE_TYPE':
@@ -12801,7 +12802,7 @@ enum SortByOrder {
   desc,
 }
 
-extension on SortByOrder {
+extension SortByOrderValue on SortByOrder {
   String toValue() {
     switch (this) {
       case SortByOrder.asc:
@@ -12812,7 +12813,7 @@ extension on SortByOrder {
   }
 }
 
-extension on String {
+extension SortByOrderFromString on String {
   SortByOrder toSortByOrder() {
     switch (this) {
       case 'ASC':
@@ -12832,7 +12833,7 @@ enum SourceType {
   scheduledAction,
 }
 
-extension on SourceType {
+extension SourceTypeValue on SourceType {
   String toValue() {
     switch (this) {
       case SourceType.cluster:
@@ -12849,7 +12850,7 @@ extension on SourceType {
   }
 }
 
-extension on String {
+extension SourceTypeFromString on String {
   SourceType toSourceType() {
     switch (this) {
       case 'cluster':
@@ -13064,7 +13065,7 @@ enum TableRestoreStatusType {
   canceled,
 }
 
-extension on TableRestoreStatusType {
+extension TableRestoreStatusTypeValue on TableRestoreStatusType {
   String toValue() {
     switch (this) {
       case TableRestoreStatusType.pending:
@@ -13081,7 +13082,7 @@ extension on TableRestoreStatusType {
   }
 }
 
-extension on String {
+extension TableRestoreStatusTypeFromString on String {
   TableRestoreStatusType toTableRestoreStatusType() {
     switch (this) {
       case 'PENDING':
@@ -13353,7 +13354,7 @@ enum UsageLimitBreachAction {
   disable,
 }
 
-extension on UsageLimitBreachAction {
+extension UsageLimitBreachActionValue on UsageLimitBreachAction {
   String toValue() {
     switch (this) {
       case UsageLimitBreachAction.log:
@@ -13366,7 +13367,7 @@ extension on UsageLimitBreachAction {
   }
 }
 
-extension on String {
+extension UsageLimitBreachActionFromString on String {
   UsageLimitBreachAction toUsageLimitBreachAction() {
     switch (this) {
       case 'log':
@@ -13385,7 +13386,7 @@ enum UsageLimitFeatureType {
   concurrencyScaling,
 }
 
-extension on UsageLimitFeatureType {
+extension UsageLimitFeatureTypeValue on UsageLimitFeatureType {
   String toValue() {
     switch (this) {
       case UsageLimitFeatureType.spectrum:
@@ -13396,7 +13397,7 @@ extension on UsageLimitFeatureType {
   }
 }
 
-extension on String {
+extension UsageLimitFeatureTypeFromString on String {
   UsageLimitFeatureType toUsageLimitFeatureType() {
     switch (this) {
       case 'spectrum':
@@ -13413,7 +13414,7 @@ enum UsageLimitLimitType {
   dataScanned,
 }
 
-extension on UsageLimitLimitType {
+extension UsageLimitLimitTypeValue on UsageLimitLimitType {
   String toValue() {
     switch (this) {
       case UsageLimitLimitType.time:
@@ -13424,7 +13425,7 @@ extension on UsageLimitLimitType {
   }
 }
 
-extension on String {
+extension UsageLimitLimitTypeFromString on String {
   UsageLimitLimitType toUsageLimitLimitType() {
     switch (this) {
       case 'time':
@@ -13469,7 +13470,7 @@ enum UsageLimitPeriod {
   monthly,
 }
 
-extension on UsageLimitPeriod {
+extension UsageLimitPeriodValue on UsageLimitPeriod {
   String toValue() {
     switch (this) {
       case UsageLimitPeriod.daily:
@@ -13482,7 +13483,7 @@ extension on UsageLimitPeriod {
   }
 }
 
-extension on String {
+extension UsageLimitPeriodFromString on String {
   UsageLimitPeriod toUsageLimitPeriod() {
     switch (this) {
       case 'daily':

--- a/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
+++ b/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
@@ -4250,7 +4250,7 @@ enum Attribute {
   all,
 }
 
-extension on Attribute {
+extension AttributeValue on Attribute {
   String toValue() {
     switch (this) {
       case Attribute.$default:
@@ -4261,7 +4261,7 @@ extension on Attribute {
   }
 }
 
-extension on String {
+extension AttributeFromString on String {
   Attribute toAttribute() {
     switch (this) {
       case 'DEFAULT':
@@ -4333,7 +4333,7 @@ enum BodyPart {
   rightHand,
 }
 
-extension on BodyPart {
+extension BodyPartValue on BodyPart {
   String toValue() {
     switch (this) {
       case BodyPart.face:
@@ -4348,7 +4348,7 @@ extension on BodyPart {
   }
 }
 
-extension on String {
+extension BodyPartFromString on String {
   BodyPart toBodyPart() {
     switch (this) {
       case 'FACE':
@@ -4552,7 +4552,7 @@ enum CelebrityRecognitionSortBy {
   timestamp,
 }
 
-extension on CelebrityRecognitionSortBy {
+extension CelebrityRecognitionSortByValue on CelebrityRecognitionSortBy {
   String toValue() {
     switch (this) {
       case CelebrityRecognitionSortBy.id:
@@ -4563,7 +4563,7 @@ extension on CelebrityRecognitionSortBy {
   }
 }
 
-extension on String {
+extension CelebrityRecognitionSortByFromString on String {
   CelebrityRecognitionSortBy toCelebrityRecognitionSortBy() {
     switch (this) {
       case 'ID':
@@ -4753,7 +4753,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension on ContentClassifier {
+extension ContentClassifierValue on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -4764,7 +4764,7 @@ extension on ContentClassifier {
   }
 }
 
-extension on String {
+extension ContentClassifierFromString on String {
   ContentClassifier toContentClassifier() {
     switch (this) {
       case 'FreeOfPersonallyIdentifiableInformation':
@@ -4805,7 +4805,7 @@ enum ContentModerationSortBy {
   timestamp,
 }
 
-extension on ContentModerationSortBy {
+extension ContentModerationSortByValue on ContentModerationSortBy {
   String toValue() {
     switch (this) {
       case ContentModerationSortBy.name:
@@ -4816,7 +4816,7 @@ extension on ContentModerationSortBy {
   }
 }
 
-extension on String {
+extension ContentModerationSortByFromString on String {
   ContentModerationSortBy toContentModerationSortBy() {
     switch (this) {
       case 'NAME':
@@ -5460,7 +5460,7 @@ enum EmotionName {
   fear,
 }
 
-extension on EmotionName {
+extension EmotionNameValue on EmotionName {
   String toValue() {
     switch (this) {
       case EmotionName.happy:
@@ -5485,7 +5485,7 @@ extension on EmotionName {
   }
 }
 
-extension on String {
+extension EmotionNameFromString on String {
   EmotionName toEmotionName() {
     switch (this) {
       case 'HAPPY':
@@ -5660,7 +5660,7 @@ enum FaceAttributes {
   all,
 }
 
-extension on FaceAttributes {
+extension FaceAttributesValue on FaceAttributes {
   String toValue() {
     switch (this) {
       case FaceAttributes.$default:
@@ -5671,7 +5671,7 @@ extension on FaceAttributes {
   }
 }
 
-extension on String {
+extension FaceAttributesFromString on String {
   FaceAttributes toFaceAttributes() {
     switch (this) {
       case 'DEFAULT':
@@ -5955,7 +5955,7 @@ enum FaceSearchSortBy {
   timestamp,
 }
 
-extension on FaceSearchSortBy {
+extension FaceSearchSortByValue on FaceSearchSortBy {
   String toValue() {
     switch (this) {
       case FaceSearchSortBy.$index:
@@ -5966,7 +5966,7 @@ extension on FaceSearchSortBy {
   }
 }
 
-extension on String {
+extension FaceSearchSortByFromString on String {
   FaceSearchSortBy toFaceSearchSortBy() {
     switch (this) {
       case 'INDEX':
@@ -6018,7 +6018,7 @@ enum GenderType {
   female,
 }
 
-extension on GenderType {
+extension GenderTypeValue on GenderType {
   String toValue() {
     switch (this) {
       case GenderType.male:
@@ -6029,7 +6029,7 @@ extension on GenderType {
   }
 }
 
-extension on String {
+extension GenderTypeFromString on String {
   GenderType toGenderType() {
     switch (this) {
       case 'Male':
@@ -6903,7 +6903,7 @@ enum LabelDetectionSortBy {
   timestamp,
 }
 
-extension on LabelDetectionSortBy {
+extension LabelDetectionSortByValue on LabelDetectionSortBy {
   String toValue() {
     switch (this) {
       case LabelDetectionSortBy.name:
@@ -6914,7 +6914,7 @@ extension on LabelDetectionSortBy {
   }
 }
 
-extension on String {
+extension LabelDetectionSortByFromString on String {
   LabelDetectionSortBy toLabelDetectionSortBy() {
     switch (this) {
       case 'NAME':
@@ -6990,7 +6990,7 @@ enum LandmarkType {
   upperJawlineRight,
 }
 
-extension on LandmarkType {
+extension LandmarkTypeValue on LandmarkType {
   String toValue() {
     switch (this) {
       case LandmarkType.eyeLeft:
@@ -7057,7 +7057,7 @@ extension on LandmarkType {
   }
 }
 
-extension on String {
+extension LandmarkTypeFromString on String {
   LandmarkType toLandmarkType() {
     switch (this) {
       case 'eyeLeft':
@@ -7322,7 +7322,7 @@ enum OrientationCorrection {
   rotate_270,
 }
 
-extension on OrientationCorrection {
+extension OrientationCorrectionValue on OrientationCorrection {
   String toValue() {
     switch (this) {
       case OrientationCorrection.rotate_0:
@@ -7337,7 +7337,7 @@ extension on OrientationCorrection {
   }
 }
 
-extension on String {
+extension OrientationCorrectionFromString on String {
   OrientationCorrection toOrientationCorrection() {
     switch (this) {
       case 'ROTATE_0':
@@ -7499,7 +7499,7 @@ enum PersonTrackingSortBy {
   timestamp,
 }
 
-extension on PersonTrackingSortBy {
+extension PersonTrackingSortByValue on PersonTrackingSortBy {
   String toValue() {
     switch (this) {
       case PersonTrackingSortBy.$index:
@@ -7510,7 +7510,7 @@ extension on PersonTrackingSortBy {
   }
 }
 
-extension on String {
+extension PersonTrackingSortByFromString on String {
   PersonTrackingSortBy toPersonTrackingSortBy() {
     switch (this) {
       case 'INDEX':
@@ -7606,7 +7606,7 @@ enum ProjectStatus {
   deleting,
 }
 
-extension on ProjectStatus {
+extension ProjectStatusValue on ProjectStatus {
   String toValue() {
     switch (this) {
       case ProjectStatus.creating:
@@ -7619,7 +7619,7 @@ extension on ProjectStatus {
   }
 }
 
-extension on String {
+extension ProjectStatusFromString on String {
   ProjectStatus toProjectStatus() {
     switch (this) {
       case 'CREATING':
@@ -7735,7 +7735,7 @@ enum ProjectVersionStatus {
   deleting,
 }
 
-extension on ProjectVersionStatus {
+extension ProjectVersionStatusValue on ProjectVersionStatus {
   String toValue() {
     switch (this) {
       case ProjectVersionStatus.trainingInProgress:
@@ -7760,7 +7760,7 @@ extension on ProjectVersionStatus {
   }
 }
 
-extension on String {
+extension ProjectVersionStatusFromString on String {
   ProjectVersionStatus toProjectVersionStatus() {
     switch (this) {
       case 'TRAINING_IN_PROGRESS':
@@ -7969,7 +7969,7 @@ enum ProtectiveEquipmentType {
   headCover,
 }
 
-extension on ProtectiveEquipmentType {
+extension ProtectiveEquipmentTypeValue on ProtectiveEquipmentType {
   String toValue() {
     switch (this) {
       case ProtectiveEquipmentType.faceCover:
@@ -7982,7 +7982,7 @@ extension on ProtectiveEquipmentType {
   }
 }
 
-extension on String {
+extension ProtectiveEquipmentTypeFromString on String {
   ProtectiveEquipmentType toProtectiveEquipmentType() {
     switch (this) {
       case 'FACE_COVER':
@@ -8004,7 +8004,7 @@ enum QualityFilter {
   high,
 }
 
-extension on QualityFilter {
+extension QualityFilterValue on QualityFilter {
   String toValue() {
     switch (this) {
       case QualityFilter.none:
@@ -8021,7 +8021,7 @@ extension on QualityFilter {
   }
 }
 
-extension on String {
+extension QualityFilterFromString on String {
   QualityFilter toQualityFilter() {
     switch (this) {
       case 'NONE':
@@ -8049,7 +8049,7 @@ enum Reason {
   lowFaceQuality,
 }
 
-extension on Reason {
+extension ReasonValue on Reason {
   String toValue() {
     switch (this) {
       case Reason.exceedsMaxFaces:
@@ -8070,7 +8070,7 @@ extension on Reason {
   }
 }
 
-extension on String {
+extension ReasonFromString on String {
   Reason toReason() {
     switch (this) {
       case 'EXCEEDS_MAX_FACES':
@@ -8348,7 +8348,7 @@ enum SegmentType {
   shot,
 }
 
-extension on SegmentType {
+extension SegmentTypeValue on SegmentType {
   String toValue() {
     switch (this) {
       case SegmentType.technicalCue:
@@ -8359,7 +8359,7 @@ extension on SegmentType {
   }
 }
 
-extension on String {
+extension SegmentTypeFromString on String {
   SegmentType toSegmentType() {
     switch (this) {
       case 'TECHNICAL_CUE':
@@ -8815,7 +8815,7 @@ enum StreamProcessorStatus {
   stopping,
 }
 
-extension on StreamProcessorStatus {
+extension StreamProcessorStatusValue on StreamProcessorStatus {
   String toValue() {
     switch (this) {
       case StreamProcessorStatus.stopped:
@@ -8832,7 +8832,7 @@ extension on StreamProcessorStatus {
   }
 }
 
-extension on String {
+extension StreamProcessorStatusFromString on String {
   StreamProcessorStatus toStreamProcessorStatus() {
     switch (this) {
       case 'STOPPED':
@@ -8920,7 +8920,7 @@ enum TechnicalCueType {
   blackFrames,
 }
 
-extension on TechnicalCueType {
+extension TechnicalCueTypeValue on TechnicalCueType {
   String toValue() {
     switch (this) {
       case TechnicalCueType.colorBars:
@@ -8933,7 +8933,7 @@ extension on TechnicalCueType {
   }
 }
 
-extension on String {
+extension TechnicalCueTypeFromString on String {
   TechnicalCueType toTechnicalCueType() {
     switch (this) {
       case 'ColorBars':
@@ -9106,7 +9106,7 @@ enum TextTypes {
   word,
 }
 
-extension on TextTypes {
+extension TextTypesValue on TextTypes {
   String toValue() {
     switch (this) {
       case TextTypes.line:
@@ -9117,7 +9117,7 @@ extension on TextTypes {
   }
 }
 
-extension on String {
+extension TextTypesFromString on String {
   TextTypes toTextTypes() {
     switch (this) {
       case 'LINE':
@@ -9297,7 +9297,7 @@ enum VideoJobStatus {
   failed,
 }
 
-extension on VideoJobStatus {
+extension VideoJobStatusValue on VideoJobStatus {
   String toValue() {
     switch (this) {
       case VideoJobStatus.inProgress:
@@ -9310,7 +9310,7 @@ extension on VideoJobStatus {
   }
 }
 
-extension on String {
+extension VideoJobStatusFromString on String {
   VideoJobStatus toVideoJobStatus() {
     switch (this) {
       case 'IN_PROGRESS':

--- a/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
+++ b/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
@@ -4250,7 +4250,7 @@ enum Attribute {
   all,
 }
 
-extension AttributeValue on Attribute {
+extension AttributeValueExtension on Attribute {
   String toValue() {
     switch (this) {
       case Attribute.$default:
@@ -4333,7 +4333,7 @@ enum BodyPart {
   rightHand,
 }
 
-extension BodyPartValue on BodyPart {
+extension BodyPartValueExtension on BodyPart {
   String toValue() {
     switch (this) {
       case BodyPart.face:
@@ -4552,7 +4552,8 @@ enum CelebrityRecognitionSortBy {
   timestamp,
 }
 
-extension CelebrityRecognitionSortByValue on CelebrityRecognitionSortBy {
+extension CelebrityRecognitionSortByValueExtension
+    on CelebrityRecognitionSortBy {
   String toValue() {
     switch (this) {
       case CelebrityRecognitionSortBy.id:
@@ -4753,7 +4754,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension ContentClassifierValue on ContentClassifier {
+extension ContentClassifierValueExtension on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -4805,7 +4806,7 @@ enum ContentModerationSortBy {
   timestamp,
 }
 
-extension ContentModerationSortByValue on ContentModerationSortBy {
+extension ContentModerationSortByValueExtension on ContentModerationSortBy {
   String toValue() {
     switch (this) {
       case ContentModerationSortBy.name:
@@ -5460,7 +5461,7 @@ enum EmotionName {
   fear,
 }
 
-extension EmotionNameValue on EmotionName {
+extension EmotionNameValueExtension on EmotionName {
   String toValue() {
     switch (this) {
       case EmotionName.happy:
@@ -5660,7 +5661,7 @@ enum FaceAttributes {
   all,
 }
 
-extension FaceAttributesValue on FaceAttributes {
+extension FaceAttributesValueExtension on FaceAttributes {
   String toValue() {
     switch (this) {
       case FaceAttributes.$default:
@@ -5955,7 +5956,7 @@ enum FaceSearchSortBy {
   timestamp,
 }
 
-extension FaceSearchSortByValue on FaceSearchSortBy {
+extension FaceSearchSortByValueExtension on FaceSearchSortBy {
   String toValue() {
     switch (this) {
       case FaceSearchSortBy.$index:
@@ -6018,7 +6019,7 @@ enum GenderType {
   female,
 }
 
-extension GenderTypeValue on GenderType {
+extension GenderTypeValueExtension on GenderType {
   String toValue() {
     switch (this) {
       case GenderType.male:
@@ -6903,7 +6904,7 @@ enum LabelDetectionSortBy {
   timestamp,
 }
 
-extension LabelDetectionSortByValue on LabelDetectionSortBy {
+extension LabelDetectionSortByValueExtension on LabelDetectionSortBy {
   String toValue() {
     switch (this) {
       case LabelDetectionSortBy.name:
@@ -6990,7 +6991,7 @@ enum LandmarkType {
   upperJawlineRight,
 }
 
-extension LandmarkTypeValue on LandmarkType {
+extension LandmarkTypeValueExtension on LandmarkType {
   String toValue() {
     switch (this) {
       case LandmarkType.eyeLeft:
@@ -7322,7 +7323,7 @@ enum OrientationCorrection {
   rotate_270,
 }
 
-extension OrientationCorrectionValue on OrientationCorrection {
+extension OrientationCorrectionValueExtension on OrientationCorrection {
   String toValue() {
     switch (this) {
       case OrientationCorrection.rotate_0:
@@ -7499,7 +7500,7 @@ enum PersonTrackingSortBy {
   timestamp,
 }
 
-extension PersonTrackingSortByValue on PersonTrackingSortBy {
+extension PersonTrackingSortByValueExtension on PersonTrackingSortBy {
   String toValue() {
     switch (this) {
       case PersonTrackingSortBy.$index:
@@ -7606,7 +7607,7 @@ enum ProjectStatus {
   deleting,
 }
 
-extension ProjectStatusValue on ProjectStatus {
+extension ProjectStatusValueExtension on ProjectStatus {
   String toValue() {
     switch (this) {
       case ProjectStatus.creating:
@@ -7735,7 +7736,7 @@ enum ProjectVersionStatus {
   deleting,
 }
 
-extension ProjectVersionStatusValue on ProjectVersionStatus {
+extension ProjectVersionStatusValueExtension on ProjectVersionStatus {
   String toValue() {
     switch (this) {
       case ProjectVersionStatus.trainingInProgress:
@@ -7969,7 +7970,7 @@ enum ProtectiveEquipmentType {
   headCover,
 }
 
-extension ProtectiveEquipmentTypeValue on ProtectiveEquipmentType {
+extension ProtectiveEquipmentTypeValueExtension on ProtectiveEquipmentType {
   String toValue() {
     switch (this) {
       case ProtectiveEquipmentType.faceCover:
@@ -8004,7 +8005,7 @@ enum QualityFilter {
   high,
 }
 
-extension QualityFilterValue on QualityFilter {
+extension QualityFilterValueExtension on QualityFilter {
   String toValue() {
     switch (this) {
       case QualityFilter.none:
@@ -8049,7 +8050,7 @@ enum Reason {
   lowFaceQuality,
 }
 
-extension ReasonValue on Reason {
+extension ReasonValueExtension on Reason {
   String toValue() {
     switch (this) {
       case Reason.exceedsMaxFaces:
@@ -8348,7 +8349,7 @@ enum SegmentType {
   shot,
 }
 
-extension SegmentTypeValue on SegmentType {
+extension SegmentTypeValueExtension on SegmentType {
   String toValue() {
     switch (this) {
       case SegmentType.technicalCue:
@@ -8815,7 +8816,7 @@ enum StreamProcessorStatus {
   stopping,
 }
 
-extension StreamProcessorStatusValue on StreamProcessorStatus {
+extension StreamProcessorStatusValueExtension on StreamProcessorStatus {
   String toValue() {
     switch (this) {
       case StreamProcessorStatus.stopped:
@@ -8920,7 +8921,7 @@ enum TechnicalCueType {
   blackFrames,
 }
 
-extension TechnicalCueTypeValue on TechnicalCueType {
+extension TechnicalCueTypeValueExtension on TechnicalCueType {
   String toValue() {
     switch (this) {
       case TechnicalCueType.colorBars:
@@ -9106,7 +9107,7 @@ enum TextTypes {
   word,
 }
 
-extension TextTypesValue on TextTypes {
+extension TextTypesValueExtension on TextTypes {
   String toValue() {
     switch (this) {
       case TextTypes.line:
@@ -9297,7 +9298,7 @@ enum VideoJobStatus {
   failed,
 }
 
-extension VideoJobStatusValue on VideoJobStatus {
+extension VideoJobStatusValueExtension on VideoJobStatus {
   String toValue() {
     switch (this) {
       case VideoJobStatus.inProgress:

--- a/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
+++ b/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
@@ -1452,7 +1452,7 @@ enum GroupConfigurationStatus {
   updateFailed,
 }
 
-extension GroupConfigurationStatusValue on GroupConfigurationStatus {
+extension GroupConfigurationStatusValueExtension on GroupConfigurationStatus {
   String toValue() {
     switch (this) {
       case GroupConfigurationStatus.updating:
@@ -1508,7 +1508,7 @@ enum GroupFilterName {
   configurationType,
 }
 
-extension GroupFilterNameValue on GroupFilterName {
+extension GroupFilterNameValueExtension on GroupFilterName {
   String toValue() {
     switch (this) {
       case GroupFilterName.resourceType:
@@ -1795,7 +1795,7 @@ enum QueryErrorCode {
   cloudformationStackNotExisting,
 }
 
-extension QueryErrorCodeValue on QueryErrorCode {
+extension QueryErrorCodeValueExtension on QueryErrorCode {
   String toValue() {
     switch (this) {
       case QueryErrorCode.cloudformationStackInactive:
@@ -1823,7 +1823,7 @@ enum QueryType {
   cloudformationStack_1_0,
 }
 
-extension QueryTypeValue on QueryType {
+extension QueryTypeValueExtension on QueryType {
   String toValue() {
     switch (this) {
       case QueryType.tagFilters_1_0:
@@ -1874,7 +1874,7 @@ enum ResourceFilterName {
   resourceType,
 }
 
-extension ResourceFilterNameValue on ResourceFilterName {
+extension ResourceFilterNameValueExtension on ResourceFilterName {
   String toValue() {
     switch (this) {
       case ResourceFilterName.resourceType:
@@ -2091,7 +2091,7 @@ enum ResourceStatusValue {
   pending,
 }
 
-extension ResourceStatusValueValue on ResourceStatusValue {
+extension ResourceStatusValueValueExtension on ResourceStatusValue {
   String toValue() {
     switch (this) {
       case ResourceStatusValue.pending:

--- a/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
+++ b/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
@@ -1452,7 +1452,7 @@ enum GroupConfigurationStatus {
   updateFailed,
 }
 
-extension on GroupConfigurationStatus {
+extension GroupConfigurationStatusValue on GroupConfigurationStatus {
   String toValue() {
     switch (this) {
       case GroupConfigurationStatus.updating:
@@ -1465,7 +1465,7 @@ extension on GroupConfigurationStatus {
   }
 }
 
-extension on String {
+extension GroupConfigurationStatusFromString on String {
   GroupConfigurationStatus toGroupConfigurationStatus() {
     switch (this) {
       case 'UPDATING':
@@ -1508,7 +1508,7 @@ enum GroupFilterName {
   configurationType,
 }
 
-extension on GroupFilterName {
+extension GroupFilterNameValue on GroupFilterName {
   String toValue() {
     switch (this) {
       case GroupFilterName.resourceType:
@@ -1519,7 +1519,7 @@ extension on GroupFilterName {
   }
 }
 
-extension on String {
+extension GroupFilterNameFromString on String {
   GroupFilterName toGroupFilterName() {
     switch (this) {
       case 'resource-type':
@@ -1795,7 +1795,7 @@ enum QueryErrorCode {
   cloudformationStackNotExisting,
 }
 
-extension on QueryErrorCode {
+extension QueryErrorCodeValue on QueryErrorCode {
   String toValue() {
     switch (this) {
       case QueryErrorCode.cloudformationStackInactive:
@@ -1806,7 +1806,7 @@ extension on QueryErrorCode {
   }
 }
 
-extension on String {
+extension QueryErrorCodeFromString on String {
   QueryErrorCode toQueryErrorCode() {
     switch (this) {
       case 'CLOUDFORMATION_STACK_INACTIVE':
@@ -1823,7 +1823,7 @@ enum QueryType {
   cloudformationStack_1_0,
 }
 
-extension on QueryType {
+extension QueryTypeValue on QueryType {
   String toValue() {
     switch (this) {
       case QueryType.tagFilters_1_0:
@@ -1834,7 +1834,7 @@ extension on QueryType {
   }
 }
 
-extension on String {
+extension QueryTypeFromString on String {
   QueryType toQueryType() {
     switch (this) {
       case 'TAG_FILTERS_1_0':
@@ -1874,7 +1874,7 @@ enum ResourceFilterName {
   resourceType,
 }
 
-extension on ResourceFilterName {
+extension ResourceFilterNameValue on ResourceFilterName {
   String toValue() {
     switch (this) {
       case ResourceFilterName.resourceType:
@@ -1883,7 +1883,7 @@ extension on ResourceFilterName {
   }
 }
 
-extension on String {
+extension ResourceFilterNameFromString on String {
   ResourceFilterName toResourceFilterName() {
     switch (this) {
       case 'resource-type':
@@ -2091,7 +2091,7 @@ enum ResourceStatusValue {
   pending,
 }
 
-extension on ResourceStatusValue {
+extension ResourceStatusValueValue on ResourceStatusValue {
   String toValue() {
     switch (this) {
       case ResourceStatusValue.pending:
@@ -2100,7 +2100,7 @@ extension on ResourceStatusValue {
   }
 }
 
-extension on String {
+extension ResourceStatusValueFromString on String {
   ResourceStatusValue toResourceStatusValue() {
     switch (this) {
       case 'PENDING':

--- a/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
@@ -757,7 +757,7 @@ enum ErrorCode {
   invalidParameterException,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.internalServiceException:
@@ -768,7 +768,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'InternalServiceException':
@@ -941,7 +941,7 @@ enum GroupByAttribute {
   resourceType,
 }
 
-extension on GroupByAttribute {
+extension GroupByAttributeValue on GroupByAttribute {
   String toValue() {
     switch (this) {
       case GroupByAttribute.targetId:
@@ -954,7 +954,7 @@ extension on GroupByAttribute {
   }
 }
 
-extension on String {
+extension GroupByAttributeFromString on String {
   GroupByAttribute toGroupByAttribute() {
     switch (this) {
       case 'TARGET_ID':
@@ -1128,7 +1128,7 @@ enum TargetIdType {
   root,
 }
 
-extension on TargetIdType {
+extension TargetIdTypeValue on TargetIdType {
   String toValue() {
     switch (this) {
       case TargetIdType.account:
@@ -1141,7 +1141,7 @@ extension on TargetIdType {
   }
 }
 
-extension on String {
+extension TargetIdTypeFromString on String {
   TargetIdType toTargetIdType() {
     switch (this) {
       case 'ACCOUNT':

--- a/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
@@ -757,7 +757,7 @@ enum ErrorCode {
   invalidParameterException,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.internalServiceException:
@@ -941,7 +941,7 @@ enum GroupByAttribute {
   resourceType,
 }
 
-extension GroupByAttributeValue on GroupByAttribute {
+extension GroupByAttributeValueExtension on GroupByAttribute {
   String toValue() {
     switch (this) {
       case GroupByAttribute.targetId:
@@ -1128,7 +1128,7 @@ enum TargetIdType {
   root,
 }
 
-extension TargetIdTypeValue on TargetIdType {
+extension TargetIdTypeValueExtension on TargetIdType {
   String toValue() {
     switch (this) {
       case TargetIdType.account:

--- a/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
+++ b/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
@@ -2709,7 +2709,7 @@ enum Architecture {
   armhf,
 }
 
-extension ArchitectureValue on Architecture {
+extension ArchitectureValueExtension on Architecture {
   String toValue() {
     switch (this) {
       case Architecture.x86_64:
@@ -3970,7 +3970,7 @@ enum DeploymentJobErrorCode {
   internalServerError,
 }
 
-extension DeploymentJobErrorCodeValue on DeploymentJobErrorCode {
+extension DeploymentJobErrorCodeValueExtension on DeploymentJobErrorCode {
   String toValue() {
     switch (this) {
       case DeploymentJobErrorCode.resourceNotFound:
@@ -4130,7 +4130,7 @@ enum DeploymentStatus {
   canceled,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pending:
@@ -5126,7 +5126,7 @@ enum FailureBehavior {
   $continue,
 }
 
-extension FailureBehaviorValue on FailureBehavior {
+extension FailureBehaviorValueExtension on FailureBehavior {
   String toValue() {
     switch (this) {
       case FailureBehavior.fail:
@@ -5902,7 +5902,7 @@ enum RenderingEngineType {
   ogre,
 }
 
-extension RenderingEngineTypeValue on RenderingEngineType {
+extension RenderingEngineTypeValueExtension on RenderingEngineType {
   String toValue() {
     switch (this) {
       case RenderingEngineType.ogre:
@@ -6117,7 +6117,7 @@ enum RobotDeploymentStep {
   finished,
 }
 
-extension RobotDeploymentStepValue on RobotDeploymentStep {
+extension RobotDeploymentStepValueExtension on RobotDeploymentStep {
   String toValue() {
     switch (this) {
       case RobotDeploymentStep.validating:
@@ -6194,7 +6194,7 @@ enum RobotSoftwareSuiteType {
   ros2,
 }
 
-extension RobotSoftwareSuiteTypeValue on RobotSoftwareSuiteType {
+extension RobotSoftwareSuiteTypeValueExtension on RobotSoftwareSuiteType {
   String toValue() {
     switch (this) {
       case RobotSoftwareSuiteType.ros:
@@ -6223,7 +6223,8 @@ enum RobotSoftwareSuiteVersionType {
   dashing,
 }
 
-extension RobotSoftwareSuiteVersionTypeValue on RobotSoftwareSuiteVersionType {
+extension RobotSoftwareSuiteVersionTypeValueExtension
+    on RobotSoftwareSuiteVersionType {
   String toValue() {
     switch (this) {
       case RobotSoftwareSuiteVersionType.kinetic:
@@ -6260,7 +6261,7 @@ enum RobotStatus {
   noResponse,
 }
 
-extension RobotStatusValue on RobotStatus {
+extension RobotStatusValueExtension on RobotStatus {
   String toValue() {
     switch (this) {
       case RobotStatus.available:
@@ -6610,7 +6611,8 @@ enum SimulationJobBatchErrorCode {
   internalServiceError,
 }
 
-extension SimulationJobBatchErrorCodeValue on SimulationJobBatchErrorCode {
+extension SimulationJobBatchErrorCodeValueExtension
+    on SimulationJobBatchErrorCode {
   String toValue() {
     switch (this) {
       case SimulationJobBatchErrorCode.internalServiceError:
@@ -6641,7 +6643,7 @@ enum SimulationJobBatchStatus {
   timedOut,
 }
 
-extension SimulationJobBatchStatusValue on SimulationJobBatchStatus {
+extension SimulationJobBatchStatusValueExtension on SimulationJobBatchStatus {
   String toValue() {
     switch (this) {
       case SimulationJobBatchStatus.pending:
@@ -6800,7 +6802,7 @@ enum SimulationJobErrorCode {
   wrongRegionSimulationApplication,
 }
 
-extension SimulationJobErrorCodeValue on SimulationJobErrorCode {
+extension SimulationJobErrorCodeValueExtension on SimulationJobErrorCode {
   String toValue() {
     switch (this) {
       case SimulationJobErrorCode.internalServiceError:
@@ -7070,7 +7072,7 @@ enum SimulationJobStatus {
   canceled,
 }
 
-extension SimulationJobStatusValue on SimulationJobStatus {
+extension SimulationJobStatusValueExtension on SimulationJobStatus {
   String toValue() {
     switch (this) {
       case SimulationJobStatus.pending:
@@ -7214,7 +7216,8 @@ enum SimulationSoftwareSuiteType {
   rosbagPlay,
 }
 
-extension SimulationSoftwareSuiteTypeValue on SimulationSoftwareSuiteType {
+extension SimulationSoftwareSuiteTypeValueExtension
+    on SimulationSoftwareSuiteType {
   String toValue() {
     switch (this) {
       case SimulationSoftwareSuiteType.gazebo:
@@ -7866,7 +7869,7 @@ enum WorldExportJobErrorCode {
   accessDenied,
 }
 
-extension WorldExportJobErrorCodeValue on WorldExportJobErrorCode {
+extension WorldExportJobErrorCodeValueExtension on WorldExportJobErrorCode {
   String toValue() {
     switch (this) {
       case WorldExportJobErrorCode.internalServiceError:
@@ -7914,7 +7917,7 @@ enum WorldExportJobStatus {
   canceled,
 }
 
-extension WorldExportJobStatusValue on WorldExportJobStatus {
+extension WorldExportJobStatusValueExtension on WorldExportJobStatus {
   String toValue() {
     switch (this) {
       case WorldExportJobStatus.pending:
@@ -8049,7 +8052,8 @@ enum WorldGenerationJobErrorCode {
   allWorldGenerationFailed,
 }
 
-extension WorldGenerationJobErrorCodeValue on WorldGenerationJobErrorCode {
+extension WorldGenerationJobErrorCodeValueExtension
+    on WorldGenerationJobErrorCode {
   String toValue() {
     switch (this) {
       case WorldGenerationJobErrorCode.internalServiceError:
@@ -8098,7 +8102,7 @@ enum WorldGenerationJobStatus {
   canceled,
 }
 
-extension WorldGenerationJobStatusValue on WorldGenerationJobStatus {
+extension WorldGenerationJobStatusValueExtension on WorldGenerationJobStatus {
   String toValue() {
     switch (this) {
       case WorldGenerationJobStatus.pending:

--- a/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
+++ b/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
@@ -2709,7 +2709,7 @@ enum Architecture {
   armhf,
 }
 
-extension on Architecture {
+extension ArchitectureValue on Architecture {
   String toValue() {
     switch (this) {
       case Architecture.x86_64:
@@ -2722,7 +2722,7 @@ extension on Architecture {
   }
 }
 
-extension on String {
+extension ArchitectureFromString on String {
   Architecture toArchitecture() {
     switch (this) {
       case 'X86_64':
@@ -3970,7 +3970,7 @@ enum DeploymentJobErrorCode {
   internalServerError,
 }
 
-extension on DeploymentJobErrorCode {
+extension DeploymentJobErrorCodeValue on DeploymentJobErrorCode {
   String toValue() {
     switch (this) {
       case DeploymentJobErrorCode.resourceNotFound:
@@ -4017,7 +4017,7 @@ extension on DeploymentJobErrorCode {
   }
 }
 
-extension on String {
+extension DeploymentJobErrorCodeFromString on String {
   DeploymentJobErrorCode toDeploymentJobErrorCode() {
     switch (this) {
       case 'ResourceNotFound':
@@ -4130,7 +4130,7 @@ enum DeploymentStatus {
   canceled,
 }
 
-extension on DeploymentStatus {
+extension DeploymentStatusValue on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pending:
@@ -4149,7 +4149,7 @@ extension on DeploymentStatus {
   }
 }
 
-extension on String {
+extension DeploymentStatusFromString on String {
   DeploymentStatus toDeploymentStatus() {
     switch (this) {
       case 'Pending':
@@ -5126,7 +5126,7 @@ enum FailureBehavior {
   $continue,
 }
 
-extension on FailureBehavior {
+extension FailureBehaviorValue on FailureBehavior {
   String toValue() {
     switch (this) {
       case FailureBehavior.fail:
@@ -5137,7 +5137,7 @@ extension on FailureBehavior {
   }
 }
 
-extension on String {
+extension FailureBehaviorFromString on String {
   FailureBehavior toFailureBehavior() {
     switch (this) {
       case 'Fail':
@@ -5902,7 +5902,7 @@ enum RenderingEngineType {
   ogre,
 }
 
-extension on RenderingEngineType {
+extension RenderingEngineTypeValue on RenderingEngineType {
   String toValue() {
     switch (this) {
       case RenderingEngineType.ogre:
@@ -5911,7 +5911,7 @@ extension on RenderingEngineType {
   }
 }
 
-extension on String {
+extension RenderingEngineTypeFromString on String {
   RenderingEngineType toRenderingEngineType() {
     switch (this) {
       case 'OGRE':
@@ -6117,7 +6117,7 @@ enum RobotDeploymentStep {
   finished,
 }
 
-extension on RobotDeploymentStep {
+extension RobotDeploymentStepValue on RobotDeploymentStep {
   String toValue() {
     switch (this) {
       case RobotDeploymentStep.validating:
@@ -6138,7 +6138,7 @@ extension on RobotDeploymentStep {
   }
 }
 
-extension on String {
+extension RobotDeploymentStepFromString on String {
   RobotDeploymentStep toRobotDeploymentStep() {
     switch (this) {
       case 'Validating':
@@ -6194,7 +6194,7 @@ enum RobotSoftwareSuiteType {
   ros2,
 }
 
-extension on RobotSoftwareSuiteType {
+extension RobotSoftwareSuiteTypeValue on RobotSoftwareSuiteType {
   String toValue() {
     switch (this) {
       case RobotSoftwareSuiteType.ros:
@@ -6205,7 +6205,7 @@ extension on RobotSoftwareSuiteType {
   }
 }
 
-extension on String {
+extension RobotSoftwareSuiteTypeFromString on String {
   RobotSoftwareSuiteType toRobotSoftwareSuiteType() {
     switch (this) {
       case 'ROS':
@@ -6223,7 +6223,7 @@ enum RobotSoftwareSuiteVersionType {
   dashing,
 }
 
-extension on RobotSoftwareSuiteVersionType {
+extension RobotSoftwareSuiteVersionTypeValue on RobotSoftwareSuiteVersionType {
   String toValue() {
     switch (this) {
       case RobotSoftwareSuiteVersionType.kinetic:
@@ -6236,7 +6236,7 @@ extension on RobotSoftwareSuiteVersionType {
   }
 }
 
-extension on String {
+extension RobotSoftwareSuiteVersionTypeFromString on String {
   RobotSoftwareSuiteVersionType toRobotSoftwareSuiteVersionType() {
     switch (this) {
       case 'Kinetic':
@@ -6260,7 +6260,7 @@ enum RobotStatus {
   noResponse,
 }
 
-extension on RobotStatus {
+extension RobotStatusValue on RobotStatus {
   String toValue() {
     switch (this) {
       case RobotStatus.available:
@@ -6281,7 +6281,7 @@ extension on RobotStatus {
   }
 }
 
-extension on String {
+extension RobotStatusFromString on String {
   RobotStatus toRobotStatus() {
     switch (this) {
       case 'Available':
@@ -6610,7 +6610,7 @@ enum SimulationJobBatchErrorCode {
   internalServiceError,
 }
 
-extension on SimulationJobBatchErrorCode {
+extension SimulationJobBatchErrorCodeValue on SimulationJobBatchErrorCode {
   String toValue() {
     switch (this) {
       case SimulationJobBatchErrorCode.internalServiceError:
@@ -6619,7 +6619,7 @@ extension on SimulationJobBatchErrorCode {
   }
 }
 
-extension on String {
+extension SimulationJobBatchErrorCodeFromString on String {
   SimulationJobBatchErrorCode toSimulationJobBatchErrorCode() {
     switch (this) {
       case 'InternalServiceError':
@@ -6641,7 +6641,7 @@ enum SimulationJobBatchStatus {
   timedOut,
 }
 
-extension on SimulationJobBatchStatus {
+extension SimulationJobBatchStatusValue on SimulationJobBatchStatus {
   String toValue() {
     switch (this) {
       case SimulationJobBatchStatus.pending:
@@ -6666,7 +6666,7 @@ extension on SimulationJobBatchStatus {
   }
 }
 
-extension on String {
+extension SimulationJobBatchStatusFromString on String {
   SimulationJobBatchStatus toSimulationJobBatchStatus() {
     switch (this) {
       case 'Pending':
@@ -6800,7 +6800,7 @@ enum SimulationJobErrorCode {
   wrongRegionSimulationApplication,
 }
 
-extension on SimulationJobErrorCode {
+extension SimulationJobErrorCodeValue on SimulationJobErrorCode {
   String toValue() {
     switch (this) {
       case SimulationJobErrorCode.internalServiceError:
@@ -6861,7 +6861,7 @@ extension on SimulationJobErrorCode {
   }
 }
 
-extension on String {
+extension SimulationJobErrorCodeFromString on String {
   SimulationJobErrorCode toSimulationJobErrorCode() {
     switch (this) {
       case 'InternalServiceError':
@@ -7070,7 +7070,7 @@ enum SimulationJobStatus {
   canceled,
 }
 
-extension on SimulationJobStatus {
+extension SimulationJobStatusValue on SimulationJobStatus {
   String toValue() {
     switch (this) {
       case SimulationJobStatus.pending:
@@ -7097,7 +7097,7 @@ extension on SimulationJobStatus {
   }
 }
 
-extension on String {
+extension SimulationJobStatusFromString on String {
   SimulationJobStatus toSimulationJobStatus() {
     switch (this) {
       case 'Pending':
@@ -7214,7 +7214,7 @@ enum SimulationSoftwareSuiteType {
   rosbagPlay,
 }
 
-extension on SimulationSoftwareSuiteType {
+extension SimulationSoftwareSuiteTypeValue on SimulationSoftwareSuiteType {
   String toValue() {
     switch (this) {
       case SimulationSoftwareSuiteType.gazebo:
@@ -7225,7 +7225,7 @@ extension on SimulationSoftwareSuiteType {
   }
 }
 
-extension on String {
+extension SimulationSoftwareSuiteTypeFromString on String {
   SimulationSoftwareSuiteType toSimulationSoftwareSuiteType() {
     switch (this) {
       case 'Gazebo':
@@ -7866,7 +7866,7 @@ enum WorldExportJobErrorCode {
   accessDenied,
 }
 
-extension on WorldExportJobErrorCode {
+extension WorldExportJobErrorCodeValue on WorldExportJobErrorCode {
   String toValue() {
     switch (this) {
       case WorldExportJobErrorCode.internalServiceError:
@@ -7885,7 +7885,7 @@ extension on WorldExportJobErrorCode {
   }
 }
 
-extension on String {
+extension WorldExportJobErrorCodeFromString on String {
   WorldExportJobErrorCode toWorldExportJobErrorCode() {
     switch (this) {
       case 'InternalServiceError':
@@ -7914,7 +7914,7 @@ enum WorldExportJobStatus {
   canceled,
 }
 
-extension on WorldExportJobStatus {
+extension WorldExportJobStatusValue on WorldExportJobStatus {
   String toValue() {
     switch (this) {
       case WorldExportJobStatus.pending:
@@ -7933,7 +7933,7 @@ extension on WorldExportJobStatus {
   }
 }
 
-extension on String {
+extension WorldExportJobStatusFromString on String {
   WorldExportJobStatus toWorldExportJobStatus() {
     switch (this) {
       case 'Pending':
@@ -8049,7 +8049,7 @@ enum WorldGenerationJobErrorCode {
   allWorldGenerationFailed,
 }
 
-extension on WorldGenerationJobErrorCode {
+extension WorldGenerationJobErrorCodeValue on WorldGenerationJobErrorCode {
   String toValue() {
     switch (this) {
       case WorldGenerationJobErrorCode.internalServiceError:
@@ -8068,7 +8068,7 @@ extension on WorldGenerationJobErrorCode {
   }
 }
 
-extension on String {
+extension WorldGenerationJobErrorCodeFromString on String {
   WorldGenerationJobErrorCode toWorldGenerationJobErrorCode() {
     switch (this) {
       case 'InternalServiceError':
@@ -8098,7 +8098,7 @@ enum WorldGenerationJobStatus {
   canceled,
 }
 
-extension on WorldGenerationJobStatus {
+extension WorldGenerationJobStatusValue on WorldGenerationJobStatus {
   String toValue() {
     switch (this) {
       case WorldGenerationJobStatus.pending:
@@ -8119,7 +8119,7 @@ extension on WorldGenerationJobStatus {
   }
 }
 
-extension on String {
+extension WorldGenerationJobStatusFromString on String {
   WorldGenerationJobStatus toWorldGenerationJobStatus() {
     switch (this) {
       case 'Pending':

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -4835,7 +4835,7 @@ enum AccountLimitType {
   maxTrafficPoliciesByOwner,
 }
 
-extension on AccountLimitType {
+extension AccountLimitTypeValue on AccountLimitType {
   String toValue() {
     switch (this) {
       case AccountLimitType.maxHealthChecksByOwner:
@@ -4852,7 +4852,7 @@ extension on AccountLimitType {
   }
 }
 
-extension on String {
+extension AccountLimitTypeFromString on String {
   AccountLimitType toAccountLimitType() {
     switch (this) {
       case 'MAX_HEALTH_CHECKS_BY_OWNER':
@@ -5460,7 +5460,7 @@ enum ChangeAction {
   upsert,
 }
 
-extension on ChangeAction {
+extension ChangeActionValue on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.create:
@@ -5473,7 +5473,7 @@ extension on ChangeAction {
   }
 }
 
-extension on String {
+extension ChangeActionFromString on String {
   ChangeAction toChangeAction() {
     switch (this) {
       case 'CREATE':
@@ -5616,7 +5616,7 @@ enum ChangeStatus {
   insync,
 }
 
-extension on ChangeStatus {
+extension ChangeStatusValue on ChangeStatus {
   String toValue() {
     switch (this) {
       case ChangeStatus.pending:
@@ -5627,7 +5627,7 @@ extension on ChangeStatus {
   }
 }
 
-extension on String {
+extension ChangeStatusFromString on String {
   ChangeStatus toChangeStatus() {
     switch (this) {
       case 'PENDING':
@@ -5808,7 +5808,7 @@ enum CloudWatchRegion {
   usIsobEast_1,
 }
 
-extension on CloudWatchRegion {
+extension CloudWatchRegionValue on CloudWatchRegion {
   String toValue() {
     switch (this) {
       case CloudWatchRegion.usEast_1:
@@ -5869,7 +5869,7 @@ extension on CloudWatchRegion {
   }
 }
 
-extension on String {
+extension CloudWatchRegionFromString on String {
   CloudWatchRegion toCloudWatchRegion() {
     switch (this) {
       case 'us-east-1':
@@ -5938,7 +5938,7 @@ enum ComparisonOperator {
   lessThanOrEqualToThreshold,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -5953,7 +5953,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'GreaterThanOrEqualToThreshold':
@@ -7974,7 +7974,7 @@ enum HealthCheckRegion {
   saEast_1,
 }
 
-extension on HealthCheckRegion {
+extension HealthCheckRegionValue on HealthCheckRegion {
   String toValue() {
     switch (this) {
       case HealthCheckRegion.usEast_1:
@@ -7997,7 +7997,7 @@ extension on HealthCheckRegion {
   }
 }
 
-extension on String {
+extension HealthCheckRegionFromString on String {
   HealthCheckRegion toHealthCheckRegion() {
     switch (this) {
       case 'us-east-1':
@@ -8031,7 +8031,7 @@ enum HealthCheckType {
   cloudwatchMetric,
 }
 
-extension on HealthCheckType {
+extension HealthCheckTypeValue on HealthCheckType {
   String toValue() {
     switch (this) {
       case HealthCheckType.http:
@@ -8052,7 +8052,7 @@ extension on HealthCheckType {
   }
 }
 
-extension on String {
+extension HealthCheckTypeFromString on String {
   HealthCheckType toHealthCheckType() {
     switch (this) {
       case 'HTTP':
@@ -8209,7 +8209,7 @@ enum HostedZoneLimitType {
   maxVpcsAssociatedByZone,
 }
 
-extension on HostedZoneLimitType {
+extension HostedZoneLimitTypeValue on HostedZoneLimitType {
   String toValue() {
     switch (this) {
       case HostedZoneLimitType.maxRrsetsByZone:
@@ -8220,7 +8220,7 @@ extension on HostedZoneLimitType {
   }
 }
 
-extension on String {
+extension HostedZoneLimitTypeFromString on String {
   HostedZoneLimitType toHostedZoneLimitType() {
     switch (this) {
       case 'MAX_RRSETS_BY_ZONE':
@@ -8302,7 +8302,7 @@ enum InsufficientDataHealthStatus {
   lastKnownStatus,
 }
 
-extension on InsufficientDataHealthStatus {
+extension InsufficientDataHealthStatusValue on InsufficientDataHealthStatus {
   String toValue() {
     switch (this) {
       case InsufficientDataHealthStatus.healthy:
@@ -8315,7 +8315,7 @@ extension on InsufficientDataHealthStatus {
   }
 }
 
-extension on String {
+extension InsufficientDataHealthStatusFromString on String {
   InsufficientDataHealthStatus toInsufficientDataHealthStatus() {
     switch (this) {
       case 'Healthy':
@@ -9382,7 +9382,7 @@ enum RRType {
   ds,
 }
 
-extension on RRType {
+extension RRTypeValue on RRType {
   String toValue() {
     switch (this) {
       case RRType.soa:
@@ -9415,7 +9415,7 @@ extension on RRType {
   }
 }
 
-extension on String {
+extension RRTypeFromString on String {
   RRType toRRType() {
     switch (this) {
       case 'SOA':
@@ -9456,7 +9456,7 @@ enum ResettableElementName {
   childHealthChecks,
 }
 
-extension on ResettableElementName {
+extension ResettableElementNameValue on ResettableElementName {
   String toValue() {
     switch (this) {
       case ResettableElementName.fullyQualifiedDomainName:
@@ -9471,7 +9471,7 @@ extension on ResettableElementName {
   }
 }
 
-extension on String {
+extension ResettableElementNameFromString on String {
   ResettableElementName toResettableElementName() {
     switch (this) {
       case 'FullyQualifiedDomainName':
@@ -10215,7 +10215,7 @@ enum ResourceRecordSetFailover {
   secondary,
 }
 
-extension on ResourceRecordSetFailover {
+extension ResourceRecordSetFailoverValue on ResourceRecordSetFailover {
   String toValue() {
     switch (this) {
       case ResourceRecordSetFailover.primary:
@@ -10226,7 +10226,7 @@ extension on ResourceRecordSetFailover {
   }
 }
 
-extension on String {
+extension ResourceRecordSetFailoverFromString on String {
   ResourceRecordSetFailover toResourceRecordSetFailover() {
     switch (this) {
       case 'PRIMARY':
@@ -10264,7 +10264,7 @@ enum ResourceRecordSetRegion {
   euSouth_1,
 }
 
-extension on ResourceRecordSetRegion {
+extension ResourceRecordSetRegionValue on ResourceRecordSetRegion {
   String toValue() {
     switch (this) {
       case ResourceRecordSetRegion.usEast_1:
@@ -10317,7 +10317,7 @@ extension on ResourceRecordSetRegion {
   }
 }
 
-extension on String {
+extension ResourceRecordSetRegionFromString on String {
   ResourceRecordSetRegion toResourceRecordSetRegion() {
     switch (this) {
       case 'us-east-1':
@@ -10438,7 +10438,8 @@ enum ReusableDelegationSetLimitType {
   maxZonesByReusableDelegationSet,
 }
 
-extension on ReusableDelegationSetLimitType {
+extension ReusableDelegationSetLimitTypeValue
+    on ReusableDelegationSetLimitType {
   String toValue() {
     switch (this) {
       case ReusableDelegationSetLimitType.maxZonesByReusableDelegationSet:
@@ -10447,7 +10448,7 @@ extension on ReusableDelegationSetLimitType {
   }
 }
 
-extension on String {
+extension ReusableDelegationSetLimitTypeFromString on String {
   ReusableDelegationSetLimitType toReusableDelegationSetLimitType() {
     switch (this) {
       case 'MAX_ZONES_BY_REUSABLE_DELEGATION_SET':
@@ -10466,7 +10467,7 @@ enum Statistic {
   minimum,
 }
 
-extension on Statistic {
+extension StatisticValue on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.average:
@@ -10483,7 +10484,7 @@ extension on Statistic {
   }
 }
 
-extension on String {
+extension StatisticFromString on String {
   Statistic toStatistic() {
     switch (this) {
       case 'Average':
@@ -10604,7 +10605,7 @@ enum TagResourceType {
   hostedzone,
 }
 
-extension on TagResourceType {
+extension TagResourceTypeValue on TagResourceType {
   String toValue() {
     switch (this) {
       case TagResourceType.healthcheck:
@@ -10615,7 +10616,7 @@ extension on TagResourceType {
   }
 }
 
-extension on String {
+extension TagResourceTypeFromString on String {
   TagResourceType toTagResourceType() {
     switch (this) {
       case 'healthcheck':
@@ -11541,7 +11542,7 @@ enum VPCRegion {
   euSouth_1,
 }
 
-extension on VPCRegion {
+extension VPCRegionValue on VPCRegion {
   String toValue() {
     switch (this) {
       case VPCRegion.usEast_1:
@@ -11600,7 +11601,7 @@ extension on VPCRegion {
   }
 }
 
-extension on String {
+extension VPCRegionFromString on String {
   VPCRegion toVPCRegion() {
     switch (this) {
       case 'us-east-1':

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -4835,7 +4835,7 @@ enum AccountLimitType {
   maxTrafficPoliciesByOwner,
 }
 
-extension AccountLimitTypeValue on AccountLimitType {
+extension AccountLimitTypeValueExtension on AccountLimitType {
   String toValue() {
     switch (this) {
       case AccountLimitType.maxHealthChecksByOwner:
@@ -5460,7 +5460,7 @@ enum ChangeAction {
   upsert,
 }
 
-extension ChangeActionValue on ChangeAction {
+extension ChangeActionValueExtension on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.create:
@@ -5616,7 +5616,7 @@ enum ChangeStatus {
   insync,
 }
 
-extension ChangeStatusValue on ChangeStatus {
+extension ChangeStatusValueExtension on ChangeStatus {
   String toValue() {
     switch (this) {
       case ChangeStatus.pending:
@@ -5808,7 +5808,7 @@ enum CloudWatchRegion {
   usIsobEast_1,
 }
 
-extension CloudWatchRegionValue on CloudWatchRegion {
+extension CloudWatchRegionValueExtension on CloudWatchRegion {
   String toValue() {
     switch (this) {
       case CloudWatchRegion.usEast_1:
@@ -5938,7 +5938,7 @@ enum ComparisonOperator {
   lessThanOrEqualToThreshold,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.greaterThanOrEqualToThreshold:
@@ -7974,7 +7974,7 @@ enum HealthCheckRegion {
   saEast_1,
 }
 
-extension HealthCheckRegionValue on HealthCheckRegion {
+extension HealthCheckRegionValueExtension on HealthCheckRegion {
   String toValue() {
     switch (this) {
       case HealthCheckRegion.usEast_1:
@@ -8031,7 +8031,7 @@ enum HealthCheckType {
   cloudwatchMetric,
 }
 
-extension HealthCheckTypeValue on HealthCheckType {
+extension HealthCheckTypeValueExtension on HealthCheckType {
   String toValue() {
     switch (this) {
       case HealthCheckType.http:
@@ -8209,7 +8209,7 @@ enum HostedZoneLimitType {
   maxVpcsAssociatedByZone,
 }
 
-extension HostedZoneLimitTypeValue on HostedZoneLimitType {
+extension HostedZoneLimitTypeValueExtension on HostedZoneLimitType {
   String toValue() {
     switch (this) {
       case HostedZoneLimitType.maxRrsetsByZone:
@@ -8302,7 +8302,8 @@ enum InsufficientDataHealthStatus {
   lastKnownStatus,
 }
 
-extension InsufficientDataHealthStatusValue on InsufficientDataHealthStatus {
+extension InsufficientDataHealthStatusValueExtension
+    on InsufficientDataHealthStatus {
   String toValue() {
     switch (this) {
       case InsufficientDataHealthStatus.healthy:
@@ -9382,7 +9383,7 @@ enum RRType {
   ds,
 }
 
-extension RRTypeValue on RRType {
+extension RRTypeValueExtension on RRType {
   String toValue() {
     switch (this) {
       case RRType.soa:
@@ -9456,7 +9457,7 @@ enum ResettableElementName {
   childHealthChecks,
 }
 
-extension ResettableElementNameValue on ResettableElementName {
+extension ResettableElementNameValueExtension on ResettableElementName {
   String toValue() {
     switch (this) {
       case ResettableElementName.fullyQualifiedDomainName:
@@ -10215,7 +10216,7 @@ enum ResourceRecordSetFailover {
   secondary,
 }
 
-extension ResourceRecordSetFailoverValue on ResourceRecordSetFailover {
+extension ResourceRecordSetFailoverValueExtension on ResourceRecordSetFailover {
   String toValue() {
     switch (this) {
       case ResourceRecordSetFailover.primary:
@@ -10264,7 +10265,7 @@ enum ResourceRecordSetRegion {
   euSouth_1,
 }
 
-extension ResourceRecordSetRegionValue on ResourceRecordSetRegion {
+extension ResourceRecordSetRegionValueExtension on ResourceRecordSetRegion {
   String toValue() {
     switch (this) {
       case ResourceRecordSetRegion.usEast_1:
@@ -10438,7 +10439,7 @@ enum ReusableDelegationSetLimitType {
   maxZonesByReusableDelegationSet,
 }
 
-extension ReusableDelegationSetLimitTypeValue
+extension ReusableDelegationSetLimitTypeValueExtension
     on ReusableDelegationSetLimitType {
   String toValue() {
     switch (this) {
@@ -10467,7 +10468,7 @@ enum Statistic {
   minimum,
 }
 
-extension StatisticValue on Statistic {
+extension StatisticValueExtension on Statistic {
   String toValue() {
     switch (this) {
       case Statistic.average:
@@ -10605,7 +10606,7 @@ enum TagResourceType {
   hostedzone,
 }
 
-extension TagResourceTypeValue on TagResourceType {
+extension TagResourceTypeValueExtension on TagResourceType {
   String toValue() {
     switch (this) {
       case TagResourceType.healthcheck:
@@ -11542,7 +11543,7 @@ enum VPCRegion {
   euSouth_1,
 }
 
-extension VPCRegionValue on VPCRegion {
+extension VPCRegionValueExtension on VPCRegion {
   String toValue() {
     switch (this) {
       case VPCRegion.usEast_1:

--- a/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
+++ b/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
@@ -2223,7 +2223,7 @@ enum ContactType {
   reseller,
 }
 
-extension ContactTypeValue on ContactType {
+extension ContactTypeValueExtension on ContactType {
   String toValue() {
     switch (this) {
       case ContactType.person:
@@ -2490,7 +2490,7 @@ enum CountryCode {
   zw,
 }
 
-extension CountryCodeValue on CountryCode {
+extension CountryCodeValueExtension on CountryCode {
   String toValue() {
     switch (this) {
       case CountryCode.ad:
@@ -3464,7 +3464,7 @@ enum DomainAvailability {
   dontKnow,
 }
 
-extension DomainAvailabilityValue on DomainAvailability {
+extension DomainAvailabilityValueExtension on DomainAvailability {
   String toValue() {
     switch (this) {
       case DomainAvailability.available:
@@ -4214,7 +4214,7 @@ enum ExtraParamName {
   ukCompanyNumber,
 }
 
-extension ExtraParamNameValue on ExtraParamName {
+extension ExtraParamNameValueExtension on ExtraParamName {
   String toValue() {
     switch (this) {
       case ExtraParamName.dunsNumber:
@@ -4712,7 +4712,7 @@ enum OperationStatus {
   failed,
 }
 
-extension OperationStatusValue on OperationStatus {
+extension OperationStatusValueExtension on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.submitted:
@@ -4799,7 +4799,7 @@ enum OperationType {
   internalTransferInDomain,
 }
 
-extension OperationTypeValue on OperationType {
+extension OperationTypeValueExtension on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.registerDomain:
@@ -4892,7 +4892,7 @@ enum ReachabilityStatus {
   expired,
 }
 
-extension ReachabilityStatusValue on ReachabilityStatus {
+extension ReachabilityStatusValueExtension on ReachabilityStatus {
   String toValue() {
     switch (this) {
       case ReachabilityStatus.pending:
@@ -5117,7 +5117,7 @@ enum Transferable {
   dontKnow,
 }
 
-extension TransferableValue on Transferable {
+extension TransferableValueExtension on Transferable {
   String toValue() {
     switch (this) {
       case Transferable.transferable:

--- a/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
+++ b/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
@@ -2223,7 +2223,7 @@ enum ContactType {
   reseller,
 }
 
-extension on ContactType {
+extension ContactTypeValue on ContactType {
   String toValue() {
     switch (this) {
       case ContactType.person:
@@ -2240,7 +2240,7 @@ extension on ContactType {
   }
 }
 
-extension on String {
+extension ContactTypeFromString on String {
   ContactType toContactType() {
     switch (this) {
       case 'PERSON':
@@ -2490,7 +2490,7 @@ enum CountryCode {
   zw,
 }
 
-extension on CountryCode {
+extension CountryCodeValue on CountryCode {
   String toValue() {
     switch (this) {
       case CountryCode.ad:
@@ -2955,7 +2955,7 @@ extension on CountryCode {
   }
 }
 
-extension on String {
+extension CountryCodeFromString on String {
   CountryCode toCountryCode() {
     switch (this) {
       case 'AD':
@@ -3464,7 +3464,7 @@ enum DomainAvailability {
   dontKnow,
 }
 
-extension on DomainAvailability {
+extension DomainAvailabilityValue on DomainAvailability {
   String toValue() {
     switch (this) {
       case DomainAvailability.available:
@@ -3487,7 +3487,7 @@ extension on DomainAvailability {
   }
 }
 
-extension on String {
+extension DomainAvailabilityFromString on String {
   DomainAvailability toDomainAvailability() {
     switch (this) {
       case 'AVAILABLE':
@@ -4214,7 +4214,7 @@ enum ExtraParamName {
   ukCompanyNumber,
 }
 
-extension on ExtraParamName {
+extension ExtraParamNameValue on ExtraParamName {
   String toValue() {
     switch (this) {
       case ExtraParamName.dunsNumber:
@@ -4279,7 +4279,7 @@ extension on ExtraParamName {
   }
 }
 
-extension on String {
+extension ExtraParamNameFromString on String {
   ExtraParamName toExtraParamName() {
     switch (this) {
       case 'DUNS_NUMBER':
@@ -4712,7 +4712,7 @@ enum OperationStatus {
   failed,
 }
 
-extension on OperationStatus {
+extension OperationStatusValue on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.submitted:
@@ -4729,7 +4729,7 @@ extension on OperationStatus {
   }
 }
 
-extension on String {
+extension OperationStatusFromString on String {
   OperationStatus toOperationStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -4799,7 +4799,7 @@ enum OperationType {
   internalTransferInDomain,
 }
 
-extension on OperationType {
+extension OperationTypeValue on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.registerDomain:
@@ -4842,7 +4842,7 @@ extension on OperationType {
   }
 }
 
-extension on String {
+extension OperationTypeFromString on String {
   OperationType toOperationType() {
     switch (this) {
       case 'REGISTER_DOMAIN':
@@ -4892,7 +4892,7 @@ enum ReachabilityStatus {
   expired,
 }
 
-extension on ReachabilityStatus {
+extension ReachabilityStatusValue on ReachabilityStatus {
   String toValue() {
     switch (this) {
       case ReachabilityStatus.pending:
@@ -4905,7 +4905,7 @@ extension on ReachabilityStatus {
   }
 }
 
-extension on String {
+extension ReachabilityStatusFromString on String {
   ReachabilityStatus toReachabilityStatus() {
     switch (this) {
       case 'PENDING':
@@ -5117,7 +5117,7 @@ enum Transferable {
   dontKnow,
 }
 
-extension on Transferable {
+extension TransferableValue on Transferable {
   String toValue() {
     switch (this) {
       case Transferable.transferable:
@@ -5130,7 +5130,7 @@ extension on Transferable {
   }
 }
 
-extension on String {
+extension TransferableFromString on String {
   Transferable toTransferable() {
     switch (this) {
       case 'TRANSFERABLE':

--- a/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
+++ b/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
@@ -3207,7 +3207,7 @@ enum IpAddressStatus {
   deleteFailedFasExpired,
 }
 
-extension IpAddressStatusValue on IpAddressStatus {
+extension IpAddressStatusValueExtension on IpAddressStatus {
   String toValue() {
     switch (this) {
       case IpAddressStatus.creating:
@@ -3621,7 +3621,7 @@ enum ResolverDNSSECValidationStatus {
   disabled,
 }
 
-extension ResolverDNSSECValidationStatusValue
+extension ResolverDNSSECValidationStatusValueExtension
     on ResolverDNSSECValidationStatus {
   String toValue() {
     switch (this) {
@@ -3864,7 +3864,7 @@ enum ResolverEndpointDirection {
   outbound,
 }
 
-extension ResolverEndpointDirectionValue on ResolverEndpointDirection {
+extension ResolverEndpointDirectionValueExtension on ResolverEndpointDirection {
   String toValue() {
     switch (this) {
       case ResolverEndpointDirection.inbound:
@@ -3896,7 +3896,7 @@ enum ResolverEndpointStatus {
   deleting,
 }
 
-extension ResolverEndpointStatusValue on ResolverEndpointStatus {
+extension ResolverEndpointStatusValueExtension on ResolverEndpointStatus {
   String toValue() {
     switch (this) {
       case ResolverEndpointStatus.creating:
@@ -4142,7 +4142,7 @@ enum ResolverQueryLogConfigAssociationError {
   internalServiceError,
 }
 
-extension ResolverQueryLogConfigAssociationErrorValue
+extension ResolverQueryLogConfigAssociationErrorValueExtension
     on ResolverQueryLogConfigAssociationError {
   String toValue() {
     switch (this) {
@@ -4184,7 +4184,7 @@ enum ResolverQueryLogConfigAssociationStatus {
   failed,
 }
 
-extension ResolverQueryLogConfigAssociationStatusValue
+extension ResolverQueryLogConfigAssociationStatusValueExtension
     on ResolverQueryLogConfigAssociationStatus {
   String toValue() {
     switch (this) {
@@ -4229,7 +4229,8 @@ enum ResolverQueryLogConfigStatus {
   failed,
 }
 
-extension ResolverQueryLogConfigStatusValue on ResolverQueryLogConfigStatus {
+extension ResolverQueryLogConfigStatusValueExtension
+    on ResolverQueryLogConfigStatus {
   String toValue() {
     switch (this) {
       case ResolverQueryLogConfigStatus.creating:
@@ -4445,7 +4446,8 @@ enum ResolverRuleAssociationStatus {
   overridden,
 }
 
-extension ResolverRuleAssociationStatusValue on ResolverRuleAssociationStatus {
+extension ResolverRuleAssociationStatusValueExtension
+    on ResolverRuleAssociationStatus {
   String toValue() {
     switch (this) {
       case ResolverRuleAssociationStatus.creating:
@@ -4520,7 +4522,7 @@ enum ResolverRuleStatus {
   failed,
 }
 
-extension ResolverRuleStatusValue on ResolverRuleStatus {
+extension ResolverRuleStatusValueExtension on ResolverRuleStatus {
   String toValue() {
     switch (this) {
       case ResolverRuleStatus.complete:
@@ -4557,7 +4559,7 @@ enum RuleTypeOption {
   recursive,
 }
 
-extension RuleTypeOptionValue on RuleTypeOption {
+extension RuleTypeOptionValueExtension on RuleTypeOption {
   String toValue() {
     switch (this) {
       case RuleTypeOption.forward:
@@ -4590,7 +4592,7 @@ enum ShareStatus {
   sharedByMe,
 }
 
-extension ShareStatusValue on ShareStatus {
+extension ShareStatusValueExtension on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.notShared:
@@ -4622,7 +4624,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -4782,7 +4784,7 @@ enum Validation {
   disable,
 }
 
-extension ValidationValue on Validation {
+extension ValidationValueExtension on Validation {
   String toValue() {
     switch (this) {
       case Validation.enable:

--- a/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
+++ b/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
@@ -3207,7 +3207,7 @@ enum IpAddressStatus {
   deleteFailedFasExpired,
 }
 
-extension on IpAddressStatus {
+extension IpAddressStatusValue on IpAddressStatus {
   String toValue() {
     switch (this) {
       case IpAddressStatus.creating:
@@ -3234,7 +3234,7 @@ extension on IpAddressStatus {
   }
 }
 
-extension on String {
+extension IpAddressStatusFromString on String {
   IpAddressStatus toIpAddressStatus() {
     switch (this) {
       case 'CREATING':
@@ -3621,7 +3621,8 @@ enum ResolverDNSSECValidationStatus {
   disabled,
 }
 
-extension on ResolverDNSSECValidationStatus {
+extension ResolverDNSSECValidationStatusValue
+    on ResolverDNSSECValidationStatus {
   String toValue() {
     switch (this) {
       case ResolverDNSSECValidationStatus.enabling:
@@ -3636,7 +3637,7 @@ extension on ResolverDNSSECValidationStatus {
   }
 }
 
-extension on String {
+extension ResolverDNSSECValidationStatusFromString on String {
   ResolverDNSSECValidationStatus toResolverDNSSECValidationStatus() {
     switch (this) {
       case 'ENABLING':
@@ -3863,7 +3864,7 @@ enum ResolverEndpointDirection {
   outbound,
 }
 
-extension on ResolverEndpointDirection {
+extension ResolverEndpointDirectionValue on ResolverEndpointDirection {
   String toValue() {
     switch (this) {
       case ResolverEndpointDirection.inbound:
@@ -3874,7 +3875,7 @@ extension on ResolverEndpointDirection {
   }
 }
 
-extension on String {
+extension ResolverEndpointDirectionFromString on String {
   ResolverEndpointDirection toResolverEndpointDirection() {
     switch (this) {
       case 'INBOUND':
@@ -3895,7 +3896,7 @@ enum ResolverEndpointStatus {
   deleting,
 }
 
-extension on ResolverEndpointStatus {
+extension ResolverEndpointStatusValue on ResolverEndpointStatus {
   String toValue() {
     switch (this) {
       case ResolverEndpointStatus.creating:
@@ -3914,7 +3915,7 @@ extension on ResolverEndpointStatus {
   }
 }
 
-extension on String {
+extension ResolverEndpointStatusFromString on String {
   ResolverEndpointStatus toResolverEndpointStatus() {
     switch (this) {
       case 'CREATING':
@@ -4141,7 +4142,8 @@ enum ResolverQueryLogConfigAssociationError {
   internalServiceError,
 }
 
-extension on ResolverQueryLogConfigAssociationError {
+extension ResolverQueryLogConfigAssociationErrorValue
+    on ResolverQueryLogConfigAssociationError {
   String toValue() {
     switch (this) {
       case ResolverQueryLogConfigAssociationError.none:
@@ -4156,7 +4158,7 @@ extension on ResolverQueryLogConfigAssociationError {
   }
 }
 
-extension on String {
+extension ResolverQueryLogConfigAssociationErrorFromString on String {
   ResolverQueryLogConfigAssociationError
       toResolverQueryLogConfigAssociationError() {
     switch (this) {
@@ -4182,7 +4184,8 @@ enum ResolverQueryLogConfigAssociationStatus {
   failed,
 }
 
-extension on ResolverQueryLogConfigAssociationStatus {
+extension ResolverQueryLogConfigAssociationStatusValue
+    on ResolverQueryLogConfigAssociationStatus {
   String toValue() {
     switch (this) {
       case ResolverQueryLogConfigAssociationStatus.creating:
@@ -4199,7 +4202,7 @@ extension on ResolverQueryLogConfigAssociationStatus {
   }
 }
 
-extension on String {
+extension ResolverQueryLogConfigAssociationStatusFromString on String {
   ResolverQueryLogConfigAssociationStatus
       toResolverQueryLogConfigAssociationStatus() {
     switch (this) {
@@ -4226,7 +4229,7 @@ enum ResolverQueryLogConfigStatus {
   failed,
 }
 
-extension on ResolverQueryLogConfigStatus {
+extension ResolverQueryLogConfigStatusValue on ResolverQueryLogConfigStatus {
   String toValue() {
     switch (this) {
       case ResolverQueryLogConfigStatus.creating:
@@ -4241,7 +4244,7 @@ extension on ResolverQueryLogConfigStatus {
   }
 }
 
-extension on String {
+extension ResolverQueryLogConfigStatusFromString on String {
   ResolverQueryLogConfigStatus toResolverQueryLogConfigStatus() {
     switch (this) {
       case 'CREATING':
@@ -4442,7 +4445,7 @@ enum ResolverRuleAssociationStatus {
   overridden,
 }
 
-extension on ResolverRuleAssociationStatus {
+extension ResolverRuleAssociationStatusValue on ResolverRuleAssociationStatus {
   String toValue() {
     switch (this) {
       case ResolverRuleAssociationStatus.creating:
@@ -4459,7 +4462,7 @@ extension on ResolverRuleAssociationStatus {
   }
 }
 
-extension on String {
+extension ResolverRuleAssociationStatusFromString on String {
   ResolverRuleAssociationStatus toResolverRuleAssociationStatus() {
     switch (this) {
       case 'CREATING':
@@ -4517,7 +4520,7 @@ enum ResolverRuleStatus {
   failed,
 }
 
-extension on ResolverRuleStatus {
+extension ResolverRuleStatusValue on ResolverRuleStatus {
   String toValue() {
     switch (this) {
       case ResolverRuleStatus.complete:
@@ -4532,7 +4535,7 @@ extension on ResolverRuleStatus {
   }
 }
 
-extension on String {
+extension ResolverRuleStatusFromString on String {
   ResolverRuleStatus toResolverRuleStatus() {
     switch (this) {
       case 'COMPLETE':
@@ -4554,7 +4557,7 @@ enum RuleTypeOption {
   recursive,
 }
 
-extension on RuleTypeOption {
+extension RuleTypeOptionValue on RuleTypeOption {
   String toValue() {
     switch (this) {
       case RuleTypeOption.forward:
@@ -4567,7 +4570,7 @@ extension on RuleTypeOption {
   }
 }
 
-extension on String {
+extension RuleTypeOptionFromString on String {
   RuleTypeOption toRuleTypeOption() {
     switch (this) {
       case 'FORWARD':
@@ -4587,7 +4590,7 @@ enum ShareStatus {
   sharedByMe,
 }
 
-extension on ShareStatus {
+extension ShareStatusValue on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.notShared:
@@ -4600,7 +4603,7 @@ extension on ShareStatus {
   }
 }
 
-extension on String {
+extension ShareStatusFromString on String {
   ShareStatus toShareStatus() {
     switch (this) {
       case 'NOT_SHARED':
@@ -4619,7 +4622,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -4630,7 +4633,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -4779,7 +4782,7 @@ enum Validation {
   disable,
 }
 
-extension on Validation {
+extension ValidationValue on Validation {
   String toValue() {
     switch (this) {
       case Validation.enable:
@@ -4790,7 +4793,7 @@ extension on Validation {
   }
 }
 
-extension on String {
+extension ValidationFromString on String {
   Validation toValidation() {
     switch (this) {
       case 'ENABLE':

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -11553,7 +11553,7 @@ enum AnalyticsS3ExportFileFormat {
   csv,
 }
 
-extension on AnalyticsS3ExportFileFormat {
+extension AnalyticsS3ExportFileFormatValue on AnalyticsS3ExportFileFormat {
   String toValue() {
     switch (this) {
       case AnalyticsS3ExportFileFormat.csv:
@@ -11562,7 +11562,7 @@ extension on AnalyticsS3ExportFileFormat {
   }
 }
 
-extension on String {
+extension AnalyticsS3ExportFileFormatFromString on String {
   AnalyticsS3ExportFileFormat toAnalyticsS3ExportFileFormat() {
     switch (this) {
       case 'CSV':
@@ -11577,7 +11577,7 @@ enum ArchiveStatus {
   deepArchiveAccess,
 }
 
-extension on ArchiveStatus {
+extension ArchiveStatusValue on ArchiveStatus {
   String toValue() {
     switch (this) {
       case ArchiveStatus.archiveAccess:
@@ -11588,7 +11588,7 @@ extension on ArchiveStatus {
   }
 }
 
-extension on String {
+extension ArchiveStatusFromString on String {
   ArchiveStatus toArchiveStatus() {
     switch (this) {
       case 'ARCHIVE_ACCESS':
@@ -11627,7 +11627,7 @@ enum BucketAccelerateStatus {
   suspended,
 }
 
-extension on BucketAccelerateStatus {
+extension BucketAccelerateStatusValue on BucketAccelerateStatus {
   String toValue() {
     switch (this) {
       case BucketAccelerateStatus.enabled:
@@ -11638,7 +11638,7 @@ extension on BucketAccelerateStatus {
   }
 }
 
-extension on String {
+extension BucketAccelerateStatusFromString on String {
   BucketAccelerateStatus toBucketAccelerateStatus() {
     switch (this) {
       case 'Enabled':
@@ -11657,7 +11657,7 @@ enum BucketCannedACL {
   authenticatedRead,
 }
 
-extension on BucketCannedACL {
+extension BucketCannedACLValue on BucketCannedACL {
   String toValue() {
     switch (this) {
       case BucketCannedACL.private:
@@ -11672,7 +11672,7 @@ extension on BucketCannedACL {
   }
 }
 
-extension on String {
+extension BucketCannedACLFromString on String {
   BucketCannedACL toBucketCannedACL() {
     switch (this) {
       case 'private':
@@ -11744,7 +11744,7 @@ enum BucketLocationConstraint {
   usWest_2,
 }
 
-extension on BucketLocationConstraint {
+extension BucketLocationConstraintValue on BucketLocationConstraint {
   String toValue() {
     switch (this) {
       case BucketLocationConstraint.afSouth_1:
@@ -11801,7 +11801,7 @@ extension on BucketLocationConstraint {
   }
 }
 
-extension on String {
+extension BucketLocationConstraintFromString on String {
   BucketLocationConstraint toBucketLocationConstraint() {
     switch (this) {
       case 'af-south-1':
@@ -11888,7 +11888,7 @@ enum BucketLogsPermission {
   write,
 }
 
-extension on BucketLogsPermission {
+extension BucketLogsPermissionValue on BucketLogsPermission {
   String toValue() {
     switch (this) {
       case BucketLogsPermission.fullControl:
@@ -11901,7 +11901,7 @@ extension on BucketLogsPermission {
   }
 }
 
-extension on String {
+extension BucketLogsPermissionFromString on String {
   BucketLogsPermission toBucketLogsPermission() {
     switch (this) {
       case 'FULL_CONTROL':
@@ -11920,7 +11920,7 @@ enum BucketVersioningStatus {
   suspended,
 }
 
-extension on BucketVersioningStatus {
+extension BucketVersioningStatusValue on BucketVersioningStatus {
   String toValue() {
     switch (this) {
       case BucketVersioningStatus.enabled:
@@ -11931,7 +11931,7 @@ extension on BucketVersioningStatus {
   }
 }
 
-extension on String {
+extension BucketVersioningStatusFromString on String {
   BucketVersioningStatus toBucketVersioningStatus() {
     switch (this) {
       case 'Enabled':
@@ -12429,7 +12429,7 @@ enum CompressionType {
   bzip2,
 }
 
-extension on CompressionType {
+extension CompressionTypeValue on CompressionType {
   String toValue() {
     switch (this) {
       case CompressionType.none:
@@ -12442,7 +12442,7 @@ extension on CompressionType {
   }
 }
 
-extension on String {
+extension CompressionTypeFromString on String {
   CompressionType toCompressionType() {
     switch (this) {
       case 'NONE':
@@ -12927,7 +12927,7 @@ enum DeleteMarkerReplicationStatus {
   disabled,
 }
 
-extension on DeleteMarkerReplicationStatus {
+extension DeleteMarkerReplicationStatusValue on DeleteMarkerReplicationStatus {
   String toValue() {
     switch (this) {
       case DeleteMarkerReplicationStatus.enabled:
@@ -12938,7 +12938,7 @@ extension on DeleteMarkerReplicationStatus {
   }
 }
 
-extension on String {
+extension DeleteMarkerReplicationStatusFromString on String {
   DeleteMarkerReplicationStatus toDeleteMarkerReplicationStatus() {
     switch (this) {
       case 'Enabled':
@@ -13147,7 +13147,7 @@ enum EncodingType {
   url,
 }
 
-extension on EncodingType {
+extension EncodingTypeValue on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.url:
@@ -13156,7 +13156,7 @@ extension on EncodingType {
   }
 }
 
-extension on String {
+extension EncodingTypeFromString on String {
   EncodingType toEncodingType() {
     switch (this) {
       case 'url':
@@ -14743,7 +14743,7 @@ enum Event {
   s3ReplicationOperationReplicatedAfterThreshold,
 }
 
-extension on Event {
+extension EventValue on Event {
   String toValue() {
     switch (this) {
       case Event.s3ReducedRedundancyLostObject:
@@ -14784,7 +14784,7 @@ extension on Event {
   }
 }
 
-extension on String {
+extension EventFromString on String {
   Event toEvent() {
     switch (this) {
       case 's3:ReducedRedundancyLostObject':
@@ -14866,7 +14866,8 @@ enum ExistingObjectReplicationStatus {
   disabled,
 }
 
-extension on ExistingObjectReplicationStatus {
+extension ExistingObjectReplicationStatusValue
+    on ExistingObjectReplicationStatus {
   String toValue() {
     switch (this) {
       case ExistingObjectReplicationStatus.enabled:
@@ -14877,7 +14878,7 @@ extension on ExistingObjectReplicationStatus {
   }
 }
 
-extension on String {
+extension ExistingObjectReplicationStatusFromString on String {
   ExistingObjectReplicationStatus toExistingObjectReplicationStatus() {
     switch (this) {
       case 'Enabled':
@@ -14895,7 +14896,7 @@ enum ExpirationStatus {
   disabled,
 }
 
-extension on ExpirationStatus {
+extension ExpirationStatusValue on ExpirationStatus {
   String toValue() {
     switch (this) {
       case ExpirationStatus.enabled:
@@ -14906,7 +14907,7 @@ extension on ExpirationStatus {
   }
 }
 
-extension on String {
+extension ExpirationStatusFromString on String {
   ExpirationStatus toExpirationStatus() {
     switch (this) {
       case 'Enabled':
@@ -14922,7 +14923,7 @@ enum ExpressionType {
   sql,
 }
 
-extension on ExpressionType {
+extension ExpressionTypeValue on ExpressionType {
   String toValue() {
     switch (this) {
       case ExpressionType.sql:
@@ -14931,7 +14932,7 @@ extension on ExpressionType {
   }
 }
 
-extension on String {
+extension ExpressionTypeFromString on String {
   ExpressionType toExpressionType() {
     switch (this) {
       case 'SQL':
@@ -14947,7 +14948,7 @@ enum FileHeaderInfo {
   none,
 }
 
-extension on FileHeaderInfo {
+extension FileHeaderInfoValue on FileHeaderInfo {
   String toValue() {
     switch (this) {
       case FileHeaderInfo.use:
@@ -14960,7 +14961,7 @@ extension on FileHeaderInfo {
   }
 }
 
-extension on String {
+extension FileHeaderInfoFromString on String {
   FileHeaderInfo toFileHeaderInfo() {
     switch (this) {
       case 'USE':
@@ -15023,7 +15024,7 @@ enum FilterRuleName {
   suffix,
 }
 
-extension on FilterRuleName {
+extension FilterRuleNameValue on FilterRuleName {
   String toValue() {
     switch (this) {
       case FilterRuleName.prefix:
@@ -15034,7 +15035,7 @@ extension on FilterRuleName {
   }
 }
 
-extension on String {
+extension FilterRuleNameFromString on String {
   FilterRuleName toFilterRuleName() {
     switch (this) {
       case 'prefix':
@@ -16059,7 +16060,7 @@ enum IntelligentTieringAccessTier {
   deepArchiveAccess,
 }
 
-extension on IntelligentTieringAccessTier {
+extension IntelligentTieringAccessTierValue on IntelligentTieringAccessTier {
   String toValue() {
     switch (this) {
       case IntelligentTieringAccessTier.archiveAccess:
@@ -16070,7 +16071,7 @@ extension on IntelligentTieringAccessTier {
   }
 }
 
-extension on String {
+extension IntelligentTieringAccessTierFromString on String {
   IntelligentTieringAccessTier toIntelligentTieringAccessTier() {
     switch (this) {
       case 'ARCHIVE_ACCESS':
@@ -16238,7 +16239,7 @@ enum IntelligentTieringStatus {
   disabled,
 }
 
-extension on IntelligentTieringStatus {
+extension IntelligentTieringStatusValue on IntelligentTieringStatus {
   String toValue() {
     switch (this) {
       case IntelligentTieringStatus.enabled:
@@ -16249,7 +16250,7 @@ extension on IntelligentTieringStatus {
   }
 }
 
-extension on String {
+extension IntelligentTieringStatusFromString on String {
   IntelligentTieringStatus toIntelligentTieringStatus() {
     switch (this) {
       case 'Enabled':
@@ -16468,7 +16469,7 @@ enum InventoryFormat {
   parquet,
 }
 
-extension on InventoryFormat {
+extension InventoryFormatValue on InventoryFormat {
   String toValue() {
     switch (this) {
       case InventoryFormat.csv:
@@ -16481,7 +16482,7 @@ extension on InventoryFormat {
   }
 }
 
-extension on String {
+extension InventoryFormatFromString on String {
   InventoryFormat toInventoryFormat() {
     switch (this) {
       case 'CSV':
@@ -16500,7 +16501,7 @@ enum InventoryFrequency {
   weekly,
 }
 
-extension on InventoryFrequency {
+extension InventoryFrequencyValue on InventoryFrequency {
   String toValue() {
     switch (this) {
       case InventoryFrequency.daily:
@@ -16511,7 +16512,7 @@ extension on InventoryFrequency {
   }
 }
 
-extension on String {
+extension InventoryFrequencyFromString on String {
   InventoryFrequency toInventoryFrequency() {
     switch (this) {
       case 'Daily':
@@ -16528,7 +16529,8 @@ enum InventoryIncludedObjectVersions {
   current,
 }
 
-extension on InventoryIncludedObjectVersions {
+extension InventoryIncludedObjectVersionsValue
+    on InventoryIncludedObjectVersions {
   String toValue() {
     switch (this) {
       case InventoryIncludedObjectVersions.all:
@@ -16539,7 +16541,7 @@ extension on InventoryIncludedObjectVersions {
   }
 }
 
-extension on String {
+extension InventoryIncludedObjectVersionsFromString on String {
   InventoryIncludedObjectVersions toInventoryIncludedObjectVersions() {
     switch (this) {
       case 'All':
@@ -16566,7 +16568,7 @@ enum InventoryOptionalField {
   intelligentTieringAccessTier,
 }
 
-extension on InventoryOptionalField {
+extension InventoryOptionalFieldValue on InventoryOptionalField {
   String toValue() {
     switch (this) {
       case InventoryOptionalField.size:
@@ -16595,7 +16597,7 @@ extension on InventoryOptionalField {
   }
 }
 
-extension on String {
+extension InventoryOptionalFieldFromString on String {
   InventoryOptionalField toInventoryOptionalField() {
     switch (this) {
       case 'Size':
@@ -16779,7 +16781,7 @@ enum JSONType {
   lines,
 }
 
-extension on JSONType {
+extension JSONTypeValue on JSONType {
   String toValue() {
     switch (this) {
       case JSONType.document:
@@ -16790,7 +16792,7 @@ extension on JSONType {
   }
 }
 
-extension on String {
+extension JSONTypeFromString on String {
   JSONType toJSONType() {
     switch (this) {
       case 'DOCUMENT':
@@ -17885,7 +17887,7 @@ enum MFADelete {
   disabled,
 }
 
-extension on MFADelete {
+extension MFADeleteValue on MFADelete {
   String toValue() {
     switch (this) {
       case MFADelete.enabled:
@@ -17896,7 +17898,7 @@ extension on MFADelete {
   }
 }
 
-extension on String {
+extension MFADeleteFromString on String {
   MFADelete toMFADelete() {
     switch (this) {
       case 'Enabled':
@@ -17913,7 +17915,7 @@ enum MFADeleteStatus {
   disabled,
 }
 
-extension on MFADeleteStatus {
+extension MFADeleteStatusValue on MFADeleteStatus {
   String toValue() {
     switch (this) {
       case MFADeleteStatus.enabled:
@@ -17924,7 +17926,7 @@ extension on MFADeleteStatus {
   }
 }
 
-extension on String {
+extension MFADeleteStatusFromString on String {
   MFADeleteStatus toMFADeleteStatus() {
     switch (this) {
       case 'Enabled':
@@ -17941,7 +17943,7 @@ enum MetadataDirective {
   replace,
 }
 
-extension on MetadataDirective {
+extension MetadataDirectiveValue on MetadataDirective {
   String toValue() {
     switch (this) {
       case MetadataDirective.copy:
@@ -17952,7 +17954,7 @@ extension on MetadataDirective {
   }
 }
 
-extension on String {
+extension MetadataDirectiveFromString on String {
   MetadataDirective toMetadataDirective() {
     switch (this) {
       case 'COPY':
@@ -18177,7 +18179,7 @@ enum MetricsStatus {
   disabled,
 }
 
-extension on MetricsStatus {
+extension MetricsStatusValue on MetricsStatus {
   String toValue() {
     switch (this) {
       case MetricsStatus.enabled:
@@ -18188,7 +18190,7 @@ extension on MetricsStatus {
   }
 }
 
-extension on String {
+extension MetricsStatusFromString on String {
   MetricsStatus toMetricsStatus() {
     switch (this) {
       case 'Enabled':
@@ -18563,7 +18565,7 @@ enum ObjectCannedACL {
   bucketOwnerFullControl,
 }
 
-extension on ObjectCannedACL {
+extension ObjectCannedACLValue on ObjectCannedACL {
   String toValue() {
     switch (this) {
       case ObjectCannedACL.private:
@@ -18584,7 +18586,7 @@ extension on ObjectCannedACL {
   }
 }
 
-extension on String {
+extension ObjectCannedACLFromString on String {
   ObjectCannedACL toObjectCannedACL() {
     switch (this) {
       case 'private':
@@ -18683,7 +18685,7 @@ enum ObjectLockEnabled {
   enabled,
 }
 
-extension on ObjectLockEnabled {
+extension ObjectLockEnabledValue on ObjectLockEnabled {
   String toValue() {
     switch (this) {
       case ObjectLockEnabled.enabled:
@@ -18692,7 +18694,7 @@ extension on ObjectLockEnabled {
   }
 }
 
-extension on String {
+extension ObjectLockEnabledFromString on String {
   ObjectLockEnabled toObjectLockEnabled() {
     switch (this) {
       case 'Enabled':
@@ -18739,7 +18741,7 @@ enum ObjectLockLegalHoldStatus {
   off,
 }
 
-extension on ObjectLockLegalHoldStatus {
+extension ObjectLockLegalHoldStatusValue on ObjectLockLegalHoldStatus {
   String toValue() {
     switch (this) {
       case ObjectLockLegalHoldStatus.on:
@@ -18750,7 +18752,7 @@ extension on ObjectLockLegalHoldStatus {
   }
 }
 
-extension on String {
+extension ObjectLockLegalHoldStatusFromString on String {
   ObjectLockLegalHoldStatus toObjectLockLegalHoldStatus() {
     switch (this) {
       case 'ON':
@@ -18767,7 +18769,7 @@ enum ObjectLockMode {
   compliance,
 }
 
-extension on ObjectLockMode {
+extension ObjectLockModeValue on ObjectLockMode {
   String toValue() {
     switch (this) {
       case ObjectLockMode.governance:
@@ -18778,7 +18780,7 @@ extension on ObjectLockMode {
   }
 }
 
-extension on String {
+extension ObjectLockModeFromString on String {
   ObjectLockMode toObjectLockMode() {
     switch (this) {
       case 'GOVERNANCE':
@@ -18835,7 +18837,7 @@ enum ObjectLockRetentionMode {
   compliance,
 }
 
-extension on ObjectLockRetentionMode {
+extension ObjectLockRetentionModeValue on ObjectLockRetentionMode {
   String toValue() {
     switch (this) {
       case ObjectLockRetentionMode.governance:
@@ -18846,7 +18848,7 @@ extension on ObjectLockRetentionMode {
   }
 }
 
-extension on String {
+extension ObjectLockRetentionModeFromString on String {
   ObjectLockRetentionMode toObjectLockRetentionMode() {
     switch (this) {
       case 'GOVERNANCE':
@@ -18905,7 +18907,7 @@ enum ObjectOwnership {
   objectWriter,
 }
 
-extension on ObjectOwnership {
+extension ObjectOwnershipValue on ObjectOwnership {
   String toValue() {
     switch (this) {
       case ObjectOwnership.bucketOwnerPreferred:
@@ -18916,7 +18918,7 @@ extension on ObjectOwnership {
   }
 }
 
-extension on String {
+extension ObjectOwnershipFromString on String {
   ObjectOwnership toObjectOwnership() {
     switch (this) {
       case 'BucketOwnerPreferred':
@@ -18939,7 +18941,7 @@ enum ObjectStorageClass {
   outposts,
 }
 
-extension on ObjectStorageClass {
+extension ObjectStorageClassValue on ObjectStorageClass {
   String toValue() {
     switch (this) {
       case ObjectStorageClass.standard:
@@ -18962,7 +18964,7 @@ extension on ObjectStorageClass {
   }
 }
 
-extension on String {
+extension ObjectStorageClassFromString on String {
   ObjectStorageClass toObjectStorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -19043,7 +19045,7 @@ enum ObjectVersionStorageClass {
   standard,
 }
 
-extension on ObjectVersionStorageClass {
+extension ObjectVersionStorageClassValue on ObjectVersionStorageClass {
   String toValue() {
     switch (this) {
       case ObjectVersionStorageClass.standard:
@@ -19052,7 +19054,7 @@ extension on ObjectVersionStorageClass {
   }
 }
 
-extension on String {
+extension ObjectVersionStorageClassFromString on String {
   ObjectVersionStorageClass toObjectVersionStorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -19159,7 +19161,7 @@ enum OwnerOverride {
   destination,
 }
 
-extension on OwnerOverride {
+extension OwnerOverrideValue on OwnerOverride {
   String toValue() {
     switch (this) {
       case OwnerOverride.destination:
@@ -19168,7 +19170,7 @@ extension on OwnerOverride {
   }
 }
 
-extension on String {
+extension OwnerOverrideFromString on String {
   OwnerOverride toOwnerOverride() {
     switch (this) {
       case 'Destination':
@@ -19294,7 +19296,7 @@ enum Payer {
   bucketOwner,
 }
 
-extension on Payer {
+extension PayerValue on Payer {
   String toValue() {
     switch (this) {
       case Payer.requester:
@@ -19305,7 +19307,7 @@ extension on Payer {
   }
 }
 
-extension on String {
+extension PayerFromString on String {
   Payer toPayer() {
     switch (this) {
       case 'Requester':
@@ -19325,7 +19327,7 @@ enum Permission {
   readAcp,
 }
 
-extension on Permission {
+extension PermissionValue on Permission {
   String toValue() {
     switch (this) {
       case Permission.fullControl:
@@ -19342,7 +19344,7 @@ extension on Permission {
   }
 }
 
-extension on String {
+extension PermissionFromString on String {
   Permission toPermission() {
     switch (this) {
       case 'FULL_CONTROL':
@@ -19424,7 +19426,7 @@ enum Protocol {
   https,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.http:
@@ -19435,7 +19437,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'http':
@@ -19759,7 +19761,7 @@ enum QuoteFields {
   asneeded,
 }
 
-extension on QuoteFields {
+extension QuoteFieldsValue on QuoteFields {
   String toValue() {
     switch (this) {
       case QuoteFields.always:
@@ -19770,7 +19772,7 @@ extension on QuoteFields {
   }
 }
 
-extension on String {
+extension QuoteFieldsFromString on String {
   QuoteFields toQuoteFields() {
     switch (this) {
       case 'ALWAYS':
@@ -19958,7 +19960,7 @@ enum ReplicaModificationsStatus {
   disabled,
 }
 
-extension on ReplicaModificationsStatus {
+extension ReplicaModificationsStatusValue on ReplicaModificationsStatus {
   String toValue() {
     switch (this) {
       case ReplicaModificationsStatus.enabled:
@@ -19969,7 +19971,7 @@ extension on ReplicaModificationsStatus {
   }
 }
 
-extension on String {
+extension ReplicaModificationsStatusFromString on String {
   ReplicaModificationsStatus toReplicaModificationsStatus() {
     switch (this) {
       case 'Enabled':
@@ -20262,7 +20264,7 @@ enum ReplicationRuleStatus {
   disabled,
 }
 
-extension on ReplicationRuleStatus {
+extension ReplicationRuleStatusValue on ReplicationRuleStatus {
   String toValue() {
     switch (this) {
       case ReplicationRuleStatus.enabled:
@@ -20273,7 +20275,7 @@ extension on ReplicationRuleStatus {
   }
 }
 
-extension on String {
+extension ReplicationRuleStatusFromString on String {
   ReplicationRuleStatus toReplicationRuleStatus() {
     switch (this) {
       case 'Enabled':
@@ -20292,7 +20294,7 @@ enum ReplicationStatus {
   replica,
 }
 
-extension on ReplicationStatus {
+extension ReplicationStatusValue on ReplicationStatus {
   String toValue() {
     switch (this) {
       case ReplicationStatus.complete:
@@ -20307,7 +20309,7 @@ extension on ReplicationStatus {
   }
 }
 
-extension on String {
+extension ReplicationStatusFromString on String {
   ReplicationStatus toReplicationStatus() {
     switch (this) {
       case 'COMPLETE':
@@ -20370,7 +20372,7 @@ enum ReplicationTimeStatus {
   disabled,
 }
 
-extension on ReplicationTimeStatus {
+extension ReplicationTimeStatusValue on ReplicationTimeStatus {
   String toValue() {
     switch (this) {
       case ReplicationTimeStatus.enabled:
@@ -20381,7 +20383,7 @@ extension on ReplicationTimeStatus {
   }
 }
 
-extension on String {
+extension ReplicationTimeStatusFromString on String {
   ReplicationTimeStatus toReplicationTimeStatus() {
     switch (this) {
       case 'Enabled':
@@ -20432,7 +20434,7 @@ enum RequestCharged {
   requester,
 }
 
-extension on RequestCharged {
+extension RequestChargedValue on RequestCharged {
   String toValue() {
     switch (this) {
       case RequestCharged.requester:
@@ -20441,7 +20443,7 @@ extension on RequestCharged {
   }
 }
 
-extension on String {
+extension RequestChargedFromString on String {
   RequestCharged toRequestCharged() {
     switch (this) {
       case 'requester':
@@ -20461,7 +20463,7 @@ enum RequestPayer {
   requester,
 }
 
-extension on RequestPayer {
+extension RequestPayerValue on RequestPayer {
   String toValue() {
     switch (this) {
       case RequestPayer.requester:
@@ -20470,7 +20472,7 @@ extension on RequestPayer {
   }
 }
 
-extension on String {
+extension RequestPayerFromString on String {
   RequestPayer toRequestPayer() {
     switch (this) {
       case 'requester':
@@ -20614,7 +20616,7 @@ enum RestoreRequestType {
   select,
 }
 
-extension on RestoreRequestType {
+extension RestoreRequestTypeValue on RestoreRequestType {
   String toValue() {
     switch (this) {
       case RestoreRequestType.select:
@@ -20623,7 +20625,7 @@ extension on RestoreRequestType {
   }
 }
 
-extension on String {
+extension RestoreRequestTypeFromString on String {
   RestoreRequestType toRestoreRequestType() {
     switch (this) {
       case 'SELECT':
@@ -21200,7 +21202,7 @@ enum ServerSideEncryption {
   awsKms,
 }
 
-extension on ServerSideEncryption {
+extension ServerSideEncryptionValue on ServerSideEncryption {
   String toValue() {
     switch (this) {
       case ServerSideEncryption.aes256:
@@ -21211,7 +21213,7 @@ extension on ServerSideEncryption {
   }
 }
 
-extension on String {
+extension ServerSideEncryptionFromString on String {
   ServerSideEncryption toServerSideEncryption() {
     switch (this) {
       case 'AES256':
@@ -21480,7 +21482,7 @@ enum SseKmsEncryptedObjectsStatus {
   disabled,
 }
 
-extension on SseKmsEncryptedObjectsStatus {
+extension SseKmsEncryptedObjectsStatusValue on SseKmsEncryptedObjectsStatus {
   String toValue() {
     switch (this) {
       case SseKmsEncryptedObjectsStatus.enabled:
@@ -21491,7 +21493,7 @@ extension on SseKmsEncryptedObjectsStatus {
   }
 }
 
-extension on String {
+extension SseKmsEncryptedObjectsStatusFromString on String {
   SseKmsEncryptedObjectsStatus toSseKmsEncryptedObjectsStatus() {
     switch (this) {
       case 'Enabled':
@@ -21555,7 +21557,7 @@ enum StorageClass {
   outposts,
 }
 
-extension on StorageClass {
+extension StorageClassValue on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.standard:
@@ -21578,7 +21580,7 @@ extension on StorageClass {
   }
 }
 
-extension on String {
+extension StorageClassFromString on String {
   StorageClass toStorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -21684,7 +21686,8 @@ enum StorageClassAnalysisSchemaVersion {
   v_1,
 }
 
-extension on StorageClassAnalysisSchemaVersion {
+extension StorageClassAnalysisSchemaVersionValue
+    on StorageClassAnalysisSchemaVersion {
   String toValue() {
     switch (this) {
       case StorageClassAnalysisSchemaVersion.v_1:
@@ -21693,7 +21696,7 @@ extension on StorageClassAnalysisSchemaVersion {
   }
 }
 
-extension on String {
+extension StorageClassAnalysisSchemaVersionFromString on String {
   StorageClassAnalysisSchemaVersion toStorageClassAnalysisSchemaVersion() {
     switch (this) {
       case 'V_1':
@@ -21771,7 +21774,7 @@ enum TaggingDirective {
   replace,
 }
 
-extension on TaggingDirective {
+extension TaggingDirectiveValue on TaggingDirective {
   String toValue() {
     switch (this) {
       case TaggingDirective.copy:
@@ -21782,7 +21785,7 @@ extension on TaggingDirective {
   }
 }
 
-extension on String {
+extension TaggingDirectiveFromString on String {
   TaggingDirective toTaggingDirective() {
     switch (this) {
       case 'COPY':
@@ -21841,7 +21844,7 @@ enum Tier {
   expedited,
 }
 
-extension on Tier {
+extension TierValue on Tier {
   String toValue() {
     switch (this) {
       case Tier.standard:
@@ -21854,7 +21857,7 @@ extension on Tier {
   }
 }
 
-extension on String {
+extension TierFromString on String {
   Tier toTier() {
     switch (this) {
       case 'Standard':
@@ -22096,7 +22099,7 @@ enum TransitionStorageClass {
   deepArchive,
 }
 
-extension on TransitionStorageClass {
+extension TransitionStorageClassValue on TransitionStorageClass {
   String toValue() {
     switch (this) {
       case TransitionStorageClass.glacier:
@@ -22113,7 +22116,7 @@ extension on TransitionStorageClass {
   }
 }
 
-extension on String {
+extension TransitionStorageClassFromString on String {
   TransitionStorageClass toTransitionStorageClass() {
     switch (this) {
       case 'GLACIER':
@@ -22137,7 +22140,7 @@ enum Type {
   group,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.canonicalUser:
@@ -22150,7 +22153,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'CanonicalUser':

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -11553,7 +11553,8 @@ enum AnalyticsS3ExportFileFormat {
   csv,
 }
 
-extension AnalyticsS3ExportFileFormatValue on AnalyticsS3ExportFileFormat {
+extension AnalyticsS3ExportFileFormatValueExtension
+    on AnalyticsS3ExportFileFormat {
   String toValue() {
     switch (this) {
       case AnalyticsS3ExportFileFormat.csv:
@@ -11577,7 +11578,7 @@ enum ArchiveStatus {
   deepArchiveAccess,
 }
 
-extension ArchiveStatusValue on ArchiveStatus {
+extension ArchiveStatusValueExtension on ArchiveStatus {
   String toValue() {
     switch (this) {
       case ArchiveStatus.archiveAccess:
@@ -11627,7 +11628,7 @@ enum BucketAccelerateStatus {
   suspended,
 }
 
-extension BucketAccelerateStatusValue on BucketAccelerateStatus {
+extension BucketAccelerateStatusValueExtension on BucketAccelerateStatus {
   String toValue() {
     switch (this) {
       case BucketAccelerateStatus.enabled:
@@ -11657,7 +11658,7 @@ enum BucketCannedACL {
   authenticatedRead,
 }
 
-extension BucketCannedACLValue on BucketCannedACL {
+extension BucketCannedACLValueExtension on BucketCannedACL {
   String toValue() {
     switch (this) {
       case BucketCannedACL.private:
@@ -11744,7 +11745,7 @@ enum BucketLocationConstraint {
   usWest_2,
 }
 
-extension BucketLocationConstraintValue on BucketLocationConstraint {
+extension BucketLocationConstraintValueExtension on BucketLocationConstraint {
   String toValue() {
     switch (this) {
       case BucketLocationConstraint.afSouth_1:
@@ -11888,7 +11889,7 @@ enum BucketLogsPermission {
   write,
 }
 
-extension BucketLogsPermissionValue on BucketLogsPermission {
+extension BucketLogsPermissionValueExtension on BucketLogsPermission {
   String toValue() {
     switch (this) {
       case BucketLogsPermission.fullControl:
@@ -11920,7 +11921,7 @@ enum BucketVersioningStatus {
   suspended,
 }
 
-extension BucketVersioningStatusValue on BucketVersioningStatus {
+extension BucketVersioningStatusValueExtension on BucketVersioningStatus {
   String toValue() {
     switch (this) {
       case BucketVersioningStatus.enabled:
@@ -12429,7 +12430,7 @@ enum CompressionType {
   bzip2,
 }
 
-extension CompressionTypeValue on CompressionType {
+extension CompressionTypeValueExtension on CompressionType {
   String toValue() {
     switch (this) {
       case CompressionType.none:
@@ -12927,7 +12928,8 @@ enum DeleteMarkerReplicationStatus {
   disabled,
 }
 
-extension DeleteMarkerReplicationStatusValue on DeleteMarkerReplicationStatus {
+extension DeleteMarkerReplicationStatusValueExtension
+    on DeleteMarkerReplicationStatus {
   String toValue() {
     switch (this) {
       case DeleteMarkerReplicationStatus.enabled:
@@ -13147,7 +13149,7 @@ enum EncodingType {
   url,
 }
 
-extension EncodingTypeValue on EncodingType {
+extension EncodingTypeValueExtension on EncodingType {
   String toValue() {
     switch (this) {
       case EncodingType.url:
@@ -14743,7 +14745,7 @@ enum Event {
   s3ReplicationOperationReplicatedAfterThreshold,
 }
 
-extension EventValue on Event {
+extension EventValueExtension on Event {
   String toValue() {
     switch (this) {
       case Event.s3ReducedRedundancyLostObject:
@@ -14866,7 +14868,7 @@ enum ExistingObjectReplicationStatus {
   disabled,
 }
 
-extension ExistingObjectReplicationStatusValue
+extension ExistingObjectReplicationStatusValueExtension
     on ExistingObjectReplicationStatus {
   String toValue() {
     switch (this) {
@@ -14896,7 +14898,7 @@ enum ExpirationStatus {
   disabled,
 }
 
-extension ExpirationStatusValue on ExpirationStatus {
+extension ExpirationStatusValueExtension on ExpirationStatus {
   String toValue() {
     switch (this) {
       case ExpirationStatus.enabled:
@@ -14923,7 +14925,7 @@ enum ExpressionType {
   sql,
 }
 
-extension ExpressionTypeValue on ExpressionType {
+extension ExpressionTypeValueExtension on ExpressionType {
   String toValue() {
     switch (this) {
       case ExpressionType.sql:
@@ -14948,7 +14950,7 @@ enum FileHeaderInfo {
   none,
 }
 
-extension FileHeaderInfoValue on FileHeaderInfo {
+extension FileHeaderInfoValueExtension on FileHeaderInfo {
   String toValue() {
     switch (this) {
       case FileHeaderInfo.use:
@@ -15024,7 +15026,7 @@ enum FilterRuleName {
   suffix,
 }
 
-extension FilterRuleNameValue on FilterRuleName {
+extension FilterRuleNameValueExtension on FilterRuleName {
   String toValue() {
     switch (this) {
       case FilterRuleName.prefix:
@@ -16060,7 +16062,8 @@ enum IntelligentTieringAccessTier {
   deepArchiveAccess,
 }
 
-extension IntelligentTieringAccessTierValue on IntelligentTieringAccessTier {
+extension IntelligentTieringAccessTierValueExtension
+    on IntelligentTieringAccessTier {
   String toValue() {
     switch (this) {
       case IntelligentTieringAccessTier.archiveAccess:
@@ -16239,7 +16242,7 @@ enum IntelligentTieringStatus {
   disabled,
 }
 
-extension IntelligentTieringStatusValue on IntelligentTieringStatus {
+extension IntelligentTieringStatusValueExtension on IntelligentTieringStatus {
   String toValue() {
     switch (this) {
       case IntelligentTieringStatus.enabled:
@@ -16469,7 +16472,7 @@ enum InventoryFormat {
   parquet,
 }
 
-extension InventoryFormatValue on InventoryFormat {
+extension InventoryFormatValueExtension on InventoryFormat {
   String toValue() {
     switch (this) {
       case InventoryFormat.csv:
@@ -16501,7 +16504,7 @@ enum InventoryFrequency {
   weekly,
 }
 
-extension InventoryFrequencyValue on InventoryFrequency {
+extension InventoryFrequencyValueExtension on InventoryFrequency {
   String toValue() {
     switch (this) {
       case InventoryFrequency.daily:
@@ -16529,7 +16532,7 @@ enum InventoryIncludedObjectVersions {
   current,
 }
 
-extension InventoryIncludedObjectVersionsValue
+extension InventoryIncludedObjectVersionsValueExtension
     on InventoryIncludedObjectVersions {
   String toValue() {
     switch (this) {
@@ -16568,7 +16571,7 @@ enum InventoryOptionalField {
   intelligentTieringAccessTier,
 }
 
-extension InventoryOptionalFieldValue on InventoryOptionalField {
+extension InventoryOptionalFieldValueExtension on InventoryOptionalField {
   String toValue() {
     switch (this) {
       case InventoryOptionalField.size:
@@ -16781,7 +16784,7 @@ enum JSONType {
   lines,
 }
 
-extension JSONTypeValue on JSONType {
+extension JSONTypeValueExtension on JSONType {
   String toValue() {
     switch (this) {
       case JSONType.document:
@@ -17887,7 +17890,7 @@ enum MFADelete {
   disabled,
 }
 
-extension MFADeleteValue on MFADelete {
+extension MFADeleteValueExtension on MFADelete {
   String toValue() {
     switch (this) {
       case MFADelete.enabled:
@@ -17915,7 +17918,7 @@ enum MFADeleteStatus {
   disabled,
 }
 
-extension MFADeleteStatusValue on MFADeleteStatus {
+extension MFADeleteStatusValueExtension on MFADeleteStatus {
   String toValue() {
     switch (this) {
       case MFADeleteStatus.enabled:
@@ -17943,7 +17946,7 @@ enum MetadataDirective {
   replace,
 }
 
-extension MetadataDirectiveValue on MetadataDirective {
+extension MetadataDirectiveValueExtension on MetadataDirective {
   String toValue() {
     switch (this) {
       case MetadataDirective.copy:
@@ -18179,7 +18182,7 @@ enum MetricsStatus {
   disabled,
 }
 
-extension MetricsStatusValue on MetricsStatus {
+extension MetricsStatusValueExtension on MetricsStatus {
   String toValue() {
     switch (this) {
       case MetricsStatus.enabled:
@@ -18565,7 +18568,7 @@ enum ObjectCannedACL {
   bucketOwnerFullControl,
 }
 
-extension ObjectCannedACLValue on ObjectCannedACL {
+extension ObjectCannedACLValueExtension on ObjectCannedACL {
   String toValue() {
     switch (this) {
       case ObjectCannedACL.private:
@@ -18685,7 +18688,7 @@ enum ObjectLockEnabled {
   enabled,
 }
 
-extension ObjectLockEnabledValue on ObjectLockEnabled {
+extension ObjectLockEnabledValueExtension on ObjectLockEnabled {
   String toValue() {
     switch (this) {
       case ObjectLockEnabled.enabled:
@@ -18741,7 +18744,7 @@ enum ObjectLockLegalHoldStatus {
   off,
 }
 
-extension ObjectLockLegalHoldStatusValue on ObjectLockLegalHoldStatus {
+extension ObjectLockLegalHoldStatusValueExtension on ObjectLockLegalHoldStatus {
   String toValue() {
     switch (this) {
       case ObjectLockLegalHoldStatus.on:
@@ -18769,7 +18772,7 @@ enum ObjectLockMode {
   compliance,
 }
 
-extension ObjectLockModeValue on ObjectLockMode {
+extension ObjectLockModeValueExtension on ObjectLockMode {
   String toValue() {
     switch (this) {
       case ObjectLockMode.governance:
@@ -18837,7 +18840,7 @@ enum ObjectLockRetentionMode {
   compliance,
 }
 
-extension ObjectLockRetentionModeValue on ObjectLockRetentionMode {
+extension ObjectLockRetentionModeValueExtension on ObjectLockRetentionMode {
   String toValue() {
     switch (this) {
       case ObjectLockRetentionMode.governance:
@@ -18907,7 +18910,7 @@ enum ObjectOwnership {
   objectWriter,
 }
 
-extension ObjectOwnershipValue on ObjectOwnership {
+extension ObjectOwnershipValueExtension on ObjectOwnership {
   String toValue() {
     switch (this) {
       case ObjectOwnership.bucketOwnerPreferred:
@@ -18941,7 +18944,7 @@ enum ObjectStorageClass {
   outposts,
 }
 
-extension ObjectStorageClassValue on ObjectStorageClass {
+extension ObjectStorageClassValueExtension on ObjectStorageClass {
   String toValue() {
     switch (this) {
       case ObjectStorageClass.standard:
@@ -19045,7 +19048,7 @@ enum ObjectVersionStorageClass {
   standard,
 }
 
-extension ObjectVersionStorageClassValue on ObjectVersionStorageClass {
+extension ObjectVersionStorageClassValueExtension on ObjectVersionStorageClass {
   String toValue() {
     switch (this) {
       case ObjectVersionStorageClass.standard:
@@ -19161,7 +19164,7 @@ enum OwnerOverride {
   destination,
 }
 
-extension OwnerOverrideValue on OwnerOverride {
+extension OwnerOverrideValueExtension on OwnerOverride {
   String toValue() {
     switch (this) {
       case OwnerOverride.destination:
@@ -19296,7 +19299,7 @@ enum Payer {
   bucketOwner,
 }
 
-extension PayerValue on Payer {
+extension PayerValueExtension on Payer {
   String toValue() {
     switch (this) {
       case Payer.requester:
@@ -19327,7 +19330,7 @@ enum Permission {
   readAcp,
 }
 
-extension PermissionValue on Permission {
+extension PermissionValueExtension on Permission {
   String toValue() {
     switch (this) {
       case Permission.fullControl:
@@ -19426,7 +19429,7 @@ enum Protocol {
   https,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.http:
@@ -19761,7 +19764,7 @@ enum QuoteFields {
   asneeded,
 }
 
-extension QuoteFieldsValue on QuoteFields {
+extension QuoteFieldsValueExtension on QuoteFields {
   String toValue() {
     switch (this) {
       case QuoteFields.always:
@@ -19960,7 +19963,8 @@ enum ReplicaModificationsStatus {
   disabled,
 }
 
-extension ReplicaModificationsStatusValue on ReplicaModificationsStatus {
+extension ReplicaModificationsStatusValueExtension
+    on ReplicaModificationsStatus {
   String toValue() {
     switch (this) {
       case ReplicaModificationsStatus.enabled:
@@ -20264,7 +20268,7 @@ enum ReplicationRuleStatus {
   disabled,
 }
 
-extension ReplicationRuleStatusValue on ReplicationRuleStatus {
+extension ReplicationRuleStatusValueExtension on ReplicationRuleStatus {
   String toValue() {
     switch (this) {
       case ReplicationRuleStatus.enabled:
@@ -20294,7 +20298,7 @@ enum ReplicationStatus {
   replica,
 }
 
-extension ReplicationStatusValue on ReplicationStatus {
+extension ReplicationStatusValueExtension on ReplicationStatus {
   String toValue() {
     switch (this) {
       case ReplicationStatus.complete:
@@ -20372,7 +20376,7 @@ enum ReplicationTimeStatus {
   disabled,
 }
 
-extension ReplicationTimeStatusValue on ReplicationTimeStatus {
+extension ReplicationTimeStatusValueExtension on ReplicationTimeStatus {
   String toValue() {
     switch (this) {
       case ReplicationTimeStatus.enabled:
@@ -20434,7 +20438,7 @@ enum RequestCharged {
   requester,
 }
 
-extension RequestChargedValue on RequestCharged {
+extension RequestChargedValueExtension on RequestCharged {
   String toValue() {
     switch (this) {
       case RequestCharged.requester:
@@ -20463,7 +20467,7 @@ enum RequestPayer {
   requester,
 }
 
-extension RequestPayerValue on RequestPayer {
+extension RequestPayerValueExtension on RequestPayer {
   String toValue() {
     switch (this) {
       case RequestPayer.requester:
@@ -20616,7 +20620,7 @@ enum RestoreRequestType {
   select,
 }
 
-extension RestoreRequestTypeValue on RestoreRequestType {
+extension RestoreRequestTypeValueExtension on RestoreRequestType {
   String toValue() {
     switch (this) {
       case RestoreRequestType.select:
@@ -21202,7 +21206,7 @@ enum ServerSideEncryption {
   awsKms,
 }
 
-extension ServerSideEncryptionValue on ServerSideEncryption {
+extension ServerSideEncryptionValueExtension on ServerSideEncryption {
   String toValue() {
     switch (this) {
       case ServerSideEncryption.aes256:
@@ -21482,7 +21486,8 @@ enum SseKmsEncryptedObjectsStatus {
   disabled,
 }
 
-extension SseKmsEncryptedObjectsStatusValue on SseKmsEncryptedObjectsStatus {
+extension SseKmsEncryptedObjectsStatusValueExtension
+    on SseKmsEncryptedObjectsStatus {
   String toValue() {
     switch (this) {
       case SseKmsEncryptedObjectsStatus.enabled:
@@ -21557,7 +21562,7 @@ enum StorageClass {
   outposts,
 }
 
-extension StorageClassValue on StorageClass {
+extension StorageClassValueExtension on StorageClass {
   String toValue() {
     switch (this) {
       case StorageClass.standard:
@@ -21686,7 +21691,7 @@ enum StorageClassAnalysisSchemaVersion {
   v_1,
 }
 
-extension StorageClassAnalysisSchemaVersionValue
+extension StorageClassAnalysisSchemaVersionValueExtension
     on StorageClassAnalysisSchemaVersion {
   String toValue() {
     switch (this) {
@@ -21774,7 +21779,7 @@ enum TaggingDirective {
   replace,
 }
 
-extension TaggingDirectiveValue on TaggingDirective {
+extension TaggingDirectiveValueExtension on TaggingDirective {
   String toValue() {
     switch (this) {
       case TaggingDirective.copy:
@@ -21844,7 +21849,7 @@ enum Tier {
   expedited,
 }
 
-extension TierValue on Tier {
+extension TierValueExtension on Tier {
   String toValue() {
     switch (this) {
       case Tier.standard:
@@ -22099,7 +22104,7 @@ enum TransitionStorageClass {
   deepArchive,
 }
 
-extension TransitionStorageClassValue on TransitionStorageClass {
+extension TransitionStorageClassValueExtension on TransitionStorageClass {
   String toValue() {
     switch (this) {
       case TransitionStorageClass.glacier:
@@ -22140,7 +22145,7 @@ enum Type {
   group,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.canonicalUser:

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -3607,7 +3607,7 @@ enum BucketCannedACL {
   authenticatedRead,
 }
 
-extension on BucketCannedACL {
+extension BucketCannedACLValue on BucketCannedACL {
   String toValue() {
     switch (this) {
       case BucketCannedACL.private:
@@ -3622,7 +3622,7 @@ extension on BucketCannedACL {
   }
 }
 
-extension on String {
+extension BucketCannedACLFromString on String {
   BucketCannedACL toBucketCannedACL() {
     switch (this) {
       case 'private':
@@ -3693,7 +3693,7 @@ enum BucketLocationConstraint {
   euCentral_1,
 }
 
-extension on BucketLocationConstraint {
+extension BucketLocationConstraintValue on BucketLocationConstraint {
   String toValue() {
     switch (this) {
       case BucketLocationConstraint.eu:
@@ -3722,7 +3722,7 @@ extension on BucketLocationConstraint {
   }
 }
 
-extension on String {
+extension BucketLocationConstraintFromString on String {
   BucketLocationConstraint toBucketLocationConstraint() {
     switch (this) {
       case 'EU':
@@ -4082,7 +4082,7 @@ enum ExpirationStatus {
   disabled,
 }
 
-extension on ExpirationStatus {
+extension ExpirationStatusValue on ExpirationStatus {
   String toValue() {
     switch (this) {
       case ExpirationStatus.enabled:
@@ -4093,7 +4093,7 @@ extension on ExpirationStatus {
   }
 }
 
-extension on String {
+extension ExpirationStatusFromString on String {
   ExpirationStatus toExpirationStatus() {
     switch (this) {
       case 'Enabled':
@@ -4110,7 +4110,7 @@ enum Format {
   parquet,
 }
 
-extension on Format {
+extension FormatValue on Format {
   String toValue() {
     switch (this) {
       case Format.csv:
@@ -4121,7 +4121,7 @@ extension on Format {
   }
 }
 
-extension on String {
+extension FormatFromString on String {
   Format toFormat() {
     switch (this) {
       case 'CSV':
@@ -4628,7 +4628,7 @@ enum JobManifestFieldName {
   versionId,
 }
 
-extension on JobManifestFieldName {
+extension JobManifestFieldNameValue on JobManifestFieldName {
   String toValue() {
     switch (this) {
       case JobManifestFieldName.ignore:
@@ -4643,7 +4643,7 @@ extension on JobManifestFieldName {
   }
 }
 
-extension on String {
+extension JobManifestFieldNameFromString on String {
   JobManifestFieldName toJobManifestFieldName() {
     switch (this) {
       case 'Ignore':
@@ -4664,7 +4664,7 @@ enum JobManifestFormat {
   s3InventoryReportCsv_20161130,
 }
 
-extension on JobManifestFormat {
+extension JobManifestFormatValue on JobManifestFormat {
   String toValue() {
     switch (this) {
       case JobManifestFormat.s3BatchOperationsCsv_20180820:
@@ -4675,7 +4675,7 @@ extension on JobManifestFormat {
   }
 }
 
-extension on String {
+extension JobManifestFormatFromString on String {
   JobManifestFormat toJobManifestFormat() {
     switch (this) {
       case 'S3BatchOperations_CSV_20180820':
@@ -4967,7 +4967,7 @@ enum JobReportFormat {
   reportCsv_20180820,
 }
 
-extension on JobReportFormat {
+extension JobReportFormatValue on JobReportFormat {
   String toValue() {
     switch (this) {
       case JobReportFormat.reportCsv_20180820:
@@ -4976,7 +4976,7 @@ extension on JobReportFormat {
   }
 }
 
-extension on String {
+extension JobReportFormatFromString on String {
   JobReportFormat toJobReportFormat() {
     switch (this) {
       case 'Report_CSV_20180820':
@@ -4991,7 +4991,7 @@ enum JobReportScope {
   failedTasksOnly,
 }
 
-extension on JobReportScope {
+extension JobReportScopeValue on JobReportScope {
   String toValue() {
     switch (this) {
       case JobReportScope.allTasks:
@@ -5002,7 +5002,7 @@ extension on JobReportScope {
   }
 }
 
-extension on String {
+extension JobReportScopeFromString on String {
   JobReportScope toJobReportScope() {
     switch (this) {
       case 'AllTasks':
@@ -5030,7 +5030,7 @@ enum JobStatus {
   suspended,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.active:
@@ -5063,7 +5063,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'Active':
@@ -5558,7 +5558,7 @@ enum NetworkOrigin {
   vpc,
 }
 
-extension on NetworkOrigin {
+extension NetworkOriginValue on NetworkOrigin {
   String toValue() {
     switch (this) {
       case NetworkOrigin.internet:
@@ -5569,7 +5569,7 @@ extension on NetworkOrigin {
   }
 }
 
-extension on String {
+extension NetworkOriginFromString on String {
   NetworkOrigin toNetworkOrigin() {
     switch (this) {
       case 'Internet':
@@ -5673,7 +5673,7 @@ enum OperationName {
   s3PutObjectRetention,
 }
 
-extension on OperationName {
+extension OperationNameValue on OperationName {
   String toValue() {
     switch (this) {
       case OperationName.lambdaInvoke:
@@ -5694,7 +5694,7 @@ extension on OperationName {
   }
 }
 
-extension on String {
+extension OperationNameFromString on String {
   OperationName toOperationName() {
     switch (this) {
       case 'LambdaInvoke':
@@ -5720,7 +5720,7 @@ enum OutputSchemaVersion {
   v_1,
 }
 
-extension on OutputSchemaVersion {
+extension OutputSchemaVersionValue on OutputSchemaVersion {
   String toValue() {
     switch (this) {
       case OutputSchemaVersion.v_1:
@@ -5729,7 +5729,7 @@ extension on OutputSchemaVersion {
   }
 }
 
-extension on String {
+extension OutputSchemaVersionFromString on String {
   OutputSchemaVersion toOutputSchemaVersion() {
     switch (this) {
       case 'V_1':
@@ -6209,7 +6209,7 @@ enum RequestedJobStatus {
   ready,
 }
 
-extension on RequestedJobStatus {
+extension RequestedJobStatusValue on RequestedJobStatus {
   String toValue() {
     switch (this) {
       case RequestedJobStatus.cancelled:
@@ -6220,7 +6220,7 @@ extension on RequestedJobStatus {
   }
 }
 
-extension on String {
+extension RequestedJobStatusFromString on String {
   RequestedJobStatus toRequestedJobStatus() {
     switch (this) {
       case 'Cancelled':
@@ -6401,7 +6401,7 @@ enum S3CannedAccessControlList {
   bucketOwnerFullControl,
 }
 
-extension on S3CannedAccessControlList {
+extension S3CannedAccessControlListValue on S3CannedAccessControlList {
   String toValue() {
     switch (this) {
       case S3CannedAccessControlList.private:
@@ -6422,7 +6422,7 @@ extension on S3CannedAccessControlList {
   }
 }
 
-extension on String {
+extension S3CannedAccessControlListFromString on String {
   S3CannedAccessControlList toS3CannedAccessControlList() {
     switch (this) {
       case 'private':
@@ -6642,7 +6642,7 @@ enum S3GlacierJobTier {
   standard,
 }
 
-extension on S3GlacierJobTier {
+extension S3GlacierJobTierValue on S3GlacierJobTier {
   String toValue() {
     switch (this) {
       case S3GlacierJobTier.bulk:
@@ -6653,7 +6653,7 @@ extension on S3GlacierJobTier {
   }
 }
 
-extension on String {
+extension S3GlacierJobTierFromString on String {
   S3GlacierJobTier toS3GlacierJobTier() {
     switch (this) {
       case 'BULK':
@@ -6759,7 +6759,7 @@ enum S3GranteeTypeIdentifier {
   uri,
 }
 
-extension on S3GranteeTypeIdentifier {
+extension S3GranteeTypeIdentifierValue on S3GranteeTypeIdentifier {
   String toValue() {
     switch (this) {
       case S3GranteeTypeIdentifier.id:
@@ -6772,7 +6772,7 @@ extension on S3GranteeTypeIdentifier {
   }
 }
 
-extension on String {
+extension S3GranteeTypeIdentifierFromString on String {
   S3GranteeTypeIdentifier toS3GranteeTypeIdentifier() {
     switch (this) {
       case 'id':
@@ -6836,7 +6836,7 @@ enum S3MetadataDirective {
   replace,
 }
 
-extension on S3MetadataDirective {
+extension S3MetadataDirectiveValue on S3MetadataDirective {
   String toValue() {
     switch (this) {
       case S3MetadataDirective.copy:
@@ -6847,7 +6847,7 @@ extension on S3MetadataDirective {
   }
 }
 
-extension on String {
+extension S3MetadataDirectiveFromString on String {
   S3MetadataDirective toS3MetadataDirective() {
     switch (this) {
       case 'COPY':
@@ -6898,7 +6898,7 @@ enum S3ObjectLockLegalHoldStatus {
   on,
 }
 
-extension on S3ObjectLockLegalHoldStatus {
+extension S3ObjectLockLegalHoldStatusValue on S3ObjectLockLegalHoldStatus {
   String toValue() {
     switch (this) {
       case S3ObjectLockLegalHoldStatus.off:
@@ -6909,7 +6909,7 @@ extension on S3ObjectLockLegalHoldStatus {
   }
 }
 
-extension on String {
+extension S3ObjectLockLegalHoldStatusFromString on String {
   S3ObjectLockLegalHoldStatus toS3ObjectLockLegalHoldStatus() {
     switch (this) {
       case 'OFF':
@@ -6926,7 +6926,7 @@ enum S3ObjectLockMode {
   governance,
 }
 
-extension on S3ObjectLockMode {
+extension S3ObjectLockModeValue on S3ObjectLockMode {
   String toValue() {
     switch (this) {
       case S3ObjectLockMode.compliance:
@@ -6937,7 +6937,7 @@ extension on S3ObjectLockMode {
   }
 }
 
-extension on String {
+extension S3ObjectLockModeFromString on String {
   S3ObjectLockMode toS3ObjectLockMode() {
     switch (this) {
       case 'COMPLIANCE':
@@ -6954,7 +6954,7 @@ enum S3ObjectLockRetentionMode {
   governance,
 }
 
-extension on S3ObjectLockRetentionMode {
+extension S3ObjectLockRetentionModeValue on S3ObjectLockRetentionMode {
   String toValue() {
     switch (this) {
       case S3ObjectLockRetentionMode.compliance:
@@ -6965,7 +6965,7 @@ extension on S3ObjectLockRetentionMode {
   }
 }
 
-extension on String {
+extension S3ObjectLockRetentionModeFromString on String {
   S3ObjectLockRetentionMode toS3ObjectLockRetentionMode() {
     switch (this) {
       case 'COMPLIANCE':
@@ -7149,7 +7149,7 @@ enum S3Permission {
   writeAcp,
 }
 
-extension on S3Permission {
+extension S3PermissionValue on S3Permission {
   String toValue() {
     switch (this) {
       case S3Permission.fullControl:
@@ -7166,7 +7166,7 @@ extension on S3Permission {
   }
 }
 
-extension on String {
+extension S3PermissionFromString on String {
   S3Permission toS3Permission() {
     switch (this) {
       case 'FULL_CONTROL':
@@ -7236,7 +7236,7 @@ enum S3SSEAlgorithm {
   kms,
 }
 
-extension on S3SSEAlgorithm {
+extension S3SSEAlgorithmValue on S3SSEAlgorithm {
   String toValue() {
     switch (this) {
       case S3SSEAlgorithm.aes256:
@@ -7247,7 +7247,7 @@ extension on S3SSEAlgorithm {
   }
 }
 
-extension on String {
+extension S3SSEAlgorithmFromString on String {
   S3SSEAlgorithm toS3SSEAlgorithm() {
     switch (this) {
       case 'AES256':
@@ -7431,7 +7431,7 @@ enum S3StorageClass {
   deepArchive,
 }
 
-extension on S3StorageClass {
+extension S3StorageClassValue on S3StorageClass {
   String toValue() {
     switch (this) {
       case S3StorageClass.standard:
@@ -7450,7 +7450,7 @@ extension on S3StorageClass {
   }
 }
 
-extension on String {
+extension S3StorageClassFromString on String {
   S3StorageClass toS3StorageClass() {
     switch (this) {
       case 'STANDARD':
@@ -7936,7 +7936,7 @@ enum TransitionStorageClass {
   deepArchive,
 }
 
-extension on TransitionStorageClass {
+extension TransitionStorageClassValue on TransitionStorageClass {
   String toValue() {
     switch (this) {
       case TransitionStorageClass.glacier:
@@ -7953,7 +7953,7 @@ extension on TransitionStorageClass {
   }
 }
 
-extension on String {
+extension TransitionStorageClassFromString on String {
   TransitionStorageClass toTransitionStorageClass() {
     switch (this) {
       case 'GLACIER':

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -3607,7 +3607,7 @@ enum BucketCannedACL {
   authenticatedRead,
 }
 
-extension BucketCannedACLValue on BucketCannedACL {
+extension BucketCannedACLValueExtension on BucketCannedACL {
   String toValue() {
     switch (this) {
       case BucketCannedACL.private:
@@ -3693,7 +3693,7 @@ enum BucketLocationConstraint {
   euCentral_1,
 }
 
-extension BucketLocationConstraintValue on BucketLocationConstraint {
+extension BucketLocationConstraintValueExtension on BucketLocationConstraint {
   String toValue() {
     switch (this) {
       case BucketLocationConstraint.eu:
@@ -4082,7 +4082,7 @@ enum ExpirationStatus {
   disabled,
 }
 
-extension ExpirationStatusValue on ExpirationStatus {
+extension ExpirationStatusValueExtension on ExpirationStatus {
   String toValue() {
     switch (this) {
       case ExpirationStatus.enabled:
@@ -4110,7 +4110,7 @@ enum Format {
   parquet,
 }
 
-extension FormatValue on Format {
+extension FormatValueExtension on Format {
   String toValue() {
     switch (this) {
       case Format.csv:
@@ -4628,7 +4628,7 @@ enum JobManifestFieldName {
   versionId,
 }
 
-extension JobManifestFieldNameValue on JobManifestFieldName {
+extension JobManifestFieldNameValueExtension on JobManifestFieldName {
   String toValue() {
     switch (this) {
       case JobManifestFieldName.ignore:
@@ -4664,7 +4664,7 @@ enum JobManifestFormat {
   s3InventoryReportCsv_20161130,
 }
 
-extension JobManifestFormatValue on JobManifestFormat {
+extension JobManifestFormatValueExtension on JobManifestFormat {
   String toValue() {
     switch (this) {
       case JobManifestFormat.s3BatchOperationsCsv_20180820:
@@ -4967,7 +4967,7 @@ enum JobReportFormat {
   reportCsv_20180820,
 }
 
-extension JobReportFormatValue on JobReportFormat {
+extension JobReportFormatValueExtension on JobReportFormat {
   String toValue() {
     switch (this) {
       case JobReportFormat.reportCsv_20180820:
@@ -4991,7 +4991,7 @@ enum JobReportScope {
   failedTasksOnly,
 }
 
-extension JobReportScopeValue on JobReportScope {
+extension JobReportScopeValueExtension on JobReportScope {
   String toValue() {
     switch (this) {
       case JobReportScope.allTasks:
@@ -5030,7 +5030,7 @@ enum JobStatus {
   suspended,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.active:
@@ -5558,7 +5558,7 @@ enum NetworkOrigin {
   vpc,
 }
 
-extension NetworkOriginValue on NetworkOrigin {
+extension NetworkOriginValueExtension on NetworkOrigin {
   String toValue() {
     switch (this) {
       case NetworkOrigin.internet:
@@ -5673,7 +5673,7 @@ enum OperationName {
   s3PutObjectRetention,
 }
 
-extension OperationNameValue on OperationName {
+extension OperationNameValueExtension on OperationName {
   String toValue() {
     switch (this) {
       case OperationName.lambdaInvoke:
@@ -5720,7 +5720,7 @@ enum OutputSchemaVersion {
   v_1,
 }
 
-extension OutputSchemaVersionValue on OutputSchemaVersion {
+extension OutputSchemaVersionValueExtension on OutputSchemaVersion {
   String toValue() {
     switch (this) {
       case OutputSchemaVersion.v_1:
@@ -6209,7 +6209,7 @@ enum RequestedJobStatus {
   ready,
 }
 
-extension RequestedJobStatusValue on RequestedJobStatus {
+extension RequestedJobStatusValueExtension on RequestedJobStatus {
   String toValue() {
     switch (this) {
       case RequestedJobStatus.cancelled:
@@ -6401,7 +6401,7 @@ enum S3CannedAccessControlList {
   bucketOwnerFullControl,
 }
 
-extension S3CannedAccessControlListValue on S3CannedAccessControlList {
+extension S3CannedAccessControlListValueExtension on S3CannedAccessControlList {
   String toValue() {
     switch (this) {
       case S3CannedAccessControlList.private:
@@ -6642,7 +6642,7 @@ enum S3GlacierJobTier {
   standard,
 }
 
-extension S3GlacierJobTierValue on S3GlacierJobTier {
+extension S3GlacierJobTierValueExtension on S3GlacierJobTier {
   String toValue() {
     switch (this) {
       case S3GlacierJobTier.bulk:
@@ -6759,7 +6759,7 @@ enum S3GranteeTypeIdentifier {
   uri,
 }
 
-extension S3GranteeTypeIdentifierValue on S3GranteeTypeIdentifier {
+extension S3GranteeTypeIdentifierValueExtension on S3GranteeTypeIdentifier {
   String toValue() {
     switch (this) {
       case S3GranteeTypeIdentifier.id:
@@ -6836,7 +6836,7 @@ enum S3MetadataDirective {
   replace,
 }
 
-extension S3MetadataDirectiveValue on S3MetadataDirective {
+extension S3MetadataDirectiveValueExtension on S3MetadataDirective {
   String toValue() {
     switch (this) {
       case S3MetadataDirective.copy:
@@ -6898,7 +6898,8 @@ enum S3ObjectLockLegalHoldStatus {
   on,
 }
 
-extension S3ObjectLockLegalHoldStatusValue on S3ObjectLockLegalHoldStatus {
+extension S3ObjectLockLegalHoldStatusValueExtension
+    on S3ObjectLockLegalHoldStatus {
   String toValue() {
     switch (this) {
       case S3ObjectLockLegalHoldStatus.off:
@@ -6926,7 +6927,7 @@ enum S3ObjectLockMode {
   governance,
 }
 
-extension S3ObjectLockModeValue on S3ObjectLockMode {
+extension S3ObjectLockModeValueExtension on S3ObjectLockMode {
   String toValue() {
     switch (this) {
       case S3ObjectLockMode.compliance:
@@ -6954,7 +6955,7 @@ enum S3ObjectLockRetentionMode {
   governance,
 }
 
-extension S3ObjectLockRetentionModeValue on S3ObjectLockRetentionMode {
+extension S3ObjectLockRetentionModeValueExtension on S3ObjectLockRetentionMode {
   String toValue() {
     switch (this) {
       case S3ObjectLockRetentionMode.compliance:
@@ -7149,7 +7150,7 @@ enum S3Permission {
   writeAcp,
 }
 
-extension S3PermissionValue on S3Permission {
+extension S3PermissionValueExtension on S3Permission {
   String toValue() {
     switch (this) {
       case S3Permission.fullControl:
@@ -7236,7 +7237,7 @@ enum S3SSEAlgorithm {
   kms,
 }
 
-extension S3SSEAlgorithmValue on S3SSEAlgorithm {
+extension S3SSEAlgorithmValueExtension on S3SSEAlgorithm {
   String toValue() {
     switch (this) {
       case S3SSEAlgorithm.aes256:
@@ -7431,7 +7432,7 @@ enum S3StorageClass {
   deepArchive,
 }
 
-extension S3StorageClassValue on S3StorageClass {
+extension S3StorageClassValueExtension on S3StorageClass {
   String toValue() {
     switch (this) {
       case S3StorageClass.standard:
@@ -7936,7 +7937,7 @@ enum TransitionStorageClass {
   deepArchive,
 }
 
-extension TransitionStorageClassValue on TransitionStorageClass {
+extension TransitionStorageClassValueExtension on TransitionStorageClass {
   String toValue() {
     switch (this) {
       case TransitionStorageClass.glacier:

--- a/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
@@ -326,7 +326,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension on ContentClassifier {
+extension ContentClassifierValue on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -337,7 +337,7 @@ extension on ContentClassifier {
   }
 }
 
-extension on String {
+extension ContentClassifierFromString on String {
   ContentClassifier toContentClassifier() {
     switch (this) {
       case 'FreeOfPersonallyIdentifiableInformation':
@@ -474,7 +474,7 @@ enum HumanLoopStatus {
   stopping,
 }
 
-extension on HumanLoopStatus {
+extension HumanLoopStatusValue on HumanLoopStatus {
   String toValue() {
     switch (this) {
       case HumanLoopStatus.inProgress:
@@ -491,7 +491,7 @@ extension on HumanLoopStatus {
   }
 }
 
-extension on String {
+extension HumanLoopStatusFromString on String {
   HumanLoopStatus toHumanLoopStatus() {
     switch (this) {
       case 'InProgress':
@@ -574,7 +574,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -585,7 +585,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'Ascending':

--- a/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
@@ -326,7 +326,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension ContentClassifierValue on ContentClassifier {
+extension ContentClassifierValueExtension on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -474,7 +474,7 @@ enum HumanLoopStatus {
   stopping,
 }
 
-extension HumanLoopStatusValue on HumanLoopStatus {
+extension HumanLoopStatusValueExtension on HumanLoopStatus {
   String toValue() {
     switch (this) {
       case HumanLoopStatus.inProgress:
@@ -574,7 +574,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:

--- a/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
+++ b/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
@@ -15739,7 +15739,7 @@ enum ActionStatus {
   stopped,
 }
 
-extension on ActionStatus {
+extension ActionStatusValue on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.unknown:
@@ -15758,7 +15758,7 @@ extension on ActionStatus {
   }
 }
 
-extension on String {
+extension ActionStatusFromString on String {
   ActionStatus toActionStatus() {
     switch (this) {
       case 'Unknown':
@@ -15911,7 +15911,7 @@ enum AlgorithmSortBy {
   creationTime,
 }
 
-extension on AlgorithmSortBy {
+extension AlgorithmSortByValue on AlgorithmSortBy {
   String toValue() {
     switch (this) {
       case AlgorithmSortBy.name:
@@ -15922,7 +15922,7 @@ extension on AlgorithmSortBy {
   }
 }
 
-extension on String {
+extension AlgorithmSortByFromString on String {
   AlgorithmSortBy toAlgorithmSortBy() {
     switch (this) {
       case 'Name':
@@ -16067,7 +16067,7 @@ enum AlgorithmStatus {
   deleting,
 }
 
-extension on AlgorithmStatus {
+extension AlgorithmStatusValue on AlgorithmStatus {
   String toValue() {
     switch (this) {
       case AlgorithmStatus.pending:
@@ -16084,7 +16084,7 @@ extension on AlgorithmStatus {
   }
 }
 
-extension on String {
+extension AlgorithmStatusFromString on String {
   AlgorithmStatus toAlgorithmStatus() {
     switch (this) {
       case 'Pending':
@@ -17118,7 +17118,7 @@ enum AppImageConfigSortKey {
   name,
 }
 
-extension on AppImageConfigSortKey {
+extension AppImageConfigSortKeyValue on AppImageConfigSortKey {
   String toValue() {
     switch (this) {
       case AppImageConfigSortKey.creationTime:
@@ -17131,7 +17131,7 @@ extension on AppImageConfigSortKey {
   }
 }
 
-extension on String {
+extension AppImageConfigSortKeyFromString on String {
   AppImageConfigSortKey toAppImageConfigSortKey() {
     switch (this) {
       case 'CreationTime':
@@ -17180,7 +17180,7 @@ enum AppInstanceType {
   mlG4dn_16xlarge,
 }
 
-extension on AppInstanceType {
+extension AppInstanceTypeValue on AppInstanceType {
   String toValue() {
     switch (this) {
       case AppInstanceType.system:
@@ -17251,7 +17251,7 @@ extension on AppInstanceType {
   }
 }
 
-extension on String {
+extension AppInstanceTypeFromString on String {
   AppInstanceType toAppInstanceType() {
     switch (this) {
       case 'system':
@@ -17328,7 +17328,7 @@ enum AppNetworkAccessType {
   vpcOnly,
 }
 
-extension on AppNetworkAccessType {
+extension AppNetworkAccessTypeValue on AppNetworkAccessType {
   String toValue() {
     switch (this) {
       case AppNetworkAccessType.publicInternetOnly:
@@ -17339,7 +17339,7 @@ extension on AppNetworkAccessType {
   }
 }
 
-extension on String {
+extension AppNetworkAccessTypeFromString on String {
   AppNetworkAccessType toAppNetworkAccessType() {
     switch (this) {
       case 'PublicInternetOnly':
@@ -17355,7 +17355,7 @@ enum AppSortKey {
   creationTime,
 }
 
-extension on AppSortKey {
+extension AppSortKeyValue on AppSortKey {
   String toValue() {
     switch (this) {
       case AppSortKey.creationTime:
@@ -17364,7 +17364,7 @@ extension on AppSortKey {
   }
 }
 
-extension on String {
+extension AppSortKeyFromString on String {
   AppSortKey toAppSortKey() {
     switch (this) {
       case 'CreationTime':
@@ -17425,7 +17425,7 @@ enum AppStatus {
   pending,
 }
 
-extension on AppStatus {
+extension AppStatusValue on AppStatus {
   String toValue() {
     switch (this) {
       case AppStatus.deleted:
@@ -17442,7 +17442,7 @@ extension on AppStatus {
   }
 }
 
-extension on String {
+extension AppStatusFromString on String {
   AppStatus toAppStatus() {
     switch (this) {
       case 'Deleted':
@@ -17466,7 +17466,7 @@ enum AppType {
   tensorBoard,
 }
 
-extension on AppType {
+extension AppTypeValue on AppType {
   String toValue() {
     switch (this) {
       case AppType.jupyterServer:
@@ -17479,7 +17479,7 @@ extension on AppType {
   }
 }
 
-extension on String {
+extension AppTypeFromString on String {
   AppType toAppType() {
     switch (this) {
       case 'JupyterServer':
@@ -17532,7 +17532,7 @@ enum ArtifactSourceIdType {
   custom,
 }
 
-extension on ArtifactSourceIdType {
+extension ArtifactSourceIdTypeValue on ArtifactSourceIdType {
   String toValue() {
     switch (this) {
       case ArtifactSourceIdType.mD5Hash:
@@ -17547,7 +17547,7 @@ extension on ArtifactSourceIdType {
   }
 }
 
-extension on String {
+extension ArtifactSourceIdTypeFromString on String {
   ArtifactSourceIdType toArtifactSourceIdType() {
     switch (this) {
       case 'MD5Hash':
@@ -17640,7 +17640,7 @@ enum AssemblyType {
   line,
 }
 
-extension on AssemblyType {
+extension AssemblyTypeValue on AssemblyType {
   String toValue() {
     switch (this) {
       case AssemblyType.none:
@@ -17651,7 +17651,7 @@ extension on AssemblyType {
   }
 }
 
-extension on String {
+extension AssemblyTypeFromString on String {
   AssemblyType toAssemblyType() {
     switch (this) {
       case 'None':
@@ -17689,7 +17689,7 @@ enum AssociationEdgeType {
   produced,
 }
 
-extension on AssociationEdgeType {
+extension AssociationEdgeTypeValue on AssociationEdgeType {
   String toValue() {
     switch (this) {
       case AssociationEdgeType.contributedTo:
@@ -17704,7 +17704,7 @@ extension on AssociationEdgeType {
   }
 }
 
-extension on String {
+extension AssociationEdgeTypeFromString on String {
   AssociationEdgeType toAssociationEdgeType() {
     switch (this) {
       case 'ContributedTo':
@@ -17848,7 +17848,7 @@ enum AthenaResultCompressionType {
   zlib,
 }
 
-extension on AthenaResultCompressionType {
+extension AthenaResultCompressionTypeValue on AthenaResultCompressionType {
   String toValue() {
     switch (this) {
       case AthenaResultCompressionType.gzip:
@@ -17861,7 +17861,7 @@ extension on AthenaResultCompressionType {
   }
 }
 
-extension on String {
+extension AthenaResultCompressionTypeFromString on String {
   AthenaResultCompressionType toAthenaResultCompressionType() {
     switch (this) {
       case 'GZIP':
@@ -17884,7 +17884,7 @@ enum AthenaResultFormat {
   textfile,
 }
 
-extension on AthenaResultFormat {
+extension AthenaResultFormatValue on AthenaResultFormat {
   String toValue() {
     switch (this) {
       case AthenaResultFormat.parquet:
@@ -17901,7 +17901,7 @@ extension on AthenaResultFormat {
   }
 }
 
-extension on String {
+extension AthenaResultFormatFromString on String {
   AthenaResultFormat toAthenaResultFormat() {
     switch (this) {
       case 'PARQUET':
@@ -17924,7 +17924,7 @@ enum AuthMode {
   iam,
 }
 
-extension on AuthMode {
+extension AuthModeValue on AuthMode {
   String toValue() {
     switch (this) {
       case AuthMode.sso:
@@ -17935,7 +17935,7 @@ extension on AuthMode {
   }
 }
 
-extension on String {
+extension AuthModeFromString on String {
   AuthMode toAuthMode() {
     switch (this) {
       case 'SSO':
@@ -18348,7 +18348,7 @@ enum AutoMLJobObjectiveType {
   minimize,
 }
 
-extension on AutoMLJobObjectiveType {
+extension AutoMLJobObjectiveTypeValue on AutoMLJobObjectiveType {
   String toValue() {
     switch (this) {
       case AutoMLJobObjectiveType.maximize:
@@ -18359,7 +18359,7 @@ extension on AutoMLJobObjectiveType {
   }
 }
 
-extension on String {
+extension AutoMLJobObjectiveTypeFromString on String {
   AutoMLJobObjectiveType toAutoMLJobObjectiveType() {
     switch (this) {
       case 'Maximize':
@@ -18384,7 +18384,7 @@ enum AutoMLJobSecondaryStatus {
   candidateDefinitionsGenerated,
 }
 
-extension on AutoMLJobSecondaryStatus {
+extension AutoMLJobSecondaryStatusValue on AutoMLJobSecondaryStatus {
   String toValue() {
     switch (this) {
       case AutoMLJobSecondaryStatus.starting:
@@ -18411,7 +18411,7 @@ extension on AutoMLJobSecondaryStatus {
   }
 }
 
-extension on String {
+extension AutoMLJobSecondaryStatusFromString on String {
   AutoMLJobSecondaryStatus toAutoMLJobSecondaryStatus() {
     switch (this) {
       case 'Starting':
@@ -18447,7 +18447,7 @@ enum AutoMLJobStatus {
   stopping,
 }
 
-extension on AutoMLJobStatus {
+extension AutoMLJobStatusValue on AutoMLJobStatus {
   String toValue() {
     switch (this) {
       case AutoMLJobStatus.completed:
@@ -18464,7 +18464,7 @@ extension on AutoMLJobStatus {
   }
 }
 
-extension on String {
+extension AutoMLJobStatusFromString on String {
   AutoMLJobStatus toAutoMLJobStatus() {
     switch (this) {
       case 'Completed':
@@ -18543,7 +18543,7 @@ enum AutoMLMetricEnum {
   auc,
 }
 
-extension on AutoMLMetricEnum {
+extension AutoMLMetricEnumValue on AutoMLMetricEnum {
   String toValue() {
     switch (this) {
       case AutoMLMetricEnum.accuracy:
@@ -18560,7 +18560,7 @@ extension on AutoMLMetricEnum {
   }
 }
 
-extension on String {
+extension AutoMLMetricEnumFromString on String {
   AutoMLMetricEnum toAutoMLMetricEnum() {
     switch (this) {
       case 'Accuracy':
@@ -18641,7 +18641,7 @@ enum AutoMLS3DataType {
   s3Prefix,
 }
 
-extension on AutoMLS3DataType {
+extension AutoMLS3DataTypeValue on AutoMLS3DataType {
   String toValue() {
     switch (this) {
       case AutoMLS3DataType.manifestFile:
@@ -18652,7 +18652,7 @@ extension on AutoMLS3DataType {
   }
 }
 
-extension on String {
+extension AutoMLS3DataTypeFromString on String {
   AutoMLS3DataType toAutoMLS3DataType() {
     switch (this) {
       case 'ManifestFile':
@@ -18712,7 +18712,7 @@ enum AutoMLSortBy {
   status,
 }
 
-extension on AutoMLSortBy {
+extension AutoMLSortByValue on AutoMLSortBy {
   String toValue() {
     switch (this) {
       case AutoMLSortBy.name:
@@ -18725,7 +18725,7 @@ extension on AutoMLSortBy {
   }
 }
 
-extension on String {
+extension AutoMLSortByFromString on String {
   AutoMLSortBy toAutoMLSortBy() {
     switch (this) {
       case 'Name':
@@ -18744,7 +18744,7 @@ enum AutoMLSortOrder {
   descending,
 }
 
-extension on AutoMLSortOrder {
+extension AutoMLSortOrderValue on AutoMLSortOrder {
   String toValue() {
     switch (this) {
       case AutoMLSortOrder.ascending:
@@ -18755,7 +18755,7 @@ extension on AutoMLSortOrder {
   }
 }
 
-extension on String {
+extension AutoMLSortOrderFromString on String {
   AutoMLSortOrder toAutoMLSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -18797,7 +18797,8 @@ enum AwsManagedHumanLoopRequestSource {
   awsTextractAnalyzeDocumentFormsV1,
 }
 
-extension on AwsManagedHumanLoopRequestSource {
+extension AwsManagedHumanLoopRequestSourceValue
+    on AwsManagedHumanLoopRequestSource {
   String toValue() {
     switch (this) {
       case AwsManagedHumanLoopRequestSource
@@ -18809,7 +18810,7 @@ extension on AwsManagedHumanLoopRequestSource {
   }
 }
 
-extension on String {
+extension AwsManagedHumanLoopRequestSourceFromString on String {
   AwsManagedHumanLoopRequestSource toAwsManagedHumanLoopRequestSource() {
     switch (this) {
       case 'AWS/Rekognition/DetectModerationLabels/Image/V3':
@@ -18829,7 +18830,7 @@ enum BatchStrategy {
   singleRecord,
 }
 
-extension on BatchStrategy {
+extension BatchStrategyValue on BatchStrategy {
   String toValue() {
     switch (this) {
       case BatchStrategy.multiRecord:
@@ -18840,7 +18841,7 @@ extension on BatchStrategy {
   }
 }
 
-extension on String {
+extension BatchStrategyFromString on String {
   BatchStrategy toBatchStrategy() {
     switch (this) {
       case 'MultiRecord':
@@ -18922,7 +18923,7 @@ enum BooleanOperator {
   or,
 }
 
-extension on BooleanOperator {
+extension BooleanOperatorValue on BooleanOperator {
   String toValue() {
     switch (this) {
       case BooleanOperator.and:
@@ -18933,7 +18934,7 @@ extension on BooleanOperator {
   }
 }
 
-extension on String {
+extension BooleanOperatorFromString on String {
   BooleanOperator toBooleanOperator() {
     switch (this) {
       case 'And':
@@ -18966,7 +18967,7 @@ enum CandidateSortBy {
   finalObjectiveMetricValue,
 }
 
-extension on CandidateSortBy {
+extension CandidateSortByValue on CandidateSortBy {
   String toValue() {
     switch (this) {
       case CandidateSortBy.creationTime:
@@ -18979,7 +18980,7 @@ extension on CandidateSortBy {
   }
 }
 
-extension on String {
+extension CandidateSortByFromString on String {
   CandidateSortBy toCandidateSortBy() {
     switch (this) {
       case 'CreationTime':
@@ -19001,7 +19002,7 @@ enum CandidateStatus {
   stopping,
 }
 
-extension on CandidateStatus {
+extension CandidateStatusValue on CandidateStatus {
   String toValue() {
     switch (this) {
       case CandidateStatus.completed:
@@ -19018,7 +19019,7 @@ extension on CandidateStatus {
   }
 }
 
-extension on String {
+extension CandidateStatusFromString on String {
   CandidateStatus toCandidateStatus() {
     switch (this) {
       case 'Completed':
@@ -19042,7 +19043,7 @@ enum CandidateStepType {
   awsSageMakerProcessingJob,
 }
 
-extension on CandidateStepType {
+extension CandidateStepTypeValue on CandidateStepType {
   String toValue() {
     switch (this) {
       case CandidateStepType.awsSageMakerTrainingJob:
@@ -19055,7 +19056,7 @@ extension on CandidateStepType {
   }
 }
 
-extension on String {
+extension CandidateStepTypeFromString on String {
   CandidateStepType toCandidateStepType() {
     switch (this) {
       case 'AWS::SageMaker::TrainingJob':
@@ -19103,7 +19104,7 @@ enum CapacitySizeType {
   capacityPercent,
 }
 
-extension on CapacitySizeType {
+extension CapacitySizeTypeValue on CapacitySizeType {
   String toValue() {
     switch (this) {
       case CapacitySizeType.instanceCount:
@@ -19114,7 +19115,7 @@ extension on CapacitySizeType {
   }
 }
 
-extension on String {
+extension CapacitySizeTypeFromString on String {
   CapacitySizeType toCapacitySizeType() {
     switch (this) {
       case 'INSTANCE_COUNT':
@@ -19166,7 +19167,7 @@ enum CaptureMode {
   output,
 }
 
-extension on CaptureMode {
+extension CaptureModeValue on CaptureMode {
   String toValue() {
     switch (this) {
       case CaptureMode.input:
@@ -19177,7 +19178,7 @@ extension on CaptureMode {
   }
 }
 
-extension on String {
+extension CaptureModeFromString on String {
   CaptureMode toCaptureMode() {
     switch (this) {
       case 'Input':
@@ -19216,7 +19217,7 @@ enum CaptureStatus {
   stopped,
 }
 
-extension on CaptureStatus {
+extension CaptureStatusValue on CaptureStatus {
   String toValue() {
     switch (this) {
       case CaptureStatus.started:
@@ -19227,7 +19228,7 @@ extension on CaptureStatus {
   }
 }
 
-extension on String {
+extension CaptureStatusFromString on String {
   CaptureStatus toCaptureStatus() {
     switch (this) {
       case 'Started':
@@ -19519,7 +19520,7 @@ enum CodeRepositorySortBy {
   lastModifiedTime,
 }
 
-extension on CodeRepositorySortBy {
+extension CodeRepositorySortByValue on CodeRepositorySortBy {
   String toValue() {
     switch (this) {
       case CodeRepositorySortBy.name:
@@ -19532,7 +19533,7 @@ extension on CodeRepositorySortBy {
   }
 }
 
-extension on String {
+extension CodeRepositorySortByFromString on String {
   CodeRepositorySortBy toCodeRepositorySortBy() {
     switch (this) {
       case 'Name':
@@ -19551,7 +19552,7 @@ enum CodeRepositorySortOrder {
   descending,
 }
 
-extension on CodeRepositorySortOrder {
+extension CodeRepositorySortOrderValue on CodeRepositorySortOrder {
   String toValue() {
     switch (this) {
       case CodeRepositorySortOrder.ascending:
@@ -19562,7 +19563,7 @@ extension on CodeRepositorySortOrder {
   }
 }
 
-extension on String {
+extension CodeRepositorySortOrderFromString on String {
   CodeRepositorySortOrder toCodeRepositorySortOrder() {
     switch (this) {
       case 'Ascending':
@@ -19736,7 +19737,7 @@ enum CompilationJobStatus {
   stopped,
 }
 
-extension on CompilationJobStatus {
+extension CompilationJobStatusValue on CompilationJobStatus {
   String toValue() {
     switch (this) {
       case CompilationJobStatus.inprogress:
@@ -19755,7 +19756,7 @@ extension on CompilationJobStatus {
   }
 }
 
-extension on String {
+extension CompilationJobStatusFromString on String {
   CompilationJobStatus toCompilationJobStatus() {
     switch (this) {
       case 'INPROGRESS':
@@ -19858,7 +19859,7 @@ enum CompressionType {
   gzip,
 }
 
-extension on CompressionType {
+extension CompressionTypeValue on CompressionType {
   String toValue() {
     switch (this) {
       case CompressionType.none:
@@ -19869,7 +19870,7 @@ extension on CompressionType {
   }
 }
 
-extension on String {
+extension CompressionTypeFromString on String {
   CompressionType toCompressionType() {
     switch (this) {
       case 'None':
@@ -19886,7 +19887,7 @@ enum ConditionOutcome {
   $false,
 }
 
-extension on ConditionOutcome {
+extension ConditionOutcomeValue on ConditionOutcome {
   String toValue() {
     switch (this) {
       case ConditionOutcome.$true:
@@ -19897,7 +19898,7 @@ extension on ConditionOutcome {
   }
 }
 
-extension on String {
+extension ConditionOutcomeFromString on String {
   ConditionOutcome toConditionOutcome() {
     switch (this) {
       case 'True':
@@ -20049,7 +20050,7 @@ enum ContainerMode {
   multiModel,
 }
 
-extension on ContainerMode {
+extension ContainerModeValue on ContainerMode {
   String toValue() {
     switch (this) {
       case ContainerMode.singleModel:
@@ -20060,7 +20061,7 @@ extension on ContainerMode {
   }
 }
 
-extension on String {
+extension ContainerModeFromString on String {
   ContainerMode toContainerMode() {
     switch (this) {
       case 'SingleModel':
@@ -20077,7 +20078,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension on ContentClassifier {
+extension ContentClassifierValue on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -20088,7 +20089,7 @@ extension on ContentClassifier {
   }
 }
 
-extension on String {
+extension ContentClassifierFromString on String {
   ContentClassifier toContentClassifier() {
     switch (this) {
       case 'FreeOfPersonallyIdentifiableInformation':
@@ -21075,7 +21076,7 @@ enum DataDistributionType {
   shardedByS3Key,
 }
 
-extension on DataDistributionType {
+extension DataDistributionTypeValue on DataDistributionType {
   String toValue() {
     switch (this) {
       case DataDistributionType.fullyReplicated:
@@ -21086,7 +21087,7 @@ extension on DataDistributionType {
   }
 }
 
-extension on String {
+extension DataDistributionTypeFromString on String {
   DataDistributionType toDataDistributionType() {
     switch (this) {
       case 'FullyReplicated':
@@ -25745,7 +25746,7 @@ enum DetailedAlgorithmStatus {
   failed,
 }
 
-extension on DetailedAlgorithmStatus {
+extension DetailedAlgorithmStatusValue on DetailedAlgorithmStatus {
   String toValue() {
     switch (this) {
       case DetailedAlgorithmStatus.notStarted:
@@ -25760,7 +25761,7 @@ extension on DetailedAlgorithmStatus {
   }
 }
 
-extension on String {
+extension DetailedAlgorithmStatusFromString on String {
   DetailedAlgorithmStatus toDetailedAlgorithmStatus() {
     switch (this) {
       case 'NotStarted':
@@ -25783,7 +25784,7 @@ enum DetailedModelPackageStatus {
   failed,
 }
 
-extension on DetailedModelPackageStatus {
+extension DetailedModelPackageStatusValue on DetailedModelPackageStatus {
   String toValue() {
     switch (this) {
       case DetailedModelPackageStatus.notStarted:
@@ -25798,7 +25799,7 @@ extension on DetailedModelPackageStatus {
   }
 }
 
-extension on String {
+extension DetailedModelPackageStatusFromString on String {
   DetailedModelPackageStatus toDetailedModelPackageStatus() {
     switch (this) {
       case 'NotStarted':
@@ -25951,7 +25952,7 @@ enum DirectInternetAccess {
   disabled,
 }
 
-extension on DirectInternetAccess {
+extension DirectInternetAccessValue on DirectInternetAccess {
   String toValue() {
     switch (this) {
       case DirectInternetAccess.enabled:
@@ -25962,7 +25963,7 @@ extension on DirectInternetAccess {
   }
 }
 
-extension on String {
+extension DirectInternetAccessFromString on String {
   DirectInternetAccess toDirectInternetAccess() {
     switch (this) {
       case 'Enabled':
@@ -26057,7 +26058,7 @@ enum DomainStatus {
   deleteFailed,
 }
 
-extension on DomainStatus {
+extension DomainStatusValue on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.deleting:
@@ -26078,7 +26079,7 @@ extension on DomainStatus {
   }
 }
 
-extension on String {
+extension DomainStatusFromString on String {
   DomainStatus toDomainStatus() {
     switch (this) {
       case 'Deleting':
@@ -26233,7 +26234,7 @@ enum EdgePackagingJobStatus {
   stopped,
 }
 
-extension on EdgePackagingJobStatus {
+extension EdgePackagingJobStatusValue on EdgePackagingJobStatus {
   String toValue() {
     switch (this) {
       case EdgePackagingJobStatus.starting:
@@ -26252,7 +26253,7 @@ extension on EdgePackagingJobStatus {
   }
 }
 
-extension on String {
+extension EdgePackagingJobStatusFromString on String {
   EdgePackagingJobStatus toEdgePackagingJobStatus() {
     switch (this) {
       case 'STARTING':
@@ -26421,7 +26422,7 @@ enum EndpointConfigSortKey {
   creationTime,
 }
 
-extension on EndpointConfigSortKey {
+extension EndpointConfigSortKeyValue on EndpointConfigSortKey {
   String toValue() {
     switch (this) {
       case EndpointConfigSortKey.name:
@@ -26432,7 +26433,7 @@ extension on EndpointConfigSortKey {
   }
 }
 
-extension on String {
+extension EndpointConfigSortKeyFromString on String {
   EndpointConfigSortKey toEndpointConfigSortKey() {
     switch (this) {
       case 'Name':
@@ -26580,7 +26581,7 @@ enum EndpointSortKey {
   status,
 }
 
-extension on EndpointSortKey {
+extension EndpointSortKeyValue on EndpointSortKey {
   String toValue() {
     switch (this) {
       case EndpointSortKey.name:
@@ -26593,7 +26594,7 @@ extension on EndpointSortKey {
   }
 }
 
-extension on String {
+extension EndpointSortKeyFromString on String {
   EndpointSortKey toEndpointSortKey() {
     switch (this) {
       case 'Name':
@@ -26618,7 +26619,7 @@ enum EndpointStatus {
   failed,
 }
 
-extension on EndpointStatus {
+extension EndpointStatusValue on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.outOfService:
@@ -26641,7 +26642,7 @@ extension on EndpointStatus {
   }
 }
 
-extension on String {
+extension EndpointStatusFromString on String {
   EndpointStatus toEndpointStatus() {
     switch (this) {
       case 'OutOfService':
@@ -26756,7 +26757,7 @@ enum ExecutionStatus {
   stopped,
 }
 
-extension on ExecutionStatus {
+extension ExecutionStatusValue on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.pending:
@@ -26777,7 +26778,7 @@ extension on ExecutionStatus {
   }
 }
 
-extension on String {
+extension ExecutionStatusFromString on String {
   ExecutionStatus toExecutionStatus() {
     switch (this) {
       case 'Pending':
@@ -27164,7 +27165,7 @@ enum FeatureGroupSortBy {
   creationTime,
 }
 
-extension on FeatureGroupSortBy {
+extension FeatureGroupSortByValue on FeatureGroupSortBy {
   String toValue() {
     switch (this) {
       case FeatureGroupSortBy.name:
@@ -27179,7 +27180,7 @@ extension on FeatureGroupSortBy {
   }
 }
 
-extension on String {
+extension FeatureGroupSortByFromString on String {
   FeatureGroupSortBy toFeatureGroupSortBy() {
     switch (this) {
       case 'Name':
@@ -27200,7 +27201,7 @@ enum FeatureGroupSortOrder {
   descending,
 }
 
-extension on FeatureGroupSortOrder {
+extension FeatureGroupSortOrderValue on FeatureGroupSortOrder {
   String toValue() {
     switch (this) {
       case FeatureGroupSortOrder.ascending:
@@ -27211,7 +27212,7 @@ extension on FeatureGroupSortOrder {
   }
 }
 
-extension on String {
+extension FeatureGroupSortOrderFromString on String {
   FeatureGroupSortOrder toFeatureGroupSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -27231,7 +27232,7 @@ enum FeatureGroupStatus {
   deleteFailed,
 }
 
-extension on FeatureGroupStatus {
+extension FeatureGroupStatusValue on FeatureGroupStatus {
   String toValue() {
     switch (this) {
       case FeatureGroupStatus.creating:
@@ -27248,7 +27249,7 @@ extension on FeatureGroupStatus {
   }
 }
 
-extension on String {
+extension FeatureGroupStatusFromString on String {
   FeatureGroupStatus toFeatureGroupStatus() {
     switch (this) {
       case 'Creating':
@@ -27318,7 +27319,7 @@ enum FeatureType {
   string,
 }
 
-extension on FeatureType {
+extension FeatureTypeValue on FeatureType {
   String toValue() {
     switch (this) {
       case FeatureType.integral:
@@ -27331,7 +27332,7 @@ extension on FeatureType {
   }
 }
 
-extension on String {
+extension FeatureTypeFromString on String {
   FeatureType toFeatureType() {
     switch (this) {
       case 'Integral':
@@ -27350,7 +27351,7 @@ enum FileSystemAccessMode {
   ro,
 }
 
-extension on FileSystemAccessMode {
+extension FileSystemAccessModeValue on FileSystemAccessMode {
   String toValue() {
     switch (this) {
       case FileSystemAccessMode.rw:
@@ -27361,7 +27362,7 @@ extension on FileSystemAccessMode {
   }
 }
 
-extension on String {
+extension FileSystemAccessModeFromString on String {
   FileSystemAccessMode toFileSystemAccessMode() {
     switch (this) {
       case 'rw':
@@ -27465,7 +27466,7 @@ enum FileSystemType {
   fSxLustre,
 }
 
-extension on FileSystemType {
+extension FileSystemTypeValue on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.efs:
@@ -27476,7 +27477,7 @@ extension on FileSystemType {
   }
 }
 
-extension on String {
+extension FileSystemTypeFromString on String {
   FileSystemType toFileSystemType() {
     switch (this) {
       case 'EFS':
@@ -27733,7 +27734,7 @@ enum FlowDefinitionStatus {
   deleting,
 }
 
-extension on FlowDefinitionStatus {
+extension FlowDefinitionStatusValue on FlowDefinitionStatus {
   String toValue() {
     switch (this) {
       case FlowDefinitionStatus.initializing:
@@ -27748,7 +27749,7 @@ extension on FlowDefinitionStatus {
   }
 }
 
-extension on String {
+extension FlowDefinitionStatusFromString on String {
   FlowDefinitionStatus toFlowDefinitionStatus() {
     switch (this) {
       case 'Initializing':
@@ -27814,7 +27815,7 @@ enum Framework {
   sklearn,
 }
 
-extension on Framework {
+extension FrameworkValue on Framework {
   String toValue() {
     switch (this) {
       case Framework.tensorflow:
@@ -27839,7 +27840,7 @@ extension on Framework {
   }
 }
 
-extension on String {
+extension FrameworkFromString on String {
   Framework toFramework() {
     switch (this) {
       case 'TENSORFLOW':
@@ -29297,7 +29298,7 @@ enum HumanTaskUiStatus {
   deleting,
 }
 
-extension on HumanTaskUiStatus {
+extension HumanTaskUiStatusValue on HumanTaskUiStatus {
   String toValue() {
     switch (this) {
       case HumanTaskUiStatus.active:
@@ -29308,7 +29309,7 @@ extension on HumanTaskUiStatus {
   }
 }
 
-extension on String {
+extension HumanTaskUiStatusFromString on String {
   HumanTaskUiStatus toHumanTaskUiStatus() {
     switch (this) {
       case 'Active':
@@ -29426,7 +29427,7 @@ enum HyperParameterScalingType {
   reverseLogarithmic,
 }
 
-extension on HyperParameterScalingType {
+extension HyperParameterScalingTypeValue on HyperParameterScalingType {
   String toValue() {
     switch (this) {
       case HyperParameterScalingType.auto:
@@ -29441,7 +29442,7 @@ extension on HyperParameterScalingType {
   }
 }
 
-extension on String {
+extension HyperParameterScalingTypeFromString on String {
   HyperParameterScalingType toHyperParameterScalingType() {
     switch (this) {
       case 'Auto':
@@ -29944,7 +29945,8 @@ enum HyperParameterTuningJobObjectiveType {
   minimize,
 }
 
-extension on HyperParameterTuningJobObjectiveType {
+extension HyperParameterTuningJobObjectiveTypeValue
+    on HyperParameterTuningJobObjectiveType {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobObjectiveType.maximize:
@@ -29955,7 +29957,7 @@ extension on HyperParameterTuningJobObjectiveType {
   }
 }
 
-extension on String {
+extension HyperParameterTuningJobObjectiveTypeFromString on String {
   HyperParameterTuningJobObjectiveType
       toHyperParameterTuningJobObjectiveType() {
     switch (this) {
@@ -29975,7 +29977,8 @@ enum HyperParameterTuningJobSortByOptions {
   creationTime,
 }
 
-extension on HyperParameterTuningJobSortByOptions {
+extension HyperParameterTuningJobSortByOptionsValue
+    on HyperParameterTuningJobSortByOptions {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobSortByOptions.name:
@@ -29988,7 +29991,7 @@ extension on HyperParameterTuningJobSortByOptions {
   }
 }
 
-extension on String {
+extension HyperParameterTuningJobSortByOptionsFromString on String {
   HyperParameterTuningJobSortByOptions
       toHyperParameterTuningJobSortByOptions() {
     switch (this) {
@@ -30012,7 +30015,7 @@ enum HyperParameterTuningJobStatus {
   stopping,
 }
 
-extension on HyperParameterTuningJobStatus {
+extension HyperParameterTuningJobStatusValue on HyperParameterTuningJobStatus {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobStatus.completed:
@@ -30029,7 +30032,7 @@ extension on HyperParameterTuningJobStatus {
   }
 }
 
-extension on String {
+extension HyperParameterTuningJobStatusFromString on String {
   HyperParameterTuningJobStatus toHyperParameterTuningJobStatus() {
     switch (this) {
       case 'Completed':
@@ -30055,7 +30058,8 @@ enum HyperParameterTuningJobStrategyType {
   random,
 }
 
-extension on HyperParameterTuningJobStrategyType {
+extension HyperParameterTuningJobStrategyTypeValue
+    on HyperParameterTuningJobStrategyType {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobStrategyType.bayesian:
@@ -30066,7 +30070,7 @@ extension on HyperParameterTuningJobStrategyType {
   }
 }
 
-extension on String {
+extension HyperParameterTuningJobStrategyTypeFromString on String {
   HyperParameterTuningJobStrategyType toHyperParameterTuningJobStrategyType() {
     switch (this) {
       case 'Bayesian':
@@ -30241,7 +30245,8 @@ enum HyperParameterTuningJobWarmStartType {
   transferLearning,
 }
 
-extension on HyperParameterTuningJobWarmStartType {
+extension HyperParameterTuningJobWarmStartTypeValue
+    on HyperParameterTuningJobWarmStartType {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobWarmStartType.identicalDataAndAlgorithm:
@@ -30252,7 +30257,7 @@ extension on HyperParameterTuningJobWarmStartType {
   }
 }
 
-extension on String {
+extension HyperParameterTuningJobWarmStartTypeFromString on String {
   HyperParameterTuningJobWarmStartType
       toHyperParameterTuningJobWarmStartType() {
     switch (this) {
@@ -30361,7 +30366,7 @@ enum ImageSortBy {
   imageName,
 }
 
-extension on ImageSortBy {
+extension ImageSortByValue on ImageSortBy {
   String toValue() {
     switch (this) {
       case ImageSortBy.creationTime:
@@ -30374,7 +30379,7 @@ extension on ImageSortBy {
   }
 }
 
-extension on String {
+extension ImageSortByFromString on String {
   ImageSortBy toImageSortBy() {
     switch (this) {
       case 'CREATION_TIME':
@@ -30393,7 +30398,7 @@ enum ImageSortOrder {
   descending,
 }
 
-extension on ImageSortOrder {
+extension ImageSortOrderValue on ImageSortOrder {
   String toValue() {
     switch (this) {
       case ImageSortOrder.ascending:
@@ -30404,7 +30409,7 @@ extension on ImageSortOrder {
   }
 }
 
-extension on String {
+extension ImageSortOrderFromString on String {
   ImageSortOrder toImageSortOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -30426,7 +30431,7 @@ enum ImageStatus {
   deleteFailed,
 }
 
-extension on ImageStatus {
+extension ImageStatusValue on ImageStatus {
   String toValue() {
     switch (this) {
       case ImageStatus.creating:
@@ -30447,7 +30452,7 @@ extension on ImageStatus {
   }
 }
 
-extension on String {
+extension ImageStatusFromString on String {
   ImageStatus toImageStatus() {
     switch (this) {
       case 'CREATING':
@@ -30524,7 +30529,7 @@ enum ImageVersionSortBy {
   version,
 }
 
-extension on ImageVersionSortBy {
+extension ImageVersionSortByValue on ImageVersionSortBy {
   String toValue() {
     switch (this) {
       case ImageVersionSortBy.creationTime:
@@ -30537,7 +30542,7 @@ extension on ImageVersionSortBy {
   }
 }
 
-extension on String {
+extension ImageVersionSortByFromString on String {
   ImageVersionSortBy toImageVersionSortBy() {
     switch (this) {
       case 'CREATION_TIME':
@@ -30556,7 +30561,7 @@ enum ImageVersionSortOrder {
   descending,
 }
 
-extension on ImageVersionSortOrder {
+extension ImageVersionSortOrderValue on ImageVersionSortOrder {
   String toValue() {
     switch (this) {
       case ImageVersionSortOrder.ascending:
@@ -30567,7 +30572,7 @@ extension on ImageVersionSortOrder {
   }
 }
 
-extension on String {
+extension ImageVersionSortOrderFromString on String {
   ImageVersionSortOrder toImageVersionSortOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -30587,7 +30592,7 @@ enum ImageVersionStatus {
   deleteFailed,
 }
 
-extension on ImageVersionStatus {
+extension ImageVersionStatusValue on ImageVersionStatus {
   String toValue() {
     switch (this) {
       case ImageVersionStatus.creating:
@@ -30604,7 +30609,7 @@ extension on ImageVersionStatus {
   }
 }
 
-extension on String {
+extension ImageVersionStatusFromString on String {
   ImageVersionStatus toImageVersionStatus() {
     switch (this) {
       case 'CREATING':
@@ -30993,7 +30998,7 @@ enum InputMode {
   file,
 }
 
-extension on InputMode {
+extension InputModeValue on InputMode {
   String toValue() {
     switch (this) {
       case InputMode.pipe:
@@ -31004,7 +31009,7 @@ extension on InputMode {
   }
 }
 
-extension on String {
+extension InputModeFromString on String {
   InputMode toInputMode() {
     switch (this) {
       case 'Pipe':
@@ -31057,7 +31062,7 @@ enum InstanceType {
   mlP3_16xlarge,
 }
 
-extension on InstanceType {
+extension InstanceTypeValue on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.mlT2Medium:
@@ -31140,7 +31145,7 @@ extension on InstanceType {
   }
 }
 
-extension on String {
+extension InstanceTypeFromString on String {
   InstanceType toInstanceType() {
     switch (this) {
       case 'ml.t2.medium':
@@ -31320,7 +31325,7 @@ enum JoinSource {
   none,
 }
 
-extension on JoinSource {
+extension JoinSourceValue on JoinSource {
   String toValue() {
     switch (this) {
       case JoinSource.input:
@@ -31331,7 +31336,7 @@ extension on JoinSource {
   }
 }
 
-extension on String {
+extension JoinSourceFromString on String {
   JoinSource toJoinSource() {
     switch (this) {
       case 'Input':
@@ -31946,7 +31951,7 @@ enum LabelingJobStatus {
   stopped,
 }
 
-extension on LabelingJobStatus {
+extension LabelingJobStatusValue on LabelingJobStatus {
   String toValue() {
     switch (this) {
       case LabelingJobStatus.initializing:
@@ -31965,7 +31970,7 @@ extension on LabelingJobStatus {
   }
 }
 
-extension on String {
+extension LabelingJobStatusFromString on String {
   LabelingJobStatus toLabelingJobStatus() {
     switch (this) {
       case 'Initializing':
@@ -32370,7 +32375,7 @@ enum ListCompilationJobsSortBy {
   status,
 }
 
-extension on ListCompilationJobsSortBy {
+extension ListCompilationJobsSortByValue on ListCompilationJobsSortBy {
   String toValue() {
     switch (this) {
       case ListCompilationJobsSortBy.name:
@@ -32383,7 +32388,7 @@ extension on ListCompilationJobsSortBy {
   }
 }
 
-extension on String {
+extension ListCompilationJobsSortByFromString on String {
   ListCompilationJobsSortBy toListCompilationJobsSortBy() {
     switch (this) {
       case 'Name':
@@ -32475,7 +32480,7 @@ enum ListDeviceFleetsSortBy {
   lastModifiedTime,
 }
 
-extension on ListDeviceFleetsSortBy {
+extension ListDeviceFleetsSortByValue on ListDeviceFleetsSortBy {
   String toValue() {
     switch (this) {
       case ListDeviceFleetsSortBy.name:
@@ -32488,7 +32493,7 @@ extension on ListDeviceFleetsSortBy {
   }
 }
 
-extension on String {
+extension ListDeviceFleetsSortByFromString on String {
   ListDeviceFleetsSortBy toListDeviceFleetsSortBy() {
     switch (this) {
       case 'NAME':
@@ -32579,7 +32584,7 @@ enum ListEdgePackagingJobsSortBy {
   status,
 }
 
-extension on ListEdgePackagingJobsSortBy {
+extension ListEdgePackagingJobsSortByValue on ListEdgePackagingJobsSortBy {
   String toValue() {
     switch (this) {
       case ListEdgePackagingJobsSortBy.name:
@@ -32596,7 +32601,7 @@ extension on ListEdgePackagingJobsSortBy {
   }
 }
 
-extension on String {
+extension ListEdgePackagingJobsSortByFromString on String {
   ListEdgePackagingJobsSortBy toListEdgePackagingJobsSortBy() {
     switch (this) {
       case 'NAME':
@@ -32852,7 +32857,8 @@ enum ListLabelingJobsForWorkteamSortByOptions {
   creationTime,
 }
 
-extension on ListLabelingJobsForWorkteamSortByOptions {
+extension ListLabelingJobsForWorkteamSortByOptionsValue
+    on ListLabelingJobsForWorkteamSortByOptions {
   String toValue() {
     switch (this) {
       case ListLabelingJobsForWorkteamSortByOptions.creationTime:
@@ -32861,7 +32867,7 @@ extension on ListLabelingJobsForWorkteamSortByOptions {
   }
 }
 
-extension on String {
+extension ListLabelingJobsForWorkteamSortByOptionsFromString on String {
   ListLabelingJobsForWorkteamSortByOptions
       toListLabelingJobsForWorkteamSortByOptions() {
     switch (this) {
@@ -33525,7 +33531,7 @@ enum ListWorkforcesSortByOptions {
   createDate,
 }
 
-extension on ListWorkforcesSortByOptions {
+extension ListWorkforcesSortByOptionsValue on ListWorkforcesSortByOptions {
   String toValue() {
     switch (this) {
       case ListWorkforcesSortByOptions.name:
@@ -33536,7 +33542,7 @@ extension on ListWorkforcesSortByOptions {
   }
 }
 
-extension on String {
+extension ListWorkforcesSortByOptionsFromString on String {
   ListWorkforcesSortByOptions toListWorkforcesSortByOptions() {
     switch (this) {
       case 'Name':
@@ -33576,7 +33582,7 @@ enum ListWorkteamsSortByOptions {
   createDate,
 }
 
-extension on ListWorkteamsSortByOptions {
+extension ListWorkteamsSortByOptionsValue on ListWorkteamsSortByOptions {
   String toValue() {
     switch (this) {
       case ListWorkteamsSortByOptions.name:
@@ -33587,7 +33593,7 @@ extension on ListWorkteamsSortByOptions {
   }
 }
 
-extension on String {
+extension ListWorkteamsSortByOptionsFromString on String {
   ListWorkteamsSortByOptions toListWorkteamsSortByOptions() {
     switch (this) {
       case 'Name':
@@ -33788,7 +33794,7 @@ enum ModelApprovalStatus {
   pendingManualApproval,
 }
 
-extension on ModelApprovalStatus {
+extension ModelApprovalStatusValue on ModelApprovalStatus {
   String toValue() {
     switch (this) {
       case ModelApprovalStatus.approved:
@@ -33801,7 +33807,7 @@ extension on ModelApprovalStatus {
   }
 }
 
-extension on String {
+extension ModelApprovalStatusFromString on String {
   ModelApprovalStatus toModelApprovalStatus() {
     switch (this) {
       case 'Approved':
@@ -34476,7 +34482,7 @@ enum ModelPackageGroupSortBy {
   creationTime,
 }
 
-extension on ModelPackageGroupSortBy {
+extension ModelPackageGroupSortByValue on ModelPackageGroupSortBy {
   String toValue() {
     switch (this) {
       case ModelPackageGroupSortBy.name:
@@ -34487,7 +34493,7 @@ extension on ModelPackageGroupSortBy {
   }
 }
 
-extension on String {
+extension ModelPackageGroupSortByFromString on String {
   ModelPackageGroupSortBy toModelPackageGroupSortBy() {
     switch (this) {
       case 'Name':
@@ -34508,7 +34514,7 @@ enum ModelPackageGroupStatus {
   deleteFailed,
 }
 
-extension on ModelPackageGroupStatus {
+extension ModelPackageGroupStatusValue on ModelPackageGroupStatus {
   String toValue() {
     switch (this) {
       case ModelPackageGroupStatus.pending:
@@ -34527,7 +34533,7 @@ extension on ModelPackageGroupStatus {
   }
 }
 
-extension on String {
+extension ModelPackageGroupStatusFromString on String {
   ModelPackageGroupStatus toModelPackageGroupStatus() {
     switch (this) {
       case 'Pending':
@@ -34590,7 +34596,7 @@ enum ModelPackageSortBy {
   creationTime,
 }
 
-extension on ModelPackageSortBy {
+extension ModelPackageSortByValue on ModelPackageSortBy {
   String toValue() {
     switch (this) {
       case ModelPackageSortBy.name:
@@ -34601,7 +34607,7 @@ extension on ModelPackageSortBy {
   }
 }
 
-extension on String {
+extension ModelPackageSortByFromString on String {
   ModelPackageSortBy toModelPackageSortBy() {
     switch (this) {
       case 'Name':
@@ -34621,7 +34627,7 @@ enum ModelPackageStatus {
   deleting,
 }
 
-extension on ModelPackageStatus {
+extension ModelPackageStatusValue on ModelPackageStatus {
   String toValue() {
     switch (this) {
       case ModelPackageStatus.pending:
@@ -34638,7 +34644,7 @@ extension on ModelPackageStatus {
   }
 }
 
-extension on String {
+extension ModelPackageStatusFromString on String {
   ModelPackageStatus toModelPackageStatus() {
     switch (this) {
       case 'Pending':
@@ -34783,7 +34789,7 @@ enum ModelPackageType {
   both,
 }
 
-extension on ModelPackageType {
+extension ModelPackageTypeValue on ModelPackageType {
   String toValue() {
     switch (this) {
       case ModelPackageType.versioned:
@@ -34796,7 +34802,7 @@ extension on ModelPackageType {
   }
 }
 
-extension on String {
+extension ModelPackageTypeFromString on String {
   ModelPackageType toModelPackageType() {
     switch (this) {
       case 'Versioned':
@@ -35067,7 +35073,7 @@ enum ModelSortKey {
   creationTime,
 }
 
-extension on ModelSortKey {
+extension ModelSortKeyValue on ModelSortKey {
   String toValue() {
     switch (this) {
       case ModelSortKey.name:
@@ -35078,7 +35084,7 @@ extension on ModelSortKey {
   }
 }
 
-extension on String {
+extension ModelSortKeyFromString on String {
   ModelSortKey toModelSortKey() {
     switch (this) {
       case 'Name':
@@ -35320,7 +35326,7 @@ enum MonitoringExecutionSortKey {
   status,
 }
 
-extension on MonitoringExecutionSortKey {
+extension MonitoringExecutionSortKeyValue on MonitoringExecutionSortKey {
   String toValue() {
     switch (this) {
       case MonitoringExecutionSortKey.creationTime:
@@ -35333,7 +35339,7 @@ extension on MonitoringExecutionSortKey {
   }
 }
 
-extension on String {
+extension MonitoringExecutionSortKeyFromString on String {
   MonitoringExecutionSortKey toMonitoringExecutionSortKey() {
     switch (this) {
       case 'CreationTime':
@@ -35562,7 +35568,8 @@ enum MonitoringJobDefinitionSortKey {
   creationTime,
 }
 
-extension on MonitoringJobDefinitionSortKey {
+extension MonitoringJobDefinitionSortKeyValue
+    on MonitoringJobDefinitionSortKey {
   String toValue() {
     switch (this) {
       case MonitoringJobDefinitionSortKey.name:
@@ -35573,7 +35580,7 @@ extension on MonitoringJobDefinitionSortKey {
   }
 }
 
-extension on String {
+extension MonitoringJobDefinitionSortKeyFromString on String {
   MonitoringJobDefinitionSortKey toMonitoringJobDefinitionSortKey() {
     switch (this) {
       case 'Name':
@@ -35727,7 +35734,7 @@ enum MonitoringProblemType {
   regression,
 }
 
-extension on MonitoringProblemType {
+extension MonitoringProblemTypeValue on MonitoringProblemType {
   String toValue() {
     switch (this) {
       case MonitoringProblemType.binaryClassification:
@@ -35740,7 +35747,7 @@ extension on MonitoringProblemType {
   }
 }
 
-extension on String {
+extension MonitoringProblemTypeFromString on String {
   MonitoringProblemType toMonitoringProblemType() {
     switch (this) {
       case 'BinaryClassification':
@@ -35971,7 +35978,7 @@ enum MonitoringScheduleSortKey {
   status,
 }
 
-extension on MonitoringScheduleSortKey {
+extension MonitoringScheduleSortKeyValue on MonitoringScheduleSortKey {
   String toValue() {
     switch (this) {
       case MonitoringScheduleSortKey.name:
@@ -35984,7 +35991,7 @@ extension on MonitoringScheduleSortKey {
   }
 }
 
-extension on String {
+extension MonitoringScheduleSortKeyFromString on String {
   MonitoringScheduleSortKey toMonitoringScheduleSortKey() {
     switch (this) {
       case 'Name':
@@ -36104,7 +36111,7 @@ enum MonitoringType {
   modelExplainability,
 }
 
-extension on MonitoringType {
+extension MonitoringTypeValue on MonitoringType {
   String toValue() {
     switch (this) {
       case MonitoringType.dataQuality:
@@ -36119,7 +36126,7 @@ extension on MonitoringType {
   }
 }
 
-extension on String {
+extension MonitoringTypeFromString on String {
   MonitoringType toMonitoringType() {
     switch (this) {
       case 'DataQuality':
@@ -36236,7 +36243,8 @@ enum NotebookInstanceAcceleratorType {
   mlEia2Xlarge,
 }
 
-extension on NotebookInstanceAcceleratorType {
+extension NotebookInstanceAcceleratorTypeValue
+    on NotebookInstanceAcceleratorType {
   String toValue() {
     switch (this) {
       case NotebookInstanceAcceleratorType.mlEia1Medium:
@@ -36255,7 +36263,7 @@ extension on NotebookInstanceAcceleratorType {
   }
 }
 
-extension on String {
+extension NotebookInstanceAcceleratorTypeFromString on String {
   NotebookInstanceAcceleratorType toNotebookInstanceAcceleratorType() {
     switch (this) {
       case 'ml.eia1.medium':
@@ -36282,7 +36290,8 @@ enum NotebookInstanceLifecycleConfigSortKey {
   lastModifiedTime,
 }
 
-extension on NotebookInstanceLifecycleConfigSortKey {
+extension NotebookInstanceLifecycleConfigSortKeyValue
+    on NotebookInstanceLifecycleConfigSortKey {
   String toValue() {
     switch (this) {
       case NotebookInstanceLifecycleConfigSortKey.name:
@@ -36295,7 +36304,7 @@ extension on NotebookInstanceLifecycleConfigSortKey {
   }
 }
 
-extension on String {
+extension NotebookInstanceLifecycleConfigSortKeyFromString on String {
   NotebookInstanceLifecycleConfigSortKey
       toNotebookInstanceLifecycleConfigSortKey() {
     switch (this) {
@@ -36316,7 +36325,8 @@ enum NotebookInstanceLifecycleConfigSortOrder {
   descending,
 }
 
-extension on NotebookInstanceLifecycleConfigSortOrder {
+extension NotebookInstanceLifecycleConfigSortOrderValue
+    on NotebookInstanceLifecycleConfigSortOrder {
   String toValue() {
     switch (this) {
       case NotebookInstanceLifecycleConfigSortOrder.ascending:
@@ -36327,7 +36337,7 @@ extension on NotebookInstanceLifecycleConfigSortOrder {
   }
 }
 
-extension on String {
+extension NotebookInstanceLifecycleConfigSortOrderFromString on String {
   NotebookInstanceLifecycleConfigSortOrder
       toNotebookInstanceLifecycleConfigSortOrder() {
     switch (this) {
@@ -36420,7 +36430,7 @@ enum NotebookInstanceSortKey {
   status,
 }
 
-extension on NotebookInstanceSortKey {
+extension NotebookInstanceSortKeyValue on NotebookInstanceSortKey {
   String toValue() {
     switch (this) {
       case NotebookInstanceSortKey.name:
@@ -36433,7 +36443,7 @@ extension on NotebookInstanceSortKey {
   }
 }
 
-extension on String {
+extension NotebookInstanceSortKeyFromString on String {
   NotebookInstanceSortKey toNotebookInstanceSortKey() {
     switch (this) {
       case 'Name':
@@ -36452,7 +36462,7 @@ enum NotebookInstanceSortOrder {
   descending,
 }
 
-extension on NotebookInstanceSortOrder {
+extension NotebookInstanceSortOrderValue on NotebookInstanceSortOrder {
   String toValue() {
     switch (this) {
       case NotebookInstanceSortOrder.ascending:
@@ -36463,7 +36473,7 @@ extension on NotebookInstanceSortOrder {
   }
 }
 
-extension on String {
+extension NotebookInstanceSortOrderFromString on String {
   NotebookInstanceSortOrder toNotebookInstanceSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -36485,7 +36495,7 @@ enum NotebookInstanceStatus {
   updating,
 }
 
-extension on NotebookInstanceStatus {
+extension NotebookInstanceStatusValue on NotebookInstanceStatus {
   String toValue() {
     switch (this) {
       case NotebookInstanceStatus.pending:
@@ -36506,7 +36516,7 @@ extension on NotebookInstanceStatus {
   }
 }
 
-extension on String {
+extension NotebookInstanceStatusFromString on String {
   NotebookInstanceStatus toNotebookInstanceStatus() {
     switch (this) {
       case 'Pending':
@@ -36620,7 +36630,7 @@ enum NotebookOutputOption {
   disabled,
 }
 
-extension on NotebookOutputOption {
+extension NotebookOutputOptionValue on NotebookOutputOption {
   String toValue() {
     switch (this) {
       case NotebookOutputOption.allowed:
@@ -36631,7 +36641,7 @@ extension on NotebookOutputOption {
   }
 }
 
-extension on String {
+extension NotebookOutputOptionFromString on String {
   NotebookOutputOption toNotebookOutputOption() {
     switch (this) {
       case 'Allowed':
@@ -36673,7 +36683,7 @@ enum ObjectiveStatus {
   failed,
 }
 
-extension on ObjectiveStatus {
+extension ObjectiveStatusValue on ObjectiveStatus {
   String toValue() {
     switch (this) {
       case ObjectiveStatus.succeeded:
@@ -36686,7 +36696,7 @@ extension on ObjectiveStatus {
   }
 }
 
-extension on String {
+extension ObjectiveStatusFromString on String {
   ObjectiveStatus toObjectiveStatus() {
     switch (this) {
       case 'Succeeded':
@@ -36809,7 +36819,7 @@ enum OfflineStoreStatusValue {
   disabled,
 }
 
-extension on OfflineStoreStatusValue {
+extension OfflineStoreStatusValueValue on OfflineStoreStatusValue {
   String toValue() {
     switch (this) {
       case OfflineStoreStatusValue.active:
@@ -36822,7 +36832,7 @@ extension on OfflineStoreStatusValue {
   }
 }
 
-extension on String {
+extension OfflineStoreStatusValueFromString on String {
   OfflineStoreStatusValue toOfflineStoreStatusValue() {
     switch (this) {
       case 'Active':
@@ -37102,7 +37112,7 @@ enum Operator {
   $in,
 }
 
-extension on Operator {
+extension OperatorValue on Operator {
   String toValue() {
     switch (this) {
       case Operator.equals:
@@ -37129,7 +37139,7 @@ extension on Operator {
   }
 }
 
-extension on String {
+extension OperatorFromString on String {
   Operator toOperator() {
     switch (this) {
       case 'Equals':
@@ -37162,7 +37172,7 @@ enum OrderKey {
   descending,
 }
 
-extension on OrderKey {
+extension OrderKeyValue on OrderKey {
   String toValue() {
     switch (this) {
       case OrderKey.ascending:
@@ -37173,7 +37183,7 @@ extension on OrderKey {
   }
 }
 
-extension on String {
+extension OrderKeyFromString on String {
   OrderKey toOrderKey() {
     switch (this) {
       case 'Ascending':
@@ -37652,7 +37662,7 @@ enum ParameterType {
   freeText,
 }
 
-extension on ParameterType {
+extension ParameterTypeValue on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.integer:
@@ -37667,7 +37677,7 @@ extension on ParameterType {
   }
 }
 
-extension on String {
+extension ParameterTypeFromString on String {
   ParameterType toParameterType() {
     switch (this) {
       case 'Integer':
@@ -37880,7 +37890,7 @@ enum PipelineExecutionStatus {
   succeeded,
 }
 
-extension on PipelineExecutionStatus {
+extension PipelineExecutionStatusValue on PipelineExecutionStatus {
   String toValue() {
     switch (this) {
       case PipelineExecutionStatus.executing:
@@ -37897,7 +37907,7 @@ extension on PipelineExecutionStatus {
   }
 }
 
-extension on String {
+extension PipelineExecutionStatusFromString on String {
   PipelineExecutionStatus toPipelineExecutionStatus() {
     switch (this) {
       case 'Executing':
@@ -38069,7 +38079,7 @@ enum PipelineStatus {
   active,
 }
 
-extension on PipelineStatus {
+extension PipelineStatusValue on PipelineStatus {
   String toValue() {
     switch (this) {
       case PipelineStatus.active:
@@ -38078,7 +38088,7 @@ extension on PipelineStatus {
   }
 }
 
-extension on String {
+extension PipelineStatusFromString on String {
   PipelineStatus toPipelineStatus() {
     switch (this) {
       case 'Active':
@@ -38144,7 +38154,7 @@ enum ProblemType {
   regression,
 }
 
-extension on ProblemType {
+extension ProblemTypeValue on ProblemType {
   String toValue() {
     switch (this) {
       case ProblemType.binaryClassification:
@@ -38157,7 +38167,7 @@ extension on ProblemType {
   }
 }
 
-extension on String {
+extension ProblemTypeFromString on String {
   ProblemType toProblemType() {
     switch (this) {
       case 'BinaryClassification':
@@ -38334,7 +38344,7 @@ enum ProcessingInstanceType {
   mlR5_24xlarge,
 }
 
-extension on ProcessingInstanceType {
+extension ProcessingInstanceTypeValue on ProcessingInstanceType {
   String toValue() {
     switch (this) {
       case ProcessingInstanceType.mlT3Medium:
@@ -38417,7 +38427,7 @@ extension on ProcessingInstanceType {
   }
 }
 
-extension on String {
+extension ProcessingInstanceTypeFromString on String {
   ProcessingInstanceType toProcessingInstanceType() {
     switch (this) {
       case 'ml.t3.medium':
@@ -38654,7 +38664,7 @@ enum ProcessingJobStatus {
   stopped,
 }
 
-extension on ProcessingJobStatus {
+extension ProcessingJobStatusValue on ProcessingJobStatus {
   String toValue() {
     switch (this) {
       case ProcessingJobStatus.inProgress:
@@ -38671,7 +38681,7 @@ extension on ProcessingJobStatus {
   }
 }
 
-extension on String {
+extension ProcessingJobStatusFromString on String {
   ProcessingJobStatus toProcessingJobStatus() {
     switch (this) {
       case 'InProgress':
@@ -38879,7 +38889,7 @@ enum ProcessingS3CompressionType {
   gzip,
 }
 
-extension on ProcessingS3CompressionType {
+extension ProcessingS3CompressionTypeValue on ProcessingS3CompressionType {
   String toValue() {
     switch (this) {
       case ProcessingS3CompressionType.none:
@@ -38890,7 +38900,7 @@ extension on ProcessingS3CompressionType {
   }
 }
 
-extension on String {
+extension ProcessingS3CompressionTypeFromString on String {
   ProcessingS3CompressionType toProcessingS3CompressionType() {
     switch (this) {
       case 'None':
@@ -38907,7 +38917,8 @@ enum ProcessingS3DataDistributionType {
   shardedByS3Key,
 }
 
-extension on ProcessingS3DataDistributionType {
+extension ProcessingS3DataDistributionTypeValue
+    on ProcessingS3DataDistributionType {
   String toValue() {
     switch (this) {
       case ProcessingS3DataDistributionType.fullyReplicated:
@@ -38918,7 +38929,7 @@ extension on ProcessingS3DataDistributionType {
   }
 }
 
-extension on String {
+extension ProcessingS3DataDistributionTypeFromString on String {
   ProcessingS3DataDistributionType toProcessingS3DataDistributionType() {
     switch (this) {
       case 'FullyReplicated':
@@ -38936,7 +38947,7 @@ enum ProcessingS3DataType {
   s3Prefix,
 }
 
-extension on ProcessingS3DataType {
+extension ProcessingS3DataTypeValue on ProcessingS3DataType {
   String toValue() {
     switch (this) {
       case ProcessingS3DataType.manifestFile:
@@ -38947,7 +38958,7 @@ extension on ProcessingS3DataType {
   }
 }
 
-extension on String {
+extension ProcessingS3DataTypeFromString on String {
   ProcessingS3DataType toProcessingS3DataType() {
     switch (this) {
       case 'ManifestFile':
@@ -39043,7 +39054,7 @@ enum ProcessingS3InputMode {
   file,
 }
 
-extension on ProcessingS3InputMode {
+extension ProcessingS3InputModeValue on ProcessingS3InputMode {
   String toValue() {
     switch (this) {
       case ProcessingS3InputMode.pipe:
@@ -39054,7 +39065,7 @@ extension on ProcessingS3InputMode {
   }
 }
 
-extension on String {
+extension ProcessingS3InputModeFromString on String {
   ProcessingS3InputMode toProcessingS3InputMode() {
     switch (this) {
       case 'Pipe':
@@ -39111,7 +39122,7 @@ enum ProcessingS3UploadMode {
   endOfJob,
 }
 
-extension on ProcessingS3UploadMode {
+extension ProcessingS3UploadModeValue on ProcessingS3UploadMode {
   String toValue() {
     switch (this) {
       case ProcessingS3UploadMode.continuous:
@@ -39122,7 +39133,7 @@ extension on ProcessingS3UploadMode {
   }
 }
 
-extension on String {
+extension ProcessingS3UploadModeFromString on String {
   ProcessingS3UploadMode toProcessingS3UploadMode() {
     switch (this) {
       case 'Continuous':
@@ -39236,7 +39247,8 @@ enum ProductionVariantAcceleratorType {
   mlEia2Xlarge,
 }
 
-extension on ProductionVariantAcceleratorType {
+extension ProductionVariantAcceleratorTypeValue
+    on ProductionVariantAcceleratorType {
   String toValue() {
     switch (this) {
       case ProductionVariantAcceleratorType.mlEia1Medium:
@@ -39255,7 +39267,7 @@ extension on ProductionVariantAcceleratorType {
   }
 }
 
-extension on String {
+extension ProductionVariantAcceleratorTypeFromString on String {
   ProductionVariantAcceleratorType toProductionVariantAcceleratorType() {
     switch (this) {
       case 'ml.eia1.medium':
@@ -39345,7 +39357,7 @@ enum ProductionVariantInstanceType {
   mlInf1_24xlarge,
 }
 
-extension on ProductionVariantInstanceType {
+extension ProductionVariantInstanceTypeValue on ProductionVariantInstanceType {
   String toValue() {
     switch (this) {
       case ProductionVariantInstanceType.mlT2Medium:
@@ -39484,7 +39496,7 @@ extension on ProductionVariantInstanceType {
   }
 }
 
-extension on String {
+extension ProductionVariantInstanceTypeFromString on String {
   ProductionVariantInstanceType toProductionVariantInstanceType() {
     switch (this) {
       case 'ml.t2.medium':
@@ -39888,7 +39900,7 @@ enum ProfilingStatus {
   disabled,
 }
 
-extension on ProfilingStatus {
+extension ProfilingStatusValue on ProfilingStatus {
   String toValue() {
     switch (this) {
       case ProfilingStatus.enabled:
@@ -39899,7 +39911,7 @@ extension on ProfilingStatus {
   }
 }
 
-extension on String {
+extension ProfilingStatusFromString on String {
   ProfilingStatus toProfilingStatus() {
     switch (this) {
       case 'Enabled':
@@ -39916,7 +39928,7 @@ enum ProjectSortBy {
   creationTime,
 }
 
-extension on ProjectSortBy {
+extension ProjectSortByValue on ProjectSortBy {
   String toValue() {
     switch (this) {
       case ProjectSortBy.name:
@@ -39927,7 +39939,7 @@ extension on ProjectSortBy {
   }
 }
 
-extension on String {
+extension ProjectSortByFromString on String {
   ProjectSortBy toProjectSortBy() {
     switch (this) {
       case 'Name':
@@ -39944,7 +39956,7 @@ enum ProjectSortOrder {
   descending,
 }
 
-extension on ProjectSortOrder {
+extension ProjectSortOrderValue on ProjectSortOrder {
   String toValue() {
     switch (this) {
       case ProjectSortOrder.ascending:
@@ -39955,7 +39967,7 @@ extension on ProjectSortOrder {
   }
 }
 
-extension on String {
+extension ProjectSortOrderFromString on String {
   ProjectSortOrder toProjectSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -39977,7 +39989,7 @@ enum ProjectStatus {
   deleteCompleted,
 }
 
-extension on ProjectStatus {
+extension ProjectStatusValue on ProjectStatus {
   String toValue() {
     switch (this) {
       case ProjectStatus.pending:
@@ -39998,7 +40010,7 @@ extension on ProjectStatus {
   }
 }
 
-extension on String {
+extension ProjectStatusFromString on String {
   ProjectStatus toProjectStatus() {
     switch (this) {
       case 'Pending':
@@ -40480,7 +40492,7 @@ enum RecordWrapper {
   recordIO,
 }
 
-extension on RecordWrapper {
+extension RecordWrapperValue on RecordWrapper {
   String toValue() {
     switch (this) {
       case RecordWrapper.none:
@@ -40491,7 +40503,7 @@ extension on RecordWrapper {
   }
 }
 
-extension on String {
+extension RecordWrapperFromString on String {
   RecordWrapper toRecordWrapper() {
     switch (this) {
       case 'None':
@@ -40583,7 +40595,7 @@ enum RedshiftResultCompressionType {
   snappy,
 }
 
-extension on RedshiftResultCompressionType {
+extension RedshiftResultCompressionTypeValue on RedshiftResultCompressionType {
   String toValue() {
     switch (this) {
       case RedshiftResultCompressionType.none:
@@ -40600,7 +40612,7 @@ extension on RedshiftResultCompressionType {
   }
 }
 
-extension on String {
+extension RedshiftResultCompressionTypeFromString on String {
   RedshiftResultCompressionType toRedshiftResultCompressionType() {
     switch (this) {
       case 'None':
@@ -40624,7 +40636,7 @@ enum RedshiftResultFormat {
   csv,
 }
 
-extension on RedshiftResultFormat {
+extension RedshiftResultFormatValue on RedshiftResultFormat {
   String toValue() {
     switch (this) {
       case RedshiftResultFormat.parquet:
@@ -40635,7 +40647,7 @@ extension on RedshiftResultFormat {
   }
 }
 
-extension on String {
+extension RedshiftResultFormatFromString on String {
   RedshiftResultFormat toRedshiftResultFormat() {
     switch (this) {
       case 'PARQUET':
@@ -40731,7 +40743,7 @@ enum RepositoryAccessMode {
   vpc,
 }
 
-extension on RepositoryAccessMode {
+extension RepositoryAccessModeValue on RepositoryAccessMode {
   String toValue() {
     switch (this) {
       case RepositoryAccessMode.platform:
@@ -40742,7 +40754,7 @@ extension on RepositoryAccessMode {
   }
 }
 
-extension on String {
+extension RepositoryAccessModeFromString on String {
   RepositoryAccessMode toRepositoryAccessMode() {
     switch (this) {
       case 'Platform':
@@ -40962,7 +40974,7 @@ enum ResourceType {
   featureGroup,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.trainingJob:
@@ -40989,7 +41001,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'TrainingJob':
@@ -41043,7 +41055,7 @@ enum RetentionType {
   delete,
 }
 
-extension on RetentionType {
+extension RetentionTypeValue on RetentionType {
   String toValue() {
     switch (this) {
       case RetentionType.retain:
@@ -41054,7 +41066,7 @@ extension on RetentionType {
   }
 }
 
-extension on String {
+extension RetentionTypeFromString on String {
   RetentionType toRetentionType() {
     switch (this) {
       case 'Retain':
@@ -41071,7 +41083,7 @@ enum RootAccess {
   disabled,
 }
 
-extension on RootAccess {
+extension RootAccessValue on RootAccess {
   String toValue() {
     switch (this) {
       case RootAccess.enabled:
@@ -41082,7 +41094,7 @@ extension on RootAccess {
   }
 }
 
-extension on String {
+extension RootAccessFromString on String {
   RootAccess toRootAccess() {
     switch (this) {
       case 'Enabled':
@@ -41103,7 +41115,7 @@ enum RuleEvaluationStatus {
   stopped,
 }
 
-extension on RuleEvaluationStatus {
+extension RuleEvaluationStatusValue on RuleEvaluationStatus {
   String toValue() {
     switch (this) {
       case RuleEvaluationStatus.inProgress:
@@ -41122,7 +41134,7 @@ extension on RuleEvaluationStatus {
   }
 }
 
-extension on String {
+extension RuleEvaluationStatusFromString on String {
   RuleEvaluationStatus toRuleEvaluationStatus() {
     switch (this) {
       case 'InProgress':
@@ -41147,7 +41159,7 @@ enum S3DataDistribution {
   shardedByS3Key,
 }
 
-extension on S3DataDistribution {
+extension S3DataDistributionValue on S3DataDistribution {
   String toValue() {
     switch (this) {
       case S3DataDistribution.fullyReplicated:
@@ -41158,7 +41170,7 @@ extension on S3DataDistribution {
   }
 }
 
-extension on String {
+extension S3DataDistributionFromString on String {
   S3DataDistribution toS3DataDistribution() {
     switch (this) {
       case 'FullyReplicated':
@@ -41305,7 +41317,7 @@ enum S3DataType {
   augmentedManifestFile,
 }
 
-extension on S3DataType {
+extension S3DataTypeValue on S3DataType {
   String toValue() {
     switch (this) {
       case S3DataType.manifestFile:
@@ -41318,7 +41330,7 @@ extension on S3DataType {
   }
 }
 
-extension on String {
+extension S3DataTypeFromString on String {
   S3DataType toS3DataType() {
     switch (this) {
       case 'ManifestFile':
@@ -41381,7 +41393,7 @@ enum SagemakerServicecatalogStatus {
   disabled,
 }
 
-extension on SagemakerServicecatalogStatus {
+extension SagemakerServicecatalogStatusValue on SagemakerServicecatalogStatus {
   String toValue() {
     switch (this) {
       case SagemakerServicecatalogStatus.enabled:
@@ -41392,7 +41404,7 @@ extension on SagemakerServicecatalogStatus {
   }
 }
 
-extension on String {
+extension SagemakerServicecatalogStatusFromString on String {
   SagemakerServicecatalogStatus toSagemakerServicecatalogStatus() {
     switch (this) {
       case 'Enabled':
@@ -41483,7 +41495,7 @@ enum ScheduleStatus {
   stopped,
 }
 
-extension on ScheduleStatus {
+extension ScheduleStatusValue on ScheduleStatus {
   String toValue() {
     switch (this) {
       case ScheduleStatus.pending:
@@ -41498,7 +41510,7 @@ extension on ScheduleStatus {
   }
 }
 
-extension on String {
+extension ScheduleStatusFromString on String {
   ScheduleStatus toScheduleStatus() {
     switch (this) {
       case 'Pending':
@@ -41680,7 +41692,7 @@ enum SearchSortOrder {
   descending,
 }
 
-extension on SearchSortOrder {
+extension SearchSortOrderValue on SearchSortOrder {
   String toValue() {
     switch (this) {
       case SearchSortOrder.ascending:
@@ -41691,7 +41703,7 @@ extension on SearchSortOrder {
   }
 }
 
-extension on String {
+extension SearchSortOrderFromString on String {
   SearchSortOrder toSearchSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -41721,7 +41733,7 @@ enum SecondaryStatus {
   updating,
 }
 
-extension on SecondaryStatus {
+extension SecondaryStatusValue on SecondaryStatus {
   String toValue() {
     switch (this) {
       case SecondaryStatus.starting:
@@ -41758,7 +41770,7 @@ extension on SecondaryStatus {
   }
 }
 
-extension on String {
+extension SecondaryStatusFromString on String {
   SecondaryStatus toSecondaryStatus() {
     switch (this) {
       case 'Starting':
@@ -42139,7 +42151,7 @@ enum SortActionsBy {
   creationTime,
 }
 
-extension on SortActionsBy {
+extension SortActionsByValue on SortActionsBy {
   String toValue() {
     switch (this) {
       case SortActionsBy.name:
@@ -42150,7 +42162,7 @@ extension on SortActionsBy {
   }
 }
 
-extension on String {
+extension SortActionsByFromString on String {
   SortActionsBy toSortActionsBy() {
     switch (this) {
       case 'Name':
@@ -42166,7 +42178,7 @@ enum SortArtifactsBy {
   creationTime,
 }
 
-extension on SortArtifactsBy {
+extension SortArtifactsByValue on SortArtifactsBy {
   String toValue() {
     switch (this) {
       case SortArtifactsBy.creationTime:
@@ -42175,7 +42187,7 @@ extension on SortArtifactsBy {
   }
 }
 
-extension on String {
+extension SortArtifactsByFromString on String {
   SortArtifactsBy toSortArtifactsBy() {
     switch (this) {
       case 'CreationTime':
@@ -42193,7 +42205,7 @@ enum SortAssociationsBy {
   creationTime,
 }
 
-extension on SortAssociationsBy {
+extension SortAssociationsByValue on SortAssociationsBy {
   String toValue() {
     switch (this) {
       case SortAssociationsBy.sourceArn:
@@ -42210,7 +42222,7 @@ extension on SortAssociationsBy {
   }
 }
 
-extension on String {
+extension SortAssociationsByFromString on String {
   SortAssociationsBy toSortAssociationsBy() {
     switch (this) {
       case 'SourceArn':
@@ -42234,7 +42246,7 @@ enum SortBy {
   status,
 }
 
-extension on SortBy {
+extension SortByValue on SortBy {
   String toValue() {
     switch (this) {
       case SortBy.name:
@@ -42247,7 +42259,7 @@ extension on SortBy {
   }
 }
 
-extension on String {
+extension SortByFromString on String {
   SortBy toSortBy() {
     switch (this) {
       case 'Name':
@@ -42266,7 +42278,7 @@ enum SortContextsBy {
   creationTime,
 }
 
-extension on SortContextsBy {
+extension SortContextsByValue on SortContextsBy {
   String toValue() {
     switch (this) {
       case SortContextsBy.name:
@@ -42277,7 +42289,7 @@ extension on SortContextsBy {
   }
 }
 
-extension on String {
+extension SortContextsByFromString on String {
   SortContextsBy toSortContextsBy() {
     switch (this) {
       case 'Name':
@@ -42294,7 +42306,7 @@ enum SortExperimentsBy {
   creationTime,
 }
 
-extension on SortExperimentsBy {
+extension SortExperimentsByValue on SortExperimentsBy {
   String toValue() {
     switch (this) {
       case SortExperimentsBy.name:
@@ -42305,7 +42317,7 @@ extension on SortExperimentsBy {
   }
 }
 
-extension on String {
+extension SortExperimentsByFromString on String {
   SortExperimentsBy toSortExperimentsBy() {
     switch (this) {
       case 'Name':
@@ -42322,7 +42334,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -42333,7 +42345,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'Ascending':
@@ -42350,7 +42362,7 @@ enum SortPipelineExecutionsBy {
   pipelineExecutionArn,
 }
 
-extension on SortPipelineExecutionsBy {
+extension SortPipelineExecutionsByValue on SortPipelineExecutionsBy {
   String toValue() {
     switch (this) {
       case SortPipelineExecutionsBy.creationTime:
@@ -42361,7 +42373,7 @@ extension on SortPipelineExecutionsBy {
   }
 }
 
-extension on String {
+extension SortPipelineExecutionsByFromString on String {
   SortPipelineExecutionsBy toSortPipelineExecutionsBy() {
     switch (this) {
       case 'CreationTime':
@@ -42378,7 +42390,7 @@ enum SortPipelinesBy {
   creationTime,
 }
 
-extension on SortPipelinesBy {
+extension SortPipelinesByValue on SortPipelinesBy {
   String toValue() {
     switch (this) {
       case SortPipelinesBy.name:
@@ -42389,7 +42401,7 @@ extension on SortPipelinesBy {
   }
 }
 
-extension on String {
+extension SortPipelinesByFromString on String {
   SortPipelinesBy toSortPipelinesBy() {
     switch (this) {
       case 'Name':
@@ -42406,7 +42418,7 @@ enum SortTrialComponentsBy {
   creationTime,
 }
 
-extension on SortTrialComponentsBy {
+extension SortTrialComponentsByValue on SortTrialComponentsBy {
   String toValue() {
     switch (this) {
       case SortTrialComponentsBy.name:
@@ -42417,7 +42429,7 @@ extension on SortTrialComponentsBy {
   }
 }
 
-extension on String {
+extension SortTrialComponentsByFromString on String {
   SortTrialComponentsBy toSortTrialComponentsBy() {
     switch (this) {
       case 'Name':
@@ -42434,7 +42446,7 @@ enum SortTrialsBy {
   creationTime,
 }
 
-extension on SortTrialsBy {
+extension SortTrialsByValue on SortTrialsBy {
   String toValue() {
     switch (this) {
       case SortTrialsBy.name:
@@ -42445,7 +42457,7 @@ extension on SortTrialsBy {
   }
 }
 
-extension on String {
+extension SortTrialsByFromString on String {
   SortTrialsBy toSortTrialsBy() {
     switch (this) {
       case 'Name':
@@ -42566,7 +42578,7 @@ enum SplitType {
   tFRecord,
 }
 
-extension on SplitType {
+extension SplitTypeValue on SplitType {
   String toValue() {
     switch (this) {
       case SplitType.none:
@@ -42581,7 +42593,7 @@ extension on SplitType {
   }
 }
 
-extension on String {
+extension SplitTypeFromString on String {
   SplitType toSplitType() {
     switch (this) {
       case 'None':
@@ -42620,7 +42632,7 @@ enum StepStatus {
   succeeded,
 }
 
-extension on StepStatus {
+extension StepStatusValue on StepStatus {
   String toValue() {
     switch (this) {
       case StepStatus.starting:
@@ -42639,7 +42651,7 @@ extension on StepStatus {
   }
 }
 
-extension on String {
+extension StepStatusFromString on String {
   StepStatus toStepStatus() {
     switch (this) {
       case 'Starting':
@@ -42845,7 +42857,7 @@ enum TargetDevice {
   jacintoTda4vm,
 }
 
-extension on TargetDevice {
+extension TargetDeviceValue on TargetDevice {
   String toValue() {
     switch (this) {
       case TargetDevice.lambda:
@@ -42908,7 +42920,7 @@ extension on TargetDevice {
   }
 }
 
-extension on String {
+extension TargetDeviceFromString on String {
   TargetDevice toTargetDevice() {
     switch (this) {
       case 'lambda':
@@ -43061,7 +43073,7 @@ enum TargetPlatformAccelerator {
   nvidia,
 }
 
-extension on TargetPlatformAccelerator {
+extension TargetPlatformAcceleratorValue on TargetPlatformAccelerator {
   String toValue() {
     switch (this) {
       case TargetPlatformAccelerator.intelGraphics:
@@ -43074,7 +43086,7 @@ extension on TargetPlatformAccelerator {
   }
 }
 
-extension on String {
+extension TargetPlatformAcceleratorFromString on String {
   TargetPlatformAccelerator toTargetPlatformAccelerator() {
     switch (this) {
       case 'INTEL_GRAPHICS':
@@ -43096,7 +43108,7 @@ enum TargetPlatformArch {
   armEabihf,
 }
 
-extension on TargetPlatformArch {
+extension TargetPlatformArchValue on TargetPlatformArch {
   String toValue() {
     switch (this) {
       case TargetPlatformArch.x86_64:
@@ -43113,7 +43125,7 @@ extension on TargetPlatformArch {
   }
 }
 
-extension on String {
+extension TargetPlatformArchFromString on String {
   TargetPlatformArch toTargetPlatformArch() {
     switch (this) {
       case 'X86_64':
@@ -43136,7 +43148,7 @@ enum TargetPlatformOs {
   linux,
 }
 
-extension on TargetPlatformOs {
+extension TargetPlatformOsValue on TargetPlatformOs {
   String toValue() {
     switch (this) {
       case TargetPlatformOs.android:
@@ -43147,7 +43159,7 @@ extension on TargetPlatformOs {
   }
 }
 
-extension on String {
+extension TargetPlatformOsFromString on String {
   TargetPlatformOs toTargetPlatformOs() {
     switch (this) {
       case 'ANDROID':
@@ -43259,7 +43271,7 @@ enum TrafficRoutingConfigType {
   canary,
 }
 
-extension on TrafficRoutingConfigType {
+extension TrafficRoutingConfigTypeValue on TrafficRoutingConfigType {
   String toValue() {
     switch (this) {
       case TrafficRoutingConfigType.allAtOnce:
@@ -43270,7 +43282,7 @@ extension on TrafficRoutingConfigType {
   }
 }
 
-extension on String {
+extension TrafficRoutingConfigTypeFromString on String {
   TrafficRoutingConfigType toTrafficRoutingConfigType() {
     switch (this) {
       case 'ALL_AT_ONCE':
@@ -43287,7 +43299,7 @@ enum TrainingInputMode {
   file,
 }
 
-extension on TrainingInputMode {
+extension TrainingInputModeValue on TrainingInputMode {
   String toValue() {
     switch (this) {
       case TrainingInputMode.pipe:
@@ -43298,7 +43310,7 @@ extension on TrainingInputMode {
   }
 }
 
-extension on String {
+extension TrainingInputModeFromString on String {
   TrainingInputMode toTrainingInputMode() {
     switch (this) {
       case 'Pipe':
@@ -43352,7 +43364,7 @@ enum TrainingInstanceType {
   mlC5n_18xlarge,
 }
 
-extension on TrainingInstanceType {
+extension TrainingInstanceTypeValue on TrainingInstanceType {
   String toValue() {
     switch (this) {
       case TrainingInstanceType.mlM4Xlarge:
@@ -43437,7 +43449,7 @@ extension on TrainingInstanceType {
   }
 }
 
-extension on String {
+extension TrainingInstanceTypeFromString on String {
   TrainingInstanceType toTrainingInstanceType() {
     switch (this) {
       case 'ml.m4.xlarge':
@@ -43970,7 +43982,7 @@ enum TrainingJobEarlyStoppingType {
   auto,
 }
 
-extension on TrainingJobEarlyStoppingType {
+extension TrainingJobEarlyStoppingTypeValue on TrainingJobEarlyStoppingType {
   String toValue() {
     switch (this) {
       case TrainingJobEarlyStoppingType.off:
@@ -43981,7 +43993,7 @@ extension on TrainingJobEarlyStoppingType {
   }
 }
 
-extension on String {
+extension TrainingJobEarlyStoppingTypeFromString on String {
   TrainingJobEarlyStoppingType toTrainingJobEarlyStoppingType() {
     switch (this) {
       case 'Off':
@@ -44000,7 +44012,7 @@ enum TrainingJobSortByOptions {
   finalObjectiveMetricValue,
 }
 
-extension on TrainingJobSortByOptions {
+extension TrainingJobSortByOptionsValue on TrainingJobSortByOptions {
   String toValue() {
     switch (this) {
       case TrainingJobSortByOptions.name:
@@ -44015,7 +44027,7 @@ extension on TrainingJobSortByOptions {
   }
 }
 
-extension on String {
+extension TrainingJobSortByOptionsFromString on String {
   TrainingJobSortByOptions toTrainingJobSortByOptions() {
     switch (this) {
       case 'Name':
@@ -44039,7 +44051,7 @@ enum TrainingJobStatus {
   stopped,
 }
 
-extension on TrainingJobStatus {
+extension TrainingJobStatusValue on TrainingJobStatus {
   String toValue() {
     switch (this) {
       case TrainingJobStatus.inProgress:
@@ -44056,7 +44068,7 @@ extension on TrainingJobStatus {
   }
 }
 
-extension on String {
+extension TrainingJobStatusFromString on String {
   TrainingJobStatus toTrainingJobStatus() {
     switch (this) {
       case 'InProgress':
@@ -44424,7 +44436,7 @@ enum TransformInstanceType {
   mlM5_24xlarge,
 }
 
-extension on TransformInstanceType {
+extension TransformInstanceTypeValue on TransformInstanceType {
   String toValue() {
     switch (this) {
       case TransformInstanceType.mlM4Xlarge:
@@ -44483,7 +44495,7 @@ extension on TransformInstanceType {
   }
 }
 
-extension on String {
+extension TransformInstanceTypeFromString on String {
   TransformInstanceType toTransformInstanceType() {
     switch (this) {
       case 'ml.m4.xlarge':
@@ -44804,7 +44816,7 @@ enum TransformJobStatus {
   stopped,
 }
 
-extension on TransformJobStatus {
+extension TransformJobStatusValue on TransformJobStatus {
   String toValue() {
     switch (this) {
       case TransformJobStatus.inProgress:
@@ -44821,7 +44833,7 @@ extension on TransformJobStatus {
   }
 }
 
-extension on String {
+extension TransformJobStatusFromString on String {
   TransformJobStatus toTransformJobStatus() {
     switch (this) {
       case 'InProgress':
@@ -45498,7 +45510,7 @@ enum TrialComponentPrimaryStatus {
   stopped,
 }
 
-extension on TrialComponentPrimaryStatus {
+extension TrialComponentPrimaryStatusValue on TrialComponentPrimaryStatus {
   String toValue() {
     switch (this) {
       case TrialComponentPrimaryStatus.inProgress:
@@ -45515,7 +45527,7 @@ extension on TrialComponentPrimaryStatus {
   }
 }
 
-extension on String {
+extension TrialComponentPrimaryStatusFromString on String {
   TrialComponentPrimaryStatus toTrialComponentPrimaryStatus() {
     switch (this) {
       case 'InProgress':
@@ -46358,7 +46370,7 @@ enum UserProfileSortKey {
   lastModifiedTime,
 }
 
-extension on UserProfileSortKey {
+extension UserProfileSortKeyValue on UserProfileSortKey {
   String toValue() {
     switch (this) {
       case UserProfileSortKey.creationTime:
@@ -46369,7 +46381,7 @@ extension on UserProfileSortKey {
   }
 }
 
-extension on String {
+extension UserProfileSortKeyFromString on String {
   UserProfileSortKey toUserProfileSortKey() {
     switch (this) {
       case 'CreationTime':
@@ -46391,7 +46403,7 @@ enum UserProfileStatus {
   deleteFailed,
 }
 
-extension on UserProfileStatus {
+extension UserProfileStatusValue on UserProfileStatus {
   String toValue() {
     switch (this) {
       case UserProfileStatus.deleting:
@@ -46412,7 +46424,7 @@ extension on UserProfileStatus {
   }
 }
 
-extension on String {
+extension UserProfileStatusFromString on String {
   UserProfileStatus toUserProfileStatus() {
     switch (this) {
       case 'Deleting':
@@ -46560,7 +46572,7 @@ enum VariantPropertyType {
   dataCaptureConfig,
 }
 
-extension on VariantPropertyType {
+extension VariantPropertyTypeValue on VariantPropertyType {
   String toValue() {
     switch (this) {
       case VariantPropertyType.desiredInstanceCount:
@@ -46573,7 +46585,7 @@ extension on VariantPropertyType {
   }
 }
 
-extension on String {
+extension VariantPropertyTypeFromString on String {
   VariantPropertyType toVariantPropertyType() {
     switch (this) {
       case 'DesiredInstanceCount':

--- a/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
+++ b/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
@@ -15739,7 +15739,7 @@ enum ActionStatus {
   stopped,
 }
 
-extension ActionStatusValue on ActionStatus {
+extension ActionStatusValueExtension on ActionStatus {
   String toValue() {
     switch (this) {
       case ActionStatus.unknown:
@@ -15911,7 +15911,7 @@ enum AlgorithmSortBy {
   creationTime,
 }
 
-extension AlgorithmSortByValue on AlgorithmSortBy {
+extension AlgorithmSortByValueExtension on AlgorithmSortBy {
   String toValue() {
     switch (this) {
       case AlgorithmSortBy.name:
@@ -16067,7 +16067,7 @@ enum AlgorithmStatus {
   deleting,
 }
 
-extension AlgorithmStatusValue on AlgorithmStatus {
+extension AlgorithmStatusValueExtension on AlgorithmStatus {
   String toValue() {
     switch (this) {
       case AlgorithmStatus.pending:
@@ -17118,7 +17118,7 @@ enum AppImageConfigSortKey {
   name,
 }
 
-extension AppImageConfigSortKeyValue on AppImageConfigSortKey {
+extension AppImageConfigSortKeyValueExtension on AppImageConfigSortKey {
   String toValue() {
     switch (this) {
       case AppImageConfigSortKey.creationTime:
@@ -17180,7 +17180,7 @@ enum AppInstanceType {
   mlG4dn_16xlarge,
 }
 
-extension AppInstanceTypeValue on AppInstanceType {
+extension AppInstanceTypeValueExtension on AppInstanceType {
   String toValue() {
     switch (this) {
       case AppInstanceType.system:
@@ -17328,7 +17328,7 @@ enum AppNetworkAccessType {
   vpcOnly,
 }
 
-extension AppNetworkAccessTypeValue on AppNetworkAccessType {
+extension AppNetworkAccessTypeValueExtension on AppNetworkAccessType {
   String toValue() {
     switch (this) {
       case AppNetworkAccessType.publicInternetOnly:
@@ -17355,7 +17355,7 @@ enum AppSortKey {
   creationTime,
 }
 
-extension AppSortKeyValue on AppSortKey {
+extension AppSortKeyValueExtension on AppSortKey {
   String toValue() {
     switch (this) {
       case AppSortKey.creationTime:
@@ -17425,7 +17425,7 @@ enum AppStatus {
   pending,
 }
 
-extension AppStatusValue on AppStatus {
+extension AppStatusValueExtension on AppStatus {
   String toValue() {
     switch (this) {
       case AppStatus.deleted:
@@ -17466,7 +17466,7 @@ enum AppType {
   tensorBoard,
 }
 
-extension AppTypeValue on AppType {
+extension AppTypeValueExtension on AppType {
   String toValue() {
     switch (this) {
       case AppType.jupyterServer:
@@ -17532,7 +17532,7 @@ enum ArtifactSourceIdType {
   custom,
 }
 
-extension ArtifactSourceIdTypeValue on ArtifactSourceIdType {
+extension ArtifactSourceIdTypeValueExtension on ArtifactSourceIdType {
   String toValue() {
     switch (this) {
       case ArtifactSourceIdType.mD5Hash:
@@ -17640,7 +17640,7 @@ enum AssemblyType {
   line,
 }
 
-extension AssemblyTypeValue on AssemblyType {
+extension AssemblyTypeValueExtension on AssemblyType {
   String toValue() {
     switch (this) {
       case AssemblyType.none:
@@ -17689,7 +17689,7 @@ enum AssociationEdgeType {
   produced,
 }
 
-extension AssociationEdgeTypeValue on AssociationEdgeType {
+extension AssociationEdgeTypeValueExtension on AssociationEdgeType {
   String toValue() {
     switch (this) {
       case AssociationEdgeType.contributedTo:
@@ -17848,7 +17848,8 @@ enum AthenaResultCompressionType {
   zlib,
 }
 
-extension AthenaResultCompressionTypeValue on AthenaResultCompressionType {
+extension AthenaResultCompressionTypeValueExtension
+    on AthenaResultCompressionType {
   String toValue() {
     switch (this) {
       case AthenaResultCompressionType.gzip:
@@ -17884,7 +17885,7 @@ enum AthenaResultFormat {
   textfile,
 }
 
-extension AthenaResultFormatValue on AthenaResultFormat {
+extension AthenaResultFormatValueExtension on AthenaResultFormat {
   String toValue() {
     switch (this) {
       case AthenaResultFormat.parquet:
@@ -17924,7 +17925,7 @@ enum AuthMode {
   iam,
 }
 
-extension AuthModeValue on AuthMode {
+extension AuthModeValueExtension on AuthMode {
   String toValue() {
     switch (this) {
       case AuthMode.sso:
@@ -18348,7 +18349,7 @@ enum AutoMLJobObjectiveType {
   minimize,
 }
 
-extension AutoMLJobObjectiveTypeValue on AutoMLJobObjectiveType {
+extension AutoMLJobObjectiveTypeValueExtension on AutoMLJobObjectiveType {
   String toValue() {
     switch (this) {
       case AutoMLJobObjectiveType.maximize:
@@ -18384,7 +18385,7 @@ enum AutoMLJobSecondaryStatus {
   candidateDefinitionsGenerated,
 }
 
-extension AutoMLJobSecondaryStatusValue on AutoMLJobSecondaryStatus {
+extension AutoMLJobSecondaryStatusValueExtension on AutoMLJobSecondaryStatus {
   String toValue() {
     switch (this) {
       case AutoMLJobSecondaryStatus.starting:
@@ -18447,7 +18448,7 @@ enum AutoMLJobStatus {
   stopping,
 }
 
-extension AutoMLJobStatusValue on AutoMLJobStatus {
+extension AutoMLJobStatusValueExtension on AutoMLJobStatus {
   String toValue() {
     switch (this) {
       case AutoMLJobStatus.completed:
@@ -18543,7 +18544,7 @@ enum AutoMLMetricEnum {
   auc,
 }
 
-extension AutoMLMetricEnumValue on AutoMLMetricEnum {
+extension AutoMLMetricEnumValueExtension on AutoMLMetricEnum {
   String toValue() {
     switch (this) {
       case AutoMLMetricEnum.accuracy:
@@ -18641,7 +18642,7 @@ enum AutoMLS3DataType {
   s3Prefix,
 }
 
-extension AutoMLS3DataTypeValue on AutoMLS3DataType {
+extension AutoMLS3DataTypeValueExtension on AutoMLS3DataType {
   String toValue() {
     switch (this) {
       case AutoMLS3DataType.manifestFile:
@@ -18712,7 +18713,7 @@ enum AutoMLSortBy {
   status,
 }
 
-extension AutoMLSortByValue on AutoMLSortBy {
+extension AutoMLSortByValueExtension on AutoMLSortBy {
   String toValue() {
     switch (this) {
       case AutoMLSortBy.name:
@@ -18744,7 +18745,7 @@ enum AutoMLSortOrder {
   descending,
 }
 
-extension AutoMLSortOrderValue on AutoMLSortOrder {
+extension AutoMLSortOrderValueExtension on AutoMLSortOrder {
   String toValue() {
     switch (this) {
       case AutoMLSortOrder.ascending:
@@ -18797,7 +18798,7 @@ enum AwsManagedHumanLoopRequestSource {
   awsTextractAnalyzeDocumentFormsV1,
 }
 
-extension AwsManagedHumanLoopRequestSourceValue
+extension AwsManagedHumanLoopRequestSourceValueExtension
     on AwsManagedHumanLoopRequestSource {
   String toValue() {
     switch (this) {
@@ -18830,7 +18831,7 @@ enum BatchStrategy {
   singleRecord,
 }
 
-extension BatchStrategyValue on BatchStrategy {
+extension BatchStrategyValueExtension on BatchStrategy {
   String toValue() {
     switch (this) {
       case BatchStrategy.multiRecord:
@@ -18923,7 +18924,7 @@ enum BooleanOperator {
   or,
 }
 
-extension BooleanOperatorValue on BooleanOperator {
+extension BooleanOperatorValueExtension on BooleanOperator {
   String toValue() {
     switch (this) {
       case BooleanOperator.and:
@@ -18967,7 +18968,7 @@ enum CandidateSortBy {
   finalObjectiveMetricValue,
 }
 
-extension CandidateSortByValue on CandidateSortBy {
+extension CandidateSortByValueExtension on CandidateSortBy {
   String toValue() {
     switch (this) {
       case CandidateSortBy.creationTime:
@@ -19002,7 +19003,7 @@ enum CandidateStatus {
   stopping,
 }
 
-extension CandidateStatusValue on CandidateStatus {
+extension CandidateStatusValueExtension on CandidateStatus {
   String toValue() {
     switch (this) {
       case CandidateStatus.completed:
@@ -19043,7 +19044,7 @@ enum CandidateStepType {
   awsSageMakerProcessingJob,
 }
 
-extension CandidateStepTypeValue on CandidateStepType {
+extension CandidateStepTypeValueExtension on CandidateStepType {
   String toValue() {
     switch (this) {
       case CandidateStepType.awsSageMakerTrainingJob:
@@ -19104,7 +19105,7 @@ enum CapacitySizeType {
   capacityPercent,
 }
 
-extension CapacitySizeTypeValue on CapacitySizeType {
+extension CapacitySizeTypeValueExtension on CapacitySizeType {
   String toValue() {
     switch (this) {
       case CapacitySizeType.instanceCount:
@@ -19167,7 +19168,7 @@ enum CaptureMode {
   output,
 }
 
-extension CaptureModeValue on CaptureMode {
+extension CaptureModeValueExtension on CaptureMode {
   String toValue() {
     switch (this) {
       case CaptureMode.input:
@@ -19217,7 +19218,7 @@ enum CaptureStatus {
   stopped,
 }
 
-extension CaptureStatusValue on CaptureStatus {
+extension CaptureStatusValueExtension on CaptureStatus {
   String toValue() {
     switch (this) {
       case CaptureStatus.started:
@@ -19520,7 +19521,7 @@ enum CodeRepositorySortBy {
   lastModifiedTime,
 }
 
-extension CodeRepositorySortByValue on CodeRepositorySortBy {
+extension CodeRepositorySortByValueExtension on CodeRepositorySortBy {
   String toValue() {
     switch (this) {
       case CodeRepositorySortBy.name:
@@ -19552,7 +19553,7 @@ enum CodeRepositorySortOrder {
   descending,
 }
 
-extension CodeRepositorySortOrderValue on CodeRepositorySortOrder {
+extension CodeRepositorySortOrderValueExtension on CodeRepositorySortOrder {
   String toValue() {
     switch (this) {
       case CodeRepositorySortOrder.ascending:
@@ -19737,7 +19738,7 @@ enum CompilationJobStatus {
   stopped,
 }
 
-extension CompilationJobStatusValue on CompilationJobStatus {
+extension CompilationJobStatusValueExtension on CompilationJobStatus {
   String toValue() {
     switch (this) {
       case CompilationJobStatus.inprogress:
@@ -19859,7 +19860,7 @@ enum CompressionType {
   gzip,
 }
 
-extension CompressionTypeValue on CompressionType {
+extension CompressionTypeValueExtension on CompressionType {
   String toValue() {
     switch (this) {
       case CompressionType.none:
@@ -19887,7 +19888,7 @@ enum ConditionOutcome {
   $false,
 }
 
-extension ConditionOutcomeValue on ConditionOutcome {
+extension ConditionOutcomeValueExtension on ConditionOutcome {
   String toValue() {
     switch (this) {
       case ConditionOutcome.$true:
@@ -20050,7 +20051,7 @@ enum ContainerMode {
   multiModel,
 }
 
-extension ContainerModeValue on ContainerMode {
+extension ContainerModeValueExtension on ContainerMode {
   String toValue() {
     switch (this) {
       case ContainerMode.singleModel:
@@ -20078,7 +20079,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension ContentClassifierValue on ContentClassifier {
+extension ContentClassifierValueExtension on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -21076,7 +21077,7 @@ enum DataDistributionType {
   shardedByS3Key,
 }
 
-extension DataDistributionTypeValue on DataDistributionType {
+extension DataDistributionTypeValueExtension on DataDistributionType {
   String toValue() {
     switch (this) {
       case DataDistributionType.fullyReplicated:
@@ -25746,7 +25747,7 @@ enum DetailedAlgorithmStatus {
   failed,
 }
 
-extension DetailedAlgorithmStatusValue on DetailedAlgorithmStatus {
+extension DetailedAlgorithmStatusValueExtension on DetailedAlgorithmStatus {
   String toValue() {
     switch (this) {
       case DetailedAlgorithmStatus.notStarted:
@@ -25784,7 +25785,8 @@ enum DetailedModelPackageStatus {
   failed,
 }
 
-extension DetailedModelPackageStatusValue on DetailedModelPackageStatus {
+extension DetailedModelPackageStatusValueExtension
+    on DetailedModelPackageStatus {
   String toValue() {
     switch (this) {
       case DetailedModelPackageStatus.notStarted:
@@ -25952,7 +25954,7 @@ enum DirectInternetAccess {
   disabled,
 }
 
-extension DirectInternetAccessValue on DirectInternetAccess {
+extension DirectInternetAccessValueExtension on DirectInternetAccess {
   String toValue() {
     switch (this) {
       case DirectInternetAccess.enabled:
@@ -26058,7 +26060,7 @@ enum DomainStatus {
   deleteFailed,
 }
 
-extension DomainStatusValue on DomainStatus {
+extension DomainStatusValueExtension on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.deleting:
@@ -26234,7 +26236,7 @@ enum EdgePackagingJobStatus {
   stopped,
 }
 
-extension EdgePackagingJobStatusValue on EdgePackagingJobStatus {
+extension EdgePackagingJobStatusValueExtension on EdgePackagingJobStatus {
   String toValue() {
     switch (this) {
       case EdgePackagingJobStatus.starting:
@@ -26422,7 +26424,7 @@ enum EndpointConfigSortKey {
   creationTime,
 }
 
-extension EndpointConfigSortKeyValue on EndpointConfigSortKey {
+extension EndpointConfigSortKeyValueExtension on EndpointConfigSortKey {
   String toValue() {
     switch (this) {
       case EndpointConfigSortKey.name:
@@ -26581,7 +26583,7 @@ enum EndpointSortKey {
   status,
 }
 
-extension EndpointSortKeyValue on EndpointSortKey {
+extension EndpointSortKeyValueExtension on EndpointSortKey {
   String toValue() {
     switch (this) {
       case EndpointSortKey.name:
@@ -26619,7 +26621,7 @@ enum EndpointStatus {
   failed,
 }
 
-extension EndpointStatusValue on EndpointStatus {
+extension EndpointStatusValueExtension on EndpointStatus {
   String toValue() {
     switch (this) {
       case EndpointStatus.outOfService:
@@ -26757,7 +26759,7 @@ enum ExecutionStatus {
   stopped,
 }
 
-extension ExecutionStatusValue on ExecutionStatus {
+extension ExecutionStatusValueExtension on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.pending:
@@ -27165,7 +27167,7 @@ enum FeatureGroupSortBy {
   creationTime,
 }
 
-extension FeatureGroupSortByValue on FeatureGroupSortBy {
+extension FeatureGroupSortByValueExtension on FeatureGroupSortBy {
   String toValue() {
     switch (this) {
       case FeatureGroupSortBy.name:
@@ -27201,7 +27203,7 @@ enum FeatureGroupSortOrder {
   descending,
 }
 
-extension FeatureGroupSortOrderValue on FeatureGroupSortOrder {
+extension FeatureGroupSortOrderValueExtension on FeatureGroupSortOrder {
   String toValue() {
     switch (this) {
       case FeatureGroupSortOrder.ascending:
@@ -27232,7 +27234,7 @@ enum FeatureGroupStatus {
   deleteFailed,
 }
 
-extension FeatureGroupStatusValue on FeatureGroupStatus {
+extension FeatureGroupStatusValueExtension on FeatureGroupStatus {
   String toValue() {
     switch (this) {
       case FeatureGroupStatus.creating:
@@ -27319,7 +27321,7 @@ enum FeatureType {
   string,
 }
 
-extension FeatureTypeValue on FeatureType {
+extension FeatureTypeValueExtension on FeatureType {
   String toValue() {
     switch (this) {
       case FeatureType.integral:
@@ -27351,7 +27353,7 @@ enum FileSystemAccessMode {
   ro,
 }
 
-extension FileSystemAccessModeValue on FileSystemAccessMode {
+extension FileSystemAccessModeValueExtension on FileSystemAccessMode {
   String toValue() {
     switch (this) {
       case FileSystemAccessMode.rw:
@@ -27466,7 +27468,7 @@ enum FileSystemType {
   fSxLustre,
 }
 
-extension FileSystemTypeValue on FileSystemType {
+extension FileSystemTypeValueExtension on FileSystemType {
   String toValue() {
     switch (this) {
       case FileSystemType.efs:
@@ -27734,7 +27736,7 @@ enum FlowDefinitionStatus {
   deleting,
 }
 
-extension FlowDefinitionStatusValue on FlowDefinitionStatus {
+extension FlowDefinitionStatusValueExtension on FlowDefinitionStatus {
   String toValue() {
     switch (this) {
       case FlowDefinitionStatus.initializing:
@@ -27815,7 +27817,7 @@ enum Framework {
   sklearn,
 }
 
-extension FrameworkValue on Framework {
+extension FrameworkValueExtension on Framework {
   String toValue() {
     switch (this) {
       case Framework.tensorflow:
@@ -29298,7 +29300,7 @@ enum HumanTaskUiStatus {
   deleting,
 }
 
-extension HumanTaskUiStatusValue on HumanTaskUiStatus {
+extension HumanTaskUiStatusValueExtension on HumanTaskUiStatus {
   String toValue() {
     switch (this) {
       case HumanTaskUiStatus.active:
@@ -29427,7 +29429,7 @@ enum HyperParameterScalingType {
   reverseLogarithmic,
 }
 
-extension HyperParameterScalingTypeValue on HyperParameterScalingType {
+extension HyperParameterScalingTypeValueExtension on HyperParameterScalingType {
   String toValue() {
     switch (this) {
       case HyperParameterScalingType.auto:
@@ -29945,7 +29947,7 @@ enum HyperParameterTuningJobObjectiveType {
   minimize,
 }
 
-extension HyperParameterTuningJobObjectiveTypeValue
+extension HyperParameterTuningJobObjectiveTypeValueExtension
     on HyperParameterTuningJobObjectiveType {
   String toValue() {
     switch (this) {
@@ -29977,7 +29979,7 @@ enum HyperParameterTuningJobSortByOptions {
   creationTime,
 }
 
-extension HyperParameterTuningJobSortByOptionsValue
+extension HyperParameterTuningJobSortByOptionsValueExtension
     on HyperParameterTuningJobSortByOptions {
   String toValue() {
     switch (this) {
@@ -30015,7 +30017,8 @@ enum HyperParameterTuningJobStatus {
   stopping,
 }
 
-extension HyperParameterTuningJobStatusValue on HyperParameterTuningJobStatus {
+extension HyperParameterTuningJobStatusValueExtension
+    on HyperParameterTuningJobStatus {
   String toValue() {
     switch (this) {
       case HyperParameterTuningJobStatus.completed:
@@ -30058,7 +30061,7 @@ enum HyperParameterTuningJobStrategyType {
   random,
 }
 
-extension HyperParameterTuningJobStrategyTypeValue
+extension HyperParameterTuningJobStrategyTypeValueExtension
     on HyperParameterTuningJobStrategyType {
   String toValue() {
     switch (this) {
@@ -30245,7 +30248,7 @@ enum HyperParameterTuningJobWarmStartType {
   transferLearning,
 }
 
-extension HyperParameterTuningJobWarmStartTypeValue
+extension HyperParameterTuningJobWarmStartTypeValueExtension
     on HyperParameterTuningJobWarmStartType {
   String toValue() {
     switch (this) {
@@ -30366,7 +30369,7 @@ enum ImageSortBy {
   imageName,
 }
 
-extension ImageSortByValue on ImageSortBy {
+extension ImageSortByValueExtension on ImageSortBy {
   String toValue() {
     switch (this) {
       case ImageSortBy.creationTime:
@@ -30398,7 +30401,7 @@ enum ImageSortOrder {
   descending,
 }
 
-extension ImageSortOrderValue on ImageSortOrder {
+extension ImageSortOrderValueExtension on ImageSortOrder {
   String toValue() {
     switch (this) {
       case ImageSortOrder.ascending:
@@ -30431,7 +30434,7 @@ enum ImageStatus {
   deleteFailed,
 }
 
-extension ImageStatusValue on ImageStatus {
+extension ImageStatusValueExtension on ImageStatus {
   String toValue() {
     switch (this) {
       case ImageStatus.creating:
@@ -30529,7 +30532,7 @@ enum ImageVersionSortBy {
   version,
 }
 
-extension ImageVersionSortByValue on ImageVersionSortBy {
+extension ImageVersionSortByValueExtension on ImageVersionSortBy {
   String toValue() {
     switch (this) {
       case ImageVersionSortBy.creationTime:
@@ -30561,7 +30564,7 @@ enum ImageVersionSortOrder {
   descending,
 }
 
-extension ImageVersionSortOrderValue on ImageVersionSortOrder {
+extension ImageVersionSortOrderValueExtension on ImageVersionSortOrder {
   String toValue() {
     switch (this) {
       case ImageVersionSortOrder.ascending:
@@ -30592,7 +30595,7 @@ enum ImageVersionStatus {
   deleteFailed,
 }
 
-extension ImageVersionStatusValue on ImageVersionStatus {
+extension ImageVersionStatusValueExtension on ImageVersionStatus {
   String toValue() {
     switch (this) {
       case ImageVersionStatus.creating:
@@ -30998,7 +31001,7 @@ enum InputMode {
   file,
 }
 
-extension InputModeValue on InputMode {
+extension InputModeValueExtension on InputMode {
   String toValue() {
     switch (this) {
       case InputMode.pipe:
@@ -31062,7 +31065,7 @@ enum InstanceType {
   mlP3_16xlarge,
 }
 
-extension InstanceTypeValue on InstanceType {
+extension InstanceTypeValueExtension on InstanceType {
   String toValue() {
     switch (this) {
       case InstanceType.mlT2Medium:
@@ -31325,7 +31328,7 @@ enum JoinSource {
   none,
 }
 
-extension JoinSourceValue on JoinSource {
+extension JoinSourceValueExtension on JoinSource {
   String toValue() {
     switch (this) {
       case JoinSource.input:
@@ -31951,7 +31954,7 @@ enum LabelingJobStatus {
   stopped,
 }
 
-extension LabelingJobStatusValue on LabelingJobStatus {
+extension LabelingJobStatusValueExtension on LabelingJobStatus {
   String toValue() {
     switch (this) {
       case LabelingJobStatus.initializing:
@@ -32375,7 +32378,7 @@ enum ListCompilationJobsSortBy {
   status,
 }
 
-extension ListCompilationJobsSortByValue on ListCompilationJobsSortBy {
+extension ListCompilationJobsSortByValueExtension on ListCompilationJobsSortBy {
   String toValue() {
     switch (this) {
       case ListCompilationJobsSortBy.name:
@@ -32480,7 +32483,7 @@ enum ListDeviceFleetsSortBy {
   lastModifiedTime,
 }
 
-extension ListDeviceFleetsSortByValue on ListDeviceFleetsSortBy {
+extension ListDeviceFleetsSortByValueExtension on ListDeviceFleetsSortBy {
   String toValue() {
     switch (this) {
       case ListDeviceFleetsSortBy.name:
@@ -32584,7 +32587,8 @@ enum ListEdgePackagingJobsSortBy {
   status,
 }
 
-extension ListEdgePackagingJobsSortByValue on ListEdgePackagingJobsSortBy {
+extension ListEdgePackagingJobsSortByValueExtension
+    on ListEdgePackagingJobsSortBy {
   String toValue() {
     switch (this) {
       case ListEdgePackagingJobsSortBy.name:
@@ -32857,7 +32861,7 @@ enum ListLabelingJobsForWorkteamSortByOptions {
   creationTime,
 }
 
-extension ListLabelingJobsForWorkteamSortByOptionsValue
+extension ListLabelingJobsForWorkteamSortByOptionsValueExtension
     on ListLabelingJobsForWorkteamSortByOptions {
   String toValue() {
     switch (this) {
@@ -33531,7 +33535,8 @@ enum ListWorkforcesSortByOptions {
   createDate,
 }
 
-extension ListWorkforcesSortByOptionsValue on ListWorkforcesSortByOptions {
+extension ListWorkforcesSortByOptionsValueExtension
+    on ListWorkforcesSortByOptions {
   String toValue() {
     switch (this) {
       case ListWorkforcesSortByOptions.name:
@@ -33582,7 +33587,8 @@ enum ListWorkteamsSortByOptions {
   createDate,
 }
 
-extension ListWorkteamsSortByOptionsValue on ListWorkteamsSortByOptions {
+extension ListWorkteamsSortByOptionsValueExtension
+    on ListWorkteamsSortByOptions {
   String toValue() {
     switch (this) {
       case ListWorkteamsSortByOptions.name:
@@ -33794,7 +33800,7 @@ enum ModelApprovalStatus {
   pendingManualApproval,
 }
 
-extension ModelApprovalStatusValue on ModelApprovalStatus {
+extension ModelApprovalStatusValueExtension on ModelApprovalStatus {
   String toValue() {
     switch (this) {
       case ModelApprovalStatus.approved:
@@ -34482,7 +34488,7 @@ enum ModelPackageGroupSortBy {
   creationTime,
 }
 
-extension ModelPackageGroupSortByValue on ModelPackageGroupSortBy {
+extension ModelPackageGroupSortByValueExtension on ModelPackageGroupSortBy {
   String toValue() {
     switch (this) {
       case ModelPackageGroupSortBy.name:
@@ -34514,7 +34520,7 @@ enum ModelPackageGroupStatus {
   deleteFailed,
 }
 
-extension ModelPackageGroupStatusValue on ModelPackageGroupStatus {
+extension ModelPackageGroupStatusValueExtension on ModelPackageGroupStatus {
   String toValue() {
     switch (this) {
       case ModelPackageGroupStatus.pending:
@@ -34596,7 +34602,7 @@ enum ModelPackageSortBy {
   creationTime,
 }
 
-extension ModelPackageSortByValue on ModelPackageSortBy {
+extension ModelPackageSortByValueExtension on ModelPackageSortBy {
   String toValue() {
     switch (this) {
       case ModelPackageSortBy.name:
@@ -34627,7 +34633,7 @@ enum ModelPackageStatus {
   deleting,
 }
 
-extension ModelPackageStatusValue on ModelPackageStatus {
+extension ModelPackageStatusValueExtension on ModelPackageStatus {
   String toValue() {
     switch (this) {
       case ModelPackageStatus.pending:
@@ -34789,7 +34795,7 @@ enum ModelPackageType {
   both,
 }
 
-extension ModelPackageTypeValue on ModelPackageType {
+extension ModelPackageTypeValueExtension on ModelPackageType {
   String toValue() {
     switch (this) {
       case ModelPackageType.versioned:
@@ -35073,7 +35079,7 @@ enum ModelSortKey {
   creationTime,
 }
 
-extension ModelSortKeyValue on ModelSortKey {
+extension ModelSortKeyValueExtension on ModelSortKey {
   String toValue() {
     switch (this) {
       case ModelSortKey.name:
@@ -35326,7 +35332,8 @@ enum MonitoringExecutionSortKey {
   status,
 }
 
-extension MonitoringExecutionSortKeyValue on MonitoringExecutionSortKey {
+extension MonitoringExecutionSortKeyValueExtension
+    on MonitoringExecutionSortKey {
   String toValue() {
     switch (this) {
       case MonitoringExecutionSortKey.creationTime:
@@ -35568,7 +35575,7 @@ enum MonitoringJobDefinitionSortKey {
   creationTime,
 }
 
-extension MonitoringJobDefinitionSortKeyValue
+extension MonitoringJobDefinitionSortKeyValueExtension
     on MonitoringJobDefinitionSortKey {
   String toValue() {
     switch (this) {
@@ -35734,7 +35741,7 @@ enum MonitoringProblemType {
   regression,
 }
 
-extension MonitoringProblemTypeValue on MonitoringProblemType {
+extension MonitoringProblemTypeValueExtension on MonitoringProblemType {
   String toValue() {
     switch (this) {
       case MonitoringProblemType.binaryClassification:
@@ -35978,7 +35985,7 @@ enum MonitoringScheduleSortKey {
   status,
 }
 
-extension MonitoringScheduleSortKeyValue on MonitoringScheduleSortKey {
+extension MonitoringScheduleSortKeyValueExtension on MonitoringScheduleSortKey {
   String toValue() {
     switch (this) {
       case MonitoringScheduleSortKey.name:
@@ -36111,7 +36118,7 @@ enum MonitoringType {
   modelExplainability,
 }
 
-extension MonitoringTypeValue on MonitoringType {
+extension MonitoringTypeValueExtension on MonitoringType {
   String toValue() {
     switch (this) {
       case MonitoringType.dataQuality:
@@ -36243,7 +36250,7 @@ enum NotebookInstanceAcceleratorType {
   mlEia2Xlarge,
 }
 
-extension NotebookInstanceAcceleratorTypeValue
+extension NotebookInstanceAcceleratorTypeValueExtension
     on NotebookInstanceAcceleratorType {
   String toValue() {
     switch (this) {
@@ -36290,7 +36297,7 @@ enum NotebookInstanceLifecycleConfigSortKey {
   lastModifiedTime,
 }
 
-extension NotebookInstanceLifecycleConfigSortKeyValue
+extension NotebookInstanceLifecycleConfigSortKeyValueExtension
     on NotebookInstanceLifecycleConfigSortKey {
   String toValue() {
     switch (this) {
@@ -36325,7 +36332,7 @@ enum NotebookInstanceLifecycleConfigSortOrder {
   descending,
 }
 
-extension NotebookInstanceLifecycleConfigSortOrderValue
+extension NotebookInstanceLifecycleConfigSortOrderValueExtension
     on NotebookInstanceLifecycleConfigSortOrder {
   String toValue() {
     switch (this) {
@@ -36430,7 +36437,7 @@ enum NotebookInstanceSortKey {
   status,
 }
 
-extension NotebookInstanceSortKeyValue on NotebookInstanceSortKey {
+extension NotebookInstanceSortKeyValueExtension on NotebookInstanceSortKey {
   String toValue() {
     switch (this) {
       case NotebookInstanceSortKey.name:
@@ -36462,7 +36469,7 @@ enum NotebookInstanceSortOrder {
   descending,
 }
 
-extension NotebookInstanceSortOrderValue on NotebookInstanceSortOrder {
+extension NotebookInstanceSortOrderValueExtension on NotebookInstanceSortOrder {
   String toValue() {
     switch (this) {
       case NotebookInstanceSortOrder.ascending:
@@ -36495,7 +36502,7 @@ enum NotebookInstanceStatus {
   updating,
 }
 
-extension NotebookInstanceStatusValue on NotebookInstanceStatus {
+extension NotebookInstanceStatusValueExtension on NotebookInstanceStatus {
   String toValue() {
     switch (this) {
       case NotebookInstanceStatus.pending:
@@ -36630,7 +36637,7 @@ enum NotebookOutputOption {
   disabled,
 }
 
-extension NotebookOutputOptionValue on NotebookOutputOption {
+extension NotebookOutputOptionValueExtension on NotebookOutputOption {
   String toValue() {
     switch (this) {
       case NotebookOutputOption.allowed:
@@ -36683,7 +36690,7 @@ enum ObjectiveStatus {
   failed,
 }
 
-extension ObjectiveStatusValue on ObjectiveStatus {
+extension ObjectiveStatusValueExtension on ObjectiveStatus {
   String toValue() {
     switch (this) {
       case ObjectiveStatus.succeeded:
@@ -36819,7 +36826,7 @@ enum OfflineStoreStatusValue {
   disabled,
 }
 
-extension OfflineStoreStatusValueValue on OfflineStoreStatusValue {
+extension OfflineStoreStatusValueValueExtension on OfflineStoreStatusValue {
   String toValue() {
     switch (this) {
       case OfflineStoreStatusValue.active:
@@ -37112,7 +37119,7 @@ enum Operator {
   $in,
 }
 
-extension OperatorValue on Operator {
+extension OperatorValueExtension on Operator {
   String toValue() {
     switch (this) {
       case Operator.equals:
@@ -37172,7 +37179,7 @@ enum OrderKey {
   descending,
 }
 
-extension OrderKeyValue on OrderKey {
+extension OrderKeyValueExtension on OrderKey {
   String toValue() {
     switch (this) {
       case OrderKey.ascending:
@@ -37662,7 +37669,7 @@ enum ParameterType {
   freeText,
 }
 
-extension ParameterTypeValue on ParameterType {
+extension ParameterTypeValueExtension on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.integer:
@@ -37890,7 +37897,7 @@ enum PipelineExecutionStatus {
   succeeded,
 }
 
-extension PipelineExecutionStatusValue on PipelineExecutionStatus {
+extension PipelineExecutionStatusValueExtension on PipelineExecutionStatus {
   String toValue() {
     switch (this) {
       case PipelineExecutionStatus.executing:
@@ -38079,7 +38086,7 @@ enum PipelineStatus {
   active,
 }
 
-extension PipelineStatusValue on PipelineStatus {
+extension PipelineStatusValueExtension on PipelineStatus {
   String toValue() {
     switch (this) {
       case PipelineStatus.active:
@@ -38154,7 +38161,7 @@ enum ProblemType {
   regression,
 }
 
-extension ProblemTypeValue on ProblemType {
+extension ProblemTypeValueExtension on ProblemType {
   String toValue() {
     switch (this) {
       case ProblemType.binaryClassification:
@@ -38344,7 +38351,7 @@ enum ProcessingInstanceType {
   mlR5_24xlarge,
 }
 
-extension ProcessingInstanceTypeValue on ProcessingInstanceType {
+extension ProcessingInstanceTypeValueExtension on ProcessingInstanceType {
   String toValue() {
     switch (this) {
       case ProcessingInstanceType.mlT3Medium:
@@ -38664,7 +38671,7 @@ enum ProcessingJobStatus {
   stopped,
 }
 
-extension ProcessingJobStatusValue on ProcessingJobStatus {
+extension ProcessingJobStatusValueExtension on ProcessingJobStatus {
   String toValue() {
     switch (this) {
       case ProcessingJobStatus.inProgress:
@@ -38889,7 +38896,8 @@ enum ProcessingS3CompressionType {
   gzip,
 }
 
-extension ProcessingS3CompressionTypeValue on ProcessingS3CompressionType {
+extension ProcessingS3CompressionTypeValueExtension
+    on ProcessingS3CompressionType {
   String toValue() {
     switch (this) {
       case ProcessingS3CompressionType.none:
@@ -38917,7 +38925,7 @@ enum ProcessingS3DataDistributionType {
   shardedByS3Key,
 }
 
-extension ProcessingS3DataDistributionTypeValue
+extension ProcessingS3DataDistributionTypeValueExtension
     on ProcessingS3DataDistributionType {
   String toValue() {
     switch (this) {
@@ -38947,7 +38955,7 @@ enum ProcessingS3DataType {
   s3Prefix,
 }
 
-extension ProcessingS3DataTypeValue on ProcessingS3DataType {
+extension ProcessingS3DataTypeValueExtension on ProcessingS3DataType {
   String toValue() {
     switch (this) {
       case ProcessingS3DataType.manifestFile:
@@ -39054,7 +39062,7 @@ enum ProcessingS3InputMode {
   file,
 }
 
-extension ProcessingS3InputModeValue on ProcessingS3InputMode {
+extension ProcessingS3InputModeValueExtension on ProcessingS3InputMode {
   String toValue() {
     switch (this) {
       case ProcessingS3InputMode.pipe:
@@ -39122,7 +39130,7 @@ enum ProcessingS3UploadMode {
   endOfJob,
 }
 
-extension ProcessingS3UploadModeValue on ProcessingS3UploadMode {
+extension ProcessingS3UploadModeValueExtension on ProcessingS3UploadMode {
   String toValue() {
     switch (this) {
       case ProcessingS3UploadMode.continuous:
@@ -39247,7 +39255,7 @@ enum ProductionVariantAcceleratorType {
   mlEia2Xlarge,
 }
 
-extension ProductionVariantAcceleratorTypeValue
+extension ProductionVariantAcceleratorTypeValueExtension
     on ProductionVariantAcceleratorType {
   String toValue() {
     switch (this) {
@@ -39357,7 +39365,8 @@ enum ProductionVariantInstanceType {
   mlInf1_24xlarge,
 }
 
-extension ProductionVariantInstanceTypeValue on ProductionVariantInstanceType {
+extension ProductionVariantInstanceTypeValueExtension
+    on ProductionVariantInstanceType {
   String toValue() {
     switch (this) {
       case ProductionVariantInstanceType.mlT2Medium:
@@ -39900,7 +39909,7 @@ enum ProfilingStatus {
   disabled,
 }
 
-extension ProfilingStatusValue on ProfilingStatus {
+extension ProfilingStatusValueExtension on ProfilingStatus {
   String toValue() {
     switch (this) {
       case ProfilingStatus.enabled:
@@ -39928,7 +39937,7 @@ enum ProjectSortBy {
   creationTime,
 }
 
-extension ProjectSortByValue on ProjectSortBy {
+extension ProjectSortByValueExtension on ProjectSortBy {
   String toValue() {
     switch (this) {
       case ProjectSortBy.name:
@@ -39956,7 +39965,7 @@ enum ProjectSortOrder {
   descending,
 }
 
-extension ProjectSortOrderValue on ProjectSortOrder {
+extension ProjectSortOrderValueExtension on ProjectSortOrder {
   String toValue() {
     switch (this) {
       case ProjectSortOrder.ascending:
@@ -39989,7 +39998,7 @@ enum ProjectStatus {
   deleteCompleted,
 }
 
-extension ProjectStatusValue on ProjectStatus {
+extension ProjectStatusValueExtension on ProjectStatus {
   String toValue() {
     switch (this) {
       case ProjectStatus.pending:
@@ -40492,7 +40501,7 @@ enum RecordWrapper {
   recordIO,
 }
 
-extension RecordWrapperValue on RecordWrapper {
+extension RecordWrapperValueExtension on RecordWrapper {
   String toValue() {
     switch (this) {
       case RecordWrapper.none:
@@ -40595,7 +40604,8 @@ enum RedshiftResultCompressionType {
   snappy,
 }
 
-extension RedshiftResultCompressionTypeValue on RedshiftResultCompressionType {
+extension RedshiftResultCompressionTypeValueExtension
+    on RedshiftResultCompressionType {
   String toValue() {
     switch (this) {
       case RedshiftResultCompressionType.none:
@@ -40636,7 +40646,7 @@ enum RedshiftResultFormat {
   csv,
 }
 
-extension RedshiftResultFormatValue on RedshiftResultFormat {
+extension RedshiftResultFormatValueExtension on RedshiftResultFormat {
   String toValue() {
     switch (this) {
       case RedshiftResultFormat.parquet:
@@ -40743,7 +40753,7 @@ enum RepositoryAccessMode {
   vpc,
 }
 
-extension RepositoryAccessModeValue on RepositoryAccessMode {
+extension RepositoryAccessModeValueExtension on RepositoryAccessMode {
   String toValue() {
     switch (this) {
       case RepositoryAccessMode.platform:
@@ -40974,7 +40984,7 @@ enum ResourceType {
   featureGroup,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.trainingJob:
@@ -41055,7 +41065,7 @@ enum RetentionType {
   delete,
 }
 
-extension RetentionTypeValue on RetentionType {
+extension RetentionTypeValueExtension on RetentionType {
   String toValue() {
     switch (this) {
       case RetentionType.retain:
@@ -41083,7 +41093,7 @@ enum RootAccess {
   disabled,
 }
 
-extension RootAccessValue on RootAccess {
+extension RootAccessValueExtension on RootAccess {
   String toValue() {
     switch (this) {
       case RootAccess.enabled:
@@ -41115,7 +41125,7 @@ enum RuleEvaluationStatus {
   stopped,
 }
 
-extension RuleEvaluationStatusValue on RuleEvaluationStatus {
+extension RuleEvaluationStatusValueExtension on RuleEvaluationStatus {
   String toValue() {
     switch (this) {
       case RuleEvaluationStatus.inProgress:
@@ -41159,7 +41169,7 @@ enum S3DataDistribution {
   shardedByS3Key,
 }
 
-extension S3DataDistributionValue on S3DataDistribution {
+extension S3DataDistributionValueExtension on S3DataDistribution {
   String toValue() {
     switch (this) {
       case S3DataDistribution.fullyReplicated:
@@ -41317,7 +41327,7 @@ enum S3DataType {
   augmentedManifestFile,
 }
 
-extension S3DataTypeValue on S3DataType {
+extension S3DataTypeValueExtension on S3DataType {
   String toValue() {
     switch (this) {
       case S3DataType.manifestFile:
@@ -41393,7 +41403,8 @@ enum SagemakerServicecatalogStatus {
   disabled,
 }
 
-extension SagemakerServicecatalogStatusValue on SagemakerServicecatalogStatus {
+extension SagemakerServicecatalogStatusValueExtension
+    on SagemakerServicecatalogStatus {
   String toValue() {
     switch (this) {
       case SagemakerServicecatalogStatus.enabled:
@@ -41495,7 +41506,7 @@ enum ScheduleStatus {
   stopped,
 }
 
-extension ScheduleStatusValue on ScheduleStatus {
+extension ScheduleStatusValueExtension on ScheduleStatus {
   String toValue() {
     switch (this) {
       case ScheduleStatus.pending:
@@ -41692,7 +41703,7 @@ enum SearchSortOrder {
   descending,
 }
 
-extension SearchSortOrderValue on SearchSortOrder {
+extension SearchSortOrderValueExtension on SearchSortOrder {
   String toValue() {
     switch (this) {
       case SearchSortOrder.ascending:
@@ -41733,7 +41744,7 @@ enum SecondaryStatus {
   updating,
 }
 
-extension SecondaryStatusValue on SecondaryStatus {
+extension SecondaryStatusValueExtension on SecondaryStatus {
   String toValue() {
     switch (this) {
       case SecondaryStatus.starting:
@@ -42151,7 +42162,7 @@ enum SortActionsBy {
   creationTime,
 }
 
-extension SortActionsByValue on SortActionsBy {
+extension SortActionsByValueExtension on SortActionsBy {
   String toValue() {
     switch (this) {
       case SortActionsBy.name:
@@ -42178,7 +42189,7 @@ enum SortArtifactsBy {
   creationTime,
 }
 
-extension SortArtifactsByValue on SortArtifactsBy {
+extension SortArtifactsByValueExtension on SortArtifactsBy {
   String toValue() {
     switch (this) {
       case SortArtifactsBy.creationTime:
@@ -42205,7 +42216,7 @@ enum SortAssociationsBy {
   creationTime,
 }
 
-extension SortAssociationsByValue on SortAssociationsBy {
+extension SortAssociationsByValueExtension on SortAssociationsBy {
   String toValue() {
     switch (this) {
       case SortAssociationsBy.sourceArn:
@@ -42246,7 +42257,7 @@ enum SortBy {
   status,
 }
 
-extension SortByValue on SortBy {
+extension SortByValueExtension on SortBy {
   String toValue() {
     switch (this) {
       case SortBy.name:
@@ -42278,7 +42289,7 @@ enum SortContextsBy {
   creationTime,
 }
 
-extension SortContextsByValue on SortContextsBy {
+extension SortContextsByValueExtension on SortContextsBy {
   String toValue() {
     switch (this) {
       case SortContextsBy.name:
@@ -42306,7 +42317,7 @@ enum SortExperimentsBy {
   creationTime,
 }
 
-extension SortExperimentsByValue on SortExperimentsBy {
+extension SortExperimentsByValueExtension on SortExperimentsBy {
   String toValue() {
     switch (this) {
       case SortExperimentsBy.name:
@@ -42334,7 +42345,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -42362,7 +42373,7 @@ enum SortPipelineExecutionsBy {
   pipelineExecutionArn,
 }
 
-extension SortPipelineExecutionsByValue on SortPipelineExecutionsBy {
+extension SortPipelineExecutionsByValueExtension on SortPipelineExecutionsBy {
   String toValue() {
     switch (this) {
       case SortPipelineExecutionsBy.creationTime:
@@ -42390,7 +42401,7 @@ enum SortPipelinesBy {
   creationTime,
 }
 
-extension SortPipelinesByValue on SortPipelinesBy {
+extension SortPipelinesByValueExtension on SortPipelinesBy {
   String toValue() {
     switch (this) {
       case SortPipelinesBy.name:
@@ -42418,7 +42429,7 @@ enum SortTrialComponentsBy {
   creationTime,
 }
 
-extension SortTrialComponentsByValue on SortTrialComponentsBy {
+extension SortTrialComponentsByValueExtension on SortTrialComponentsBy {
   String toValue() {
     switch (this) {
       case SortTrialComponentsBy.name:
@@ -42446,7 +42457,7 @@ enum SortTrialsBy {
   creationTime,
 }
 
-extension SortTrialsByValue on SortTrialsBy {
+extension SortTrialsByValueExtension on SortTrialsBy {
   String toValue() {
     switch (this) {
       case SortTrialsBy.name:
@@ -42578,7 +42589,7 @@ enum SplitType {
   tFRecord,
 }
 
-extension SplitTypeValue on SplitType {
+extension SplitTypeValueExtension on SplitType {
   String toValue() {
     switch (this) {
       case SplitType.none:
@@ -42632,7 +42643,7 @@ enum StepStatus {
   succeeded,
 }
 
-extension StepStatusValue on StepStatus {
+extension StepStatusValueExtension on StepStatus {
   String toValue() {
     switch (this) {
       case StepStatus.starting:
@@ -42857,7 +42868,7 @@ enum TargetDevice {
   jacintoTda4vm,
 }
 
-extension TargetDeviceValue on TargetDevice {
+extension TargetDeviceValueExtension on TargetDevice {
   String toValue() {
     switch (this) {
       case TargetDevice.lambda:
@@ -43073,7 +43084,7 @@ enum TargetPlatformAccelerator {
   nvidia,
 }
 
-extension TargetPlatformAcceleratorValue on TargetPlatformAccelerator {
+extension TargetPlatformAcceleratorValueExtension on TargetPlatformAccelerator {
   String toValue() {
     switch (this) {
       case TargetPlatformAccelerator.intelGraphics:
@@ -43108,7 +43119,7 @@ enum TargetPlatformArch {
   armEabihf,
 }
 
-extension TargetPlatformArchValue on TargetPlatformArch {
+extension TargetPlatformArchValueExtension on TargetPlatformArch {
   String toValue() {
     switch (this) {
       case TargetPlatformArch.x86_64:
@@ -43148,7 +43159,7 @@ enum TargetPlatformOs {
   linux,
 }
 
-extension TargetPlatformOsValue on TargetPlatformOs {
+extension TargetPlatformOsValueExtension on TargetPlatformOs {
   String toValue() {
     switch (this) {
       case TargetPlatformOs.android:
@@ -43271,7 +43282,7 @@ enum TrafficRoutingConfigType {
   canary,
 }
 
-extension TrafficRoutingConfigTypeValue on TrafficRoutingConfigType {
+extension TrafficRoutingConfigTypeValueExtension on TrafficRoutingConfigType {
   String toValue() {
     switch (this) {
       case TrafficRoutingConfigType.allAtOnce:
@@ -43299,7 +43310,7 @@ enum TrainingInputMode {
   file,
 }
 
-extension TrainingInputModeValue on TrainingInputMode {
+extension TrainingInputModeValueExtension on TrainingInputMode {
   String toValue() {
     switch (this) {
       case TrainingInputMode.pipe:
@@ -43364,7 +43375,7 @@ enum TrainingInstanceType {
   mlC5n_18xlarge,
 }
 
-extension TrainingInstanceTypeValue on TrainingInstanceType {
+extension TrainingInstanceTypeValueExtension on TrainingInstanceType {
   String toValue() {
     switch (this) {
       case TrainingInstanceType.mlM4Xlarge:
@@ -43982,7 +43993,8 @@ enum TrainingJobEarlyStoppingType {
   auto,
 }
 
-extension TrainingJobEarlyStoppingTypeValue on TrainingJobEarlyStoppingType {
+extension TrainingJobEarlyStoppingTypeValueExtension
+    on TrainingJobEarlyStoppingType {
   String toValue() {
     switch (this) {
       case TrainingJobEarlyStoppingType.off:
@@ -44012,7 +44024,7 @@ enum TrainingJobSortByOptions {
   finalObjectiveMetricValue,
 }
 
-extension TrainingJobSortByOptionsValue on TrainingJobSortByOptions {
+extension TrainingJobSortByOptionsValueExtension on TrainingJobSortByOptions {
   String toValue() {
     switch (this) {
       case TrainingJobSortByOptions.name:
@@ -44051,7 +44063,7 @@ enum TrainingJobStatus {
   stopped,
 }
 
-extension TrainingJobStatusValue on TrainingJobStatus {
+extension TrainingJobStatusValueExtension on TrainingJobStatus {
   String toValue() {
     switch (this) {
       case TrainingJobStatus.inProgress:
@@ -44436,7 +44448,7 @@ enum TransformInstanceType {
   mlM5_24xlarge,
 }
 
-extension TransformInstanceTypeValue on TransformInstanceType {
+extension TransformInstanceTypeValueExtension on TransformInstanceType {
   String toValue() {
     switch (this) {
       case TransformInstanceType.mlM4Xlarge:
@@ -44816,7 +44828,7 @@ enum TransformJobStatus {
   stopped,
 }
 
-extension TransformJobStatusValue on TransformJobStatus {
+extension TransformJobStatusValueExtension on TransformJobStatus {
   String toValue() {
     switch (this) {
       case TransformJobStatus.inProgress:
@@ -45510,7 +45522,8 @@ enum TrialComponentPrimaryStatus {
   stopped,
 }
 
-extension TrialComponentPrimaryStatusValue on TrialComponentPrimaryStatus {
+extension TrialComponentPrimaryStatusValueExtension
+    on TrialComponentPrimaryStatus {
   String toValue() {
     switch (this) {
       case TrialComponentPrimaryStatus.inProgress:
@@ -46370,7 +46383,7 @@ enum UserProfileSortKey {
   lastModifiedTime,
 }
 
-extension UserProfileSortKeyValue on UserProfileSortKey {
+extension UserProfileSortKeyValueExtension on UserProfileSortKey {
   String toValue() {
     switch (this) {
       case UserProfileSortKey.creationTime:
@@ -46403,7 +46416,7 @@ enum UserProfileStatus {
   deleteFailed,
 }
 
-extension UserProfileStatusValue on UserProfileStatus {
+extension UserProfileStatusValueExtension on UserProfileStatus {
   String toValue() {
     switch (this) {
       case UserProfileStatus.deleting:
@@ -46572,7 +46585,7 @@ enum VariantPropertyType {
   dataCaptureConfig,
 }
 
-extension VariantPropertyTypeValue on VariantPropertyType {
+extension VariantPropertyTypeValueExtension on VariantPropertyType {
   String toValue() {
     switch (this) {
       case VariantPropertyType.desiredInstanceCount:

--- a/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
+++ b/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
@@ -535,7 +535,7 @@ enum CurrencyCode {
   usd,
 }
 
-extension on CurrencyCode {
+extension CurrencyCodeValue on CurrencyCode {
   String toValue() {
     switch (this) {
       case CurrencyCode.cny:
@@ -546,7 +546,7 @@ extension on CurrencyCode {
   }
 }
 
-extension on String {
+extension CurrencyCodeFromString on String {
   CurrencyCode toCurrencyCode() {
     switch (this) {
       case 'CNY':
@@ -927,7 +927,8 @@ enum SavingsPlanOfferingFilterAttribute {
   instanceFamily,
 }
 
-extension on SavingsPlanOfferingFilterAttribute {
+extension SavingsPlanOfferingFilterAttributeValue
+    on SavingsPlanOfferingFilterAttribute {
   String toValue() {
     switch (this) {
       case SavingsPlanOfferingFilterAttribute.region:
@@ -938,7 +939,7 @@ extension on SavingsPlanOfferingFilterAttribute {
   }
 }
 
-extension on String {
+extension SavingsPlanOfferingFilterAttributeFromString on String {
   SavingsPlanOfferingFilterAttribute toSavingsPlanOfferingFilterAttribute() {
     switch (this) {
       case 'region':
@@ -998,7 +999,8 @@ enum SavingsPlanOfferingPropertyKey {
   instanceFamily,
 }
 
-extension on SavingsPlanOfferingPropertyKey {
+extension SavingsPlanOfferingPropertyKeyValue
+    on SavingsPlanOfferingPropertyKey {
   String toValue() {
     switch (this) {
       case SavingsPlanOfferingPropertyKey.region:
@@ -1009,7 +1011,7 @@ extension on SavingsPlanOfferingPropertyKey {
   }
 }
 
-extension on String {
+extension SavingsPlanOfferingPropertyKeyFromString on String {
   SavingsPlanOfferingPropertyKey toSavingsPlanOfferingPropertyKey() {
     switch (this) {
       case 'region':
@@ -1128,7 +1130,7 @@ enum SavingsPlanPaymentOption {
   noUpfront,
 }
 
-extension on SavingsPlanPaymentOption {
+extension SavingsPlanPaymentOptionValue on SavingsPlanPaymentOption {
   String toValue() {
     switch (this) {
       case SavingsPlanPaymentOption.allUpfront:
@@ -1141,7 +1143,7 @@ extension on SavingsPlanPaymentOption {
   }
 }
 
-extension on String {
+extension SavingsPlanPaymentOptionFromString on String {
   SavingsPlanPaymentOption toSavingsPlanPaymentOption() {
     switch (this) {
       case 'All Upfront':
@@ -1161,7 +1163,7 @@ enum SavingsPlanProductType {
   lambda,
 }
 
-extension on SavingsPlanProductType {
+extension SavingsPlanProductTypeValue on SavingsPlanProductType {
   String toValue() {
     switch (this) {
       case SavingsPlanProductType.ec2:
@@ -1174,7 +1176,7 @@ extension on SavingsPlanProductType {
   }
 }
 
-extension on String {
+extension SavingsPlanProductTypeFromString on String {
   SavingsPlanProductType toSavingsPlanProductType() {
     switch (this) {
       case 'EC2':
@@ -1274,7 +1276,8 @@ enum SavingsPlanRateFilterAttribute {
   productId,
 }
 
-extension on SavingsPlanRateFilterAttribute {
+extension SavingsPlanRateFilterAttributeValue
+    on SavingsPlanRateFilterAttribute {
   String toValue() {
     switch (this) {
       case SavingsPlanRateFilterAttribute.region:
@@ -1293,7 +1296,7 @@ extension on SavingsPlanRateFilterAttribute {
   }
 }
 
-extension on String {
+extension SavingsPlanRateFilterAttributeFromString on String {
   SavingsPlanRateFilterAttribute toSavingsPlanRateFilterAttribute() {
     switch (this) {
       case 'region':
@@ -1325,7 +1328,7 @@ enum SavingsPlanRateFilterName {
   operation,
 }
 
-extension on SavingsPlanRateFilterName {
+extension SavingsPlanRateFilterNameValue on SavingsPlanRateFilterName {
   String toValue() {
     switch (this) {
       case SavingsPlanRateFilterName.region:
@@ -1348,7 +1351,7 @@ extension on SavingsPlanRateFilterName {
   }
 }
 
-extension on String {
+extension SavingsPlanRateFilterNameFromString on String {
   SavingsPlanRateFilterName toSavingsPlanRateFilterName() {
     switch (this) {
       case 'region':
@@ -1400,7 +1403,7 @@ enum SavingsPlanRatePropertyKey {
   tenancy,
 }
 
-extension on SavingsPlanRatePropertyKey {
+extension SavingsPlanRatePropertyKeyValue on SavingsPlanRatePropertyKey {
   String toValue() {
     switch (this) {
       case SavingsPlanRatePropertyKey.region:
@@ -1417,7 +1420,7 @@ extension on SavingsPlanRatePropertyKey {
   }
 }
 
-extension on String {
+extension SavingsPlanRatePropertyKeyFromString on String {
   SavingsPlanRatePropertyKey toSavingsPlanRatePropertyKey() {
     switch (this) {
       case 'region':
@@ -1441,7 +1444,7 @@ enum SavingsPlanRateServiceCode {
   awsLambda,
 }
 
-extension on SavingsPlanRateServiceCode {
+extension SavingsPlanRateServiceCodeValue on SavingsPlanRateServiceCode {
   String toValue() {
     switch (this) {
       case SavingsPlanRateServiceCode.amazonEC2:
@@ -1454,7 +1457,7 @@ extension on SavingsPlanRateServiceCode {
   }
 }
 
-extension on String {
+extension SavingsPlanRateServiceCodeFromString on String {
   SavingsPlanRateServiceCode toSavingsPlanRateServiceCode() {
     switch (this) {
       case 'AmazonEC2':
@@ -1474,7 +1477,7 @@ enum SavingsPlanRateUnit {
   request,
 }
 
-extension on SavingsPlanRateUnit {
+extension SavingsPlanRateUnitValue on SavingsPlanRateUnit {
   String toValue() {
     switch (this) {
       case SavingsPlanRateUnit.hrs:
@@ -1487,7 +1490,7 @@ extension on SavingsPlanRateUnit {
   }
 }
 
-extension on String {
+extension SavingsPlanRateUnitFromString on String {
   SavingsPlanRateUnit toSavingsPlanRateUnit() {
     switch (this) {
       case 'Hrs':
@@ -1510,7 +1513,7 @@ enum SavingsPlanState {
   queuedDeleted,
 }
 
-extension on SavingsPlanState {
+extension SavingsPlanStateValue on SavingsPlanState {
   String toValue() {
     switch (this) {
       case SavingsPlanState.paymentPending:
@@ -1529,7 +1532,7 @@ extension on SavingsPlanState {
   }
 }
 
-extension on String {
+extension SavingsPlanStateFromString on String {
   SavingsPlanState toSavingsPlanState() {
     switch (this) {
       case 'payment-pending':
@@ -1554,7 +1557,7 @@ enum SavingsPlanType {
   eC2Instance,
 }
 
-extension on SavingsPlanType {
+extension SavingsPlanTypeValue on SavingsPlanType {
   String toValue() {
     switch (this) {
       case SavingsPlanType.compute:
@@ -1565,7 +1568,7 @@ extension on SavingsPlanType {
   }
 }
 
-extension on String {
+extension SavingsPlanTypeFromString on String {
   SavingsPlanType toSavingsPlanType() {
     switch (this) {
       case 'Compute':
@@ -1589,7 +1592,7 @@ enum SavingsPlansFilterName {
   end,
 }
 
-extension on SavingsPlansFilterName {
+extension SavingsPlansFilterNameValue on SavingsPlansFilterName {
   String toValue() {
     switch (this) {
       case SavingsPlansFilterName.region:
@@ -1614,7 +1617,7 @@ extension on SavingsPlansFilterName {
   }
 }
 
-extension on String {
+extension SavingsPlansFilterNameFromString on String {
   SavingsPlansFilterName toSavingsPlansFilterName() {
     switch (this) {
       case 'region':

--- a/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
+++ b/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
@@ -535,7 +535,7 @@ enum CurrencyCode {
   usd,
 }
 
-extension CurrencyCodeValue on CurrencyCode {
+extension CurrencyCodeValueExtension on CurrencyCode {
   String toValue() {
     switch (this) {
       case CurrencyCode.cny:
@@ -927,7 +927,7 @@ enum SavingsPlanOfferingFilterAttribute {
   instanceFamily,
 }
 
-extension SavingsPlanOfferingFilterAttributeValue
+extension SavingsPlanOfferingFilterAttributeValueExtension
     on SavingsPlanOfferingFilterAttribute {
   String toValue() {
     switch (this) {
@@ -999,7 +999,7 @@ enum SavingsPlanOfferingPropertyKey {
   instanceFamily,
 }
 
-extension SavingsPlanOfferingPropertyKeyValue
+extension SavingsPlanOfferingPropertyKeyValueExtension
     on SavingsPlanOfferingPropertyKey {
   String toValue() {
     switch (this) {
@@ -1130,7 +1130,7 @@ enum SavingsPlanPaymentOption {
   noUpfront,
 }
 
-extension SavingsPlanPaymentOptionValue on SavingsPlanPaymentOption {
+extension SavingsPlanPaymentOptionValueExtension on SavingsPlanPaymentOption {
   String toValue() {
     switch (this) {
       case SavingsPlanPaymentOption.allUpfront:
@@ -1163,7 +1163,7 @@ enum SavingsPlanProductType {
   lambda,
 }
 
-extension SavingsPlanProductTypeValue on SavingsPlanProductType {
+extension SavingsPlanProductTypeValueExtension on SavingsPlanProductType {
   String toValue() {
     switch (this) {
       case SavingsPlanProductType.ec2:
@@ -1276,7 +1276,7 @@ enum SavingsPlanRateFilterAttribute {
   productId,
 }
 
-extension SavingsPlanRateFilterAttributeValue
+extension SavingsPlanRateFilterAttributeValueExtension
     on SavingsPlanRateFilterAttribute {
   String toValue() {
     switch (this) {
@@ -1328,7 +1328,7 @@ enum SavingsPlanRateFilterName {
   operation,
 }
 
-extension SavingsPlanRateFilterNameValue on SavingsPlanRateFilterName {
+extension SavingsPlanRateFilterNameValueExtension on SavingsPlanRateFilterName {
   String toValue() {
     switch (this) {
       case SavingsPlanRateFilterName.region:
@@ -1403,7 +1403,8 @@ enum SavingsPlanRatePropertyKey {
   tenancy,
 }
 
-extension SavingsPlanRatePropertyKeyValue on SavingsPlanRatePropertyKey {
+extension SavingsPlanRatePropertyKeyValueExtension
+    on SavingsPlanRatePropertyKey {
   String toValue() {
     switch (this) {
       case SavingsPlanRatePropertyKey.region:
@@ -1444,7 +1445,8 @@ enum SavingsPlanRateServiceCode {
   awsLambda,
 }
 
-extension SavingsPlanRateServiceCodeValue on SavingsPlanRateServiceCode {
+extension SavingsPlanRateServiceCodeValueExtension
+    on SavingsPlanRateServiceCode {
   String toValue() {
     switch (this) {
       case SavingsPlanRateServiceCode.amazonEC2:
@@ -1477,7 +1479,7 @@ enum SavingsPlanRateUnit {
   request,
 }
 
-extension SavingsPlanRateUnitValue on SavingsPlanRateUnit {
+extension SavingsPlanRateUnitValueExtension on SavingsPlanRateUnit {
   String toValue() {
     switch (this) {
       case SavingsPlanRateUnit.hrs:
@@ -1513,7 +1515,7 @@ enum SavingsPlanState {
   queuedDeleted,
 }
 
-extension SavingsPlanStateValue on SavingsPlanState {
+extension SavingsPlanStateValueExtension on SavingsPlanState {
   String toValue() {
     switch (this) {
       case SavingsPlanState.paymentPending:
@@ -1557,7 +1559,7 @@ enum SavingsPlanType {
   eC2Instance,
 }
 
-extension SavingsPlanTypeValue on SavingsPlanType {
+extension SavingsPlanTypeValueExtension on SavingsPlanType {
   String toValue() {
     switch (this) {
       case SavingsPlanType.compute:
@@ -1592,7 +1594,7 @@ enum SavingsPlansFilterName {
   end,
 }
 
-extension SavingsPlansFilterNameValue on SavingsPlansFilterName {
+extension SavingsPlansFilterNameValueExtension on SavingsPlansFilterName {
   String toValue() {
     switch (this) {
       case SavingsPlansFilterName.region:

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -1201,7 +1201,7 @@ enum CodeGenerationStatus {
   createFailed,
 }
 
-extension CodeGenerationStatusValue on CodeGenerationStatus {
+extension CodeGenerationStatusValueExtension on CodeGenerationStatus {
   String toValue() {
     switch (this) {
       case CodeGenerationStatus.createInProgress:
@@ -1505,7 +1505,7 @@ enum DiscovererState {
   stopped,
 }
 
-extension DiscovererStateValue on DiscovererState {
+extension DiscovererStateValueExtension on DiscovererState {
   String toValue() {
     switch (this) {
       case DiscovererState.started:
@@ -2003,7 +2003,7 @@ enum Type {
   jSONSchemaDraft4,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.openApi3:

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -1201,7 +1201,7 @@ enum CodeGenerationStatus {
   createFailed,
 }
 
-extension on CodeGenerationStatus {
+extension CodeGenerationStatusValue on CodeGenerationStatus {
   String toValue() {
     switch (this) {
       case CodeGenerationStatus.createInProgress:
@@ -1214,7 +1214,7 @@ extension on CodeGenerationStatus {
   }
 }
 
-extension on String {
+extension CodeGenerationStatusFromString on String {
   CodeGenerationStatus toCodeGenerationStatus() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -1505,7 +1505,7 @@ enum DiscovererState {
   stopped,
 }
 
-extension on DiscovererState {
+extension DiscovererStateValue on DiscovererState {
   String toValue() {
     switch (this) {
       case DiscovererState.started:
@@ -1516,7 +1516,7 @@ extension on DiscovererState {
   }
 }
 
-extension on String {
+extension DiscovererStateFromString on String {
   DiscovererState toDiscovererState() {
     switch (this) {
       case 'STARTED':
@@ -2003,7 +2003,7 @@ enum Type {
   jSONSchemaDraft4,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.openApi3:
@@ -2014,7 +2014,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'OpenApi3':

--- a/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
+++ b/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
@@ -3029,7 +3029,7 @@ enum FilterNameStringType {
   all,
 }
 
-extension FilterNameStringTypeValue on FilterNameStringType {
+extension FilterNameStringTypeValueExtension on FilterNameStringType {
   String toValue() {
     switch (this) {
       case FilterNameStringType.description:
@@ -3555,7 +3555,7 @@ enum SortOrderType {
   desc,
 }
 
-extension SortOrderTypeValue on SortOrderType {
+extension SortOrderTypeValueExtension on SortOrderType {
   String toValue() {
     switch (this) {
       case SortOrderType.asc:

--- a/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
+++ b/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
@@ -3029,7 +3029,7 @@ enum FilterNameStringType {
   all,
 }
 
-extension on FilterNameStringType {
+extension FilterNameStringTypeValue on FilterNameStringType {
   String toValue() {
     switch (this) {
       case FilterNameStringType.description:
@@ -3046,7 +3046,7 @@ extension on FilterNameStringType {
   }
 }
 
-extension on String {
+extension FilterNameStringTypeFromString on String {
   FilterNameStringType toFilterNameStringType() {
     switch (this) {
       case 'description':
@@ -3555,7 +3555,7 @@ enum SortOrderType {
   desc,
 }
 
-extension on SortOrderType {
+extension SortOrderTypeValue on SortOrderType {
   String toValue() {
     switch (this) {
       case SortOrderType.asc:
@@ -3566,7 +3566,7 @@ extension on SortOrderType {
   }
 }
 
-extension on String {
+extension SortOrderTypeFromString on String {
   SortOrderType toSortOrderType() {
     switch (this) {
       case 'asc':

--- a/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
+++ b/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
@@ -2081,7 +2081,7 @@ enum AdminStatus {
   disableInProgress,
 }
 
-extension on AdminStatus {
+extension AdminStatusValue on AdminStatus {
   String toValue() {
     switch (this) {
       case AdminStatus.enabled:
@@ -2092,7 +2092,7 @@ extension on AdminStatus {
   }
 }
 
-extension on String {
+extension AdminStatusFromString on String {
   AdminStatus toAdminStatus() {
     switch (this) {
       case 'ENABLED':
@@ -7570,7 +7570,7 @@ enum AwsIamAccessKeyStatus {
   inactive,
 }
 
-extension on AwsIamAccessKeyStatus {
+extension AwsIamAccessKeyStatusValue on AwsIamAccessKeyStatus {
   String toValue() {
     switch (this) {
       case AwsIamAccessKeyStatus.active:
@@ -7581,7 +7581,7 @@ extension on AwsIamAccessKeyStatus {
   }
 }
 
-extension on String {
+extension AwsIamAccessKeyStatusFromString on String {
   AwsIamAccessKeyStatus toAwsIamAccessKeyStatus() {
     switch (this) {
       case 'Active':
@@ -14111,7 +14111,7 @@ enum ComplianceStatus {
   notAvailable,
 }
 
-extension on ComplianceStatus {
+extension ComplianceStatusValue on ComplianceStatus {
   String toValue() {
     switch (this) {
       case ComplianceStatus.passed:
@@ -14126,7 +14126,7 @@ extension on ComplianceStatus {
   }
 }
 
-extension on String {
+extension ComplianceStatusFromString on String {
   ComplianceStatus toComplianceStatus() {
     switch (this) {
       case 'PASSED':
@@ -14195,7 +14195,7 @@ enum ControlStatus {
   disabled,
 }
 
-extension on ControlStatus {
+extension ControlStatusValue on ControlStatus {
   String toValue() {
     switch (this) {
       case ControlStatus.enabled:
@@ -14206,7 +14206,7 @@ extension on ControlStatus {
   }
 }
 
-extension on String {
+extension ControlStatusFromString on String {
   ControlStatus toControlStatus() {
     switch (this) {
       case 'ENABLED':
@@ -14371,7 +14371,7 @@ enum DateRangeUnit {
   days,
 }
 
-extension on DateRangeUnit {
+extension DateRangeUnitValue on DateRangeUnit {
   String toValue() {
     switch (this) {
       case DateRangeUnit.days:
@@ -14380,7 +14380,7 @@ extension on DateRangeUnit {
   }
 }
 
-extension on String {
+extension DateRangeUnitFromString on String {
   DateRangeUnit toDateRangeUnit() {
     switch (this) {
       case 'DAYS':
@@ -14948,7 +14948,7 @@ enum IntegrationType {
   receiveFindingsFromSecurityHub,
 }
 
-extension on IntegrationType {
+extension IntegrationTypeValue on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.sendFindingsToSecurityHub:
@@ -14959,7 +14959,7 @@ extension on IntegrationType {
   }
 }
 
-extension on String {
+extension IntegrationTypeFromString on String {
   IntegrationType toIntegrationType() {
     switch (this) {
       case 'SEND_FINDINGS_TO_SECURITY_HUB':
@@ -15290,7 +15290,7 @@ enum MalwareState {
   removed,
 }
 
-extension on MalwareState {
+extension MalwareStateValue on MalwareState {
   String toValue() {
     switch (this) {
       case MalwareState.observed:
@@ -15303,7 +15303,7 @@ extension on MalwareState {
   }
 }
 
-extension on String {
+extension MalwareStateFromString on String {
   MalwareState toMalwareState() {
     switch (this) {
       case 'OBSERVED':
@@ -15335,7 +15335,7 @@ enum MalwareType {
   worm,
 }
 
-extension on MalwareType {
+extension MalwareTypeValue on MalwareType {
   String toValue() {
     switch (this) {
       case MalwareType.adware:
@@ -15372,7 +15372,7 @@ extension on MalwareType {
   }
 }
 
-extension on String {
+extension MalwareTypeFromString on String {
   MalwareType toMalwareType() {
     switch (this) {
       case 'ADWARE':
@@ -15478,7 +15478,7 @@ enum MapFilterComparison {
   notEquals,
 }
 
-extension on MapFilterComparison {
+extension MapFilterComparisonValue on MapFilterComparison {
   String toValue() {
     switch (this) {
       case MapFilterComparison.equals:
@@ -15489,7 +15489,7 @@ extension on MapFilterComparison {
   }
 }
 
-extension on String {
+extension MapFilterComparisonFromString on String {
   MapFilterComparison toMapFilterComparison() {
     switch (this) {
       case 'EQUALS':
@@ -15681,7 +15681,7 @@ enum NetworkDirection {
   out,
 }
 
-extension on NetworkDirection {
+extension NetworkDirectionValue on NetworkDirection {
   String toValue() {
     switch (this) {
       case NetworkDirection.$in:
@@ -15692,7 +15692,7 @@ extension on NetworkDirection {
   }
 }
 
-extension on String {
+extension NetworkDirectionFromString on String {
   NetworkDirection toNetworkDirection() {
     switch (this) {
       case 'IN':
@@ -15939,7 +15939,7 @@ enum Partition {
   awsUsGov,
 }
 
-extension on Partition {
+extension PartitionValue on Partition {
   String toValue() {
     switch (this) {
       case Partition.aws:
@@ -15952,7 +15952,7 @@ extension on Partition {
   }
 }
 
-extension on String {
+extension PartitionFromString on String {
   Partition toPartition() {
     switch (this) {
       case 'aws':
@@ -16285,7 +16285,7 @@ enum RecordState {
   archived,
 }
 
-extension on RecordState {
+extension RecordStateValue on RecordState {
   String toValue() {
     switch (this) {
       case RecordState.active:
@@ -16296,7 +16296,7 @@ extension on RecordState {
   }
 }
 
-extension on String {
+extension RecordStateFromString on String {
   RecordState toRecordState() {
     switch (this) {
       case 'ACTIVE':
@@ -17036,7 +17036,7 @@ enum SeverityLabel {
   critical,
 }
 
-extension on SeverityLabel {
+extension SeverityLabelValue on SeverityLabel {
   String toValue() {
     switch (this) {
       case SeverityLabel.informational:
@@ -17053,7 +17053,7 @@ extension on SeverityLabel {
   }
 }
 
-extension on String {
+extension SeverityLabelFromString on String {
   SeverityLabel toSeverityLabel() {
     switch (this) {
       case 'INFORMATIONAL':
@@ -17078,7 +17078,7 @@ enum SeverityRating {
   critical,
 }
 
-extension on SeverityRating {
+extension SeverityRatingValue on SeverityRating {
   String toValue() {
     switch (this) {
       case SeverityRating.low:
@@ -17093,7 +17093,7 @@ extension on SeverityRating {
   }
 }
 
-extension on String {
+extension SeverityRatingFromString on String {
   SeverityRating toSeverityRating() {
     switch (this) {
       case 'LOW':
@@ -17256,7 +17256,7 @@ enum SortOrder {
   desc,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -17267,7 +17267,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'asc':
@@ -17394,7 +17394,7 @@ enum StandardsStatus {
   incomplete,
 }
 
-extension on StandardsStatus {
+extension StandardsStatusValue on StandardsStatus {
   String toValue() {
     switch (this) {
       case StandardsStatus.pending:
@@ -17411,7 +17411,7 @@ extension on StandardsStatus {
   }
 }
 
-extension on String {
+extension StandardsStatusFromString on String {
   StandardsStatus toStandardsStatus() {
     switch (this) {
       case 'PENDING':
@@ -17640,7 +17640,7 @@ enum StringFilterComparison {
   prefixNotEquals,
 }
 
-extension on StringFilterComparison {
+extension StringFilterComparisonValue on StringFilterComparison {
   String toValue() {
     switch (this) {
       case StringFilterComparison.equals:
@@ -17655,7 +17655,7 @@ extension on StringFilterComparison {
   }
 }
 
-extension on String {
+extension StringFilterComparisonFromString on String {
   StringFilterComparison toStringFilterComparison() {
     switch (this) {
       case 'EQUALS':
@@ -17751,7 +17751,7 @@ enum ThreatIntelIndicatorCategory {
   keylogger,
 }
 
-extension on ThreatIntelIndicatorCategory {
+extension ThreatIntelIndicatorCategoryValue on ThreatIntelIndicatorCategory {
   String toValue() {
     switch (this) {
       case ThreatIntelIndicatorCategory.backdoor:
@@ -17770,7 +17770,7 @@ extension on ThreatIntelIndicatorCategory {
   }
 }
 
-extension on String {
+extension ThreatIntelIndicatorCategoryFromString on String {
   ThreatIntelIndicatorCategory toThreatIntelIndicatorCategory() {
     switch (this) {
       case 'BACKDOOR':
@@ -17804,7 +17804,7 @@ enum ThreatIntelIndicatorType {
   url,
 }
 
-extension on ThreatIntelIndicatorType {
+extension ThreatIntelIndicatorTypeValue on ThreatIntelIndicatorType {
   String toValue() {
     switch (this) {
       case ThreatIntelIndicatorType.domain:
@@ -17833,7 +17833,7 @@ extension on ThreatIntelIndicatorType {
   }
 }
 
-extension on String {
+extension ThreatIntelIndicatorTypeFromString on String {
   ThreatIntelIndicatorType toThreatIntelIndicatorType() {
     switch (this) {
       case 'DOMAIN':
@@ -17921,7 +17921,7 @@ enum VerificationState {
   benignPositive,
 }
 
-extension on VerificationState {
+extension VerificationStateValue on VerificationState {
   String toValue() {
     switch (this) {
       case VerificationState.unknown:
@@ -17936,7 +17936,7 @@ extension on VerificationState {
   }
 }
 
-extension on String {
+extension VerificationStateFromString on String {
   VerificationState toVerificationState() {
     switch (this) {
       case 'UNKNOWN':
@@ -18223,7 +18223,7 @@ enum WorkflowState {
   resolved,
 }
 
-extension on WorkflowState {
+extension WorkflowStateValue on WorkflowState {
   String toValue() {
     switch (this) {
       case WorkflowState.$new:
@@ -18240,7 +18240,7 @@ extension on WorkflowState {
   }
 }
 
-extension on String {
+extension WorkflowStateFromString on String {
   WorkflowState toWorkflowState() {
     switch (this) {
       case 'NEW':
@@ -18265,7 +18265,7 @@ enum WorkflowStatus {
   suppressed,
 }
 
-extension on WorkflowStatus {
+extension WorkflowStatusValue on WorkflowStatus {
   String toValue() {
     switch (this) {
       case WorkflowStatus.$new:
@@ -18280,7 +18280,7 @@ extension on WorkflowStatus {
   }
 }
 
-extension on String {
+extension WorkflowStatusFromString on String {
   WorkflowStatus toWorkflowStatus() {
     switch (this) {
       case 'NEW':

--- a/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
+++ b/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
@@ -2081,7 +2081,7 @@ enum AdminStatus {
   disableInProgress,
 }
 
-extension AdminStatusValue on AdminStatus {
+extension AdminStatusValueExtension on AdminStatus {
   String toValue() {
     switch (this) {
       case AdminStatus.enabled:
@@ -7570,7 +7570,7 @@ enum AwsIamAccessKeyStatus {
   inactive,
 }
 
-extension AwsIamAccessKeyStatusValue on AwsIamAccessKeyStatus {
+extension AwsIamAccessKeyStatusValueExtension on AwsIamAccessKeyStatus {
   String toValue() {
     switch (this) {
       case AwsIamAccessKeyStatus.active:
@@ -14111,7 +14111,7 @@ enum ComplianceStatus {
   notAvailable,
 }
 
-extension ComplianceStatusValue on ComplianceStatus {
+extension ComplianceStatusValueExtension on ComplianceStatus {
   String toValue() {
     switch (this) {
       case ComplianceStatus.passed:
@@ -14195,7 +14195,7 @@ enum ControlStatus {
   disabled,
 }
 
-extension ControlStatusValue on ControlStatus {
+extension ControlStatusValueExtension on ControlStatus {
   String toValue() {
     switch (this) {
       case ControlStatus.enabled:
@@ -14371,7 +14371,7 @@ enum DateRangeUnit {
   days,
 }
 
-extension DateRangeUnitValue on DateRangeUnit {
+extension DateRangeUnitValueExtension on DateRangeUnit {
   String toValue() {
     switch (this) {
       case DateRangeUnit.days:
@@ -14948,7 +14948,7 @@ enum IntegrationType {
   receiveFindingsFromSecurityHub,
 }
 
-extension IntegrationTypeValue on IntegrationType {
+extension IntegrationTypeValueExtension on IntegrationType {
   String toValue() {
     switch (this) {
       case IntegrationType.sendFindingsToSecurityHub:
@@ -15290,7 +15290,7 @@ enum MalwareState {
   removed,
 }
 
-extension MalwareStateValue on MalwareState {
+extension MalwareStateValueExtension on MalwareState {
   String toValue() {
     switch (this) {
       case MalwareState.observed:
@@ -15335,7 +15335,7 @@ enum MalwareType {
   worm,
 }
 
-extension MalwareTypeValue on MalwareType {
+extension MalwareTypeValueExtension on MalwareType {
   String toValue() {
     switch (this) {
       case MalwareType.adware:
@@ -15478,7 +15478,7 @@ enum MapFilterComparison {
   notEquals,
 }
 
-extension MapFilterComparisonValue on MapFilterComparison {
+extension MapFilterComparisonValueExtension on MapFilterComparison {
   String toValue() {
     switch (this) {
       case MapFilterComparison.equals:
@@ -15681,7 +15681,7 @@ enum NetworkDirection {
   out,
 }
 
-extension NetworkDirectionValue on NetworkDirection {
+extension NetworkDirectionValueExtension on NetworkDirection {
   String toValue() {
     switch (this) {
       case NetworkDirection.$in:
@@ -15939,7 +15939,7 @@ enum Partition {
   awsUsGov,
 }
 
-extension PartitionValue on Partition {
+extension PartitionValueExtension on Partition {
   String toValue() {
     switch (this) {
       case Partition.aws:
@@ -16285,7 +16285,7 @@ enum RecordState {
   archived,
 }
 
-extension RecordStateValue on RecordState {
+extension RecordStateValueExtension on RecordState {
   String toValue() {
     switch (this) {
       case RecordState.active:
@@ -17036,7 +17036,7 @@ enum SeverityLabel {
   critical,
 }
 
-extension SeverityLabelValue on SeverityLabel {
+extension SeverityLabelValueExtension on SeverityLabel {
   String toValue() {
     switch (this) {
       case SeverityLabel.informational:
@@ -17078,7 +17078,7 @@ enum SeverityRating {
   critical,
 }
 
-extension SeverityRatingValue on SeverityRating {
+extension SeverityRatingValueExtension on SeverityRating {
   String toValue() {
     switch (this) {
       case SeverityRating.low:
@@ -17256,7 +17256,7 @@ enum SortOrder {
   desc,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.asc:
@@ -17394,7 +17394,7 @@ enum StandardsStatus {
   incomplete,
 }
 
-extension StandardsStatusValue on StandardsStatus {
+extension StandardsStatusValueExtension on StandardsStatus {
   String toValue() {
     switch (this) {
       case StandardsStatus.pending:
@@ -17640,7 +17640,7 @@ enum StringFilterComparison {
   prefixNotEquals,
 }
 
-extension StringFilterComparisonValue on StringFilterComparison {
+extension StringFilterComparisonValueExtension on StringFilterComparison {
   String toValue() {
     switch (this) {
       case StringFilterComparison.equals:
@@ -17751,7 +17751,8 @@ enum ThreatIntelIndicatorCategory {
   keylogger,
 }
 
-extension ThreatIntelIndicatorCategoryValue on ThreatIntelIndicatorCategory {
+extension ThreatIntelIndicatorCategoryValueExtension
+    on ThreatIntelIndicatorCategory {
   String toValue() {
     switch (this) {
       case ThreatIntelIndicatorCategory.backdoor:
@@ -17804,7 +17805,7 @@ enum ThreatIntelIndicatorType {
   url,
 }
 
-extension ThreatIntelIndicatorTypeValue on ThreatIntelIndicatorType {
+extension ThreatIntelIndicatorTypeValueExtension on ThreatIntelIndicatorType {
   String toValue() {
     switch (this) {
       case ThreatIntelIndicatorType.domain:
@@ -17921,7 +17922,7 @@ enum VerificationState {
   benignPositive,
 }
 
-extension VerificationStateValue on VerificationState {
+extension VerificationStateValueExtension on VerificationState {
   String toValue() {
     switch (this) {
       case VerificationState.unknown:
@@ -18223,7 +18224,7 @@ enum WorkflowState {
   resolved,
 }
 
-extension WorkflowStateValue on WorkflowState {
+extension WorkflowStateValueExtension on WorkflowState {
   String toValue() {
     switch (this) {
       case WorkflowState.$new:
@@ -18265,7 +18266,7 @@ enum WorkflowStatus {
   suppressed,
 }
 
-extension WorkflowStatusValue on WorkflowStatus {
+extension WorkflowStatusValueExtension on WorkflowStatus {
   String toValue() {
     switch (this) {
       case WorkflowStatus.$new:

--- a/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
+++ b/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
@@ -1047,7 +1047,7 @@ enum Capability {
   capabilityResourcePolicy,
 }
 
-extension on Capability {
+extension CapabilityValue on Capability {
   String toValue() {
     switch (this) {
       case Capability.capabilityIam:
@@ -1062,7 +1062,7 @@ extension on Capability {
   }
 }
 
-extension on String {
+extension CapabilityFromString on String {
   Capability toCapability() {
     switch (this) {
       case 'CAPABILITY_IAM':
@@ -1898,7 +1898,7 @@ enum Status {
   expired,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.preparing:
@@ -1911,7 +1911,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'PREPARING':

--- a/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
+++ b/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
@@ -1047,7 +1047,7 @@ enum Capability {
   capabilityResourcePolicy,
 }
 
-extension CapabilityValue on Capability {
+extension CapabilityValueExtension on Capability {
   String toValue() {
     switch (this) {
       case Capability.capabilityIam:
@@ -1898,7 +1898,7 @@ enum Status {
   expired,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.preparing:

--- a/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
+++ b/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
@@ -1172,7 +1172,7 @@ enum ErrorCode {
   serviceQuotaNotAvailableError,
 }
 
-extension on ErrorCode {
+extension ErrorCodeValue on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.dependencyAccessDeniedError:
@@ -1187,7 +1187,7 @@ extension on ErrorCode {
   }
 }
 
-extension on String {
+extension ErrorCodeFromString on String {
   ErrorCode toErrorCode() {
     switch (this) {
       case 'DEPENDENCY_ACCESS_DENIED_ERROR':
@@ -1541,7 +1541,7 @@ enum PeriodUnit {
   week,
 }
 
-extension on PeriodUnit {
+extension PeriodUnitValue on PeriodUnit {
   String toValue() {
     switch (this) {
       case PeriodUnit.microsecond:
@@ -1562,7 +1562,7 @@ extension on PeriodUnit {
   }
 }
 
-extension on String {
+extension PeriodUnitFromString on String {
   PeriodUnit toPeriodUnit() {
     switch (this) {
       case 'MICROSECOND':
@@ -1651,7 +1651,7 @@ enum RequestStatus {
   caseClosed,
 }
 
-extension on RequestStatus {
+extension RequestStatusValue on RequestStatus {
   String toValue() {
     switch (this) {
       case RequestStatus.pending:
@@ -1668,7 +1668,7 @@ extension on RequestStatus {
   }
 }
 
-extension on String {
+extension RequestStatusFromString on String {
   RequestStatus toRequestStatus() {
     switch (this) {
       case 'PENDING':
@@ -1919,7 +1919,8 @@ enum ServiceQuotaTemplateAssociationStatus {
   disassociated,
 }
 
-extension on ServiceQuotaTemplateAssociationStatus {
+extension ServiceQuotaTemplateAssociationStatusValue
+    on ServiceQuotaTemplateAssociationStatus {
   String toValue() {
     switch (this) {
       case ServiceQuotaTemplateAssociationStatus.associated:
@@ -1930,7 +1931,7 @@ extension on ServiceQuotaTemplateAssociationStatus {
   }
 }
 
-extension on String {
+extension ServiceQuotaTemplateAssociationStatusFromString on String {
   ServiceQuotaTemplateAssociationStatus
       toServiceQuotaTemplateAssociationStatus() {
     switch (this) {

--- a/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
+++ b/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
@@ -1172,7 +1172,7 @@ enum ErrorCode {
   serviceQuotaNotAvailableError,
 }
 
-extension ErrorCodeValue on ErrorCode {
+extension ErrorCodeValueExtension on ErrorCode {
   String toValue() {
     switch (this) {
       case ErrorCode.dependencyAccessDeniedError:
@@ -1541,7 +1541,7 @@ enum PeriodUnit {
   week,
 }
 
-extension PeriodUnitValue on PeriodUnit {
+extension PeriodUnitValueExtension on PeriodUnit {
   String toValue() {
     switch (this) {
       case PeriodUnit.microsecond:
@@ -1651,7 +1651,7 @@ enum RequestStatus {
   caseClosed,
 }
 
-extension RequestStatusValue on RequestStatus {
+extension RequestStatusValueExtension on RequestStatus {
   String toValue() {
     switch (this) {
       case RequestStatus.pending:
@@ -1919,7 +1919,7 @@ enum ServiceQuotaTemplateAssociationStatus {
   disassociated,
 }
 
-extension ServiceQuotaTemplateAssociationStatusValue
+extension ServiceQuotaTemplateAssociationStatusValueExtension
     on ServiceQuotaTemplateAssociationStatus {
   String toValue() {
     switch (this) {

--- a/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
+++ b/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
@@ -7491,7 +7491,7 @@ enum AccessLevelFilterKey {
   user,
 }
 
-extension AccessLevelFilterKeyValue on AccessLevelFilterKey {
+extension AccessLevelFilterKeyValueExtension on AccessLevelFilterKey {
   String toValue() {
     switch (this) {
       case AccessLevelFilterKey.account:
@@ -7524,7 +7524,7 @@ enum AccessStatus {
   disabled,
 }
 
-extension AccessStatusValue on AccessStatus {
+extension AccessStatusValueExtension on AccessStatus {
   String toValue() {
     switch (this) {
       case AccessStatus.enabled:
@@ -7652,7 +7652,7 @@ enum ChangeAction {
   remove,
 }
 
-extension ChangeActionValue on ChangeAction {
+extension ChangeActionValueExtension on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.add:
@@ -7792,7 +7792,7 @@ enum CopyOption {
   copyTags,
 }
 
-extension CopyOptionValue on CopyOption {
+extension CopyOptionValueExtension on CopyOption {
   String toValue() {
     switch (this) {
       case CopyOption.copyTags:
@@ -7831,7 +7831,7 @@ enum CopyProductStatus {
   failed,
 }
 
-extension CopyProductStatusValue on CopyProductStatus {
+extension CopyProductStatusValueExtension on CopyProductStatus {
   String toValue() {
     switch (this) {
       case CopyProductStatus.succeeded:
@@ -8271,7 +8271,8 @@ enum DescribePortfolioShareType {
   organizationMemberAccount,
 }
 
-extension DescribePortfolioShareTypeValue on DescribePortfolioShareType {
+extension DescribePortfolioShareTypeValueExtension
+    on DescribePortfolioShareType {
   String toValue() {
     switch (this) {
       case DescribePortfolioShareType.account:
@@ -8741,7 +8742,7 @@ enum EvaluationType {
   dynamic,
 }
 
-extension EvaluationTypeValue on EvaluationType {
+extension EvaluationTypeValueExtension on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.static:
@@ -9503,7 +9504,7 @@ enum OrganizationNodeType {
   account,
 }
 
-extension OrganizationNodeTypeValue on OrganizationNodeType {
+extension OrganizationNodeTypeValueExtension on OrganizationNodeType {
   String toValue() {
     switch (this) {
       case OrganizationNodeType.organization:
@@ -9686,7 +9687,7 @@ enum PortfolioShareType {
   awsOrganizations,
 }
 
-extension PortfolioShareTypeValue on PortfolioShareType {
+extension PortfolioShareTypeValueExtension on PortfolioShareType {
   String toValue() {
     switch (this) {
       case PortfolioShareType.imported:
@@ -9737,7 +9738,7 @@ enum PrincipalType {
   iam,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.iam:
@@ -9760,7 +9761,7 @@ enum ProductSource {
   account,
 }
 
-extension ProductSourceValue on ProductSource {
+extension ProductSourceValueExtension on ProductSource {
   String toValue() {
     switch (this) {
       case ProductSource.account:
@@ -9784,7 +9785,7 @@ enum ProductType {
   marketplace,
 }
 
-extension ProductTypeValue on ProductType {
+extension ProductTypeValueExtension on ProductType {
   String toValue() {
     switch (this) {
       case ProductType.cloudFormationTemplate:
@@ -9881,7 +9882,7 @@ enum ProductViewFilterBy {
   sourceProductId,
 }
 
-extension ProductViewFilterByValue on ProductViewFilterBy {
+extension ProductViewFilterByValueExtension on ProductViewFilterBy {
   String toValue() {
     switch (this) {
       case ProductViewFilterBy.fullTextSearch:
@@ -9918,7 +9919,7 @@ enum ProductViewSortBy {
   creationDate,
 }
 
-extension ProductViewSortByValue on ProductViewSortBy {
+extension ProductViewSortByValueExtension on ProductViewSortBy {
   String toValue() {
     switch (this) {
       case ProductViewSortBy.title:
@@ -10023,7 +10024,7 @@ enum PropertyKey {
   launchRole,
 }
 
-extension PropertyKeyValue on PropertyKey {
+extension PropertyKeyValueExtension on PropertyKey {
   String toValue() {
     switch (this) {
       case PropertyKey.owner:
@@ -10494,7 +10495,8 @@ enum ProvisionedProductPlanStatus {
   executeFailed,
 }
 
-extension ProvisionedProductPlanStatusValue on ProvisionedProductPlanStatus {
+extension ProvisionedProductPlanStatusValueExtension
+    on ProvisionedProductPlanStatus {
   String toValue() {
     switch (this) {
       case ProvisionedProductPlanStatus.createInProgress:
@@ -10577,7 +10579,8 @@ enum ProvisionedProductPlanType {
   cloudformation,
 }
 
-extension ProvisionedProductPlanTypeValue on ProvisionedProductPlanType {
+extension ProvisionedProductPlanTypeValueExtension
+    on ProvisionedProductPlanType {
   String toValue() {
     switch (this) {
       case ProvisionedProductPlanType.cloudformation:
@@ -10604,7 +10607,7 @@ enum ProvisionedProductStatus {
   planInProgress,
 }
 
-extension ProvisionedProductStatusValue on ProvisionedProductStatus {
+extension ProvisionedProductStatusValueExtension on ProvisionedProductStatus {
   String toValue() {
     switch (this) {
       case ProvisionedProductStatus.available:
@@ -10643,7 +10646,7 @@ enum ProvisionedProductViewFilterBy {
   searchQuery,
 }
 
-extension ProvisionedProductViewFilterByValue
+extension ProvisionedProductViewFilterByValueExtension
     on ProvisionedProductViewFilterBy {
   String toValue() {
     switch (this) {
@@ -10765,7 +10768,8 @@ enum ProvisioningArtifactGuidance {
   deprecated,
 }
 
-extension ProvisioningArtifactGuidanceValue on ProvisioningArtifactGuidance {
+extension ProvisioningArtifactGuidanceValueExtension
+    on ProvisioningArtifactGuidance {
   String toValue() {
     switch (this) {
       case ProvisioningArtifactGuidance.$default:
@@ -10971,7 +10975,7 @@ enum ProvisioningArtifactPropertyName {
   id,
 }
 
-extension ProvisioningArtifactPropertyNameValue
+extension ProvisioningArtifactPropertyNameValueExtension
     on ProvisioningArtifactPropertyName {
   String toValue() {
     switch (this) {
@@ -11037,7 +11041,7 @@ enum ProvisioningArtifactType {
   marketplaceCar,
 }
 
-extension ProvisioningArtifactTypeValue on ProvisioningArtifactType {
+extension ProvisioningArtifactTypeValueExtension on ProvisioningArtifactType {
   String toValue() {
     switch (this) {
       case ProvisioningArtifactType.cloudFormationTemplate:
@@ -11428,7 +11432,7 @@ enum RecordStatus {
   failed,
 }
 
-extension RecordStatusValue on RecordStatus {
+extension RecordStatusValueExtension on RecordStatus {
   String toValue() {
     switch (this) {
       case RecordStatus.created:
@@ -11496,7 +11500,7 @@ enum Replacement {
   conditional,
 }
 
-extension ReplacementValue on Replacement {
+extension ReplacementValueExtension on Replacement {
   String toValue() {
     switch (this) {
       case Replacement.$true:
@@ -11529,7 +11533,7 @@ enum RequiresRecreation {
   always,
 }
 
-extension RequiresRecreationValue on RequiresRecreation {
+extension RequiresRecreationValueExtension on RequiresRecreation {
   String toValue() {
     switch (this) {
       case RequiresRecreation.never:
@@ -11565,7 +11569,7 @@ enum ResourceAttribute {
   tags,
 }
 
-extension ResourceAttributeValue on ResourceAttribute {
+extension ResourceAttributeValueExtension on ResourceAttribute {
   String toValue() {
     switch (this) {
       case ResourceAttribute.properties:
@@ -11900,7 +11904,7 @@ enum ServiceActionAssociationErrorCode {
   throttling,
 }
 
-extension ServiceActionAssociationErrorCodeValue
+extension ServiceActionAssociationErrorCodeValueExtension
     on ServiceActionAssociationErrorCode {
   String toValue() {
     switch (this) {
@@ -11944,7 +11948,8 @@ enum ServiceActionDefinitionKey {
   parameters,
 }
 
-extension ServiceActionDefinitionKeyValue on ServiceActionDefinitionKey {
+extension ServiceActionDefinitionKeyValueExtension
+    on ServiceActionDefinitionKey {
   String toValue() {
     switch (this) {
       case ServiceActionDefinitionKey.name:
@@ -11979,7 +11984,8 @@ enum ServiceActionDefinitionType {
   ssmAutomation,
 }
 
-extension ServiceActionDefinitionTypeValue on ServiceActionDefinitionType {
+extension ServiceActionDefinitionTypeValueExtension
+    on ServiceActionDefinitionType {
   String toValue() {
     switch (this) {
       case ServiceActionDefinitionType.ssmAutomation:
@@ -12116,7 +12122,7 @@ enum ShareStatus {
   error,
 }
 
-extension ShareStatusValue on ShareStatus {
+extension ShareStatusValueExtension on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.notStarted:
@@ -12156,7 +12162,7 @@ enum SortOrder {
   descending,
 }
 
-extension SortOrderValue on SortOrder {
+extension SortOrderValueExtension on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -12240,7 +12246,7 @@ enum StackInstanceStatus {
   inoperable,
 }
 
-extension StackInstanceStatusValue on StackInstanceStatus {
+extension StackInstanceStatusValueExtension on StackInstanceStatus {
   String toValue() {
     switch (this) {
       case StackInstanceStatus.current:
@@ -12273,7 +12279,7 @@ enum StackSetOperationType {
   delete,
 }
 
-extension StackSetOperationTypeValue on StackSetOperationType {
+extension StackSetOperationTypeValueExtension on StackSetOperationType {
   String toValue() {
     switch (this) {
       case StackSetOperationType.create:
@@ -12306,7 +12312,7 @@ enum Status {
   failed,
 }
 
-extension StatusValue on Status {
+extension StatusValueExtension on Status {
   String toValue() {
     switch (this) {
       case Status.available:

--- a/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
+++ b/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
@@ -7491,7 +7491,7 @@ enum AccessLevelFilterKey {
   user,
 }
 
-extension on AccessLevelFilterKey {
+extension AccessLevelFilterKeyValue on AccessLevelFilterKey {
   String toValue() {
     switch (this) {
       case AccessLevelFilterKey.account:
@@ -7504,7 +7504,7 @@ extension on AccessLevelFilterKey {
   }
 }
 
-extension on String {
+extension AccessLevelFilterKeyFromString on String {
   AccessLevelFilterKey toAccessLevelFilterKey() {
     switch (this) {
       case 'Account':
@@ -7524,7 +7524,7 @@ enum AccessStatus {
   disabled,
 }
 
-extension on AccessStatus {
+extension AccessStatusValue on AccessStatus {
   String toValue() {
     switch (this) {
       case AccessStatus.enabled:
@@ -7537,7 +7537,7 @@ extension on AccessStatus {
   }
 }
 
-extension on String {
+extension AccessStatusFromString on String {
   AccessStatus toAccessStatus() {
     switch (this) {
       case 'ENABLED':
@@ -7652,7 +7652,7 @@ enum ChangeAction {
   remove,
 }
 
-extension on ChangeAction {
+extension ChangeActionValue on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.add:
@@ -7665,7 +7665,7 @@ extension on ChangeAction {
   }
 }
 
-extension on String {
+extension ChangeActionFromString on String {
   ChangeAction toChangeAction() {
     switch (this) {
       case 'ADD':
@@ -7792,7 +7792,7 @@ enum CopyOption {
   copyTags,
 }
 
-extension on CopyOption {
+extension CopyOptionValue on CopyOption {
   String toValue() {
     switch (this) {
       case CopyOption.copyTags:
@@ -7801,7 +7801,7 @@ extension on CopyOption {
   }
 }
 
-extension on String {
+extension CopyOptionFromString on String {
   CopyOption toCopyOption() {
     switch (this) {
       case 'CopyTags':
@@ -7831,7 +7831,7 @@ enum CopyProductStatus {
   failed,
 }
 
-extension on CopyProductStatus {
+extension CopyProductStatusValue on CopyProductStatus {
   String toValue() {
     switch (this) {
       case CopyProductStatus.succeeded:
@@ -7844,7 +7844,7 @@ extension on CopyProductStatus {
   }
 }
 
-extension on String {
+extension CopyProductStatusFromString on String {
   CopyProductStatus toCopyProductStatus() {
     switch (this) {
       case 'SUCCEEDED':
@@ -8271,7 +8271,7 @@ enum DescribePortfolioShareType {
   organizationMemberAccount,
 }
 
-extension on DescribePortfolioShareType {
+extension DescribePortfolioShareTypeValue on DescribePortfolioShareType {
   String toValue() {
     switch (this) {
       case DescribePortfolioShareType.account:
@@ -8286,7 +8286,7 @@ extension on DescribePortfolioShareType {
   }
 }
 
-extension on String {
+extension DescribePortfolioShareTypeFromString on String {
   DescribePortfolioShareType toDescribePortfolioShareType() {
     switch (this) {
       case 'ACCOUNT':
@@ -8741,7 +8741,7 @@ enum EvaluationType {
   dynamic,
 }
 
-extension on EvaluationType {
+extension EvaluationTypeValue on EvaluationType {
   String toValue() {
     switch (this) {
       case EvaluationType.static:
@@ -8752,7 +8752,7 @@ extension on EvaluationType {
   }
 }
 
-extension on String {
+extension EvaluationTypeFromString on String {
   EvaluationType toEvaluationType() {
     switch (this) {
       case 'STATIC':
@@ -9503,7 +9503,7 @@ enum OrganizationNodeType {
   account,
 }
 
-extension on OrganizationNodeType {
+extension OrganizationNodeTypeValue on OrganizationNodeType {
   String toValue() {
     switch (this) {
       case OrganizationNodeType.organization:
@@ -9516,7 +9516,7 @@ extension on OrganizationNodeType {
   }
 }
 
-extension on String {
+extension OrganizationNodeTypeFromString on String {
   OrganizationNodeType toOrganizationNodeType() {
     switch (this) {
       case 'ORGANIZATION':
@@ -9686,7 +9686,7 @@ enum PortfolioShareType {
   awsOrganizations,
 }
 
-extension on PortfolioShareType {
+extension PortfolioShareTypeValue on PortfolioShareType {
   String toValue() {
     switch (this) {
       case PortfolioShareType.imported:
@@ -9699,7 +9699,7 @@ extension on PortfolioShareType {
   }
 }
 
-extension on String {
+extension PortfolioShareTypeFromString on String {
   PortfolioShareType toPortfolioShareType() {
     switch (this) {
       case 'IMPORTED':
@@ -9737,7 +9737,7 @@ enum PrincipalType {
   iam,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.iam:
@@ -9746,7 +9746,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'IAM':
@@ -9760,7 +9760,7 @@ enum ProductSource {
   account,
 }
 
-extension on ProductSource {
+extension ProductSourceValue on ProductSource {
   String toValue() {
     switch (this) {
       case ProductSource.account:
@@ -9769,7 +9769,7 @@ extension on ProductSource {
   }
 }
 
-extension on String {
+extension ProductSourceFromString on String {
   ProductSource toProductSource() {
     switch (this) {
       case 'ACCOUNT':
@@ -9784,7 +9784,7 @@ enum ProductType {
   marketplace,
 }
 
-extension on ProductType {
+extension ProductTypeValue on ProductType {
   String toValue() {
     switch (this) {
       case ProductType.cloudFormationTemplate:
@@ -9795,7 +9795,7 @@ extension on ProductType {
   }
 }
 
-extension on String {
+extension ProductTypeFromString on String {
   ProductType toProductType() {
     switch (this) {
       case 'CLOUD_FORMATION_TEMPLATE':
@@ -9881,7 +9881,7 @@ enum ProductViewFilterBy {
   sourceProductId,
 }
 
-extension on ProductViewFilterBy {
+extension ProductViewFilterByValue on ProductViewFilterBy {
   String toValue() {
     switch (this) {
       case ProductViewFilterBy.fullTextSearch:
@@ -9896,7 +9896,7 @@ extension on ProductViewFilterBy {
   }
 }
 
-extension on String {
+extension ProductViewFilterByFromString on String {
   ProductViewFilterBy toProductViewFilterBy() {
     switch (this) {
       case 'FullTextSearch':
@@ -9918,7 +9918,7 @@ enum ProductViewSortBy {
   creationDate,
 }
 
-extension on ProductViewSortBy {
+extension ProductViewSortByValue on ProductViewSortBy {
   String toValue() {
     switch (this) {
       case ProductViewSortBy.title:
@@ -9931,7 +9931,7 @@ extension on ProductViewSortBy {
   }
 }
 
-extension on String {
+extension ProductViewSortByFromString on String {
   ProductViewSortBy toProductViewSortBy() {
     switch (this) {
       case 'Title':
@@ -10023,7 +10023,7 @@ enum PropertyKey {
   launchRole,
 }
 
-extension on PropertyKey {
+extension PropertyKeyValue on PropertyKey {
   String toValue() {
     switch (this) {
       case PropertyKey.owner:
@@ -10034,7 +10034,7 @@ extension on PropertyKey {
   }
 }
 
-extension on String {
+extension PropertyKeyFromString on String {
   PropertyKey toPropertyKey() {
     switch (this) {
       case 'OWNER':
@@ -10494,7 +10494,7 @@ enum ProvisionedProductPlanStatus {
   executeFailed,
 }
 
-extension on ProvisionedProductPlanStatus {
+extension ProvisionedProductPlanStatusValue on ProvisionedProductPlanStatus {
   String toValue() {
     switch (this) {
       case ProvisionedProductPlanStatus.createInProgress:
@@ -10513,7 +10513,7 @@ extension on ProvisionedProductPlanStatus {
   }
 }
 
-extension on String {
+extension ProvisionedProductPlanStatusFromString on String {
   ProvisionedProductPlanStatus toProvisionedProductPlanStatus() {
     switch (this) {
       case 'CREATE_IN_PROGRESS':
@@ -10577,7 +10577,7 @@ enum ProvisionedProductPlanType {
   cloudformation,
 }
 
-extension on ProvisionedProductPlanType {
+extension ProvisionedProductPlanTypeValue on ProvisionedProductPlanType {
   String toValue() {
     switch (this) {
       case ProvisionedProductPlanType.cloudformation:
@@ -10586,7 +10586,7 @@ extension on ProvisionedProductPlanType {
   }
 }
 
-extension on String {
+extension ProvisionedProductPlanTypeFromString on String {
   ProvisionedProductPlanType toProvisionedProductPlanType() {
     switch (this) {
       case 'CLOUDFORMATION':
@@ -10604,7 +10604,7 @@ enum ProvisionedProductStatus {
   planInProgress,
 }
 
-extension on ProvisionedProductStatus {
+extension ProvisionedProductStatusValue on ProvisionedProductStatus {
   String toValue() {
     switch (this) {
       case ProvisionedProductStatus.available:
@@ -10621,7 +10621,7 @@ extension on ProvisionedProductStatus {
   }
 }
 
-extension on String {
+extension ProvisionedProductStatusFromString on String {
   ProvisionedProductStatus toProvisionedProductStatus() {
     switch (this) {
       case 'AVAILABLE':
@@ -10643,7 +10643,8 @@ enum ProvisionedProductViewFilterBy {
   searchQuery,
 }
 
-extension on ProvisionedProductViewFilterBy {
+extension ProvisionedProductViewFilterByValue
+    on ProvisionedProductViewFilterBy {
   String toValue() {
     switch (this) {
       case ProvisionedProductViewFilterBy.searchQuery:
@@ -10652,7 +10653,7 @@ extension on ProvisionedProductViewFilterBy {
   }
 }
 
-extension on String {
+extension ProvisionedProductViewFilterByFromString on String {
   ProvisionedProductViewFilterBy toProvisionedProductViewFilterBy() {
     switch (this) {
       case 'SearchQuery':
@@ -10764,7 +10765,7 @@ enum ProvisioningArtifactGuidance {
   deprecated,
 }
 
-extension on ProvisioningArtifactGuidance {
+extension ProvisioningArtifactGuidanceValue on ProvisioningArtifactGuidance {
   String toValue() {
     switch (this) {
       case ProvisioningArtifactGuidance.$default:
@@ -10775,7 +10776,7 @@ extension on ProvisioningArtifactGuidance {
   }
 }
 
-extension on String {
+extension ProvisioningArtifactGuidanceFromString on String {
   ProvisioningArtifactGuidance toProvisioningArtifactGuidance() {
     switch (this) {
       case 'DEFAULT':
@@ -10970,7 +10971,8 @@ enum ProvisioningArtifactPropertyName {
   id,
 }
 
-extension on ProvisioningArtifactPropertyName {
+extension ProvisioningArtifactPropertyNameValue
+    on ProvisioningArtifactPropertyName {
   String toValue() {
     switch (this) {
       case ProvisioningArtifactPropertyName.id:
@@ -10979,7 +10981,7 @@ extension on ProvisioningArtifactPropertyName {
   }
 }
 
-extension on String {
+extension ProvisioningArtifactPropertyNameFromString on String {
   ProvisioningArtifactPropertyName toProvisioningArtifactPropertyName() {
     switch (this) {
       case 'Id':
@@ -11035,7 +11037,7 @@ enum ProvisioningArtifactType {
   marketplaceCar,
 }
 
-extension on ProvisioningArtifactType {
+extension ProvisioningArtifactTypeValue on ProvisioningArtifactType {
   String toValue() {
     switch (this) {
       case ProvisioningArtifactType.cloudFormationTemplate:
@@ -11048,7 +11050,7 @@ extension on ProvisioningArtifactType {
   }
 }
 
-extension on String {
+extension ProvisioningArtifactTypeFromString on String {
   ProvisioningArtifactType toProvisioningArtifactType() {
     switch (this) {
       case 'CLOUD_FORMATION_TEMPLATE':
@@ -11426,7 +11428,7 @@ enum RecordStatus {
   failed,
 }
 
-extension on RecordStatus {
+extension RecordStatusValue on RecordStatus {
   String toValue() {
     switch (this) {
       case RecordStatus.created:
@@ -11443,7 +11445,7 @@ extension on RecordStatus {
   }
 }
 
-extension on String {
+extension RecordStatusFromString on String {
   RecordStatus toRecordStatus() {
     switch (this) {
       case 'CREATED':
@@ -11494,7 +11496,7 @@ enum Replacement {
   conditional,
 }
 
-extension on Replacement {
+extension ReplacementValue on Replacement {
   String toValue() {
     switch (this) {
       case Replacement.$true:
@@ -11507,7 +11509,7 @@ extension on Replacement {
   }
 }
 
-extension on String {
+extension ReplacementFromString on String {
   Replacement toReplacement() {
     switch (this) {
       case 'TRUE':
@@ -11527,7 +11529,7 @@ enum RequiresRecreation {
   always,
 }
 
-extension on RequiresRecreation {
+extension RequiresRecreationValue on RequiresRecreation {
   String toValue() {
     switch (this) {
       case RequiresRecreation.never:
@@ -11540,7 +11542,7 @@ extension on RequiresRecreation {
   }
 }
 
-extension on String {
+extension RequiresRecreationFromString on String {
   RequiresRecreation toRequiresRecreation() {
     switch (this) {
       case 'NEVER':
@@ -11563,7 +11565,7 @@ enum ResourceAttribute {
   tags,
 }
 
-extension on ResourceAttribute {
+extension ResourceAttributeValue on ResourceAttribute {
   String toValue() {
     switch (this) {
       case ResourceAttribute.properties:
@@ -11582,7 +11584,7 @@ extension on ResourceAttribute {
   }
 }
 
-extension on String {
+extension ResourceAttributeFromString on String {
   ResourceAttribute toResourceAttribute() {
     switch (this) {
       case 'PROPERTIES':
@@ -11898,7 +11900,8 @@ enum ServiceActionAssociationErrorCode {
   throttling,
 }
 
-extension on ServiceActionAssociationErrorCode {
+extension ServiceActionAssociationErrorCodeValue
+    on ServiceActionAssociationErrorCode {
   String toValue() {
     switch (this) {
       case ServiceActionAssociationErrorCode.duplicateResource:
@@ -11915,7 +11918,7 @@ extension on ServiceActionAssociationErrorCode {
   }
 }
 
-extension on String {
+extension ServiceActionAssociationErrorCodeFromString on String {
   ServiceActionAssociationErrorCode toServiceActionAssociationErrorCode() {
     switch (this) {
       case 'DUPLICATE_RESOURCE':
@@ -11941,7 +11944,7 @@ enum ServiceActionDefinitionKey {
   parameters,
 }
 
-extension on ServiceActionDefinitionKey {
+extension ServiceActionDefinitionKeyValue on ServiceActionDefinitionKey {
   String toValue() {
     switch (this) {
       case ServiceActionDefinitionKey.name:
@@ -11956,7 +11959,7 @@ extension on ServiceActionDefinitionKey {
   }
 }
 
-extension on String {
+extension ServiceActionDefinitionKeyFromString on String {
   ServiceActionDefinitionKey toServiceActionDefinitionKey() {
     switch (this) {
       case 'Name':
@@ -11976,7 +11979,7 @@ enum ServiceActionDefinitionType {
   ssmAutomation,
 }
 
-extension on ServiceActionDefinitionType {
+extension ServiceActionDefinitionTypeValue on ServiceActionDefinitionType {
   String toValue() {
     switch (this) {
       case ServiceActionDefinitionType.ssmAutomation:
@@ -11985,7 +11988,7 @@ extension on ServiceActionDefinitionType {
   }
 }
 
-extension on String {
+extension ServiceActionDefinitionTypeFromString on String {
   ServiceActionDefinitionType toServiceActionDefinitionType() {
     switch (this) {
       case 'SSM_AUTOMATION':
@@ -12113,7 +12116,7 @@ enum ShareStatus {
   error,
 }
 
-extension on ShareStatus {
+extension ShareStatusValue on ShareStatus {
   String toValue() {
     switch (this) {
       case ShareStatus.notStarted:
@@ -12130,7 +12133,7 @@ extension on ShareStatus {
   }
 }
 
-extension on String {
+extension ShareStatusFromString on String {
   ShareStatus toShareStatus() {
     switch (this) {
       case 'NOT_STARTED':
@@ -12153,7 +12156,7 @@ enum SortOrder {
   descending,
 }
 
-extension on SortOrder {
+extension SortOrderValue on SortOrder {
   String toValue() {
     switch (this) {
       case SortOrder.ascending:
@@ -12164,7 +12167,7 @@ extension on SortOrder {
   }
 }
 
-extension on String {
+extension SortOrderFromString on String {
   SortOrder toSortOrder() {
     switch (this) {
       case 'ASCENDING':
@@ -12237,7 +12240,7 @@ enum StackInstanceStatus {
   inoperable,
 }
 
-extension on StackInstanceStatus {
+extension StackInstanceStatusValue on StackInstanceStatus {
   String toValue() {
     switch (this) {
       case StackInstanceStatus.current:
@@ -12250,7 +12253,7 @@ extension on StackInstanceStatus {
   }
 }
 
-extension on String {
+extension StackInstanceStatusFromString on String {
   StackInstanceStatus toStackInstanceStatus() {
     switch (this) {
       case 'CURRENT':
@@ -12270,7 +12273,7 @@ enum StackSetOperationType {
   delete,
 }
 
-extension on StackSetOperationType {
+extension StackSetOperationTypeValue on StackSetOperationType {
   String toValue() {
     switch (this) {
       case StackSetOperationType.create:
@@ -12283,7 +12286,7 @@ extension on StackSetOperationType {
   }
 }
 
-extension on String {
+extension StackSetOperationTypeFromString on String {
   StackSetOperationType toStackSetOperationType() {
     switch (this) {
       case 'CREATE':
@@ -12303,7 +12306,7 @@ enum Status {
   failed,
 }
 
-extension on Status {
+extension StatusValue on Status {
   String toValue() {
     switch (this) {
       case Status.available:
@@ -12316,7 +12319,7 @@ extension on Status {
   }
 }
 
-extension on String {
+extension StatusFromString on String {
   Status toStatus() {
     switch (this) {
       case 'AVAILABLE':

--- a/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
+++ b/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
@@ -1817,7 +1817,7 @@ enum CustomHealthStatus {
   unhealthy,
 }
 
-extension on CustomHealthStatus {
+extension CustomHealthStatusValue on CustomHealthStatus {
   String toValue() {
     switch (this) {
       case CustomHealthStatus.healthy:
@@ -1828,7 +1828,7 @@ extension on CustomHealthStatus {
   }
 }
 
-extension on String {
+extension CustomHealthStatusFromString on String {
   CustomHealthStatus toCustomHealthStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -2195,7 +2195,7 @@ enum FilterCondition {
   between,
 }
 
-extension on FilterCondition {
+extension FilterConditionValue on FilterCondition {
   String toValue() {
     switch (this) {
       case FilterCondition.eq:
@@ -2208,7 +2208,7 @@ extension on FilterCondition {
   }
 }
 
-extension on String {
+extension FilterConditionFromString on String {
   FilterCondition toFilterCondition() {
     switch (this) {
       case 'EQ':
@@ -2563,7 +2563,7 @@ enum HealthCheckType {
   tcp,
 }
 
-extension on HealthCheckType {
+extension HealthCheckTypeValue on HealthCheckType {
   String toValue() {
     switch (this) {
       case HealthCheckType.http:
@@ -2576,7 +2576,7 @@ extension on HealthCheckType {
   }
 }
 
-extension on String {
+extension HealthCheckTypeFromString on String {
   HealthCheckType toHealthCheckType() {
     switch (this) {
       case 'HTTP':
@@ -2596,7 +2596,7 @@ enum HealthStatus {
   unknown,
 }
 
-extension on HealthStatus {
+extension HealthStatusValue on HealthStatus {
   String toValue() {
     switch (this) {
       case HealthStatus.healthy:
@@ -2609,7 +2609,7 @@ extension on HealthStatus {
   }
 }
 
-extension on String {
+extension HealthStatusFromString on String {
   HealthStatus toHealthStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -2629,7 +2629,7 @@ enum HealthStatusFilter {
   all,
 }
 
-extension on HealthStatusFilter {
+extension HealthStatusFilterValue on HealthStatusFilter {
   String toValue() {
     switch (this) {
       case HealthStatusFilter.healthy:
@@ -2642,7 +2642,7 @@ extension on HealthStatusFilter {
   }
 }
 
-extension on String {
+extension HealthStatusFilterFromString on String {
   HealthStatusFilter toHealthStatusFilter() {
     switch (this) {
       case 'HEALTHY':
@@ -3212,7 +3212,7 @@ enum NamespaceFilterName {
   type,
 }
 
-extension on NamespaceFilterName {
+extension NamespaceFilterNameValue on NamespaceFilterName {
   String toValue() {
     switch (this) {
       case NamespaceFilterName.type:
@@ -3221,7 +3221,7 @@ extension on NamespaceFilterName {
   }
 }
 
-extension on String {
+extension NamespaceFilterNameFromString on String {
   NamespaceFilterName toNamespaceFilterName() {
     switch (this) {
       case 'TYPE':
@@ -3319,7 +3319,7 @@ enum NamespaceType {
   http,
 }
 
-extension on NamespaceType {
+extension NamespaceTypeValue on NamespaceType {
   String toValue() {
     switch (this) {
       case NamespaceType.dnsPublic:
@@ -3332,7 +3332,7 @@ extension on NamespaceType {
   }
 }
 
-extension on String {
+extension NamespaceTypeFromString on String {
   NamespaceType toNamespaceType() {
     switch (this) {
       case 'DNS_PUBLIC':
@@ -3567,7 +3567,7 @@ enum OperationFilterName {
   updateDate,
 }
 
-extension on OperationFilterName {
+extension OperationFilterNameValue on OperationFilterName {
   String toValue() {
     switch (this) {
       case OperationFilterName.namespaceId:
@@ -3584,7 +3584,7 @@ extension on OperationFilterName {
   }
 }
 
-extension on String {
+extension OperationFilterNameFromString on String {
   OperationFilterName toOperationFilterName() {
     switch (this) {
       case 'NAMESPACE_ID':
@@ -3609,7 +3609,7 @@ enum OperationStatus {
   fail,
 }
 
-extension on OperationStatus {
+extension OperationStatusValue on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.submitted:
@@ -3624,7 +3624,7 @@ extension on OperationStatus {
   }
 }
 
-extension on String {
+extension OperationStatusFromString on String {
   OperationStatus toOperationStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -3686,7 +3686,7 @@ enum OperationTargetType {
   instance,
 }
 
-extension on OperationTargetType {
+extension OperationTargetTypeValue on OperationTargetType {
   String toValue() {
     switch (this) {
       case OperationTargetType.namespace:
@@ -3699,7 +3699,7 @@ extension on OperationTargetType {
   }
 }
 
-extension on String {
+extension OperationTargetTypeFromString on String {
   OperationTargetType toOperationTargetType() {
     switch (this) {
       case 'NAMESPACE':
@@ -3721,7 +3721,7 @@ enum OperationType {
   deregisterInstance,
 }
 
-extension on OperationType {
+extension OperationTypeValue on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.createNamespace:
@@ -3738,7 +3738,7 @@ extension on OperationType {
   }
 }
 
-extension on String {
+extension OperationTypeFromString on String {
   OperationType toOperationType() {
     switch (this) {
       case 'CREATE_NAMESPACE':
@@ -3763,7 +3763,7 @@ enum RecordType {
   cname,
 }
 
-extension on RecordType {
+extension RecordTypeValue on RecordType {
   String toValue() {
     switch (this) {
       case RecordType.srv:
@@ -3778,7 +3778,7 @@ extension on RecordType {
   }
 }
 
-extension on String {
+extension RecordTypeFromString on String {
   RecordType toRecordType() {
     switch (this) {
       case 'SRV':
@@ -3815,7 +3815,7 @@ enum RoutingPolicy {
   weighted,
 }
 
-extension on RoutingPolicy {
+extension RoutingPolicyValue on RoutingPolicy {
   String toValue() {
     switch (this) {
       case RoutingPolicy.multivalue:
@@ -3826,7 +3826,7 @@ extension on RoutingPolicy {
   }
 }
 
-extension on String {
+extension RoutingPolicyFromString on String {
   RoutingPolicy toRoutingPolicy() {
     switch (this) {
       case 'MULTIVALUE':
@@ -4013,7 +4013,7 @@ enum ServiceFilterName {
   namespaceId,
 }
 
-extension on ServiceFilterName {
+extension ServiceFilterNameValue on ServiceFilterName {
   String toValue() {
     switch (this) {
       case ServiceFilterName.namespaceId:
@@ -4022,7 +4022,7 @@ extension on ServiceFilterName {
   }
 }
 
-extension on String {
+extension ServiceFilterNameFromString on String {
   ServiceFilterName toServiceFilterName() {
     switch (this) {
       case 'NAMESPACE_ID':

--- a/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
+++ b/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
@@ -1817,7 +1817,7 @@ enum CustomHealthStatus {
   unhealthy,
 }
 
-extension CustomHealthStatusValue on CustomHealthStatus {
+extension CustomHealthStatusValueExtension on CustomHealthStatus {
   String toValue() {
     switch (this) {
       case CustomHealthStatus.healthy:
@@ -2195,7 +2195,7 @@ enum FilterCondition {
   between,
 }
 
-extension FilterConditionValue on FilterCondition {
+extension FilterConditionValueExtension on FilterCondition {
   String toValue() {
     switch (this) {
       case FilterCondition.eq:
@@ -2563,7 +2563,7 @@ enum HealthCheckType {
   tcp,
 }
 
-extension HealthCheckTypeValue on HealthCheckType {
+extension HealthCheckTypeValueExtension on HealthCheckType {
   String toValue() {
     switch (this) {
       case HealthCheckType.http:
@@ -2596,7 +2596,7 @@ enum HealthStatus {
   unknown,
 }
 
-extension HealthStatusValue on HealthStatus {
+extension HealthStatusValueExtension on HealthStatus {
   String toValue() {
     switch (this) {
       case HealthStatus.healthy:
@@ -2629,7 +2629,7 @@ enum HealthStatusFilter {
   all,
 }
 
-extension HealthStatusFilterValue on HealthStatusFilter {
+extension HealthStatusFilterValueExtension on HealthStatusFilter {
   String toValue() {
     switch (this) {
       case HealthStatusFilter.healthy:
@@ -3212,7 +3212,7 @@ enum NamespaceFilterName {
   type,
 }
 
-extension NamespaceFilterNameValue on NamespaceFilterName {
+extension NamespaceFilterNameValueExtension on NamespaceFilterName {
   String toValue() {
     switch (this) {
       case NamespaceFilterName.type:
@@ -3319,7 +3319,7 @@ enum NamespaceType {
   http,
 }
 
-extension NamespaceTypeValue on NamespaceType {
+extension NamespaceTypeValueExtension on NamespaceType {
   String toValue() {
     switch (this) {
       case NamespaceType.dnsPublic:
@@ -3567,7 +3567,7 @@ enum OperationFilterName {
   updateDate,
 }
 
-extension OperationFilterNameValue on OperationFilterName {
+extension OperationFilterNameValueExtension on OperationFilterName {
   String toValue() {
     switch (this) {
       case OperationFilterName.namespaceId:
@@ -3609,7 +3609,7 @@ enum OperationStatus {
   fail,
 }
 
-extension OperationStatusValue on OperationStatus {
+extension OperationStatusValueExtension on OperationStatus {
   String toValue() {
     switch (this) {
       case OperationStatus.submitted:
@@ -3686,7 +3686,7 @@ enum OperationTargetType {
   instance,
 }
 
-extension OperationTargetTypeValue on OperationTargetType {
+extension OperationTargetTypeValueExtension on OperationTargetType {
   String toValue() {
     switch (this) {
       case OperationTargetType.namespace:
@@ -3721,7 +3721,7 @@ enum OperationType {
   deregisterInstance,
 }
 
-extension OperationTypeValue on OperationType {
+extension OperationTypeValueExtension on OperationType {
   String toValue() {
     switch (this) {
       case OperationType.createNamespace:
@@ -3763,7 +3763,7 @@ enum RecordType {
   cname,
 }
 
-extension RecordTypeValue on RecordType {
+extension RecordTypeValueExtension on RecordType {
   String toValue() {
     switch (this) {
       case RecordType.srv:
@@ -3815,7 +3815,7 @@ enum RoutingPolicy {
   weighted,
 }
 
-extension RoutingPolicyValue on RoutingPolicy {
+extension RoutingPolicyValueExtension on RoutingPolicy {
   String toValue() {
     switch (this) {
       case RoutingPolicy.multivalue:
@@ -4013,7 +4013,7 @@ enum ServiceFilterName {
   namespaceId,
 }
 
-extension ServiceFilterNameValue on ServiceFilterName {
+extension ServiceFilterNameValueExtension on ServiceFilterName {
   String toValue() {
     switch (this) {
       case ServiceFilterName.namespaceId:

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -3709,7 +3709,7 @@ enum BehaviorOnMXFailure {
   rejectMessage,
 }
 
-extension BehaviorOnMXFailureValue on BehaviorOnMXFailure {
+extension BehaviorOnMXFailureValueExtension on BehaviorOnMXFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMXFailure.useDefaultValue:
@@ -3833,7 +3833,7 @@ enum BounceType {
   temporaryFailure,
 }
 
-extension BounceTypeValue on BounceType {
+extension BounceTypeValueExtension on BounceType {
   String toValue() {
     switch (this) {
       case BounceType.doesNotExist:
@@ -4062,7 +4062,7 @@ enum BulkEmailStatus {
   failed,
 }
 
-extension BulkEmailStatusValue on BulkEmailStatus {
+extension BulkEmailStatusValueExtension on BulkEmailStatus {
   String toValue() {
     switch (this) {
       case BulkEmailStatus.success:
@@ -4298,7 +4298,7 @@ enum ConfigurationSetAttribute {
   reputationOptions,
 }
 
-extension ConfigurationSetAttributeValue on ConfigurationSetAttribute {
+extension ConfigurationSetAttributeValueExtension on ConfigurationSetAttribute {
   String toValue() {
     switch (this) {
       case ConfigurationSetAttribute.eventDestinations:
@@ -4431,7 +4431,7 @@ enum CustomMailFromStatus {
   temporaryFailure,
 }
 
-extension CustomMailFromStatusValue on CustomMailFromStatus {
+extension CustomMailFromStatusValueExtension on CustomMailFromStatus {
   String toValue() {
     switch (this) {
       case CustomMailFromStatus.pending:
@@ -4786,7 +4786,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension DimensionValueSourceValue on DimensionValueSource {
+extension DimensionValueSourceValueExtension on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -4821,7 +4821,7 @@ enum DsnAction {
   expanded,
 }
 
-extension DsnActionValue on DsnAction {
+extension DsnActionValueExtension on DsnAction {
   String toValue() {
     switch (this) {
       case DsnAction.failed:
@@ -4964,7 +4964,7 @@ enum EventType {
   renderingFailure,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -5457,7 +5457,7 @@ enum IdentityType {
   domain,
 }
 
-extension IdentityTypeValue on IdentityType {
+extension IdentityTypeValueExtension on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -5509,7 +5509,7 @@ enum InvocationType {
   requestResponse,
 }
 
-extension InvocationTypeValue on InvocationType {
+extension InvocationTypeValueExtension on InvocationType {
   String toValue() {
     switch (this) {
       case InvocationType.event:
@@ -5946,7 +5946,7 @@ enum NotificationType {
   delivery,
 }
 
-extension NotificationTypeValue on NotificationType {
+extension NotificationTypeValueExtension on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.bounce:
@@ -6171,7 +6171,7 @@ enum ReceiptFilterPolicy {
   allow,
 }
 
-extension ReceiptFilterPolicyValue on ReceiptFilterPolicy {
+extension ReceiptFilterPolicyValueExtension on ReceiptFilterPolicy {
   String toValue() {
     switch (this) {
       case ReceiptFilterPolicy.block:
@@ -6673,7 +6673,7 @@ enum SNSActionEncoding {
   base64,
 }
 
-extension SNSActionEncodingValue on SNSActionEncoding {
+extension SNSActionEncodingValueExtension on SNSActionEncoding {
   String toValue() {
     switch (this) {
       case SNSActionEncoding.utf_8:
@@ -6978,7 +6978,7 @@ enum StopScope {
   ruleSet,
 }
 
-extension StopScopeValue on StopScope {
+extension StopScopeValueExtension on StopScope {
   String toValue() {
     switch (this) {
       case StopScope.ruleSet:
@@ -7084,7 +7084,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension TlsPolicyValue on TlsPolicy {
+extension TlsPolicyValueExtension on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -7186,7 +7186,7 @@ enum VerificationStatus {
   notStarted,
 }
 
-extension VerificationStatusValue on VerificationStatus {
+extension VerificationStatusValueExtension on VerificationStatus {
   String toValue() {
     switch (this) {
       case VerificationStatus.pending:

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -3709,7 +3709,7 @@ enum BehaviorOnMXFailure {
   rejectMessage,
 }
 
-extension on BehaviorOnMXFailure {
+extension BehaviorOnMXFailureValue on BehaviorOnMXFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMXFailure.useDefaultValue:
@@ -3720,7 +3720,7 @@ extension on BehaviorOnMXFailure {
   }
 }
 
-extension on String {
+extension BehaviorOnMXFailureFromString on String {
   BehaviorOnMXFailure toBehaviorOnMXFailure() {
     switch (this) {
       case 'UseDefaultValue':
@@ -3833,7 +3833,7 @@ enum BounceType {
   temporaryFailure,
 }
 
-extension on BounceType {
+extension BounceTypeValue on BounceType {
   String toValue() {
     switch (this) {
       case BounceType.doesNotExist:
@@ -3852,7 +3852,7 @@ extension on BounceType {
   }
 }
 
-extension on String {
+extension BounceTypeFromString on String {
   BounceType toBounceType() {
     switch (this) {
       case 'DoesNotExist':
@@ -4062,7 +4062,7 @@ enum BulkEmailStatus {
   failed,
 }
 
-extension on BulkEmailStatus {
+extension BulkEmailStatusValue on BulkEmailStatus {
   String toValue() {
     switch (this) {
       case BulkEmailStatus.success:
@@ -4097,7 +4097,7 @@ extension on BulkEmailStatus {
   }
 }
 
-extension on String {
+extension BulkEmailStatusFromString on String {
   BulkEmailStatus toBulkEmailStatus() {
     switch (this) {
       case 'Success':
@@ -4298,7 +4298,7 @@ enum ConfigurationSetAttribute {
   reputationOptions,
 }
 
-extension on ConfigurationSetAttribute {
+extension ConfigurationSetAttributeValue on ConfigurationSetAttribute {
   String toValue() {
     switch (this) {
       case ConfigurationSetAttribute.eventDestinations:
@@ -4313,7 +4313,7 @@ extension on ConfigurationSetAttribute {
   }
 }
 
-extension on String {
+extension ConfigurationSetAttributeFromString on String {
   ConfigurationSetAttribute toConfigurationSetAttribute() {
     switch (this) {
       case 'eventDestinations':
@@ -4431,7 +4431,7 @@ enum CustomMailFromStatus {
   temporaryFailure,
 }
 
-extension on CustomMailFromStatus {
+extension CustomMailFromStatusValue on CustomMailFromStatus {
   String toValue() {
     switch (this) {
       case CustomMailFromStatus.pending:
@@ -4446,7 +4446,7 @@ extension on CustomMailFromStatus {
   }
 }
 
-extension on String {
+extension CustomMailFromStatusFromString on String {
   CustomMailFromStatus toCustomMailFromStatus() {
     switch (this) {
       case 'Pending':
@@ -4786,7 +4786,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension on DimensionValueSource {
+extension DimensionValueSourceValue on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -4799,7 +4799,7 @@ extension on DimensionValueSource {
   }
 }
 
-extension on String {
+extension DimensionValueSourceFromString on String {
   DimensionValueSource toDimensionValueSource() {
     switch (this) {
       case 'messageTag':
@@ -4821,7 +4821,7 @@ enum DsnAction {
   expanded,
 }
 
-extension on DsnAction {
+extension DsnActionValue on DsnAction {
   String toValue() {
     switch (this) {
       case DsnAction.failed:
@@ -4838,7 +4838,7 @@ extension on DsnAction {
   }
 }
 
-extension on String {
+extension DsnActionFromString on String {
   DsnAction toDsnAction() {
     switch (this) {
       case 'failed':
@@ -4964,7 +4964,7 @@ enum EventType {
   renderingFailure,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -4987,7 +4987,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'send':
@@ -5457,7 +5457,7 @@ enum IdentityType {
   domain,
 }
 
-extension on IdentityType {
+extension IdentityTypeValue on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -5468,7 +5468,7 @@ extension on IdentityType {
   }
 }
 
-extension on String {
+extension IdentityTypeFromString on String {
   IdentityType toIdentityType() {
     switch (this) {
       case 'EmailAddress':
@@ -5509,7 +5509,7 @@ enum InvocationType {
   requestResponse,
 }
 
-extension on InvocationType {
+extension InvocationTypeValue on InvocationType {
   String toValue() {
     switch (this) {
       case InvocationType.event:
@@ -5520,7 +5520,7 @@ extension on InvocationType {
   }
 }
 
-extension on String {
+extension InvocationTypeFromString on String {
   InvocationType toInvocationType() {
     switch (this) {
       case 'Event':
@@ -5946,7 +5946,7 @@ enum NotificationType {
   delivery,
 }
 
-extension on NotificationType {
+extension NotificationTypeValue on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.bounce:
@@ -5959,7 +5959,7 @@ extension on NotificationType {
   }
 }
 
-extension on String {
+extension NotificationTypeFromString on String {
   NotificationType toNotificationType() {
     switch (this) {
       case 'Bounce':
@@ -6171,7 +6171,7 @@ enum ReceiptFilterPolicy {
   allow,
 }
 
-extension on ReceiptFilterPolicy {
+extension ReceiptFilterPolicyValue on ReceiptFilterPolicy {
   String toValue() {
     switch (this) {
       case ReceiptFilterPolicy.block:
@@ -6182,7 +6182,7 @@ extension on ReceiptFilterPolicy {
   }
 }
 
-extension on String {
+extension ReceiptFilterPolicyFromString on String {
   ReceiptFilterPolicy toReceiptFilterPolicy() {
     switch (this) {
       case 'Block':
@@ -6673,7 +6673,7 @@ enum SNSActionEncoding {
   base64,
 }
 
-extension on SNSActionEncoding {
+extension SNSActionEncodingValue on SNSActionEncoding {
   String toValue() {
     switch (this) {
       case SNSActionEncoding.utf_8:
@@ -6684,7 +6684,7 @@ extension on SNSActionEncoding {
   }
 }
 
-extension on String {
+extension SNSActionEncodingFromString on String {
   SNSActionEncoding toSNSActionEncoding() {
     switch (this) {
       case 'UTF-8':
@@ -6978,7 +6978,7 @@ enum StopScope {
   ruleSet,
 }
 
-extension on StopScope {
+extension StopScopeValue on StopScope {
   String toValue() {
     switch (this) {
       case StopScope.ruleSet:
@@ -6987,7 +6987,7 @@ extension on StopScope {
   }
 }
 
-extension on String {
+extension StopScopeFromString on String {
   StopScope toStopScope() {
     switch (this) {
       case 'RuleSet':
@@ -7084,7 +7084,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension on TlsPolicy {
+extension TlsPolicyValue on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -7095,7 +7095,7 @@ extension on TlsPolicy {
   }
 }
 
-extension on String {
+extension TlsPolicyFromString on String {
   TlsPolicy toTlsPolicy() {
     switch (this) {
       case 'Require':
@@ -7186,7 +7186,7 @@ enum VerificationStatus {
   notStarted,
 }
 
-extension on VerificationStatus {
+extension VerificationStatusValue on VerificationStatus {
   String toValue() {
     switch (this) {
       case VerificationStatus.pending:
@@ -7203,7 +7203,7 @@ extension on VerificationStatus {
   }
 }
 
-extension on String {
+extension VerificationStatusFromString on String {
   VerificationStatus toVerificationStatus() {
     switch (this) {
       case 'Pending':

--- a/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
+++ b/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
@@ -3569,7 +3569,7 @@ enum BehaviorOnMxFailure {
   rejectMessage,
 }
 
-extension BehaviorOnMxFailureValue on BehaviorOnMxFailure {
+extension BehaviorOnMxFailureValueExtension on BehaviorOnMxFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMxFailure.useDefaultValue:
@@ -3815,7 +3815,7 @@ enum BulkEmailStatus {
   failed,
 }
 
-extension BulkEmailStatusValue on BulkEmailStatus {
+extension BulkEmailStatusValueExtension on BulkEmailStatus {
   String toValue() {
     switch (this) {
       case BulkEmailStatus.success:
@@ -4029,7 +4029,7 @@ enum ContactLanguage {
   ja,
 }
 
-extension ContactLanguageValue on ContactLanguage {
+extension ContactLanguageValueExtension on ContactLanguage {
   String toValue() {
     switch (this) {
       case ContactLanguage.en:
@@ -4119,7 +4119,7 @@ enum ContactListImportAction {
   put,
 }
 
-extension ContactListImportActionValue on ContactListImportAction {
+extension ContactListImportActionValueExtension on ContactListImportAction {
   String toValue() {
     switch (this) {
       case ContactListImportAction.delete:
@@ -4396,7 +4396,7 @@ enum DataFormat {
   json,
 }
 
-extension DataFormatValue on DataFormat {
+extension DataFormatValueExtension on DataFormat {
   String toValue() {
     switch (this) {
       case DataFormat.csv:
@@ -4566,7 +4566,7 @@ enum DeliverabilityDashboardAccountStatus {
   disabled,
 }
 
-extension DeliverabilityDashboardAccountStatusValue
+extension DeliverabilityDashboardAccountStatusValueExtension
     on DeliverabilityDashboardAccountStatus {
   String toValue() {
     switch (this) {
@@ -4658,7 +4658,7 @@ enum DeliverabilityTestStatus {
   completed,
 }
 
-extension DeliverabilityTestStatusValue on DeliverabilityTestStatus {
+extension DeliverabilityTestStatusValueExtension on DeliverabilityTestStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityTestStatus.inProgress:
@@ -4759,7 +4759,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension DimensionValueSourceValue on DimensionValueSource {
+extension DimensionValueSourceValueExtension on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -4919,7 +4919,8 @@ enum DkimSigningAttributesOrigin {
   external,
 }
 
-extension DkimSigningAttributesOriginValue on DkimSigningAttributesOrigin {
+extension DkimSigningAttributesOriginValueExtension
+    on DkimSigningAttributesOrigin {
   String toValue() {
     switch (this) {
       case DkimSigningAttributesOrigin.awsSes:
@@ -4976,7 +4977,7 @@ enum DkimStatus {
   notStarted,
 }
 
-extension DkimStatusValue on DkimStatus {
+extension DkimStatusValueExtension on DkimStatus {
   String toValue() {
     switch (this) {
       case DkimStatus.pending:
@@ -5493,7 +5494,7 @@ enum EventType {
   subscription,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -6366,7 +6367,7 @@ enum IdentityType {
   managedDomain,
 }
 
-extension IdentityTypeValue on IdentityType {
+extension IdentityTypeValueExtension on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -6469,7 +6470,7 @@ enum ImportDestinationType {
   contactList,
 }
 
-extension ImportDestinationTypeValue on ImportDestinationType {
+extension ImportDestinationTypeValueExtension on ImportDestinationType {
   String toValue() {
     switch (this) {
       case ImportDestinationType.suppressionList:
@@ -6587,7 +6588,7 @@ enum JobStatus {
   failed,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -7110,7 +7111,7 @@ enum MailFromDomainStatus {
   temporaryFailure,
 }
 
-extension MailFromDomainStatusValue on MailFromDomainStatus {
+extension MailFromDomainStatusValueExtension on MailFromDomainStatus {
   String toValue() {
     switch (this) {
       case MailFromDomainStatus.pending:
@@ -7146,7 +7147,7 @@ enum MailType {
   transactional,
 }
 
-extension MailTypeValue on MailType {
+extension MailTypeValueExtension on MailType {
   String toValue() {
     switch (this) {
       case MailType.marketing:
@@ -7742,7 +7743,7 @@ enum ReviewStatus {
   denied,
 }
 
-extension ReviewStatusValue on ReviewStatus {
+extension ReviewStatusValueExtension on ReviewStatus {
   String toValue() {
     switch (this) {
       case ReviewStatus.pending:
@@ -7915,7 +7916,7 @@ enum SubscriptionStatus {
   optOut,
 }
 
-extension SubscriptionStatusValue on SubscriptionStatus {
+extension SubscriptionStatusValueExtension on SubscriptionStatus {
   String toValue() {
     switch (this) {
       case SubscriptionStatus.optIn:
@@ -8112,7 +8113,8 @@ enum SuppressionListImportAction {
   put,
 }
 
-extension SuppressionListImportActionValue on SuppressionListImportAction {
+extension SuppressionListImportActionValueExtension
+    on SuppressionListImportAction {
   String toValue() {
     switch (this) {
       case SuppressionListImportAction.delete:
@@ -8155,7 +8157,7 @@ enum SuppressionListReason {
   complaint,
 }
 
-extension SuppressionListReasonValue on SuppressionListReason {
+extension SuppressionListReasonValueExtension on SuppressionListReason {
   String toValue() {
     switch (this) {
       case SuppressionListReason.bounce:
@@ -8359,7 +8361,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension TlsPolicyValue on TlsPolicy {
+extension TlsPolicyValueExtension on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -8614,7 +8616,7 @@ enum WarmupStatus {
   done,
 }
 
-extension WarmupStatusValue on WarmupStatus {
+extension WarmupStatusValueExtension on WarmupStatus {
   String toValue() {
     switch (this) {
       case WarmupStatus.inProgress:

--- a/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
+++ b/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
@@ -3569,7 +3569,7 @@ enum BehaviorOnMxFailure {
   rejectMessage,
 }
 
-extension on BehaviorOnMxFailure {
+extension BehaviorOnMxFailureValue on BehaviorOnMxFailure {
   String toValue() {
     switch (this) {
       case BehaviorOnMxFailure.useDefaultValue:
@@ -3580,7 +3580,7 @@ extension on BehaviorOnMxFailure {
   }
 }
 
-extension on String {
+extension BehaviorOnMxFailureFromString on String {
   BehaviorOnMxFailure toBehaviorOnMxFailure() {
     switch (this) {
       case 'USE_DEFAULT_VALUE':
@@ -3815,7 +3815,7 @@ enum BulkEmailStatus {
   failed,
 }
 
-extension on BulkEmailStatus {
+extension BulkEmailStatusValue on BulkEmailStatus {
   String toValue() {
     switch (this) {
       case BulkEmailStatus.success:
@@ -3850,7 +3850,7 @@ extension on BulkEmailStatus {
   }
 }
 
-extension on String {
+extension BulkEmailStatusFromString on String {
   BulkEmailStatus toBulkEmailStatus() {
     switch (this) {
       case 'SUCCESS':
@@ -4029,7 +4029,7 @@ enum ContactLanguage {
   ja,
 }
 
-extension on ContactLanguage {
+extension ContactLanguageValue on ContactLanguage {
   String toValue() {
     switch (this) {
       case ContactLanguage.en:
@@ -4040,7 +4040,7 @@ extension on ContactLanguage {
   }
 }
 
-extension on String {
+extension ContactLanguageFromString on String {
   ContactLanguage toContactLanguage() {
     switch (this) {
       case 'EN':
@@ -4119,7 +4119,7 @@ enum ContactListImportAction {
   put,
 }
 
-extension on ContactListImportAction {
+extension ContactListImportActionValue on ContactListImportAction {
   String toValue() {
     switch (this) {
       case ContactListImportAction.delete:
@@ -4130,7 +4130,7 @@ extension on ContactListImportAction {
   }
 }
 
-extension on String {
+extension ContactListImportActionFromString on String {
   ContactListImportAction toContactListImportAction() {
     switch (this) {
       case 'DELETE':
@@ -4396,7 +4396,7 @@ enum DataFormat {
   json,
 }
 
-extension on DataFormat {
+extension DataFormatValue on DataFormat {
   String toValue() {
     switch (this) {
       case DataFormat.csv:
@@ -4407,7 +4407,7 @@ extension on DataFormat {
   }
 }
 
-extension on String {
+extension DataFormatFromString on String {
   DataFormat toDataFormat() {
     switch (this) {
       case 'CSV':
@@ -4566,7 +4566,8 @@ enum DeliverabilityDashboardAccountStatus {
   disabled,
 }
 
-extension on DeliverabilityDashboardAccountStatus {
+extension DeliverabilityDashboardAccountStatusValue
+    on DeliverabilityDashboardAccountStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityDashboardAccountStatus.active:
@@ -4579,7 +4580,7 @@ extension on DeliverabilityDashboardAccountStatus {
   }
 }
 
-extension on String {
+extension DeliverabilityDashboardAccountStatusFromString on String {
   DeliverabilityDashboardAccountStatus
       toDeliverabilityDashboardAccountStatus() {
     switch (this) {
@@ -4657,7 +4658,7 @@ enum DeliverabilityTestStatus {
   completed,
 }
 
-extension on DeliverabilityTestStatus {
+extension DeliverabilityTestStatusValue on DeliverabilityTestStatus {
   String toValue() {
     switch (this) {
       case DeliverabilityTestStatus.inProgress:
@@ -4668,7 +4669,7 @@ extension on DeliverabilityTestStatus {
   }
 }
 
-extension on String {
+extension DeliverabilityTestStatusFromString on String {
   DeliverabilityTestStatus toDeliverabilityTestStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -4758,7 +4759,7 @@ enum DimensionValueSource {
   linkTag,
 }
 
-extension on DimensionValueSource {
+extension DimensionValueSourceValue on DimensionValueSource {
   String toValue() {
     switch (this) {
       case DimensionValueSource.messageTag:
@@ -4771,7 +4772,7 @@ extension on DimensionValueSource {
   }
 }
 
-extension on String {
+extension DimensionValueSourceFromString on String {
   DimensionValueSource toDimensionValueSource() {
     switch (this) {
       case 'MESSAGE_TAG':
@@ -4918,7 +4919,7 @@ enum DkimSigningAttributesOrigin {
   external,
 }
 
-extension on DkimSigningAttributesOrigin {
+extension DkimSigningAttributesOriginValue on DkimSigningAttributesOrigin {
   String toValue() {
     switch (this) {
       case DkimSigningAttributesOrigin.awsSes:
@@ -4929,7 +4930,7 @@ extension on DkimSigningAttributesOrigin {
   }
 }
 
-extension on String {
+extension DkimSigningAttributesOriginFromString on String {
   DkimSigningAttributesOrigin toDkimSigningAttributesOrigin() {
     switch (this) {
       case 'AWS_SES':
@@ -4975,7 +4976,7 @@ enum DkimStatus {
   notStarted,
 }
 
-extension on DkimStatus {
+extension DkimStatusValue on DkimStatus {
   String toValue() {
     switch (this) {
       case DkimStatus.pending:
@@ -4992,7 +4993,7 @@ extension on DkimStatus {
   }
 }
 
-extension on String {
+extension DkimStatusFromString on String {
   DkimStatus toDkimStatus() {
     switch (this) {
       case 'PENDING':
@@ -5492,7 +5493,7 @@ enum EventType {
   subscription,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.send:
@@ -5519,7 +5520,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'SEND':
@@ -6365,7 +6366,7 @@ enum IdentityType {
   managedDomain,
 }
 
-extension on IdentityType {
+extension IdentityTypeValue on IdentityType {
   String toValue() {
     switch (this) {
       case IdentityType.emailAddress:
@@ -6378,7 +6379,7 @@ extension on IdentityType {
   }
 }
 
-extension on String {
+extension IdentityTypeFromString on String {
   IdentityType toIdentityType() {
     switch (this) {
       case 'EMAIL_ADDRESS':
@@ -6468,7 +6469,7 @@ enum ImportDestinationType {
   contactList,
 }
 
-extension on ImportDestinationType {
+extension ImportDestinationTypeValue on ImportDestinationType {
   String toValue() {
     switch (this) {
       case ImportDestinationType.suppressionList:
@@ -6479,7 +6480,7 @@ extension on ImportDestinationType {
   }
 }
 
-extension on String {
+extension ImportDestinationTypeFromString on String {
   ImportDestinationType toImportDestinationType() {
     switch (this) {
       case 'SUPPRESSION_LIST':
@@ -6586,7 +6587,7 @@ enum JobStatus {
   failed,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.created:
@@ -6601,7 +6602,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'CREATED':
@@ -7109,7 +7110,7 @@ enum MailFromDomainStatus {
   temporaryFailure,
 }
 
-extension on MailFromDomainStatus {
+extension MailFromDomainStatusValue on MailFromDomainStatus {
   String toValue() {
     switch (this) {
       case MailFromDomainStatus.pending:
@@ -7124,7 +7125,7 @@ extension on MailFromDomainStatus {
   }
 }
 
-extension on String {
+extension MailFromDomainStatusFromString on String {
   MailFromDomainStatus toMailFromDomainStatus() {
     switch (this) {
       case 'PENDING':
@@ -7145,7 +7146,7 @@ enum MailType {
   transactional,
 }
 
-extension on MailType {
+extension MailTypeValue on MailType {
   String toValue() {
     switch (this) {
       case MailType.marketing:
@@ -7156,7 +7157,7 @@ extension on MailType {
   }
 }
 
-extension on String {
+extension MailTypeFromString on String {
   MailType toMailType() {
     switch (this) {
       case 'MARKETING':
@@ -7741,7 +7742,7 @@ enum ReviewStatus {
   denied,
 }
 
-extension on ReviewStatus {
+extension ReviewStatusValue on ReviewStatus {
   String toValue() {
     switch (this) {
       case ReviewStatus.pending:
@@ -7756,7 +7757,7 @@ extension on ReviewStatus {
   }
 }
 
-extension on String {
+extension ReviewStatusFromString on String {
   ReviewStatus toReviewStatus() {
     switch (this) {
       case 'PENDING':
@@ -7914,7 +7915,7 @@ enum SubscriptionStatus {
   optOut,
 }
 
-extension on SubscriptionStatus {
+extension SubscriptionStatusValue on SubscriptionStatus {
   String toValue() {
     switch (this) {
       case SubscriptionStatus.optIn:
@@ -7925,7 +7926,7 @@ extension on SubscriptionStatus {
   }
 }
 
-extension on String {
+extension SubscriptionStatusFromString on String {
   SubscriptionStatus toSubscriptionStatus() {
     switch (this) {
       case 'OPT_IN':
@@ -8111,7 +8112,7 @@ enum SuppressionListImportAction {
   put,
 }
 
-extension on SuppressionListImportAction {
+extension SuppressionListImportActionValue on SuppressionListImportAction {
   String toValue() {
     switch (this) {
       case SuppressionListImportAction.delete:
@@ -8122,7 +8123,7 @@ extension on SuppressionListImportAction {
   }
 }
 
-extension on String {
+extension SuppressionListImportActionFromString on String {
   SuppressionListImportAction toSuppressionListImportAction() {
     switch (this) {
       case 'DELETE':
@@ -8154,7 +8155,7 @@ enum SuppressionListReason {
   complaint,
 }
 
-extension on SuppressionListReason {
+extension SuppressionListReasonValue on SuppressionListReason {
   String toValue() {
     switch (this) {
       case SuppressionListReason.bounce:
@@ -8165,7 +8166,7 @@ extension on SuppressionListReason {
   }
 }
 
-extension on String {
+extension SuppressionListReasonFromString on String {
   SuppressionListReason toSuppressionListReason() {
     switch (this) {
       case 'BOUNCE':
@@ -8358,7 +8359,7 @@ enum TlsPolicy {
   optional,
 }
 
-extension on TlsPolicy {
+extension TlsPolicyValue on TlsPolicy {
   String toValue() {
     switch (this) {
       case TlsPolicy.require:
@@ -8369,7 +8370,7 @@ extension on TlsPolicy {
   }
 }
 
-extension on String {
+extension TlsPolicyFromString on String {
   TlsPolicy toTlsPolicy() {
     switch (this) {
       case 'REQUIRE':
@@ -8613,7 +8614,7 @@ enum WarmupStatus {
   done,
 }
 
-extension on WarmupStatus {
+extension WarmupStatusValue on WarmupStatus {
   String toValue() {
     switch (this) {
       case WarmupStatus.inProgress:
@@ -8624,7 +8625,7 @@ extension on WarmupStatus {
   }
 }
 
-extension on String {
+extension WarmupStatusFromString on String {
   WarmupStatus toWarmupStatus() {
     switch (this) {
       case 'IN_PROGRESS':

--- a/generated/aws_sfn_api/lib/states-2016-11-23.dart
+++ b/generated/aws_sfn_api/lib/states-2016-11-23.dart
@@ -2321,7 +2321,7 @@ enum ExecutionStatus {
   aborted,
 }
 
-extension ExecutionStatusValue on ExecutionStatus {
+extension ExecutionStatusValueExtension on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.running:
@@ -2812,7 +2812,7 @@ enum HistoryEventType {
   waitStateExited,
 }
 
-extension HistoryEventTypeValue on HistoryEventType {
+extension HistoryEventTypeValueExtension on HistoryEventType {
   String toValue() {
     switch (this) {
       case HistoryEventType.activityFailed:
@@ -3326,7 +3326,7 @@ enum LogLevel {
   off,
 }
 
-extension LogLevelValue on LogLevel {
+extension LogLevelValueExtension on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.all:
@@ -3707,7 +3707,7 @@ enum StateMachineStatus {
   deleting,
 }
 
-extension StateMachineStatusValue on StateMachineStatus {
+extension StateMachineStatusValueExtension on StateMachineStatus {
   String toValue() {
     switch (this) {
       case StateMachineStatus.active:
@@ -3735,7 +3735,7 @@ enum StateMachineType {
   express,
 }
 
-extension StateMachineTypeValue on StateMachineType {
+extension StateMachineTypeValueExtension on StateMachineType {
   String toValue() {
     switch (this) {
       case StateMachineType.standard:
@@ -3778,7 +3778,7 @@ enum SyncExecutionStatus {
   timedOut,
 }
 
-extension SyncExecutionStatusValue on SyncExecutionStatus {
+extension SyncExecutionStatusValueExtension on SyncExecutionStatus {
   String toValue() {
     switch (this) {
       case SyncExecutionStatus.succeeded:

--- a/generated/aws_sfn_api/lib/states-2016-11-23.dart
+++ b/generated/aws_sfn_api/lib/states-2016-11-23.dart
@@ -2321,7 +2321,7 @@ enum ExecutionStatus {
   aborted,
 }
 
-extension on ExecutionStatus {
+extension ExecutionStatusValue on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.running:
@@ -2338,7 +2338,7 @@ extension on ExecutionStatus {
   }
 }
 
-extension on String {
+extension ExecutionStatusFromString on String {
   ExecutionStatus toExecutionStatus() {
     switch (this) {
       case 'RUNNING':
@@ -2812,7 +2812,7 @@ enum HistoryEventType {
   waitStateExited,
 }
 
-extension on HistoryEventType {
+extension HistoryEventTypeValue on HistoryEventType {
   String toValue() {
     switch (this) {
       case HistoryEventType.activityFailed:
@@ -2929,7 +2929,7 @@ extension on HistoryEventType {
   }
 }
 
-extension on String {
+extension HistoryEventTypeFromString on String {
   HistoryEventType toHistoryEventType() {
     switch (this) {
       case 'ActivityFailed':
@@ -3326,7 +3326,7 @@ enum LogLevel {
   off,
 }
 
-extension on LogLevel {
+extension LogLevelValue on LogLevel {
   String toValue() {
     switch (this) {
       case LogLevel.all:
@@ -3341,7 +3341,7 @@ extension on LogLevel {
   }
 }
 
-extension on String {
+extension LogLevelFromString on String {
   LogLevel toLogLevel() {
     switch (this) {
       case 'ALL':
@@ -3707,7 +3707,7 @@ enum StateMachineStatus {
   deleting,
 }
 
-extension on StateMachineStatus {
+extension StateMachineStatusValue on StateMachineStatus {
   String toValue() {
     switch (this) {
       case StateMachineStatus.active:
@@ -3718,7 +3718,7 @@ extension on StateMachineStatus {
   }
 }
 
-extension on String {
+extension StateMachineStatusFromString on String {
   StateMachineStatus toStateMachineStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -3735,7 +3735,7 @@ enum StateMachineType {
   express,
 }
 
-extension on StateMachineType {
+extension StateMachineTypeValue on StateMachineType {
   String toValue() {
     switch (this) {
       case StateMachineType.standard:
@@ -3746,7 +3746,7 @@ extension on StateMachineType {
   }
 }
 
-extension on String {
+extension StateMachineTypeFromString on String {
   StateMachineType toStateMachineType() {
     switch (this) {
       case 'STANDARD':
@@ -3778,7 +3778,7 @@ enum SyncExecutionStatus {
   timedOut,
 }
 
-extension on SyncExecutionStatus {
+extension SyncExecutionStatusValue on SyncExecutionStatus {
   String toValue() {
     switch (this) {
       case SyncExecutionStatus.succeeded:
@@ -3791,7 +3791,7 @@ extension on SyncExecutionStatus {
   }
 }
 
-extension on String {
+extension SyncExecutionStatusFromString on String {
   SyncExecutionStatus toSyncExecutionStatus() {
     switch (this) {
       case 'SUCCEEDED':

--- a/generated/aws_shield_api/lib/shield-2016-06-02.dart
+++ b/generated/aws_shield_api/lib/shield-2016-06-02.dart
@@ -1579,7 +1579,7 @@ enum AttackLayer {
   application,
 }
 
-extension AttackLayerValue on AttackLayer {
+extension AttackLayerValueExtension on AttackLayer {
   String toValue() {
     switch (this) {
       case AttackLayer.network:
@@ -1659,7 +1659,7 @@ enum AttackPropertyIdentifier {
   wordpressPingbackSource,
 }
 
-extension AttackPropertyIdentifierValue on AttackPropertyIdentifier {
+extension AttackPropertyIdentifierValueExtension on AttackPropertyIdentifier {
   String toValue() {
     switch (this) {
       case AttackPropertyIdentifier.destinationUrl:
@@ -1908,7 +1908,7 @@ enum AutoRenew {
   disabled,
 }
 
-extension AutoRenewValue on AutoRenew {
+extension AutoRenewValueExtension on AutoRenew {
   String toValue() {
     switch (this) {
       case AutoRenew.enabled:
@@ -2378,7 +2378,7 @@ enum ProactiveEngagementStatus {
   pending,
 }
 
-extension ProactiveEngagementStatusValue on ProactiveEngagementStatus {
+extension ProactiveEngagementStatusValueExtension on ProactiveEngagementStatus {
   String toValue() {
     switch (this) {
       case ProactiveEngagementStatus.enabled:
@@ -2414,7 +2414,7 @@ enum ProtectedResourceType {
   globalAccelerator,
 }
 
-extension ProtectedResourceTypeValue on ProtectedResourceType {
+extension ProtectedResourceTypeValueExtension on ProtectedResourceType {
   String toValue() {
     switch (this) {
       case ProtectedResourceType.cloudfrontDistribution:
@@ -2567,7 +2567,8 @@ enum ProtectionGroupAggregation {
   max,
 }
 
-extension ProtectionGroupAggregationValue on ProtectionGroupAggregation {
+extension ProtectionGroupAggregationValueExtension
+    on ProtectionGroupAggregation {
   String toValue() {
     switch (this) {
       case ProtectionGroupAggregation.sum:
@@ -2639,7 +2640,7 @@ enum ProtectionGroupPattern {
   byResourceType,
 }
 
-extension ProtectionGroupPatternValue on ProtectionGroupPattern {
+extension ProtectionGroupPatternValueExtension on ProtectionGroupPattern {
   String toValue() {
     switch (this) {
       case ProtectionGroupPattern.all:
@@ -2743,7 +2744,7 @@ enum SubResourceType {
   url,
 }
 
-extension SubResourceTypeValue on SubResourceType {
+extension SubResourceTypeValueExtension on SubResourceType {
   String toValue() {
     switch (this) {
       case SubResourceType.ip:
@@ -2863,7 +2864,7 @@ enum SubscriptionState {
   inactive,
 }
 
-extension SubscriptionStateValue on SubscriptionState {
+extension SubscriptionStateValueExtension on SubscriptionState {
   String toValue() {
     switch (this) {
       case SubscriptionState.active:
@@ -2988,7 +2989,7 @@ enum Unit {
   requests,
 }
 
-extension UnitValue on Unit {
+extension UnitValueExtension on Unit {
   String toValue() {
     switch (this) {
       case Unit.bits:

--- a/generated/aws_shield_api/lib/shield-2016-06-02.dart
+++ b/generated/aws_shield_api/lib/shield-2016-06-02.dart
@@ -1579,7 +1579,7 @@ enum AttackLayer {
   application,
 }
 
-extension on AttackLayer {
+extension AttackLayerValue on AttackLayer {
   String toValue() {
     switch (this) {
       case AttackLayer.network:
@@ -1590,7 +1590,7 @@ extension on AttackLayer {
   }
 }
 
-extension on String {
+extension AttackLayerFromString on String {
   AttackLayer toAttackLayer() {
     switch (this) {
       case 'NETWORK':
@@ -1659,7 +1659,7 @@ enum AttackPropertyIdentifier {
   wordpressPingbackSource,
 }
 
-extension on AttackPropertyIdentifier {
+extension AttackPropertyIdentifierValue on AttackPropertyIdentifier {
   String toValue() {
     switch (this) {
       case AttackPropertyIdentifier.destinationUrl:
@@ -1682,7 +1682,7 @@ extension on AttackPropertyIdentifier {
   }
 }
 
-extension on String {
+extension AttackPropertyIdentifierFromString on String {
   AttackPropertyIdentifier toAttackPropertyIdentifier() {
     switch (this) {
       case 'DESTINATION_URL':
@@ -1908,7 +1908,7 @@ enum AutoRenew {
   disabled,
 }
 
-extension on AutoRenew {
+extension AutoRenewValue on AutoRenew {
   String toValue() {
     switch (this) {
       case AutoRenew.enabled:
@@ -1919,7 +1919,7 @@ extension on AutoRenew {
   }
 }
 
-extension on String {
+extension AutoRenewFromString on String {
   AutoRenew toAutoRenew() {
     switch (this) {
       case 'ENABLED':
@@ -2378,7 +2378,7 @@ enum ProactiveEngagementStatus {
   pending,
 }
 
-extension on ProactiveEngagementStatus {
+extension ProactiveEngagementStatusValue on ProactiveEngagementStatus {
   String toValue() {
     switch (this) {
       case ProactiveEngagementStatus.enabled:
@@ -2391,7 +2391,7 @@ extension on ProactiveEngagementStatus {
   }
 }
 
-extension on String {
+extension ProactiveEngagementStatusFromString on String {
   ProactiveEngagementStatus toProactiveEngagementStatus() {
     switch (this) {
       case 'ENABLED':
@@ -2414,7 +2414,7 @@ enum ProtectedResourceType {
   globalAccelerator,
 }
 
-extension on ProtectedResourceType {
+extension ProtectedResourceTypeValue on ProtectedResourceType {
   String toValue() {
     switch (this) {
       case ProtectedResourceType.cloudfrontDistribution:
@@ -2433,7 +2433,7 @@ extension on ProtectedResourceType {
   }
 }
 
-extension on String {
+extension ProtectedResourceTypeFromString on String {
   ProtectedResourceType toProtectedResourceType() {
     switch (this) {
       case 'CLOUDFRONT_DISTRIBUTION':
@@ -2567,7 +2567,7 @@ enum ProtectionGroupAggregation {
   max,
 }
 
-extension on ProtectionGroupAggregation {
+extension ProtectionGroupAggregationValue on ProtectionGroupAggregation {
   String toValue() {
     switch (this) {
       case ProtectionGroupAggregation.sum:
@@ -2580,7 +2580,7 @@ extension on ProtectionGroupAggregation {
   }
 }
 
-extension on String {
+extension ProtectionGroupAggregationFromString on String {
   ProtectionGroupAggregation toProtectionGroupAggregation() {
     switch (this) {
       case 'SUM':
@@ -2639,7 +2639,7 @@ enum ProtectionGroupPattern {
   byResourceType,
 }
 
-extension on ProtectionGroupPattern {
+extension ProtectionGroupPatternValue on ProtectionGroupPattern {
   String toValue() {
     switch (this) {
       case ProtectionGroupPattern.all:
@@ -2652,7 +2652,7 @@ extension on ProtectionGroupPattern {
   }
 }
 
-extension on String {
+extension ProtectionGroupPatternFromString on String {
   ProtectionGroupPattern toProtectionGroupPattern() {
     switch (this) {
       case 'ALL':
@@ -2743,7 +2743,7 @@ enum SubResourceType {
   url,
 }
 
-extension on SubResourceType {
+extension SubResourceTypeValue on SubResourceType {
   String toValue() {
     switch (this) {
       case SubResourceType.ip:
@@ -2754,7 +2754,7 @@ extension on SubResourceType {
   }
 }
 
-extension on String {
+extension SubResourceTypeFromString on String {
   SubResourceType toSubResourceType() {
     switch (this) {
       case 'IP':
@@ -2863,7 +2863,7 @@ enum SubscriptionState {
   inactive,
 }
 
-extension on SubscriptionState {
+extension SubscriptionStateValue on SubscriptionState {
   String toValue() {
     switch (this) {
       case SubscriptionState.active:
@@ -2874,7 +2874,7 @@ extension on SubscriptionState {
   }
 }
 
-extension on String {
+extension SubscriptionStateFromString on String {
   SubscriptionState toSubscriptionState() {
     switch (this) {
       case 'ACTIVE':
@@ -2988,7 +2988,7 @@ enum Unit {
   requests,
 }
 
-extension on Unit {
+extension UnitValue on Unit {
   String toValue() {
     switch (this) {
       case Unit.bits:
@@ -3003,7 +3003,7 @@ extension on Unit {
   }
 }
 
-extension on String {
+extension UnitFromString on String {
   Unit toUnit() {
     switch (this) {
       case 'BITS':

--- a/generated/aws_signer_api/lib/signer-2017-08-25.dart
+++ b/generated/aws_signer_api/lib/signer-2017-08-25.dart
@@ -967,7 +967,7 @@ enum Category {
   awsIoT,
 }
 
-extension on Category {
+extension CategoryValue on Category {
   String toValue() {
     switch (this) {
       case Category.awsIoT:
@@ -976,7 +976,7 @@ extension on Category {
   }
 }
 
-extension on String {
+extension CategoryFromString on String {
   Category toCategory() {
     switch (this) {
       case 'AWSIoT':
@@ -1131,7 +1131,7 @@ enum EncryptionAlgorithm {
   ecdsa,
 }
 
-extension on EncryptionAlgorithm {
+extension EncryptionAlgorithmValue on EncryptionAlgorithm {
   String toValue() {
     switch (this) {
       case EncryptionAlgorithm.rsa:
@@ -1142,7 +1142,7 @@ extension on EncryptionAlgorithm {
   }
 }
 
-extension on String {
+extension EncryptionAlgorithmFromString on String {
   EncryptionAlgorithm toEncryptionAlgorithm() {
     switch (this) {
       case 'RSA':
@@ -1338,7 +1338,7 @@ enum HashAlgorithm {
   sha256,
 }
 
-extension on HashAlgorithm {
+extension HashAlgorithmValue on HashAlgorithm {
   String toValue() {
     switch (this) {
       case HashAlgorithm.sha1:
@@ -1349,7 +1349,7 @@ extension on HashAlgorithm {
   }
 }
 
-extension on String {
+extension HashAlgorithmFromString on String {
   HashAlgorithm toHashAlgorithm() {
     switch (this) {
       case 'SHA1':
@@ -1390,7 +1390,7 @@ enum ImageFormat {
   jSONDetached,
 }
 
-extension on ImageFormat {
+extension ImageFormatValue on ImageFormat {
   String toValue() {
     switch (this) {
       case ImageFormat.json:
@@ -1403,7 +1403,7 @@ extension on ImageFormat {
   }
 }
 
-extension on String {
+extension ImageFormatFromString on String {
   ImageFormat toImageFormat() {
     switch (this) {
       case 'JSON':
@@ -2155,7 +2155,7 @@ enum SigningProfileStatus {
   revoked,
 }
 
-extension on SigningProfileStatus {
+extension SigningProfileStatusValue on SigningProfileStatus {
   String toValue() {
     switch (this) {
       case SigningProfileStatus.active:
@@ -2168,7 +2168,7 @@ extension on SigningProfileStatus {
   }
 }
 
-extension on String {
+extension SigningProfileStatusFromString on String {
   SigningProfileStatus toSigningProfileStatus() {
     switch (this) {
       case 'Active':
@@ -2188,7 +2188,7 @@ enum SigningStatus {
   succeeded,
 }
 
-extension on SigningStatus {
+extension SigningStatusValue on SigningStatus {
   String toValue() {
     switch (this) {
       case SigningStatus.inProgress:
@@ -2201,7 +2201,7 @@ extension on SigningStatus {
   }
 }
 
-extension on String {
+extension SigningStatusFromString on String {
   SigningStatus toSigningStatus() {
     switch (this) {
       case 'InProgress':
@@ -2279,7 +2279,7 @@ enum ValidityType {
   years,
 }
 
-extension on ValidityType {
+extension ValidityTypeValue on ValidityType {
   String toValue() {
     switch (this) {
       case ValidityType.days:
@@ -2292,7 +2292,7 @@ extension on ValidityType {
   }
 }
 
-extension on String {
+extension ValidityTypeFromString on String {
   ValidityType toValidityType() {
     switch (this) {
       case 'DAYS':

--- a/generated/aws_signer_api/lib/signer-2017-08-25.dart
+++ b/generated/aws_signer_api/lib/signer-2017-08-25.dart
@@ -967,7 +967,7 @@ enum Category {
   awsIoT,
 }
 
-extension CategoryValue on Category {
+extension CategoryValueExtension on Category {
   String toValue() {
     switch (this) {
       case Category.awsIoT:
@@ -1131,7 +1131,7 @@ enum EncryptionAlgorithm {
   ecdsa,
 }
 
-extension EncryptionAlgorithmValue on EncryptionAlgorithm {
+extension EncryptionAlgorithmValueExtension on EncryptionAlgorithm {
   String toValue() {
     switch (this) {
       case EncryptionAlgorithm.rsa:
@@ -1338,7 +1338,7 @@ enum HashAlgorithm {
   sha256,
 }
 
-extension HashAlgorithmValue on HashAlgorithm {
+extension HashAlgorithmValueExtension on HashAlgorithm {
   String toValue() {
     switch (this) {
       case HashAlgorithm.sha1:
@@ -1390,7 +1390,7 @@ enum ImageFormat {
   jSONDetached,
 }
 
-extension ImageFormatValue on ImageFormat {
+extension ImageFormatValueExtension on ImageFormat {
   String toValue() {
     switch (this) {
       case ImageFormat.json:
@@ -2155,7 +2155,7 @@ enum SigningProfileStatus {
   revoked,
 }
 
-extension SigningProfileStatusValue on SigningProfileStatus {
+extension SigningProfileStatusValueExtension on SigningProfileStatus {
   String toValue() {
     switch (this) {
       case SigningProfileStatus.active:
@@ -2188,7 +2188,7 @@ enum SigningStatus {
   succeeded,
 }
 
-extension SigningStatusValue on SigningStatus {
+extension SigningStatusValueExtension on SigningStatus {
   String toValue() {
     switch (this) {
       case SigningStatus.inProgress:
@@ -2279,7 +2279,7 @@ enum ValidityType {
   years,
 }
 
-extension ValidityTypeValue on ValidityType {
+extension ValidityTypeValueExtension on ValidityType {
   String toValue() {
     switch (this) {
       case ValidityType.days:

--- a/generated/aws_sms_api/lib/sms-2016-10-24.dart
+++ b/generated/aws_sms_api/lib/sms-2016-10-24.dart
@@ -1475,7 +1475,7 @@ enum AppLaunchConfigurationStatus {
   configured,
 }
 
-extension on AppLaunchConfigurationStatus {
+extension AppLaunchConfigurationStatusValue on AppLaunchConfigurationStatus {
   String toValue() {
     switch (this) {
       case AppLaunchConfigurationStatus.notConfigured:
@@ -1486,7 +1486,7 @@ extension on AppLaunchConfigurationStatus {
   }
 }
 
-extension on String {
+extension AppLaunchConfigurationStatusFromString on String {
   AppLaunchConfigurationStatus toAppLaunchConfigurationStatus() {
     switch (this) {
       case 'NOT_CONFIGURED':
@@ -1516,7 +1516,7 @@ enum AppLaunchStatus {
   terminated,
 }
 
-extension on AppLaunchStatus {
+extension AppLaunchStatusValue on AppLaunchStatus {
   String toValue() {
     switch (this) {
       case AppLaunchStatus.readyForConfiguration:
@@ -1553,7 +1553,7 @@ extension on AppLaunchStatus {
   }
 }
 
-extension on String {
+extension AppLaunchStatusFromString on String {
   AppLaunchStatus toAppLaunchStatus() {
     switch (this) {
       case 'READY_FOR_CONFIGURATION':
@@ -1596,7 +1596,8 @@ enum AppReplicationConfigurationStatus {
   configured,
 }
 
-extension on AppReplicationConfigurationStatus {
+extension AppReplicationConfigurationStatusValue
+    on AppReplicationConfigurationStatus {
   String toValue() {
     switch (this) {
       case AppReplicationConfigurationStatus.notConfigured:
@@ -1607,7 +1608,7 @@ extension on AppReplicationConfigurationStatus {
   }
 }
 
-extension on String {
+extension AppReplicationConfigurationStatusFromString on String {
   AppReplicationConfigurationStatus toAppReplicationConfigurationStatus() {
     switch (this) {
       case 'NOT_CONFIGURED':
@@ -1639,7 +1640,7 @@ enum AppReplicationStatus {
   replicationStopped,
 }
 
-extension on AppReplicationStatus {
+extension AppReplicationStatusValue on AppReplicationStatus {
   String toValue() {
     switch (this) {
       case AppReplicationStatus.readyForConfiguration:
@@ -1678,7 +1679,7 @@ extension on AppReplicationStatus {
   }
 }
 
-extension on String {
+extension AppReplicationStatusFromString on String {
   AppReplicationStatus toAppReplicationStatus() {
     switch (this) {
       case 'READY_FOR_CONFIGURATION':
@@ -1727,7 +1728,7 @@ enum AppStatus {
   deleteFailed,
 }
 
-extension on AppStatus {
+extension AppStatusValue on AppStatus {
   String toValue() {
     switch (this) {
       case AppStatus.creating:
@@ -1746,7 +1747,7 @@ extension on AppStatus {
   }
 }
 
-extension on String {
+extension AppStatusFromString on String {
   AppStatus toAppStatus() {
     switch (this) {
       case 'CREATING':
@@ -1948,7 +1949,7 @@ enum AppValidationStrategy {
   ssm,
 }
 
-extension on AppValidationStrategy {
+extension AppValidationStrategyValue on AppValidationStrategy {
   String toValue() {
     switch (this) {
       case AppValidationStrategy.ssm:
@@ -1957,7 +1958,7 @@ extension on AppValidationStrategy {
   }
 }
 
-extension on String {
+extension AppValidationStrategyFromString on String {
   AppValidationStrategy toAppValidationStrategy() {
     switch (this) {
       case 'SSM':
@@ -2038,7 +2039,7 @@ enum ConnectorCapability {
   smsOptimized,
 }
 
-extension on ConnectorCapability {
+extension ConnectorCapabilityValue on ConnectorCapability {
   String toValue() {
     switch (this) {
       case ConnectorCapability.vsphere:
@@ -2055,7 +2056,7 @@ extension on ConnectorCapability {
   }
 }
 
-extension on String {
+extension ConnectorCapabilityFromString on String {
   ConnectorCapability toConnectorCapability() {
     switch (this) {
       case 'VSPHERE':
@@ -2078,7 +2079,7 @@ enum ConnectorStatus {
   unhealthy,
 }
 
-extension on ConnectorStatus {
+extension ConnectorStatusValue on ConnectorStatus {
   String toValue() {
     switch (this) {
       case ConnectorStatus.healthy:
@@ -2089,7 +2090,7 @@ extension on ConnectorStatus {
   }
 }
 
-extension on String {
+extension ConnectorStatusFromString on String {
   ConnectorStatus toConnectorStatus() {
     switch (this) {
       case 'HEALTHY':
@@ -2532,7 +2533,7 @@ enum LicenseType {
   byol,
 }
 
-extension on LicenseType {
+extension LicenseTypeValue on LicenseType {
   String toValue() {
     switch (this) {
       case LicenseType.aws:
@@ -2543,7 +2544,7 @@ extension on LicenseType {
   }
 }
 
-extension on String {
+extension LicenseTypeFromString on String {
   LicenseType toLicenseType() {
     switch (this) {
       case 'AWS':
@@ -2618,7 +2619,7 @@ enum OutputFormat {
   yaml,
 }
 
-extension on OutputFormat {
+extension OutputFormatValue on OutputFormat {
   String toValue() {
     switch (this) {
       case OutputFormat.json:
@@ -2629,7 +2630,7 @@ extension on OutputFormat {
   }
 }
 
-extension on String {
+extension OutputFormatFromString on String {
   OutputFormat toOutputFormat() {
     switch (this) {
       case 'JSON':
@@ -2802,7 +2803,7 @@ enum ReplicationJobState {
   failing,
 }
 
-extension on ReplicationJobState {
+extension ReplicationJobStateValue on ReplicationJobState {
   String toValue() {
     switch (this) {
       case ReplicationJobState.pending:
@@ -2825,7 +2826,7 @@ extension on ReplicationJobState {
   }
 }
 
-extension on String {
+extension ReplicationJobStateFromString on String {
   ReplicationJobState toReplicationJobState() {
     switch (this) {
       case 'PENDING':
@@ -2965,7 +2966,7 @@ enum ReplicationRunState {
   deleted,
 }
 
-extension on ReplicationRunState {
+extension ReplicationRunStateValue on ReplicationRunState {
   String toValue() {
     switch (this) {
       case ReplicationRunState.pending:
@@ -2986,7 +2987,7 @@ extension on ReplicationRunState {
   }
 }
 
-extension on String {
+extension ReplicationRunStateFromString on String {
   ReplicationRunState toReplicationRunState() {
     switch (this) {
       case 'PENDING':
@@ -3013,7 +3014,7 @@ enum ReplicationRunType {
   automatic,
 }
 
-extension on ReplicationRunType {
+extension ReplicationRunTypeValue on ReplicationRunType {
   String toValue() {
     switch (this) {
       case ReplicationRunType.onDemand:
@@ -3024,7 +3025,7 @@ extension on ReplicationRunType {
   }
 }
 
-extension on String {
+extension ReplicationRunTypeFromString on String {
   ReplicationRunType toReplicationRunType() {
     switch (this) {
       case 'ON_DEMAND':
@@ -3147,7 +3148,7 @@ enum ScriptType {
   powershellScript,
 }
 
-extension on ScriptType {
+extension ScriptTypeValue on ScriptType {
   String toValue() {
     switch (this) {
       case ScriptType.shellScript:
@@ -3158,7 +3159,7 @@ extension on ScriptType {
   }
 }
 
-extension on String {
+extension ScriptTypeFromString on String {
   ScriptType toScriptType() {
     switch (this) {
       case 'SHELL_SCRIPT':
@@ -3231,7 +3232,7 @@ enum ServerCatalogStatus {
   expired,
 }
 
-extension on ServerCatalogStatus {
+extension ServerCatalogStatusValue on ServerCatalogStatus {
   String toValue() {
     switch (this) {
       case ServerCatalogStatus.notImported:
@@ -3248,7 +3249,7 @@ extension on ServerCatalogStatus {
   }
 }
 
-extension on String {
+extension ServerCatalogStatusFromString on String {
   ServerCatalogStatus toServerCatalogStatus() {
     switch (this) {
       case 'NOT_IMPORTED':
@@ -3654,7 +3655,7 @@ enum ServerType {
   virtualMachine,
 }
 
-extension on ServerType {
+extension ServerTypeValue on ServerType {
   String toValue() {
     switch (this) {
       case ServerType.virtualMachine:
@@ -3663,7 +3664,7 @@ extension on ServerType {
   }
 }
 
-extension on String {
+extension ServerTypeFromString on String {
   ServerType toServerType() {
     switch (this) {
       case 'VIRTUAL_MACHINE':
@@ -3749,7 +3750,7 @@ enum ServerValidationStrategy {
   userdata,
 }
 
-extension on ServerValidationStrategy {
+extension ServerValidationStrategyValue on ServerValidationStrategy {
   String toValue() {
     switch (this) {
       case ServerValidationStrategy.userdata:
@@ -3758,7 +3759,7 @@ extension on ServerValidationStrategy {
   }
 }
 
-extension on String {
+extension ServerValidationStrategyFromString on String {
   ServerValidationStrategy toServerValidationStrategy() {
     switch (this) {
       case 'USERDATA':
@@ -4017,7 +4018,7 @@ enum ValidationStatus {
   failed,
 }
 
-extension on ValidationStatus {
+extension ValidationStatusValue on ValidationStatus {
   String toValue() {
     switch (this) {
       case ValidationStatus.readyForValidation:
@@ -4034,7 +4035,7 @@ extension on ValidationStatus {
   }
 }
 
-extension on String {
+extension ValidationStatusFromString on String {
   ValidationStatus toValidationStatus() {
     switch (this) {
       case 'READY_FOR_VALIDATION':
@@ -4058,7 +4059,7 @@ enum VmManagerType {
   hypervManager,
 }
 
-extension on VmManagerType {
+extension VmManagerTypeValue on VmManagerType {
   String toValue() {
     switch (this) {
       case VmManagerType.vsphere:
@@ -4071,7 +4072,7 @@ extension on VmManagerType {
   }
 }
 
-extension on String {
+extension VmManagerTypeFromString on String {
   VmManagerType toVmManagerType() {
     switch (this) {
       case 'VSPHERE':

--- a/generated/aws_sms_api/lib/sms-2016-10-24.dart
+++ b/generated/aws_sms_api/lib/sms-2016-10-24.dart
@@ -1475,7 +1475,8 @@ enum AppLaunchConfigurationStatus {
   configured,
 }
 
-extension AppLaunchConfigurationStatusValue on AppLaunchConfigurationStatus {
+extension AppLaunchConfigurationStatusValueExtension
+    on AppLaunchConfigurationStatus {
   String toValue() {
     switch (this) {
       case AppLaunchConfigurationStatus.notConfigured:
@@ -1516,7 +1517,7 @@ enum AppLaunchStatus {
   terminated,
 }
 
-extension AppLaunchStatusValue on AppLaunchStatus {
+extension AppLaunchStatusValueExtension on AppLaunchStatus {
   String toValue() {
     switch (this) {
       case AppLaunchStatus.readyForConfiguration:
@@ -1596,7 +1597,7 @@ enum AppReplicationConfigurationStatus {
   configured,
 }
 
-extension AppReplicationConfigurationStatusValue
+extension AppReplicationConfigurationStatusValueExtension
     on AppReplicationConfigurationStatus {
   String toValue() {
     switch (this) {
@@ -1640,7 +1641,7 @@ enum AppReplicationStatus {
   replicationStopped,
 }
 
-extension AppReplicationStatusValue on AppReplicationStatus {
+extension AppReplicationStatusValueExtension on AppReplicationStatus {
   String toValue() {
     switch (this) {
       case AppReplicationStatus.readyForConfiguration:
@@ -1728,7 +1729,7 @@ enum AppStatus {
   deleteFailed,
 }
 
-extension AppStatusValue on AppStatus {
+extension AppStatusValueExtension on AppStatus {
   String toValue() {
     switch (this) {
       case AppStatus.creating:
@@ -1949,7 +1950,7 @@ enum AppValidationStrategy {
   ssm,
 }
 
-extension AppValidationStrategyValue on AppValidationStrategy {
+extension AppValidationStrategyValueExtension on AppValidationStrategy {
   String toValue() {
     switch (this) {
       case AppValidationStrategy.ssm:
@@ -2039,7 +2040,7 @@ enum ConnectorCapability {
   smsOptimized,
 }
 
-extension ConnectorCapabilityValue on ConnectorCapability {
+extension ConnectorCapabilityValueExtension on ConnectorCapability {
   String toValue() {
     switch (this) {
       case ConnectorCapability.vsphere:
@@ -2079,7 +2080,7 @@ enum ConnectorStatus {
   unhealthy,
 }
 
-extension ConnectorStatusValue on ConnectorStatus {
+extension ConnectorStatusValueExtension on ConnectorStatus {
   String toValue() {
     switch (this) {
       case ConnectorStatus.healthy:
@@ -2533,7 +2534,7 @@ enum LicenseType {
   byol,
 }
 
-extension LicenseTypeValue on LicenseType {
+extension LicenseTypeValueExtension on LicenseType {
   String toValue() {
     switch (this) {
       case LicenseType.aws:
@@ -2619,7 +2620,7 @@ enum OutputFormat {
   yaml,
 }
 
-extension OutputFormatValue on OutputFormat {
+extension OutputFormatValueExtension on OutputFormat {
   String toValue() {
     switch (this) {
       case OutputFormat.json:
@@ -2803,7 +2804,7 @@ enum ReplicationJobState {
   failing,
 }
 
-extension ReplicationJobStateValue on ReplicationJobState {
+extension ReplicationJobStateValueExtension on ReplicationJobState {
   String toValue() {
     switch (this) {
       case ReplicationJobState.pending:
@@ -2966,7 +2967,7 @@ enum ReplicationRunState {
   deleted,
 }
 
-extension ReplicationRunStateValue on ReplicationRunState {
+extension ReplicationRunStateValueExtension on ReplicationRunState {
   String toValue() {
     switch (this) {
       case ReplicationRunState.pending:
@@ -3014,7 +3015,7 @@ enum ReplicationRunType {
   automatic,
 }
 
-extension ReplicationRunTypeValue on ReplicationRunType {
+extension ReplicationRunTypeValueExtension on ReplicationRunType {
   String toValue() {
     switch (this) {
       case ReplicationRunType.onDemand:
@@ -3148,7 +3149,7 @@ enum ScriptType {
   powershellScript,
 }
 
-extension ScriptTypeValue on ScriptType {
+extension ScriptTypeValueExtension on ScriptType {
   String toValue() {
     switch (this) {
       case ScriptType.shellScript:
@@ -3232,7 +3233,7 @@ enum ServerCatalogStatus {
   expired,
 }
 
-extension ServerCatalogStatusValue on ServerCatalogStatus {
+extension ServerCatalogStatusValueExtension on ServerCatalogStatus {
   String toValue() {
     switch (this) {
       case ServerCatalogStatus.notImported:
@@ -3655,7 +3656,7 @@ enum ServerType {
   virtualMachine,
 }
 
-extension ServerTypeValue on ServerType {
+extension ServerTypeValueExtension on ServerType {
   String toValue() {
     switch (this) {
       case ServerType.virtualMachine:
@@ -3750,7 +3751,7 @@ enum ServerValidationStrategy {
   userdata,
 }
 
-extension ServerValidationStrategyValue on ServerValidationStrategy {
+extension ServerValidationStrategyValueExtension on ServerValidationStrategy {
   String toValue() {
     switch (this) {
       case ServerValidationStrategy.userdata:
@@ -4018,7 +4019,7 @@ enum ValidationStatus {
   failed,
 }
 
-extension ValidationStatusValue on ValidationStatus {
+extension ValidationStatusValueExtension on ValidationStatus {
   String toValue() {
     switch (this) {
       case ValidationStatus.readyForValidation:
@@ -4059,7 +4060,7 @@ enum VmManagerType {
   hypervManager,
 }
 
-extension VmManagerTypeValue on VmManagerType {
+extension VmManagerTypeValueExtension on VmManagerType {
   String toValue() {
     switch (this) {
       case VmManagerType.vsphere:

--- a/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
+++ b/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
@@ -1738,7 +1738,7 @@ enum ClusterState {
   cancelled,
 }
 
-extension ClusterStateValue on ClusterState {
+extension ClusterStateValueExtension on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.awaitingQuorum:
@@ -2479,7 +2479,7 @@ enum JobState {
   pending,
 }
 
-extension JobStateValue on JobState {
+extension JobStateValueExtension on JobState {
   String toValue() {
     switch (this) {
       case JobState.$new:
@@ -2552,7 +2552,7 @@ enum JobType {
   localUse,
 }
 
-extension JobTypeValue on JobType {
+extension JobTypeValueExtension on JobType {
   String toValue() {
     switch (this) {
       case JobType.import:
@@ -2879,7 +2879,7 @@ enum ShipmentState {
   returned,
 }
 
-extension ShipmentStateValue on ShipmentState {
+extension ShipmentStateValueExtension on ShipmentState {
   String toValue() {
     switch (this) {
       case ShipmentState.received:
@@ -2965,7 +2965,7 @@ enum ShippingLabelStatus {
   failed,
 }
 
-extension ShippingLabelStatusValue on ShippingLabelStatus {
+extension ShippingLabelStatusValueExtension on ShippingLabelStatus {
   String toValue() {
     switch (this) {
       case ShippingLabelStatus.inProgress:
@@ -3003,7 +3003,7 @@ enum ShippingOption {
   standard,
 }
 
-extension ShippingOptionValue on ShippingOption {
+extension ShippingOptionValueExtension on ShippingOption {
   String toValue() {
     switch (this) {
       case ShippingOption.secondDay:
@@ -3044,7 +3044,7 @@ enum SnowballCapacity {
   noPreference,
 }
 
-extension SnowballCapacityValue on SnowballCapacity {
+extension SnowballCapacityValueExtension on SnowballCapacity {
   String toValue() {
     switch (this) {
       case SnowballCapacity.t50:
@@ -3096,7 +3096,7 @@ enum SnowballType {
   snc1Hdd,
 }
 
-extension SnowballTypeValue on SnowballType {
+extension SnowballTypeValueExtension on SnowballType {
   String toValue() {
     switch (this) {
       case SnowballType.standard:

--- a/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
+++ b/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
@@ -1738,7 +1738,7 @@ enum ClusterState {
   cancelled,
 }
 
-extension on ClusterState {
+extension ClusterStateValue on ClusterState {
   String toValue() {
     switch (this) {
       case ClusterState.awaitingQuorum:
@@ -1755,7 +1755,7 @@ extension on ClusterState {
   }
 }
 
-extension on String {
+extension ClusterStateFromString on String {
   ClusterState toClusterState() {
     switch (this) {
       case 'AwaitingQuorum':
@@ -2479,7 +2479,7 @@ enum JobState {
   pending,
 }
 
-extension on JobState {
+extension JobStateValue on JobState {
   String toValue() {
     switch (this) {
       case JobState.$new:
@@ -2512,7 +2512,7 @@ extension on JobState {
   }
 }
 
-extension on String {
+extension JobStateFromString on String {
   JobState toJobState() {
     switch (this) {
       case 'New':
@@ -2552,7 +2552,7 @@ enum JobType {
   localUse,
 }
 
-extension on JobType {
+extension JobTypeValue on JobType {
   String toValue() {
     switch (this) {
       case JobType.import:
@@ -2565,7 +2565,7 @@ extension on JobType {
   }
 }
 
-extension on String {
+extension JobTypeFromString on String {
   JobType toJobType() {
     switch (this) {
       case 'IMPORT':
@@ -2879,7 +2879,7 @@ enum ShipmentState {
   returned,
 }
 
-extension on ShipmentState {
+extension ShipmentStateValue on ShipmentState {
   String toValue() {
     switch (this) {
       case ShipmentState.received:
@@ -2890,7 +2890,7 @@ extension on ShipmentState {
   }
 }
 
-extension on String {
+extension ShipmentStateFromString on String {
   ShipmentState toShipmentState() {
     switch (this) {
       case 'RECEIVED':
@@ -2965,7 +2965,7 @@ enum ShippingLabelStatus {
   failed,
 }
 
-extension on ShippingLabelStatus {
+extension ShippingLabelStatusValue on ShippingLabelStatus {
   String toValue() {
     switch (this) {
       case ShippingLabelStatus.inProgress:
@@ -2980,7 +2980,7 @@ extension on ShippingLabelStatus {
   }
 }
 
-extension on String {
+extension ShippingLabelStatusFromString on String {
   ShippingLabelStatus toShippingLabelStatus() {
     switch (this) {
       case 'InProgress':
@@ -3003,7 +3003,7 @@ enum ShippingOption {
   standard,
 }
 
-extension on ShippingOption {
+extension ShippingOptionValue on ShippingOption {
   String toValue() {
     switch (this) {
       case ShippingOption.secondDay:
@@ -3018,7 +3018,7 @@ extension on ShippingOption {
   }
 }
 
-extension on String {
+extension ShippingOptionFromString on String {
   ShippingOption toShippingOption() {
     switch (this) {
       case 'SECOND_DAY':
@@ -3044,7 +3044,7 @@ enum SnowballCapacity {
   noPreference,
 }
 
-extension on SnowballCapacity {
+extension SnowballCapacityValue on SnowballCapacity {
   String toValue() {
     switch (this) {
       case SnowballCapacity.t50:
@@ -3065,7 +3065,7 @@ extension on SnowballCapacity {
   }
 }
 
-extension on String {
+extension SnowballCapacityFromString on String {
   SnowballCapacity toSnowballCapacity() {
     switch (this) {
       case 'T50':
@@ -3096,7 +3096,7 @@ enum SnowballType {
   snc1Hdd,
 }
 
-extension on SnowballType {
+extension SnowballTypeValue on SnowballType {
   String toValue() {
     switch (this) {
       case SnowballType.standard:
@@ -3115,7 +3115,7 @@ extension on SnowballType {
   }
 }
 
-extension on String {
+extension SnowballTypeFromString on String {
   SnowballType toSnowballType() {
     switch (this) {
       case 'STANDARD':

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -2881,7 +2881,7 @@ enum MessageSystemAttributeName {
   awsTraceHeader,
 }
 
-extension on MessageSystemAttributeName {
+extension MessageSystemAttributeNameValue on MessageSystemAttributeName {
   String toValue() {
     switch (this) {
       case MessageSystemAttributeName.senderId:
@@ -2904,7 +2904,7 @@ extension on MessageSystemAttributeName {
   }
 }
 
-extension on String {
+extension MessageSystemAttributeNameFromString on String {
   MessageSystemAttributeName toMessageSystemAttributeName() {
     switch (this) {
       case 'SenderId':
@@ -2932,7 +2932,8 @@ enum MessageSystemAttributeNameForSends {
   awsTraceHeader,
 }
 
-extension on MessageSystemAttributeNameForSends {
+extension MessageSystemAttributeNameForSendsValue
+    on MessageSystemAttributeNameForSends {
   String toValue() {
     switch (this) {
       case MessageSystemAttributeNameForSends.awsTraceHeader:
@@ -2941,7 +2942,7 @@ extension on MessageSystemAttributeNameForSends {
   }
 }
 
-extension on String {
+extension MessageSystemAttributeNameForSendsFromString on String {
   MessageSystemAttributeNameForSends toMessageSystemAttributeNameForSends() {
     switch (this) {
       case 'AWSTraceHeader':
@@ -3033,7 +3034,7 @@ enum QueueAttributeName {
   fifoThroughputLimit,
 }
 
-extension on QueueAttributeName {
+extension QueueAttributeNameValue on QueueAttributeName {
   String toValue() {
     switch (this) {
       case QueueAttributeName.all:
@@ -3080,7 +3081,7 @@ extension on QueueAttributeName {
   }
 }
 
-extension on String {
+extension QueueAttributeNameFromString on String {
   QueueAttributeName toQueueAttributeName() {
     switch (this) {
       case 'All':

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -2881,7 +2881,8 @@ enum MessageSystemAttributeName {
   awsTraceHeader,
 }
 
-extension MessageSystemAttributeNameValue on MessageSystemAttributeName {
+extension MessageSystemAttributeNameValueExtension
+    on MessageSystemAttributeName {
   String toValue() {
     switch (this) {
       case MessageSystemAttributeName.senderId:
@@ -2932,7 +2933,7 @@ enum MessageSystemAttributeNameForSends {
   awsTraceHeader,
 }
 
-extension MessageSystemAttributeNameForSendsValue
+extension MessageSystemAttributeNameForSendsValueExtension
     on MessageSystemAttributeNameForSends {
   String toValue() {
     switch (this) {
@@ -3034,7 +3035,7 @@ enum QueueAttributeName {
   fifoThroughputLimit,
 }
 
-extension QueueAttributeNameValue on QueueAttributeName {
+extension QueueAttributeNameValueExtension on QueueAttributeName {
   String toValue() {
     switch (this) {
       case QueueAttributeName.all:

--- a/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
+++ b/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
@@ -10084,7 +10084,7 @@ enum AssociationComplianceSeverity {
   unspecified,
 }
 
-extension on AssociationComplianceSeverity {
+extension AssociationComplianceSeverityValue on AssociationComplianceSeverity {
   String toValue() {
     switch (this) {
       case AssociationComplianceSeverity.critical:
@@ -10101,7 +10101,7 @@ extension on AssociationComplianceSeverity {
   }
 }
 
-extension on String {
+extension AssociationComplianceSeverityFromString on String {
   AssociationComplianceSeverity toAssociationComplianceSeverity() {
     switch (this) {
       case 'CRITICAL':
@@ -10390,7 +10390,7 @@ enum AssociationExecutionFilterKey {
   createdTime,
 }
 
-extension on AssociationExecutionFilterKey {
+extension AssociationExecutionFilterKeyValue on AssociationExecutionFilterKey {
   String toValue() {
     switch (this) {
       case AssociationExecutionFilterKey.executionId:
@@ -10403,7 +10403,7 @@ extension on AssociationExecutionFilterKey {
   }
 }
 
-extension on String {
+extension AssociationExecutionFilterKeyFromString on String {
   AssociationExecutionFilterKey toAssociationExecutionFilterKey() {
     switch (this) {
       case 'ExecutionId':
@@ -10502,7 +10502,8 @@ enum AssociationExecutionTargetsFilterKey {
   resourceType,
 }
 
-extension on AssociationExecutionTargetsFilterKey {
+extension AssociationExecutionTargetsFilterKeyValue
+    on AssociationExecutionTargetsFilterKey {
   String toValue() {
     switch (this) {
       case AssociationExecutionTargetsFilterKey.status:
@@ -10515,7 +10516,7 @@ extension on AssociationExecutionTargetsFilterKey {
   }
 }
 
-extension on String {
+extension AssociationExecutionTargetsFilterKeyFromString on String {
   AssociationExecutionTargetsFilterKey
       toAssociationExecutionTargetsFilterKey() {
     switch (this) {
@@ -10567,7 +10568,7 @@ enum AssociationFilterKey {
   resourceGroupName,
 }
 
-extension on AssociationFilterKey {
+extension AssociationFilterKeyValue on AssociationFilterKey {
   String toValue() {
     switch (this) {
       case AssociationFilterKey.instanceId:
@@ -10590,7 +10591,7 @@ extension on AssociationFilterKey {
   }
 }
 
-extension on String {
+extension AssociationFilterKeyFromString on String {
   AssociationFilterKey toAssociationFilterKey() {
     switch (this) {
       case 'InstanceId':
@@ -10620,7 +10621,7 @@ enum AssociationFilterOperatorType {
   greaterThan,
 }
 
-extension on AssociationFilterOperatorType {
+extension AssociationFilterOperatorTypeValue on AssociationFilterOperatorType {
   String toValue() {
     switch (this) {
       case AssociationFilterOperatorType.equal:
@@ -10633,7 +10634,7 @@ extension on AssociationFilterOperatorType {
   }
 }
 
-extension on String {
+extension AssociationFilterOperatorTypeFromString on String {
   AssociationFilterOperatorType toAssociationFilterOperatorType() {
     switch (this) {
       case 'EQUAL':
@@ -10725,7 +10726,7 @@ enum AssociationStatusName {
   failed,
 }
 
-extension on AssociationStatusName {
+extension AssociationStatusNameValue on AssociationStatusName {
   String toValue() {
     switch (this) {
       case AssociationStatusName.pending:
@@ -10738,7 +10739,7 @@ extension on AssociationStatusName {
   }
 }
 
-extension on String {
+extension AssociationStatusNameFromString on String {
   AssociationStatusName toAssociationStatusName() {
     switch (this) {
       case 'Pending':
@@ -10757,7 +10758,7 @@ enum AssociationSyncCompliance {
   manual,
 }
 
-extension on AssociationSyncCompliance {
+extension AssociationSyncComplianceValue on AssociationSyncCompliance {
   String toValue() {
     switch (this) {
       case AssociationSyncCompliance.auto:
@@ -10768,7 +10769,7 @@ extension on AssociationSyncCompliance {
   }
 }
 
-extension on String {
+extension AssociationSyncComplianceFromString on String {
   AssociationSyncCompliance toAssociationSyncCompliance() {
     switch (this) {
       case 'AUTO':
@@ -10965,7 +10966,7 @@ enum AttachmentHashType {
   sha256,
 }
 
-extension on AttachmentHashType {
+extension AttachmentHashTypeValue on AttachmentHashType {
   String toValue() {
     switch (this) {
       case AttachmentHashType.sha256:
@@ -10974,7 +10975,7 @@ extension on AttachmentHashType {
   }
 }
 
-extension on String {
+extension AttachmentHashTypeFromString on String {
   AttachmentHashType toAttachmentHashType() {
     switch (this) {
       case 'Sha256':
@@ -11069,7 +11070,7 @@ enum AttachmentsSourceKey {
   attachmentReference,
 }
 
-extension on AttachmentsSourceKey {
+extension AttachmentsSourceKeyValue on AttachmentsSourceKey {
   String toValue() {
     switch (this) {
       case AttachmentsSourceKey.sourceUrl:
@@ -11082,7 +11083,7 @@ extension on AttachmentsSourceKey {
   }
 }
 
-extension on String {
+extension AttachmentsSourceKeyFromString on String {
   AttachmentsSourceKey toAttachmentsSourceKey() {
     switch (this) {
       case 'SourceUrl':
@@ -11349,7 +11350,7 @@ enum AutomationExecutionFilterKey {
   opsItemId,
 }
 
-extension on AutomationExecutionFilterKey {
+extension AutomationExecutionFilterKeyValue on AutomationExecutionFilterKey {
   String toValue() {
     switch (this) {
       case AutomationExecutionFilterKey.documentNamePrefix:
@@ -11380,7 +11381,7 @@ extension on AutomationExecutionFilterKey {
   }
 }
 
-extension on String {
+extension AutomationExecutionFilterKeyFromString on String {
   AutomationExecutionFilterKey toAutomationExecutionFilterKey() {
     switch (this) {
       case 'DocumentNamePrefix':
@@ -11614,7 +11615,7 @@ enum AutomationExecutionStatus {
   completedWithFailure,
 }
 
-extension on AutomationExecutionStatus {
+extension AutomationExecutionStatusValue on AutomationExecutionStatus {
   String toValue() {
     switch (this) {
       case AutomationExecutionStatus.pending:
@@ -11657,7 +11658,7 @@ extension on AutomationExecutionStatus {
   }
 }
 
-extension on String {
+extension AutomationExecutionStatusFromString on String {
   AutomationExecutionStatus toAutomationExecutionStatus() {
     switch (this) {
       case 'Pending':
@@ -11705,7 +11706,7 @@ enum AutomationSubtype {
   changeRequest,
 }
 
-extension on AutomationSubtype {
+extension AutomationSubtypeValue on AutomationSubtype {
   String toValue() {
     switch (this) {
       case AutomationSubtype.changeRequest:
@@ -11714,7 +11715,7 @@ extension on AutomationSubtype {
   }
 }
 
-extension on String {
+extension AutomationSubtypeFromString on String {
   AutomationSubtype toAutomationSubtype() {
     switch (this) {
       case 'ChangeRequest':
@@ -11729,7 +11730,7 @@ enum AutomationType {
   local,
 }
 
-extension on AutomationType {
+extension AutomationTypeValue on AutomationType {
   String toValue() {
     switch (this) {
       case AutomationType.crossAccount:
@@ -11740,7 +11741,7 @@ extension on AutomationType {
   }
 }
 
-extension on String {
+extension AutomationTypeFromString on String {
   AutomationType toAutomationType() {
     switch (this) {
       case 'CrossAccount':
@@ -11757,7 +11758,7 @@ enum CalendarState {
   closed,
 }
 
-extension on CalendarState {
+extension CalendarStateValue on CalendarState {
   String toValue() {
     switch (this) {
       case CalendarState.open:
@@ -11768,7 +11769,7 @@ extension on CalendarState {
   }
 }
 
-extension on String {
+extension CalendarStateFromString on String {
   CalendarState toCalendarState() {
     switch (this) {
       case 'OPEN':
@@ -12147,7 +12148,7 @@ enum CommandFilterKey {
   documentName,
 }
 
-extension on CommandFilterKey {
+extension CommandFilterKeyValue on CommandFilterKey {
   String toValue() {
     switch (this) {
       case CommandFilterKey.invokedAfter:
@@ -12164,7 +12165,7 @@ extension on CommandFilterKey {
   }
 }
 
-extension on String {
+extension CommandFilterKeyFromString on String {
   CommandFilterKey toCommandFilterKey() {
     switch (this) {
       case 'InvokedAfter':
@@ -12362,7 +12363,7 @@ enum CommandInvocationStatus {
   cancelling,
 }
 
-extension on CommandInvocationStatus {
+extension CommandInvocationStatusValue on CommandInvocationStatus {
   String toValue() {
     switch (this) {
       case CommandInvocationStatus.pending:
@@ -12385,7 +12386,7 @@ extension on CommandInvocationStatus {
   }
 }
 
-extension on String {
+extension CommandInvocationStatusFromString on String {
   CommandInvocationStatus toCommandInvocationStatus() {
     switch (this) {
       case 'Pending':
@@ -12573,7 +12574,7 @@ enum CommandPluginStatus {
   failed,
 }
 
-extension on CommandPluginStatus {
+extension CommandPluginStatusValue on CommandPluginStatus {
   String toValue() {
     switch (this) {
       case CommandPluginStatus.pending:
@@ -12592,7 +12593,7 @@ extension on CommandPluginStatus {
   }
 }
 
-extension on String {
+extension CommandPluginStatusFromString on String {
   CommandPluginStatus toCommandPluginStatus() {
     switch (this) {
       case 'Pending':
@@ -12622,7 +12623,7 @@ enum CommandStatus {
   cancelling,
 }
 
-extension on CommandStatus {
+extension CommandStatusValue on CommandStatus {
   String toValue() {
     switch (this) {
       case CommandStatus.pending:
@@ -12643,7 +12644,7 @@ extension on CommandStatus {
   }
 }
 
-extension on String {
+extension CommandStatusFromString on String {
   CommandStatus toCommandStatus() {
     switch (this) {
       case 'Pending':
@@ -12834,7 +12835,7 @@ enum ComplianceQueryOperatorType {
   greaterThan,
 }
 
-extension on ComplianceQueryOperatorType {
+extension ComplianceQueryOperatorTypeValue on ComplianceQueryOperatorType {
   String toValue() {
     switch (this) {
       case ComplianceQueryOperatorType.equal:
@@ -12851,7 +12852,7 @@ extension on ComplianceQueryOperatorType {
   }
 }
 
-extension on String {
+extension ComplianceQueryOperatorTypeFromString on String {
   ComplianceQueryOperatorType toComplianceQueryOperatorType() {
     switch (this) {
       case 'EQUAL':
@@ -12878,7 +12879,7 @@ enum ComplianceSeverity {
   unspecified,
 }
 
-extension on ComplianceSeverity {
+extension ComplianceSeverityValue on ComplianceSeverity {
   String toValue() {
     switch (this) {
       case ComplianceSeverity.critical:
@@ -12897,7 +12898,7 @@ extension on ComplianceSeverity {
   }
 }
 
-extension on String {
+extension ComplianceSeverityFromString on String {
   ComplianceSeverity toComplianceSeverity() {
     switch (this) {
       case 'CRITICAL':
@@ -12922,7 +12923,7 @@ enum ComplianceStatus {
   nonCompliant,
 }
 
-extension on ComplianceStatus {
+extension ComplianceStatusValue on ComplianceStatus {
   String toValue() {
     switch (this) {
       case ComplianceStatus.compliant:
@@ -12933,7 +12934,7 @@ extension on ComplianceStatus {
   }
 }
 
-extension on String {
+extension ComplianceStatusFromString on String {
   ComplianceStatus toComplianceStatus() {
     switch (this) {
       case 'COMPLIANT':
@@ -13011,7 +13012,7 @@ enum ComplianceUploadType {
   partial,
 }
 
-extension on ComplianceUploadType {
+extension ComplianceUploadTypeValue on ComplianceUploadType {
   String toValue() {
     switch (this) {
       case ComplianceUploadType.complete:
@@ -13022,7 +13023,7 @@ extension on ComplianceUploadType {
   }
 }
 
-extension on String {
+extension ComplianceUploadTypeFromString on String {
   ComplianceUploadType toComplianceUploadType() {
     switch (this) {
       case 'COMPLETE':
@@ -13063,7 +13064,7 @@ enum ConnectionStatus {
   notConnected,
 }
 
-extension on ConnectionStatus {
+extension ConnectionStatusValue on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.connected:
@@ -13074,7 +13075,7 @@ extension on ConnectionStatus {
   }
 }
 
-extension on String {
+extension ConnectionStatusFromString on String {
   ConnectionStatus toConnectionStatus() {
     switch (this) {
       case 'Connected':
@@ -13652,7 +13653,7 @@ enum DescribeActivationsFilterKeys {
   iamRole,
 }
 
-extension on DescribeActivationsFilterKeys {
+extension DescribeActivationsFilterKeysValue on DescribeActivationsFilterKeys {
   String toValue() {
     switch (this) {
       case DescribeActivationsFilterKeys.activationIds:
@@ -13665,7 +13666,7 @@ extension on DescribeActivationsFilterKeys {
   }
 }
 
-extension on String {
+extension DescribeActivationsFilterKeysFromString on String {
   DescribeActivationsFilterKeys toDescribeActivationsFilterKeys() {
     switch (this) {
       case 'ActivationIds':
@@ -14753,7 +14754,7 @@ enum DocumentFilterKey {
   documentType,
 }
 
-extension on DocumentFilterKey {
+extension DocumentFilterKeyValue on DocumentFilterKey {
   String toValue() {
     switch (this) {
       case DocumentFilterKey.name:
@@ -14768,7 +14769,7 @@ extension on DocumentFilterKey {
   }
 }
 
-extension on String {
+extension DocumentFilterKeyFromString on String {
   DocumentFilterKey toDocumentFilterKey() {
     switch (this) {
       case 'Name':
@@ -14790,7 +14791,7 @@ enum DocumentFormat {
   text,
 }
 
-extension on DocumentFormat {
+extension DocumentFormatValue on DocumentFormat {
   String toValue() {
     switch (this) {
       case DocumentFormat.yaml:
@@ -14803,7 +14804,7 @@ extension on DocumentFormat {
   }
 }
 
-extension on String {
+extension DocumentFormatFromString on String {
   DocumentFormat toDocumentFormat() {
     switch (this) {
       case 'YAML':
@@ -14822,7 +14823,7 @@ enum DocumentHashType {
   sha1,
 }
 
-extension on DocumentHashType {
+extension DocumentHashTypeValue on DocumentHashType {
   String toValue() {
     switch (this) {
       case DocumentHashType.sha256:
@@ -14833,7 +14834,7 @@ extension on DocumentHashType {
   }
 }
 
-extension on String {
+extension DocumentHashTypeFromString on String {
   DocumentHashType toDocumentHashType() {
     switch (this) {
       case 'Sha256':
@@ -15055,7 +15056,7 @@ enum DocumentMetadataEnum {
   documentReviews,
 }
 
-extension on DocumentMetadataEnum {
+extension DocumentMetadataEnumValue on DocumentMetadataEnum {
   String toValue() {
     switch (this) {
       case DocumentMetadataEnum.documentReviews:
@@ -15064,7 +15065,7 @@ extension on DocumentMetadataEnum {
   }
 }
 
-extension on String {
+extension DocumentMetadataEnumFromString on String {
   DocumentMetadataEnum toDocumentMetadataEnum() {
     switch (this) {
       case 'DocumentReviews':
@@ -15131,7 +15132,7 @@ enum DocumentParameterType {
   stringList,
 }
 
-extension on DocumentParameterType {
+extension DocumentParameterTypeValue on DocumentParameterType {
   String toValue() {
     switch (this) {
       case DocumentParameterType.string:
@@ -15142,7 +15143,7 @@ extension on DocumentParameterType {
   }
 }
 
-extension on String {
+extension DocumentParameterTypeFromString on String {
   DocumentParameterType toDocumentParameterType() {
     switch (this) {
       case 'String':
@@ -15158,7 +15159,7 @@ enum DocumentPermissionType {
   share,
 }
 
-extension on DocumentPermissionType {
+extension DocumentPermissionTypeValue on DocumentPermissionType {
   String toValue() {
     switch (this) {
       case DocumentPermissionType.share:
@@ -15167,7 +15168,7 @@ extension on DocumentPermissionType {
   }
 }
 
-extension on String {
+extension DocumentPermissionTypeFromString on String {
   DocumentPermissionType toDocumentPermissionType() {
     switch (this) {
       case 'Share':
@@ -15214,7 +15215,7 @@ enum DocumentReviewAction {
   reject,
 }
 
-extension on DocumentReviewAction {
+extension DocumentReviewActionValue on DocumentReviewAction {
   String toValue() {
     switch (this) {
       case DocumentReviewAction.sendForReview:
@@ -15229,7 +15230,7 @@ extension on DocumentReviewAction {
   }
 }
 
-extension on String {
+extension DocumentReviewActionFromString on String {
   DocumentReviewAction toDocumentReviewAction() {
     switch (this) {
       case 'SendForReview':
@@ -15280,7 +15281,7 @@ enum DocumentReviewCommentType {
   comment,
 }
 
-extension on DocumentReviewCommentType {
+extension DocumentReviewCommentTypeValue on DocumentReviewCommentType {
   String toValue() {
     switch (this) {
       case DocumentReviewCommentType.comment:
@@ -15289,7 +15290,7 @@ extension on DocumentReviewCommentType {
   }
 }
 
-extension on String {
+extension DocumentReviewCommentTypeFromString on String {
   DocumentReviewCommentType toDocumentReviewCommentType() {
     switch (this) {
       case 'Comment':
@@ -15379,7 +15380,7 @@ enum DocumentStatus {
   failed,
 }
 
-extension on DocumentStatus {
+extension DocumentStatusValue on DocumentStatus {
   String toValue() {
     switch (this) {
       case DocumentStatus.creating:
@@ -15396,7 +15397,7 @@ extension on DocumentStatus {
   }
 }
 
-extension on String {
+extension DocumentStatusFromString on String {
   DocumentStatus toDocumentStatus() {
     switch (this) {
       case 'Creating':
@@ -15427,7 +15428,7 @@ enum DocumentType {
   automationChangeTemplate,
 }
 
-extension on DocumentType {
+extension DocumentTypeValue on DocumentType {
   String toValue() {
     switch (this) {
       case DocumentType.command:
@@ -15454,7 +15455,7 @@ extension on DocumentType {
   }
 }
 
-extension on String {
+extension DocumentTypeFromString on String {
   DocumentType toDocumentType() {
     switch (this) {
       case 'Command':
@@ -15582,7 +15583,7 @@ enum ExecutionMode {
   interactive,
 }
 
-extension on ExecutionMode {
+extension ExecutionModeValue on ExecutionMode {
   String toValue() {
     switch (this) {
       case ExecutionMode.auto:
@@ -15593,7 +15594,7 @@ extension on ExecutionMode {
   }
 }
 
-extension on String {
+extension ExecutionModeFromString on String {
   ExecutionMode toExecutionMode() {
     switch (this) {
       case 'Auto':
@@ -15669,7 +15670,7 @@ enum Fault {
   unknown,
 }
 
-extension on Fault {
+extension FaultValue on Fault {
   String toValue() {
     switch (this) {
       case Fault.client:
@@ -15682,7 +15683,7 @@ extension on Fault {
   }
 }
 
-extension on String {
+extension FaultFromString on String {
   Fault toFault() {
     switch (this) {
       case 'Client':
@@ -17233,7 +17234,7 @@ enum InstanceInformationFilterKey {
   associationStatus,
 }
 
-extension on InstanceInformationFilterKey {
+extension InstanceInformationFilterKeyValue on InstanceInformationFilterKey {
   String toValue() {
     switch (this) {
       case InstanceInformationFilterKey.instanceIds:
@@ -17256,7 +17257,7 @@ extension on InstanceInformationFilterKey {
   }
 }
 
-extension on String {
+extension InstanceInformationFilterKeyFromString on String {
   InstanceInformationFilterKey toInstanceInformationFilterKey() {
     switch (this) {
       case 'InstanceIds':
@@ -17505,7 +17506,8 @@ enum InstancePatchStateOperatorType {
   greaterThan,
 }
 
-extension on InstancePatchStateOperatorType {
+extension InstancePatchStateOperatorTypeValue
+    on InstancePatchStateOperatorType {
   String toValue() {
     switch (this) {
       case InstancePatchStateOperatorType.equal:
@@ -17520,7 +17522,7 @@ extension on InstancePatchStateOperatorType {
   }
 }
 
-extension on String {
+extension InstancePatchStateOperatorTypeFromString on String {
   InstancePatchStateOperatorType toInstancePatchStateOperatorType() {
     switch (this) {
       case 'Equal':
@@ -17572,7 +17574,7 @@ enum InventoryAttributeDataType {
   number,
 }
 
-extension on InventoryAttributeDataType {
+extension InventoryAttributeDataTypeValue on InventoryAttributeDataType {
   String toValue() {
     switch (this) {
       case InventoryAttributeDataType.string:
@@ -17583,7 +17585,7 @@ extension on InventoryAttributeDataType {
   }
 }
 
-extension on String {
+extension InventoryAttributeDataTypeFromString on String {
   InventoryAttributeDataType toInventoryAttributeDataType() {
     switch (this) {
       case 'string':
@@ -17600,7 +17602,7 @@ enum InventoryDeletionStatus {
   complete,
 }
 
-extension on InventoryDeletionStatus {
+extension InventoryDeletionStatusValue on InventoryDeletionStatus {
   String toValue() {
     switch (this) {
       case InventoryDeletionStatus.inProgress:
@@ -17611,7 +17613,7 @@ extension on InventoryDeletionStatus {
   }
 }
 
-extension on String {
+extension InventoryDeletionStatusFromString on String {
   InventoryDeletionStatus toInventoryDeletionStatus() {
     switch (this) {
       case 'InProgress':
@@ -17920,7 +17922,7 @@ enum InventoryQueryOperatorType {
   exists,
 }
 
-extension on InventoryQueryOperatorType {
+extension InventoryQueryOperatorTypeValue on InventoryQueryOperatorType {
   String toValue() {
     switch (this) {
       case InventoryQueryOperatorType.equal:
@@ -17939,7 +17941,7 @@ extension on InventoryQueryOperatorType {
   }
 }
 
-extension on String {
+extension InventoryQueryOperatorTypeFromString on String {
   InventoryQueryOperatorType toInventoryQueryOperatorType() {
     switch (this) {
       case 'Equal':
@@ -18030,7 +18032,7 @@ enum InventorySchemaDeleteOption {
   deleteSchema,
 }
 
-extension on InventorySchemaDeleteOption {
+extension InventorySchemaDeleteOptionValue on InventorySchemaDeleteOption {
   String toValue() {
     switch (this) {
       case InventorySchemaDeleteOption.disableSchema:
@@ -18041,7 +18043,7 @@ extension on InventorySchemaDeleteOption {
   }
 }
 
-extension on String {
+extension InventorySchemaDeleteOptionFromString on String {
   InventorySchemaDeleteOption toInventorySchemaDeleteOption() {
     switch (this) {
       case 'DisableSchema':
@@ -18084,7 +18086,7 @@ enum LastResourceDataSyncStatus {
   inProgress,
 }
 
-extension on LastResourceDataSyncStatus {
+extension LastResourceDataSyncStatusValue on LastResourceDataSyncStatus {
   String toValue() {
     switch (this) {
       case LastResourceDataSyncStatus.successful:
@@ -18097,7 +18099,7 @@ extension on LastResourceDataSyncStatus {
   }
 }
 
-extension on String {
+extension LastResourceDataSyncStatusFromString on String {
   LastResourceDataSyncStatus toLastResourceDataSyncStatus() {
     switch (this) {
       case 'Successful':
@@ -18649,7 +18651,8 @@ enum MaintenanceWindowExecutionStatus {
   skippedOverlapping,
 }
 
-extension on MaintenanceWindowExecutionStatus {
+extension MaintenanceWindowExecutionStatusValue
+    on MaintenanceWindowExecutionStatus {
   String toValue() {
     switch (this) {
       case MaintenanceWindowExecutionStatus.pending:
@@ -18672,7 +18675,7 @@ extension on MaintenanceWindowExecutionStatus {
   }
 }
 
-extension on String {
+extension MaintenanceWindowExecutionStatusFromString on String {
   MaintenanceWindowExecutionStatus toMaintenanceWindowExecutionStatus() {
     switch (this) {
       case 'PENDING':
@@ -19017,7 +19020,7 @@ enum MaintenanceWindowResourceType {
   resourceGroup,
 }
 
-extension on MaintenanceWindowResourceType {
+extension MaintenanceWindowResourceTypeValue on MaintenanceWindowResourceType {
   String toValue() {
     switch (this) {
       case MaintenanceWindowResourceType.instance:
@@ -19028,7 +19031,7 @@ extension on MaintenanceWindowResourceType {
   }
 }
 
-extension on String {
+extension MaintenanceWindowResourceTypeFromString on String {
   MaintenanceWindowResourceType toMaintenanceWindowResourceType() {
     switch (this) {
       case 'INSTANCE':
@@ -19490,7 +19493,7 @@ enum MaintenanceWindowTaskType {
   lambda,
 }
 
-extension on MaintenanceWindowTaskType {
+extension MaintenanceWindowTaskTypeValue on MaintenanceWindowTaskType {
   String toValue() {
     switch (this) {
       case MaintenanceWindowTaskType.runCommand:
@@ -19505,7 +19508,7 @@ extension on MaintenanceWindowTaskType {
   }
 }
 
-extension on String {
+extension MaintenanceWindowTaskTypeFromString on String {
   MaintenanceWindowTaskType toMaintenanceWindowTaskType() {
     switch (this) {
       case 'RUN_COMMAND':
@@ -19635,7 +19638,7 @@ enum NotificationEvent {
   failed,
 }
 
-extension on NotificationEvent {
+extension NotificationEventValue on NotificationEvent {
   String toValue() {
     switch (this) {
       case NotificationEvent.all:
@@ -19654,7 +19657,7 @@ extension on NotificationEvent {
   }
 }
 
-extension on String {
+extension NotificationEventFromString on String {
   NotificationEvent toNotificationEvent() {
     switch (this) {
       case 'All':
@@ -19679,7 +19682,7 @@ enum NotificationType {
   invocation,
 }
 
-extension on NotificationType {
+extension NotificationTypeValue on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.command:
@@ -19690,7 +19693,7 @@ extension on NotificationType {
   }
 }
 
-extension on String {
+extension NotificationTypeFromString on String {
   NotificationType toNotificationType() {
     switch (this) {
       case 'Command':
@@ -19715,7 +19718,7 @@ enum OperatingSystem {
   macos,
 }
 
-extension on OperatingSystem {
+extension OperatingSystemValue on OperatingSystem {
   String toValue() {
     switch (this) {
       case OperatingSystem.windows:
@@ -19742,7 +19745,7 @@ extension on OperatingSystem {
   }
 }
 
-extension on String {
+extension OperatingSystemFromString on String {
   OperatingSystem toOperatingSystem() {
     switch (this) {
       case 'WINDOWS':
@@ -19900,7 +19903,7 @@ enum OpsFilterOperatorType {
   exists,
 }
 
-extension on OpsFilterOperatorType {
+extension OpsFilterOperatorTypeValue on OpsFilterOperatorType {
   String toValue() {
     switch (this) {
       case OpsFilterOperatorType.equal:
@@ -19919,7 +19922,7 @@ extension on OpsFilterOperatorType {
   }
 }
 
-extension on String {
+extension OpsFilterOperatorTypeFromString on String {
   OpsFilterOperatorType toOpsFilterOperatorType() {
     switch (this) {
       case 'Equal':
@@ -20110,7 +20113,7 @@ enum OpsItemDataType {
   string,
 }
 
-extension on OpsItemDataType {
+extension OpsItemDataTypeValue on OpsItemDataType {
   String toValue() {
     switch (this) {
       case OpsItemDataType.searchableString:
@@ -20121,7 +20124,7 @@ extension on OpsItemDataType {
   }
 }
 
-extension on String {
+extension OpsItemDataTypeFromString on String {
   OpsItemDataType toOpsItemDataType() {
     switch (this) {
       case 'SearchableString':
@@ -20200,7 +20203,7 @@ enum OpsItemEventFilterKey {
   opsItemId,
 }
 
-extension on OpsItemEventFilterKey {
+extension OpsItemEventFilterKeyValue on OpsItemEventFilterKey {
   String toValue() {
     switch (this) {
       case OpsItemEventFilterKey.opsItemId:
@@ -20209,7 +20212,7 @@ extension on OpsItemEventFilterKey {
   }
 }
 
-extension on String {
+extension OpsItemEventFilterKeyFromString on String {
   OpsItemEventFilterKey toOpsItemEventFilterKey() {
     switch (this) {
       case 'OpsItemId':
@@ -20223,7 +20226,7 @@ enum OpsItemEventFilterOperator {
   equal,
 }
 
-extension on OpsItemEventFilterOperator {
+extension OpsItemEventFilterOperatorValue on OpsItemEventFilterOperator {
   String toValue() {
     switch (this) {
       case OpsItemEventFilterOperator.equal:
@@ -20232,7 +20235,7 @@ extension on OpsItemEventFilterOperator {
   }
 }
 
-extension on String {
+extension OpsItemEventFilterOperatorFromString on String {
   OpsItemEventFilterOperator toOpsItemEventFilterOperator() {
     switch (this) {
       case 'Equal':
@@ -20346,7 +20349,7 @@ enum OpsItemFilterKey {
   changeRequestByTargetsResourceGroup,
 }
 
-extension on OpsItemFilterKey {
+extension OpsItemFilterKeyValue on OpsItemFilterKey {
   String toValue() {
     switch (this) {
       case OpsItemFilterKey.status:
@@ -20405,7 +20408,7 @@ extension on OpsItemFilterKey {
   }
 }
 
-extension on String {
+extension OpsItemFilterKeyFromString on String {
   OpsItemFilterKey toOpsItemFilterKey() {
     switch (this) {
       case 'Status':
@@ -20472,7 +20475,7 @@ enum OpsItemFilterOperator {
   lessThan,
 }
 
-extension on OpsItemFilterOperator {
+extension OpsItemFilterOperatorValue on OpsItemFilterOperator {
   String toValue() {
     switch (this) {
       case OpsItemFilterOperator.equal:
@@ -20487,7 +20490,7 @@ extension on OpsItemFilterOperator {
   }
 }
 
-extension on String {
+extension OpsItemFilterOperatorFromString on String {
   OpsItemFilterOperator toOpsItemFilterOperator() {
     switch (this) {
       case 'Equal':
@@ -20563,7 +20566,7 @@ enum OpsItemStatus {
   rejected,
 }
 
-extension on OpsItemStatus {
+extension OpsItemStatusValue on OpsItemStatus {
   String toValue() {
     switch (this) {
       case OpsItemStatus.open:
@@ -20606,7 +20609,7 @@ extension on OpsItemStatus {
   }
 }
 
-extension on String {
+extension OpsItemStatusFromString on String {
   OpsItemStatus toOpsItemStatus() {
     switch (this) {
       case 'Open':
@@ -21169,7 +21172,7 @@ enum ParameterTier {
   intelligentTiering,
 }
 
-extension on ParameterTier {
+extension ParameterTierValue on ParameterTier {
   String toValue() {
     switch (this) {
       case ParameterTier.standard:
@@ -21182,7 +21185,7 @@ extension on ParameterTier {
   }
 }
 
-extension on String {
+extension ParameterTierFromString on String {
   ParameterTier toParameterTier() {
     switch (this) {
       case 'Standard':
@@ -21202,7 +21205,7 @@ enum ParameterType {
   secureString,
 }
 
-extension on ParameterType {
+extension ParameterTypeValue on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.string:
@@ -21215,7 +21218,7 @@ extension on ParameterType {
   }
 }
 
-extension on String {
+extension ParameterTypeFromString on String {
   ParameterType toParameterType() {
     switch (this) {
       case 'String':
@@ -21257,7 +21260,7 @@ enum ParametersFilterKey {
   keyId,
 }
 
-extension on ParametersFilterKey {
+extension ParametersFilterKeyValue on ParametersFilterKey {
   String toValue() {
     switch (this) {
       case ParametersFilterKey.name:
@@ -21270,7 +21273,7 @@ extension on ParametersFilterKey {
   }
 }
 
-extension on String {
+extension ParametersFilterKeyFromString on String {
   ParametersFilterKey toParametersFilterKey() {
     switch (this) {
       case 'Name':
@@ -21449,7 +21452,7 @@ enum PatchAction {
   block,
 }
 
-extension on PatchAction {
+extension PatchActionValue on PatchAction {
   String toValue() {
     switch (this) {
       case PatchAction.allowAsDependency:
@@ -21460,7 +21463,7 @@ extension on PatchAction {
   }
 }
 
-extension on String {
+extension PatchActionFromString on String {
   PatchAction toPatchAction() {
     switch (this) {
       case 'ALLOW_AS_DEPENDENCY':
@@ -21575,7 +21578,7 @@ enum PatchComplianceDataState {
   failed,
 }
 
-extension on PatchComplianceDataState {
+extension PatchComplianceDataStateValue on PatchComplianceDataState {
   String toValue() {
     switch (this) {
       case PatchComplianceDataState.installed:
@@ -21596,7 +21599,7 @@ extension on PatchComplianceDataState {
   }
 }
 
-extension on String {
+extension PatchComplianceDataStateFromString on String {
   PatchComplianceDataState toPatchComplianceDataState() {
     switch (this) {
       case 'INSTALLED':
@@ -21627,7 +21630,7 @@ enum PatchComplianceLevel {
   unspecified,
 }
 
-extension on PatchComplianceLevel {
+extension PatchComplianceLevelValue on PatchComplianceLevel {
   String toValue() {
     switch (this) {
       case PatchComplianceLevel.critical:
@@ -21646,7 +21649,7 @@ extension on PatchComplianceLevel {
   }
 }
 
-extension on String {
+extension PatchComplianceLevelFromString on String {
   PatchComplianceLevel toPatchComplianceLevel() {
     switch (this) {
       case 'CRITICAL':
@@ -21673,7 +21676,7 @@ enum PatchDeploymentStatus {
   explicitRejected,
 }
 
-extension on PatchDeploymentStatus {
+extension PatchDeploymentStatusValue on PatchDeploymentStatus {
   String toValue() {
     switch (this) {
       case PatchDeploymentStatus.approved:
@@ -21688,7 +21691,7 @@ extension on PatchDeploymentStatus {
   }
 }
 
-extension on String {
+extension PatchDeploymentStatusFromString on String {
   PatchDeploymentStatus toPatchDeploymentStatus() {
     switch (this) {
       case 'APPROVED':
@@ -21804,7 +21807,7 @@ enum PatchFilterKey {
   version,
 }
 
-extension on PatchFilterKey {
+extension PatchFilterKeyValue on PatchFilterKey {
   String toValue() {
     switch (this) {
       case PatchFilterKey.arch:
@@ -21849,7 +21852,7 @@ extension on PatchFilterKey {
   }
 }
 
-extension on String {
+extension PatchFilterKeyFromString on String {
   PatchFilterKey toPatchFilterKey() {
     switch (this) {
       case 'ARCH':
@@ -21924,7 +21927,7 @@ enum PatchOperationType {
   install,
 }
 
-extension on PatchOperationType {
+extension PatchOperationTypeValue on PatchOperationType {
   String toValue() {
     switch (this) {
       case PatchOperationType.scan:
@@ -21935,7 +21938,7 @@ extension on PatchOperationType {
   }
 }
 
-extension on String {
+extension PatchOperationTypeFromString on String {
   PatchOperationType toPatchOperationType() {
     switch (this) {
       case 'Scan':
@@ -21978,7 +21981,7 @@ enum PatchProperty {
   severity,
 }
 
-extension on PatchProperty {
+extension PatchPropertyValue on PatchProperty {
   String toValue() {
     switch (this) {
       case PatchProperty.product:
@@ -21997,7 +22000,7 @@ extension on PatchProperty {
   }
 }
 
-extension on String {
+extension PatchPropertyFromString on String {
   PatchProperty toPatchProperty() {
     switch (this) {
       case 'PRODUCT':
@@ -22109,7 +22112,7 @@ enum PatchSet {
   application,
 }
 
-extension on PatchSet {
+extension PatchSetValue on PatchSet {
   String toValue() {
     switch (this) {
       case PatchSet.os:
@@ -22120,7 +22123,7 @@ extension on PatchSet {
   }
 }
 
-extension on String {
+extension PatchSetFromString on String {
   PatchSet toPatchSet() {
     switch (this) {
       case 'OS':
@@ -22218,7 +22221,7 @@ enum PingStatus {
   inactive,
 }
 
-extension on PingStatus {
+extension PingStatusValue on PingStatus {
   String toValue() {
     switch (this) {
       case PingStatus.online:
@@ -22231,7 +22234,7 @@ extension on PingStatus {
   }
 }
 
-extension on String {
+extension PingStatusFromString on String {
   PingStatus toPingStatus() {
     switch (this) {
       case 'Online':
@@ -22250,7 +22253,7 @@ enum PlatformType {
   linux,
 }
 
-extension on PlatformType {
+extension PlatformTypeValue on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.windows:
@@ -22261,7 +22264,7 @@ extension on PlatformType {
   }
 }
 
-extension on String {
+extension PlatformTypeFromString on String {
   PlatformType toPlatformType() {
     switch (this) {
       case 'Windows':
@@ -22364,7 +22367,7 @@ enum RebootOption {
   noReboot,
 }
 
-extension on RebootOption {
+extension RebootOptionValue on RebootOption {
   String toValue() {
     switch (this) {
       case RebootOption.rebootIfNeeded:
@@ -22375,7 +22378,7 @@ extension on RebootOption {
   }
 }
 
-extension on String {
+extension RebootOptionFromString on String {
   RebootOption toRebootOption() {
     switch (this) {
       case 'RebootIfNeeded':
@@ -22820,7 +22823,7 @@ enum ResourceDataSyncS3Format {
   jsonSerDe,
 }
 
-extension on ResourceDataSyncS3Format {
+extension ResourceDataSyncS3FormatValue on ResourceDataSyncS3Format {
   String toValue() {
     switch (this) {
       case ResourceDataSyncS3Format.jsonSerDe:
@@ -22829,7 +22832,7 @@ extension on ResourceDataSyncS3Format {
   }
 }
 
-extension on String {
+extension ResourceDataSyncS3FormatFromString on String {
   ResourceDataSyncS3Format toResourceDataSyncS3Format() {
     switch (this) {
       case 'JsonSerDe':
@@ -22956,7 +22959,7 @@ enum ResourceType {
   eC2Instance,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.managedInstance:
@@ -22969,7 +22972,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'ManagedInstance':
@@ -22992,7 +22995,7 @@ enum ResourceTypeForTagging {
   opsItem,
 }
 
-extension on ResourceTypeForTagging {
+extension ResourceTypeForTaggingValue on ResourceTypeForTagging {
   String toValue() {
     switch (this) {
       case ResourceTypeForTagging.document:
@@ -23011,7 +23014,7 @@ extension on ResourceTypeForTagging {
   }
 }
 
-extension on String {
+extension ResourceTypeForTaggingFromString on String {
   ResourceTypeForTagging toResourceTypeForTagging() {
     switch (this) {
       case 'Document':
@@ -23117,7 +23120,7 @@ enum ReviewStatus {
   rejected,
 }
 
-extension on ReviewStatus {
+extension ReviewStatusValue on ReviewStatus {
   String toValue() {
     switch (this) {
       case ReviewStatus.approved:
@@ -23132,7 +23135,7 @@ extension on ReviewStatus {
   }
 }
 
-extension on String {
+extension ReviewStatusFromString on String {
   ReviewStatus toReviewStatus() {
     switch (this) {
       case 'APPROVED':
@@ -23559,7 +23562,7 @@ enum SessionFilterKey {
   sessionId,
 }
 
-extension on SessionFilterKey {
+extension SessionFilterKeyValue on SessionFilterKey {
   String toValue() {
     switch (this) {
       case SessionFilterKey.invokedAfter:
@@ -23578,7 +23581,7 @@ extension on SessionFilterKey {
   }
 }
 
-extension on String {
+extension SessionFilterKeyFromString on String {
   SessionFilterKey toSessionFilterKey() {
     switch (this) {
       case 'InvokedAfter':
@@ -23623,7 +23626,7 @@ enum SessionState {
   history,
 }
 
-extension on SessionState {
+extension SessionStateValue on SessionState {
   String toValue() {
     switch (this) {
       case SessionState.active:
@@ -23634,7 +23637,7 @@ extension on SessionState {
   }
 }
 
-extension on String {
+extension SessionStateFromString on String {
   SessionState toSessionState() {
     switch (this) {
       case 'Active':
@@ -23655,7 +23658,7 @@ enum SessionStatus {
   failed,
 }
 
-extension on SessionStatus {
+extension SessionStatusValue on SessionStatus {
   String toValue() {
     switch (this) {
       case SessionStatus.connected:
@@ -23674,7 +23677,7 @@ extension on SessionStatus {
   }
 }
 
-extension on String {
+extension SessionStatusFromString on String {
   SessionStatus toSessionStatus() {
     switch (this) {
       case 'Connected':
@@ -23755,7 +23758,7 @@ enum SignalType {
   resume,
 }
 
-extension on SignalType {
+extension SignalTypeValue on SignalType {
   String toValue() {
     switch (this) {
       case SignalType.approve:
@@ -23772,7 +23775,7 @@ extension on SignalType {
   }
 }
 
-extension on String {
+extension SignalTypeFromString on String {
   SignalType toSignalType() {
     switch (this) {
       case 'Approve':
@@ -24048,7 +24051,7 @@ enum StepExecutionFilterKey {
   action,
 }
 
-extension on StepExecutionFilterKey {
+extension StepExecutionFilterKeyValue on StepExecutionFilterKey {
   String toValue() {
     switch (this) {
       case StepExecutionFilterKey.startTimeBefore:
@@ -24067,7 +24070,7 @@ extension on StepExecutionFilterKey {
   }
 }
 
-extension on String {
+extension StepExecutionFilterKeyFromString on String {
   StepExecutionFilterKey toStepExecutionFilterKey() {
     switch (this) {
       case 'StartTimeBefore':
@@ -24099,7 +24102,7 @@ enum StopType {
   cancel,
 }
 
-extension on StopType {
+extension StopTypeValue on StopType {
   String toValue() {
     switch (this) {
       case StopType.complete:
@@ -24110,7 +24113,7 @@ extension on StopType {
   }
 }
 
-extension on String {
+extension StopTypeFromString on String {
   StopType toStopType() {
     switch (this) {
       case 'Complete':

--- a/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
+++ b/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
@@ -10084,7 +10084,8 @@ enum AssociationComplianceSeverity {
   unspecified,
 }
 
-extension AssociationComplianceSeverityValue on AssociationComplianceSeverity {
+extension AssociationComplianceSeverityValueExtension
+    on AssociationComplianceSeverity {
   String toValue() {
     switch (this) {
       case AssociationComplianceSeverity.critical:
@@ -10390,7 +10391,8 @@ enum AssociationExecutionFilterKey {
   createdTime,
 }
 
-extension AssociationExecutionFilterKeyValue on AssociationExecutionFilterKey {
+extension AssociationExecutionFilterKeyValueExtension
+    on AssociationExecutionFilterKey {
   String toValue() {
     switch (this) {
       case AssociationExecutionFilterKey.executionId:
@@ -10502,7 +10504,7 @@ enum AssociationExecutionTargetsFilterKey {
   resourceType,
 }
 
-extension AssociationExecutionTargetsFilterKeyValue
+extension AssociationExecutionTargetsFilterKeyValueExtension
     on AssociationExecutionTargetsFilterKey {
   String toValue() {
     switch (this) {
@@ -10568,7 +10570,7 @@ enum AssociationFilterKey {
   resourceGroupName,
 }
 
-extension AssociationFilterKeyValue on AssociationFilterKey {
+extension AssociationFilterKeyValueExtension on AssociationFilterKey {
   String toValue() {
     switch (this) {
       case AssociationFilterKey.instanceId:
@@ -10621,7 +10623,8 @@ enum AssociationFilterOperatorType {
   greaterThan,
 }
 
-extension AssociationFilterOperatorTypeValue on AssociationFilterOperatorType {
+extension AssociationFilterOperatorTypeValueExtension
+    on AssociationFilterOperatorType {
   String toValue() {
     switch (this) {
       case AssociationFilterOperatorType.equal:
@@ -10726,7 +10729,7 @@ enum AssociationStatusName {
   failed,
 }
 
-extension AssociationStatusNameValue on AssociationStatusName {
+extension AssociationStatusNameValueExtension on AssociationStatusName {
   String toValue() {
     switch (this) {
       case AssociationStatusName.pending:
@@ -10758,7 +10761,7 @@ enum AssociationSyncCompliance {
   manual,
 }
 
-extension AssociationSyncComplianceValue on AssociationSyncCompliance {
+extension AssociationSyncComplianceValueExtension on AssociationSyncCompliance {
   String toValue() {
     switch (this) {
       case AssociationSyncCompliance.auto:
@@ -10966,7 +10969,7 @@ enum AttachmentHashType {
   sha256,
 }
 
-extension AttachmentHashTypeValue on AttachmentHashType {
+extension AttachmentHashTypeValueExtension on AttachmentHashType {
   String toValue() {
     switch (this) {
       case AttachmentHashType.sha256:
@@ -11070,7 +11073,7 @@ enum AttachmentsSourceKey {
   attachmentReference,
 }
 
-extension AttachmentsSourceKeyValue on AttachmentsSourceKey {
+extension AttachmentsSourceKeyValueExtension on AttachmentsSourceKey {
   String toValue() {
     switch (this) {
       case AttachmentsSourceKey.sourceUrl:
@@ -11350,7 +11353,8 @@ enum AutomationExecutionFilterKey {
   opsItemId,
 }
 
-extension AutomationExecutionFilterKeyValue on AutomationExecutionFilterKey {
+extension AutomationExecutionFilterKeyValueExtension
+    on AutomationExecutionFilterKey {
   String toValue() {
     switch (this) {
       case AutomationExecutionFilterKey.documentNamePrefix:
@@ -11615,7 +11619,7 @@ enum AutomationExecutionStatus {
   completedWithFailure,
 }
 
-extension AutomationExecutionStatusValue on AutomationExecutionStatus {
+extension AutomationExecutionStatusValueExtension on AutomationExecutionStatus {
   String toValue() {
     switch (this) {
       case AutomationExecutionStatus.pending:
@@ -11706,7 +11710,7 @@ enum AutomationSubtype {
   changeRequest,
 }
 
-extension AutomationSubtypeValue on AutomationSubtype {
+extension AutomationSubtypeValueExtension on AutomationSubtype {
   String toValue() {
     switch (this) {
       case AutomationSubtype.changeRequest:
@@ -11730,7 +11734,7 @@ enum AutomationType {
   local,
 }
 
-extension AutomationTypeValue on AutomationType {
+extension AutomationTypeValueExtension on AutomationType {
   String toValue() {
     switch (this) {
       case AutomationType.crossAccount:
@@ -11758,7 +11762,7 @@ enum CalendarState {
   closed,
 }
 
-extension CalendarStateValue on CalendarState {
+extension CalendarStateValueExtension on CalendarState {
   String toValue() {
     switch (this) {
       case CalendarState.open:
@@ -12148,7 +12152,7 @@ enum CommandFilterKey {
   documentName,
 }
 
-extension CommandFilterKeyValue on CommandFilterKey {
+extension CommandFilterKeyValueExtension on CommandFilterKey {
   String toValue() {
     switch (this) {
       case CommandFilterKey.invokedAfter:
@@ -12363,7 +12367,7 @@ enum CommandInvocationStatus {
   cancelling,
 }
 
-extension CommandInvocationStatusValue on CommandInvocationStatus {
+extension CommandInvocationStatusValueExtension on CommandInvocationStatus {
   String toValue() {
     switch (this) {
       case CommandInvocationStatus.pending:
@@ -12574,7 +12578,7 @@ enum CommandPluginStatus {
   failed,
 }
 
-extension CommandPluginStatusValue on CommandPluginStatus {
+extension CommandPluginStatusValueExtension on CommandPluginStatus {
   String toValue() {
     switch (this) {
       case CommandPluginStatus.pending:
@@ -12623,7 +12627,7 @@ enum CommandStatus {
   cancelling,
 }
 
-extension CommandStatusValue on CommandStatus {
+extension CommandStatusValueExtension on CommandStatus {
   String toValue() {
     switch (this) {
       case CommandStatus.pending:
@@ -12835,7 +12839,8 @@ enum ComplianceQueryOperatorType {
   greaterThan,
 }
 
-extension ComplianceQueryOperatorTypeValue on ComplianceQueryOperatorType {
+extension ComplianceQueryOperatorTypeValueExtension
+    on ComplianceQueryOperatorType {
   String toValue() {
     switch (this) {
       case ComplianceQueryOperatorType.equal:
@@ -12879,7 +12884,7 @@ enum ComplianceSeverity {
   unspecified,
 }
 
-extension ComplianceSeverityValue on ComplianceSeverity {
+extension ComplianceSeverityValueExtension on ComplianceSeverity {
   String toValue() {
     switch (this) {
       case ComplianceSeverity.critical:
@@ -12923,7 +12928,7 @@ enum ComplianceStatus {
   nonCompliant,
 }
 
-extension ComplianceStatusValue on ComplianceStatus {
+extension ComplianceStatusValueExtension on ComplianceStatus {
   String toValue() {
     switch (this) {
       case ComplianceStatus.compliant:
@@ -13012,7 +13017,7 @@ enum ComplianceUploadType {
   partial,
 }
 
-extension ComplianceUploadTypeValue on ComplianceUploadType {
+extension ComplianceUploadTypeValueExtension on ComplianceUploadType {
   String toValue() {
     switch (this) {
       case ComplianceUploadType.complete:
@@ -13064,7 +13069,7 @@ enum ConnectionStatus {
   notConnected,
 }
 
-extension ConnectionStatusValue on ConnectionStatus {
+extension ConnectionStatusValueExtension on ConnectionStatus {
   String toValue() {
     switch (this) {
       case ConnectionStatus.connected:
@@ -13653,7 +13658,8 @@ enum DescribeActivationsFilterKeys {
   iamRole,
 }
 
-extension DescribeActivationsFilterKeysValue on DescribeActivationsFilterKeys {
+extension DescribeActivationsFilterKeysValueExtension
+    on DescribeActivationsFilterKeys {
   String toValue() {
     switch (this) {
       case DescribeActivationsFilterKeys.activationIds:
@@ -14754,7 +14760,7 @@ enum DocumentFilterKey {
   documentType,
 }
 
-extension DocumentFilterKeyValue on DocumentFilterKey {
+extension DocumentFilterKeyValueExtension on DocumentFilterKey {
   String toValue() {
     switch (this) {
       case DocumentFilterKey.name:
@@ -14791,7 +14797,7 @@ enum DocumentFormat {
   text,
 }
 
-extension DocumentFormatValue on DocumentFormat {
+extension DocumentFormatValueExtension on DocumentFormat {
   String toValue() {
     switch (this) {
       case DocumentFormat.yaml:
@@ -14823,7 +14829,7 @@ enum DocumentHashType {
   sha1,
 }
 
-extension DocumentHashTypeValue on DocumentHashType {
+extension DocumentHashTypeValueExtension on DocumentHashType {
   String toValue() {
     switch (this) {
       case DocumentHashType.sha256:
@@ -15056,7 +15062,7 @@ enum DocumentMetadataEnum {
   documentReviews,
 }
 
-extension DocumentMetadataEnumValue on DocumentMetadataEnum {
+extension DocumentMetadataEnumValueExtension on DocumentMetadataEnum {
   String toValue() {
     switch (this) {
       case DocumentMetadataEnum.documentReviews:
@@ -15132,7 +15138,7 @@ enum DocumentParameterType {
   stringList,
 }
 
-extension DocumentParameterTypeValue on DocumentParameterType {
+extension DocumentParameterTypeValueExtension on DocumentParameterType {
   String toValue() {
     switch (this) {
       case DocumentParameterType.string:
@@ -15159,7 +15165,7 @@ enum DocumentPermissionType {
   share,
 }
 
-extension DocumentPermissionTypeValue on DocumentPermissionType {
+extension DocumentPermissionTypeValueExtension on DocumentPermissionType {
   String toValue() {
     switch (this) {
       case DocumentPermissionType.share:
@@ -15215,7 +15221,7 @@ enum DocumentReviewAction {
   reject,
 }
 
-extension DocumentReviewActionValue on DocumentReviewAction {
+extension DocumentReviewActionValueExtension on DocumentReviewAction {
   String toValue() {
     switch (this) {
       case DocumentReviewAction.sendForReview:
@@ -15281,7 +15287,7 @@ enum DocumentReviewCommentType {
   comment,
 }
 
-extension DocumentReviewCommentTypeValue on DocumentReviewCommentType {
+extension DocumentReviewCommentTypeValueExtension on DocumentReviewCommentType {
   String toValue() {
     switch (this) {
       case DocumentReviewCommentType.comment:
@@ -15380,7 +15386,7 @@ enum DocumentStatus {
   failed,
 }
 
-extension DocumentStatusValue on DocumentStatus {
+extension DocumentStatusValueExtension on DocumentStatus {
   String toValue() {
     switch (this) {
       case DocumentStatus.creating:
@@ -15428,7 +15434,7 @@ enum DocumentType {
   automationChangeTemplate,
 }
 
-extension DocumentTypeValue on DocumentType {
+extension DocumentTypeValueExtension on DocumentType {
   String toValue() {
     switch (this) {
       case DocumentType.command:
@@ -15583,7 +15589,7 @@ enum ExecutionMode {
   interactive,
 }
 
-extension ExecutionModeValue on ExecutionMode {
+extension ExecutionModeValueExtension on ExecutionMode {
   String toValue() {
     switch (this) {
       case ExecutionMode.auto:
@@ -15670,7 +15676,7 @@ enum Fault {
   unknown,
 }
 
-extension FaultValue on Fault {
+extension FaultValueExtension on Fault {
   String toValue() {
     switch (this) {
       case Fault.client:
@@ -17234,7 +17240,8 @@ enum InstanceInformationFilterKey {
   associationStatus,
 }
 
-extension InstanceInformationFilterKeyValue on InstanceInformationFilterKey {
+extension InstanceInformationFilterKeyValueExtension
+    on InstanceInformationFilterKey {
   String toValue() {
     switch (this) {
       case InstanceInformationFilterKey.instanceIds:
@@ -17506,7 +17513,7 @@ enum InstancePatchStateOperatorType {
   greaterThan,
 }
 
-extension InstancePatchStateOperatorTypeValue
+extension InstancePatchStateOperatorTypeValueExtension
     on InstancePatchStateOperatorType {
   String toValue() {
     switch (this) {
@@ -17574,7 +17581,8 @@ enum InventoryAttributeDataType {
   number,
 }
 
-extension InventoryAttributeDataTypeValue on InventoryAttributeDataType {
+extension InventoryAttributeDataTypeValueExtension
+    on InventoryAttributeDataType {
   String toValue() {
     switch (this) {
       case InventoryAttributeDataType.string:
@@ -17602,7 +17610,7 @@ enum InventoryDeletionStatus {
   complete,
 }
 
-extension InventoryDeletionStatusValue on InventoryDeletionStatus {
+extension InventoryDeletionStatusValueExtension on InventoryDeletionStatus {
   String toValue() {
     switch (this) {
       case InventoryDeletionStatus.inProgress:
@@ -17922,7 +17930,8 @@ enum InventoryQueryOperatorType {
   exists,
 }
 
-extension InventoryQueryOperatorTypeValue on InventoryQueryOperatorType {
+extension InventoryQueryOperatorTypeValueExtension
+    on InventoryQueryOperatorType {
   String toValue() {
     switch (this) {
       case InventoryQueryOperatorType.equal:
@@ -18032,7 +18041,8 @@ enum InventorySchemaDeleteOption {
   deleteSchema,
 }
 
-extension InventorySchemaDeleteOptionValue on InventorySchemaDeleteOption {
+extension InventorySchemaDeleteOptionValueExtension
+    on InventorySchemaDeleteOption {
   String toValue() {
     switch (this) {
       case InventorySchemaDeleteOption.disableSchema:
@@ -18086,7 +18096,8 @@ enum LastResourceDataSyncStatus {
   inProgress,
 }
 
-extension LastResourceDataSyncStatusValue on LastResourceDataSyncStatus {
+extension LastResourceDataSyncStatusValueExtension
+    on LastResourceDataSyncStatus {
   String toValue() {
     switch (this) {
       case LastResourceDataSyncStatus.successful:
@@ -18651,7 +18662,7 @@ enum MaintenanceWindowExecutionStatus {
   skippedOverlapping,
 }
 
-extension MaintenanceWindowExecutionStatusValue
+extension MaintenanceWindowExecutionStatusValueExtension
     on MaintenanceWindowExecutionStatus {
   String toValue() {
     switch (this) {
@@ -19020,7 +19031,8 @@ enum MaintenanceWindowResourceType {
   resourceGroup,
 }
 
-extension MaintenanceWindowResourceTypeValue on MaintenanceWindowResourceType {
+extension MaintenanceWindowResourceTypeValueExtension
+    on MaintenanceWindowResourceType {
   String toValue() {
     switch (this) {
       case MaintenanceWindowResourceType.instance:
@@ -19493,7 +19505,7 @@ enum MaintenanceWindowTaskType {
   lambda,
 }
 
-extension MaintenanceWindowTaskTypeValue on MaintenanceWindowTaskType {
+extension MaintenanceWindowTaskTypeValueExtension on MaintenanceWindowTaskType {
   String toValue() {
     switch (this) {
       case MaintenanceWindowTaskType.runCommand:
@@ -19638,7 +19650,7 @@ enum NotificationEvent {
   failed,
 }
 
-extension NotificationEventValue on NotificationEvent {
+extension NotificationEventValueExtension on NotificationEvent {
   String toValue() {
     switch (this) {
       case NotificationEvent.all:
@@ -19682,7 +19694,7 @@ enum NotificationType {
   invocation,
 }
 
-extension NotificationTypeValue on NotificationType {
+extension NotificationTypeValueExtension on NotificationType {
   String toValue() {
     switch (this) {
       case NotificationType.command:
@@ -19718,7 +19730,7 @@ enum OperatingSystem {
   macos,
 }
 
-extension OperatingSystemValue on OperatingSystem {
+extension OperatingSystemValueExtension on OperatingSystem {
   String toValue() {
     switch (this) {
       case OperatingSystem.windows:
@@ -19903,7 +19915,7 @@ enum OpsFilterOperatorType {
   exists,
 }
 
-extension OpsFilterOperatorTypeValue on OpsFilterOperatorType {
+extension OpsFilterOperatorTypeValueExtension on OpsFilterOperatorType {
   String toValue() {
     switch (this) {
       case OpsFilterOperatorType.equal:
@@ -20113,7 +20125,7 @@ enum OpsItemDataType {
   string,
 }
 
-extension OpsItemDataTypeValue on OpsItemDataType {
+extension OpsItemDataTypeValueExtension on OpsItemDataType {
   String toValue() {
     switch (this) {
       case OpsItemDataType.searchableString:
@@ -20203,7 +20215,7 @@ enum OpsItemEventFilterKey {
   opsItemId,
 }
 
-extension OpsItemEventFilterKeyValue on OpsItemEventFilterKey {
+extension OpsItemEventFilterKeyValueExtension on OpsItemEventFilterKey {
   String toValue() {
     switch (this) {
       case OpsItemEventFilterKey.opsItemId:
@@ -20226,7 +20238,8 @@ enum OpsItemEventFilterOperator {
   equal,
 }
 
-extension OpsItemEventFilterOperatorValue on OpsItemEventFilterOperator {
+extension OpsItemEventFilterOperatorValueExtension
+    on OpsItemEventFilterOperator {
   String toValue() {
     switch (this) {
       case OpsItemEventFilterOperator.equal:
@@ -20349,7 +20362,7 @@ enum OpsItemFilterKey {
   changeRequestByTargetsResourceGroup,
 }
 
-extension OpsItemFilterKeyValue on OpsItemFilterKey {
+extension OpsItemFilterKeyValueExtension on OpsItemFilterKey {
   String toValue() {
     switch (this) {
       case OpsItemFilterKey.status:
@@ -20475,7 +20488,7 @@ enum OpsItemFilterOperator {
   lessThan,
 }
 
-extension OpsItemFilterOperatorValue on OpsItemFilterOperator {
+extension OpsItemFilterOperatorValueExtension on OpsItemFilterOperator {
   String toValue() {
     switch (this) {
       case OpsItemFilterOperator.equal:
@@ -20566,7 +20579,7 @@ enum OpsItemStatus {
   rejected,
 }
 
-extension OpsItemStatusValue on OpsItemStatus {
+extension OpsItemStatusValueExtension on OpsItemStatus {
   String toValue() {
     switch (this) {
       case OpsItemStatus.open:
@@ -21172,7 +21185,7 @@ enum ParameterTier {
   intelligentTiering,
 }
 
-extension ParameterTierValue on ParameterTier {
+extension ParameterTierValueExtension on ParameterTier {
   String toValue() {
     switch (this) {
       case ParameterTier.standard:
@@ -21205,7 +21218,7 @@ enum ParameterType {
   secureString,
 }
 
-extension ParameterTypeValue on ParameterType {
+extension ParameterTypeValueExtension on ParameterType {
   String toValue() {
     switch (this) {
       case ParameterType.string:
@@ -21260,7 +21273,7 @@ enum ParametersFilterKey {
   keyId,
 }
 
-extension ParametersFilterKeyValue on ParametersFilterKey {
+extension ParametersFilterKeyValueExtension on ParametersFilterKey {
   String toValue() {
     switch (this) {
       case ParametersFilterKey.name:
@@ -21452,7 +21465,7 @@ enum PatchAction {
   block,
 }
 
-extension PatchActionValue on PatchAction {
+extension PatchActionValueExtension on PatchAction {
   String toValue() {
     switch (this) {
       case PatchAction.allowAsDependency:
@@ -21578,7 +21591,7 @@ enum PatchComplianceDataState {
   failed,
 }
 
-extension PatchComplianceDataStateValue on PatchComplianceDataState {
+extension PatchComplianceDataStateValueExtension on PatchComplianceDataState {
   String toValue() {
     switch (this) {
       case PatchComplianceDataState.installed:
@@ -21630,7 +21643,7 @@ enum PatchComplianceLevel {
   unspecified,
 }
 
-extension PatchComplianceLevelValue on PatchComplianceLevel {
+extension PatchComplianceLevelValueExtension on PatchComplianceLevel {
   String toValue() {
     switch (this) {
       case PatchComplianceLevel.critical:
@@ -21676,7 +21689,7 @@ enum PatchDeploymentStatus {
   explicitRejected,
 }
 
-extension PatchDeploymentStatusValue on PatchDeploymentStatus {
+extension PatchDeploymentStatusValueExtension on PatchDeploymentStatus {
   String toValue() {
     switch (this) {
       case PatchDeploymentStatus.approved:
@@ -21807,7 +21820,7 @@ enum PatchFilterKey {
   version,
 }
 
-extension PatchFilterKeyValue on PatchFilterKey {
+extension PatchFilterKeyValueExtension on PatchFilterKey {
   String toValue() {
     switch (this) {
       case PatchFilterKey.arch:
@@ -21927,7 +21940,7 @@ enum PatchOperationType {
   install,
 }
 
-extension PatchOperationTypeValue on PatchOperationType {
+extension PatchOperationTypeValueExtension on PatchOperationType {
   String toValue() {
     switch (this) {
       case PatchOperationType.scan:
@@ -21981,7 +21994,7 @@ enum PatchProperty {
   severity,
 }
 
-extension PatchPropertyValue on PatchProperty {
+extension PatchPropertyValueExtension on PatchProperty {
   String toValue() {
     switch (this) {
       case PatchProperty.product:
@@ -22112,7 +22125,7 @@ enum PatchSet {
   application,
 }
 
-extension PatchSetValue on PatchSet {
+extension PatchSetValueExtension on PatchSet {
   String toValue() {
     switch (this) {
       case PatchSet.os:
@@ -22221,7 +22234,7 @@ enum PingStatus {
   inactive,
 }
 
-extension PingStatusValue on PingStatus {
+extension PingStatusValueExtension on PingStatus {
   String toValue() {
     switch (this) {
       case PingStatus.online:
@@ -22253,7 +22266,7 @@ enum PlatformType {
   linux,
 }
 
-extension PlatformTypeValue on PlatformType {
+extension PlatformTypeValueExtension on PlatformType {
   String toValue() {
     switch (this) {
       case PlatformType.windows:
@@ -22367,7 +22380,7 @@ enum RebootOption {
   noReboot,
 }
 
-extension RebootOptionValue on RebootOption {
+extension RebootOptionValueExtension on RebootOption {
   String toValue() {
     switch (this) {
       case RebootOption.rebootIfNeeded:
@@ -22823,7 +22836,7 @@ enum ResourceDataSyncS3Format {
   jsonSerDe,
 }
 
-extension ResourceDataSyncS3FormatValue on ResourceDataSyncS3Format {
+extension ResourceDataSyncS3FormatValueExtension on ResourceDataSyncS3Format {
   String toValue() {
     switch (this) {
       case ResourceDataSyncS3Format.jsonSerDe:
@@ -22959,7 +22972,7 @@ enum ResourceType {
   eC2Instance,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.managedInstance:
@@ -22995,7 +23008,7 @@ enum ResourceTypeForTagging {
   opsItem,
 }
 
-extension ResourceTypeForTaggingValue on ResourceTypeForTagging {
+extension ResourceTypeForTaggingValueExtension on ResourceTypeForTagging {
   String toValue() {
     switch (this) {
       case ResourceTypeForTagging.document:
@@ -23120,7 +23133,7 @@ enum ReviewStatus {
   rejected,
 }
 
-extension ReviewStatusValue on ReviewStatus {
+extension ReviewStatusValueExtension on ReviewStatus {
   String toValue() {
     switch (this) {
       case ReviewStatus.approved:
@@ -23562,7 +23575,7 @@ enum SessionFilterKey {
   sessionId,
 }
 
-extension SessionFilterKeyValue on SessionFilterKey {
+extension SessionFilterKeyValueExtension on SessionFilterKey {
   String toValue() {
     switch (this) {
       case SessionFilterKey.invokedAfter:
@@ -23626,7 +23639,7 @@ enum SessionState {
   history,
 }
 
-extension SessionStateValue on SessionState {
+extension SessionStateValueExtension on SessionState {
   String toValue() {
     switch (this) {
       case SessionState.active:
@@ -23658,7 +23671,7 @@ enum SessionStatus {
   failed,
 }
 
-extension SessionStatusValue on SessionStatus {
+extension SessionStatusValueExtension on SessionStatus {
   String toValue() {
     switch (this) {
       case SessionStatus.connected:
@@ -23758,7 +23771,7 @@ enum SignalType {
   resume,
 }
 
-extension SignalTypeValue on SignalType {
+extension SignalTypeValueExtension on SignalType {
   String toValue() {
     switch (this) {
       case SignalType.approve:
@@ -24051,7 +24064,7 @@ enum StepExecutionFilterKey {
   action,
 }
 
-extension StepExecutionFilterKeyValue on StepExecutionFilterKey {
+extension StepExecutionFilterKeyValueExtension on StepExecutionFilterKey {
   String toValue() {
     switch (this) {
       case StepExecutionFilterKey.startTimeBefore:
@@ -24102,7 +24115,7 @@ enum StopType {
   cancel,
 }
 
-extension StopTypeValue on StopType {
+extension StopTypeValueExtension on StopType {
   String toValue() {
     switch (this) {
       case StopType.complete:

--- a/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
+++ b/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
@@ -2672,7 +2672,7 @@ enum InstanceAccessControlAttributeConfigurationStatus {
   creationFailed,
 }
 
-extension InstanceAccessControlAttributeConfigurationStatusValue
+extension InstanceAccessControlAttributeConfigurationStatusValueExtension
     on InstanceAccessControlAttributeConfigurationStatus {
   String toValue() {
     switch (this) {
@@ -3110,7 +3110,7 @@ enum PrincipalType {
   group,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -3157,7 +3157,7 @@ enum ProvisionTargetType {
   allProvisionedAccounts,
 }
 
-extension ProvisionTargetTypeValue on ProvisionTargetType {
+extension ProvisionTargetTypeValueExtension on ProvisionTargetType {
   String toValue() {
     switch (this) {
       case ProvisionTargetType.awsAccount:
@@ -3185,7 +3185,7 @@ enum ProvisioningStatus {
   latestPermissionSetNotProvisioned,
 }
 
-extension ProvisioningStatusValue on ProvisioningStatus {
+extension ProvisioningStatusValueExtension on ProvisioningStatus {
   String toValue() {
     switch (this) {
       case ProvisioningStatus.latestPermissionSetProvisioned:
@@ -3222,7 +3222,7 @@ enum StatusValues {
   succeeded,
 }
 
-extension StatusValuesValue on StatusValues {
+extension StatusValuesValueExtension on StatusValues {
   String toValue() {
     switch (this) {
       case StatusValues.inProgress:
@@ -3291,7 +3291,7 @@ enum TargetType {
   awsAccount,
 }
 
-extension TargetTypeValue on TargetType {
+extension TargetTypeValueExtension on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.awsAccount:

--- a/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
+++ b/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
@@ -2672,7 +2672,8 @@ enum InstanceAccessControlAttributeConfigurationStatus {
   creationFailed,
 }
 
-extension on InstanceAccessControlAttributeConfigurationStatus {
+extension InstanceAccessControlAttributeConfigurationStatusValue
+    on InstanceAccessControlAttributeConfigurationStatus {
   String toValue() {
     switch (this) {
       case InstanceAccessControlAttributeConfigurationStatus.enabled:
@@ -2685,7 +2686,8 @@ extension on InstanceAccessControlAttributeConfigurationStatus {
   }
 }
 
-extension on String {
+extension InstanceAccessControlAttributeConfigurationStatusFromString
+    on String {
   InstanceAccessControlAttributeConfigurationStatus
       toInstanceAccessControlAttributeConfigurationStatus() {
     switch (this) {
@@ -3108,7 +3110,7 @@ enum PrincipalType {
   group,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -3119,7 +3121,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'USER':
@@ -3155,7 +3157,7 @@ enum ProvisionTargetType {
   allProvisionedAccounts,
 }
 
-extension on ProvisionTargetType {
+extension ProvisionTargetTypeValue on ProvisionTargetType {
   String toValue() {
     switch (this) {
       case ProvisionTargetType.awsAccount:
@@ -3166,7 +3168,7 @@ extension on ProvisionTargetType {
   }
 }
 
-extension on String {
+extension ProvisionTargetTypeFromString on String {
   ProvisionTargetType toProvisionTargetType() {
     switch (this) {
       case 'AWS_ACCOUNT':
@@ -3183,7 +3185,7 @@ enum ProvisioningStatus {
   latestPermissionSetNotProvisioned,
 }
 
-extension on ProvisioningStatus {
+extension ProvisioningStatusValue on ProvisioningStatus {
   String toValue() {
     switch (this) {
       case ProvisioningStatus.latestPermissionSetProvisioned:
@@ -3194,7 +3196,7 @@ extension on ProvisioningStatus {
   }
 }
 
-extension on String {
+extension ProvisioningStatusFromString on String {
   ProvisioningStatus toProvisioningStatus() {
     switch (this) {
       case 'LATEST_PERMISSION_SET_PROVISIONED':
@@ -3220,7 +3222,7 @@ enum StatusValues {
   succeeded,
 }
 
-extension on StatusValues {
+extension StatusValuesValue on StatusValues {
   String toValue() {
     switch (this) {
       case StatusValues.inProgress:
@@ -3233,7 +3235,7 @@ extension on StatusValues {
   }
 }
 
-extension on String {
+extension StatusValuesFromString on String {
   StatusValues toStatusValues() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3289,7 +3291,7 @@ enum TargetType {
   awsAccount,
 }
 
-extension on TargetType {
+extension TargetTypeValue on TargetType {
   String toValue() {
     switch (this) {
       case TargetType.awsAccount:
@@ -3298,7 +3300,7 @@ extension on TargetType {
   }
 }
 
-extension on String {
+extension TargetTypeFromString on String {
   TargetType toTargetType() {
     switch (this) {
       case 'AWS_ACCOUNT':

--- a/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
+++ b/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
@@ -6025,7 +6025,7 @@ enum ActiveDirectoryStatus {
   unknownError,
 }
 
-extension ActiveDirectoryStatusValue on ActiveDirectoryStatus {
+extension ActiveDirectoryStatusValueExtension on ActiveDirectoryStatus {
   String toValue() {
     switch (this) {
       case ActiveDirectoryStatus.accessDenied:
@@ -6266,7 +6266,8 @@ enum AvailabilityMonitorTestStatus {
   pending,
 }
 
-extension AvailabilityMonitorTestStatusValue on AvailabilityMonitorTestStatus {
+extension AvailabilityMonitorTestStatusValueExtension
+    on AvailabilityMonitorTestStatus {
   String toValue() {
     switch (this) {
       case AvailabilityMonitorTestStatus.complete:
@@ -6553,7 +6554,7 @@ enum CaseSensitivity {
   caseSensitive,
 }
 
-extension CaseSensitivityValue on CaseSensitivity {
+extension CaseSensitivityValueExtension on CaseSensitivity {
   String toValue() {
     switch (this) {
       case CaseSensitivity.clientSpecified:
@@ -7925,7 +7926,7 @@ enum FileShareType {
   smb,
 }
 
-extension FileShareTypeValue on FileShareType {
+extension FileShareTypeValueExtension on FileShareType {
   String toValue() {
     switch (this) {
       case FileShareType.nfs:
@@ -8006,7 +8007,7 @@ enum HostEnvironment {
   other,
 }
 
-extension HostEnvironmentValue on HostEnvironment {
+extension HostEnvironmentValueExtension on HostEnvironment {
   String toValue() {
     switch (this) {
       case HostEnvironment.vmware:
@@ -8619,7 +8620,7 @@ enum ObjectACL {
   awsExecRead,
 }
 
-extension ObjectACLValue on ObjectACL {
+extension ObjectACLValueExtension on ObjectACL {
   String toValue() {
     switch (this) {
       case ObjectACL.private:
@@ -8720,7 +8721,7 @@ enum PoolStatus {
   deleted,
 }
 
-extension PoolStatusValue on PoolStatus {
+extension PoolStatusValueExtension on PoolStatus {
   String toValue() {
     switch (this) {
       case PoolStatus.active:
@@ -8795,7 +8796,7 @@ enum RetentionLockType {
   none,
 }
 
-extension RetentionLockTypeValue on RetentionLockType {
+extension RetentionLockTypeValueExtension on RetentionLockType {
   String toValue() {
     switch (this) {
       case RetentionLockType.compliance:
@@ -9057,7 +9058,7 @@ enum SMBSecurityStrategy {
   mandatoryEncryption,
 }
 
-extension SMBSecurityStrategyValue on SMBSecurityStrategy {
+extension SMBSecurityStrategyValueExtension on SMBSecurityStrategy {
   String toValue() {
     switch (this) {
       case SMBSecurityStrategy.clientSpecified:
@@ -9577,7 +9578,7 @@ enum TapeStorageClass {
   glacier,
 }
 
-extension TapeStorageClassValue on TapeStorageClass {
+extension TapeStorageClassValueExtension on TapeStorageClass {
   String toValue() {
     switch (this) {
       case TapeStorageClass.deepArchive:

--- a/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
+++ b/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
@@ -6025,7 +6025,7 @@ enum ActiveDirectoryStatus {
   unknownError,
 }
 
-extension on ActiveDirectoryStatus {
+extension ActiveDirectoryStatusValue on ActiveDirectoryStatus {
   String toValue() {
     switch (this) {
       case ActiveDirectoryStatus.accessDenied:
@@ -6046,7 +6046,7 @@ extension on ActiveDirectoryStatus {
   }
 }
 
-extension on String {
+extension ActiveDirectoryStatusFromString on String {
   ActiveDirectoryStatus toActiveDirectoryStatus() {
     switch (this) {
       case 'ACCESS_DENIED':
@@ -6266,7 +6266,7 @@ enum AvailabilityMonitorTestStatus {
   pending,
 }
 
-extension on AvailabilityMonitorTestStatus {
+extension AvailabilityMonitorTestStatusValue on AvailabilityMonitorTestStatus {
   String toValue() {
     switch (this) {
       case AvailabilityMonitorTestStatus.complete:
@@ -6279,7 +6279,7 @@ extension on AvailabilityMonitorTestStatus {
   }
 }
 
-extension on String {
+extension AvailabilityMonitorTestStatusFromString on String {
   AvailabilityMonitorTestStatus toAvailabilityMonitorTestStatus() {
     switch (this) {
       case 'COMPLETE':
@@ -6553,7 +6553,7 @@ enum CaseSensitivity {
   caseSensitive,
 }
 
-extension on CaseSensitivity {
+extension CaseSensitivityValue on CaseSensitivity {
   String toValue() {
     switch (this) {
       case CaseSensitivity.clientSpecified:
@@ -6564,7 +6564,7 @@ extension on CaseSensitivity {
   }
 }
 
-extension on String {
+extension CaseSensitivityFromString on String {
   CaseSensitivity toCaseSensitivity() {
     switch (this) {
       case 'ClientSpecified':
@@ -7925,7 +7925,7 @@ enum FileShareType {
   smb,
 }
 
-extension on FileShareType {
+extension FileShareTypeValue on FileShareType {
   String toValue() {
     switch (this) {
       case FileShareType.nfs:
@@ -7936,7 +7936,7 @@ extension on FileShareType {
   }
 }
 
-extension on String {
+extension FileShareTypeFromString on String {
   FileShareType toFileShareType() {
     switch (this) {
       case 'NFS':
@@ -8006,7 +8006,7 @@ enum HostEnvironment {
   other,
 }
 
-extension on HostEnvironment {
+extension HostEnvironmentValue on HostEnvironment {
   String toValue() {
     switch (this) {
       case HostEnvironment.vmware:
@@ -8023,7 +8023,7 @@ extension on HostEnvironment {
   }
 }
 
-extension on String {
+extension HostEnvironmentFromString on String {
   HostEnvironment toHostEnvironment() {
     switch (this) {
       case 'VMWARE':
@@ -8619,7 +8619,7 @@ enum ObjectACL {
   awsExecRead,
 }
 
-extension on ObjectACL {
+extension ObjectACLValue on ObjectACL {
   String toValue() {
     switch (this) {
       case ObjectACL.private:
@@ -8640,7 +8640,7 @@ extension on ObjectACL {
   }
 }
 
-extension on String {
+extension ObjectACLFromString on String {
   ObjectACL toObjectACL() {
     switch (this) {
       case 'private':
@@ -8720,7 +8720,7 @@ enum PoolStatus {
   deleted,
 }
 
-extension on PoolStatus {
+extension PoolStatusValue on PoolStatus {
   String toValue() {
     switch (this) {
       case PoolStatus.active:
@@ -8731,7 +8731,7 @@ extension on PoolStatus {
   }
 }
 
-extension on String {
+extension PoolStatusFromString on String {
   PoolStatus toPoolStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -8795,7 +8795,7 @@ enum RetentionLockType {
   none,
 }
 
-extension on RetentionLockType {
+extension RetentionLockTypeValue on RetentionLockType {
   String toValue() {
     switch (this) {
       case RetentionLockType.compliance:
@@ -8808,7 +8808,7 @@ extension on RetentionLockType {
   }
 }
 
-extension on String {
+extension RetentionLockTypeFromString on String {
   RetentionLockType toRetentionLockType() {
     switch (this) {
       case 'COMPLIANCE':
@@ -9057,7 +9057,7 @@ enum SMBSecurityStrategy {
   mandatoryEncryption,
 }
 
-extension on SMBSecurityStrategy {
+extension SMBSecurityStrategyValue on SMBSecurityStrategy {
   String toValue() {
     switch (this) {
       case SMBSecurityStrategy.clientSpecified:
@@ -9070,7 +9070,7 @@ extension on SMBSecurityStrategy {
   }
 }
 
-extension on String {
+extension SMBSecurityStrategyFromString on String {
   SMBSecurityStrategy toSMBSecurityStrategy() {
     switch (this) {
       case 'ClientSpecified':
@@ -9577,7 +9577,7 @@ enum TapeStorageClass {
   glacier,
 }
 
-extension on TapeStorageClass {
+extension TapeStorageClassValue on TapeStorageClass {
   String toValue() {
     switch (this) {
       case TapeStorageClass.deepArchive:
@@ -9588,7 +9588,7 @@ extension on TapeStorageClass {
   }
 }
 
-extension on String {
+extension TapeStorageClassFromString on String {
   TapeStorageClass toTapeStorageClass() {
     switch (this) {
       case 'DEEP_ARCHIVE':

--- a/generated/aws_swf_api/lib/swf-2012-01-25.dart
+++ b/generated/aws_swf_api/lib/swf-2012-01-25.dart
@@ -4563,7 +4563,7 @@ enum ActivityTaskTimeoutType {
   heartbeat,
 }
 
-extension on ActivityTaskTimeoutType {
+extension ActivityTaskTimeoutTypeValue on ActivityTaskTimeoutType {
   String toValue() {
     switch (this) {
       case ActivityTaskTimeoutType.startToClose:
@@ -4578,7 +4578,7 @@ extension on ActivityTaskTimeoutType {
   }
 }
 
-extension on String {
+extension ActivityTaskTimeoutTypeFromString on String {
   ActivityTaskTimeoutType toActivityTaskTimeoutType() {
     switch (this) {
       case 'START_TO_CLOSE':
@@ -4874,7 +4874,7 @@ enum CancelTimerFailedCause {
   operationNotPermitted,
 }
 
-extension on CancelTimerFailedCause {
+extension CancelTimerFailedCauseValue on CancelTimerFailedCause {
   String toValue() {
     switch (this) {
       case CancelTimerFailedCause.timerIdUnknown:
@@ -4885,7 +4885,7 @@ extension on CancelTimerFailedCause {
   }
 }
 
-extension on String {
+extension CancelTimerFailedCauseFromString on String {
   CancelTimerFailedCause toCancelTimerFailedCause() {
     switch (this) {
       case 'TIMER_ID_UNKNOWN':
@@ -4982,7 +4982,8 @@ enum CancelWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on CancelWorkflowExecutionFailedCause {
+extension CancelWorkflowExecutionFailedCauseValue
+    on CancelWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case CancelWorkflowExecutionFailedCause.unhandledDecision:
@@ -4993,7 +4994,7 @@ extension on CancelWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension CancelWorkflowExecutionFailedCauseFromString on String {
   CancelWorkflowExecutionFailedCause toCancelWorkflowExecutionFailedCause() {
     switch (this) {
       case 'UNHANDLED_DECISION':
@@ -5047,7 +5048,7 @@ enum ChildPolicy {
   abandon,
 }
 
-extension on ChildPolicy {
+extension ChildPolicyValue on ChildPolicy {
   String toValue() {
     switch (this) {
       case ChildPolicy.terminate:
@@ -5060,7 +5061,7 @@ extension on ChildPolicy {
   }
 }
 
-extension on String {
+extension ChildPolicyFromString on String {
   ChildPolicy toChildPolicy() {
     switch (this) {
       case 'TERMINATE':
@@ -5346,7 +5347,7 @@ enum CloseStatus {
   timedOut,
 }
 
-extension on CloseStatus {
+extension CloseStatusValue on CloseStatus {
   String toValue() {
     switch (this) {
       case CloseStatus.completed:
@@ -5365,7 +5366,7 @@ extension on CloseStatus {
   }
 }
 
-extension on String {
+extension CloseStatusFromString on String {
   CloseStatus toCloseStatus() {
     switch (this) {
       case 'COMPLETED':
@@ -5452,7 +5453,8 @@ enum CompleteWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on CompleteWorkflowExecutionFailedCause {
+extension CompleteWorkflowExecutionFailedCauseValue
+    on CompleteWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case CompleteWorkflowExecutionFailedCause.unhandledDecision:
@@ -5463,7 +5465,7 @@ extension on CompleteWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension CompleteWorkflowExecutionFailedCauseFromString on String {
   CompleteWorkflowExecutionFailedCause
       toCompleteWorkflowExecutionFailedCause() {
     switch (this) {
@@ -5697,7 +5699,8 @@ enum ContinueAsNewWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on ContinueAsNewWorkflowExecutionFailedCause {
+extension ContinueAsNewWorkflowExecutionFailedCauseValue
+    on ContinueAsNewWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case ContinueAsNewWorkflowExecutionFailedCause.unhandledDecision:
@@ -5726,7 +5729,7 @@ extension on ContinueAsNewWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension ContinueAsNewWorkflowExecutionFailedCauseFromString on String {
   ContinueAsNewWorkflowExecutionFailedCause
       toContinueAsNewWorkflowExecutionFailedCause() {
     switch (this) {
@@ -6368,7 +6371,7 @@ enum DecisionTaskTimeoutType {
   startToClose,
 }
 
-extension on DecisionTaskTimeoutType {
+extension DecisionTaskTimeoutTypeValue on DecisionTaskTimeoutType {
   String toValue() {
     switch (this) {
       case DecisionTaskTimeoutType.startToClose:
@@ -6377,7 +6380,7 @@ extension on DecisionTaskTimeoutType {
   }
 }
 
-extension on String {
+extension DecisionTaskTimeoutTypeFromString on String {
   DecisionTaskTimeoutType toDecisionTaskTimeoutType() {
     switch (this) {
       case 'START_TO_CLOSE':
@@ -6403,7 +6406,7 @@ enum DecisionType {
   scheduleLambdaFunction,
 }
 
-extension on DecisionType {
+extension DecisionTypeValue on DecisionType {
   String toValue() {
     switch (this) {
       case DecisionType.scheduleActivityTask:
@@ -6436,7 +6439,7 @@ extension on DecisionType {
   }
 }
 
-extension on String {
+extension DecisionTypeFromString on String {
   DecisionType toDecisionType() {
     switch (this) {
       case 'ScheduleActivityTask':
@@ -6639,7 +6642,7 @@ enum EventType {
   startLambdaFunctionFailed,
 }
 
-extension on EventType {
+extension EventTypeValue on EventType {
   String toValue() {
     switch (this) {
       case EventType.workflowExecutionStarted:
@@ -6754,7 +6757,7 @@ extension on EventType {
   }
 }
 
-extension on String {
+extension EventTypeFromString on String {
   EventType toEventType() {
     switch (this) {
       case 'WorkflowExecutionStarted':
@@ -6875,7 +6878,7 @@ enum ExecutionStatus {
   closed,
 }
 
-extension on ExecutionStatus {
+extension ExecutionStatusValue on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.open:
@@ -6886,7 +6889,7 @@ extension on ExecutionStatus {
   }
 }
 
-extension on String {
+extension ExecutionStatusFromString on String {
   ExecutionStatus toExecutionStatus() {
     switch (this) {
       case 'OPEN':
@@ -7032,7 +7035,8 @@ enum FailWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on FailWorkflowExecutionFailedCause {
+extension FailWorkflowExecutionFailedCauseValue
+    on FailWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case FailWorkflowExecutionFailedCause.unhandledDecision:
@@ -7043,7 +7047,7 @@ extension on FailWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension FailWorkflowExecutionFailedCauseFromString on String {
   FailWorkflowExecutionFailedCause toFailWorkflowExecutionFailedCause() {
     switch (this) {
       case 'UNHANDLED_DECISION':
@@ -8206,7 +8210,7 @@ enum LambdaFunctionTimeoutType {
   startToClose,
 }
 
-extension on LambdaFunctionTimeoutType {
+extension LambdaFunctionTimeoutTypeValue on LambdaFunctionTimeoutType {
   String toValue() {
     switch (this) {
       case LambdaFunctionTimeoutType.startToClose:
@@ -8215,7 +8219,7 @@ extension on LambdaFunctionTimeoutType {
   }
 }
 
-extension on String {
+extension LambdaFunctionTimeoutTypeFromString on String {
   LambdaFunctionTimeoutType toLambdaFunctionTimeoutType() {
     switch (this) {
       case 'START_TO_CLOSE':
@@ -8344,7 +8348,7 @@ enum RecordMarkerFailedCause {
   operationNotPermitted,
 }
 
-extension on RecordMarkerFailedCause {
+extension RecordMarkerFailedCauseValue on RecordMarkerFailedCause {
   String toValue() {
     switch (this) {
       case RecordMarkerFailedCause.operationNotPermitted:
@@ -8353,7 +8357,7 @@ extension on RecordMarkerFailedCause {
   }
 }
 
-extension on String {
+extension RecordMarkerFailedCauseFromString on String {
   RecordMarkerFailedCause toRecordMarkerFailedCause() {
     switch (this) {
       case 'OPERATION_NOT_PERMITTED':
@@ -8406,7 +8410,7 @@ enum RegistrationStatus {
   deprecated,
 }
 
-extension on RegistrationStatus {
+extension RegistrationStatusValue on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.registered:
@@ -8417,7 +8421,7 @@ extension on RegistrationStatus {
   }
 }
 
-extension on String {
+extension RegistrationStatusFromString on String {
   RegistrationStatus toRegistrationStatus() {
     switch (this) {
       case 'REGISTERED':
@@ -8477,7 +8481,8 @@ enum RequestCancelActivityTaskFailedCause {
   operationNotPermitted,
 }
 
-extension on RequestCancelActivityTaskFailedCause {
+extension RequestCancelActivityTaskFailedCauseValue
+    on RequestCancelActivityTaskFailedCause {
   String toValue() {
     switch (this) {
       case RequestCancelActivityTaskFailedCause.activityIdUnknown:
@@ -8488,7 +8493,7 @@ extension on RequestCancelActivityTaskFailedCause {
   }
 }
 
-extension on String {
+extension RequestCancelActivityTaskFailedCauseFromString on String {
   RequestCancelActivityTaskFailedCause
       toRequestCancelActivityTaskFailedCause() {
     switch (this) {
@@ -8606,7 +8611,8 @@ enum RequestCancelExternalWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on RequestCancelExternalWorkflowExecutionFailedCause {
+extension RequestCancelExternalWorkflowExecutionFailedCauseValue
+    on RequestCancelExternalWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case RequestCancelExternalWorkflowExecutionFailedCause
@@ -8622,7 +8628,8 @@ extension on RequestCancelExternalWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension RequestCancelExternalWorkflowExecutionFailedCauseFromString
+    on String {
   RequestCancelExternalWorkflowExecutionFailedCause
       toRequestCancelExternalWorkflowExecutionFailedCause() {
     switch (this) {
@@ -8990,7 +8997,8 @@ enum ScheduleActivityTaskFailedCause {
   operationNotPermitted,
 }
 
-extension on ScheduleActivityTaskFailedCause {
+extension ScheduleActivityTaskFailedCauseValue
+    on ScheduleActivityTaskFailedCause {
   String toValue() {
     switch (this) {
       case ScheduleActivityTaskFailedCause.activityTypeDeprecated:
@@ -9021,7 +9029,7 @@ extension on ScheduleActivityTaskFailedCause {
   }
 }
 
-extension on String {
+extension ScheduleActivityTaskFailedCauseFromString on String {
   ScheduleActivityTaskFailedCause toScheduleActivityTaskFailedCause() {
     switch (this) {
       case 'ACTIVITY_TYPE_DEPRECATED':
@@ -9155,7 +9163,8 @@ enum ScheduleLambdaFunctionFailedCause {
   lambdaServiceNotAvailableInRegion,
 }
 
-extension on ScheduleLambdaFunctionFailedCause {
+extension ScheduleLambdaFunctionFailedCauseValue
+    on ScheduleLambdaFunctionFailedCause {
   String toValue() {
     switch (this) {
       case ScheduleLambdaFunctionFailedCause.idAlreadyInUse:
@@ -9170,7 +9179,7 @@ extension on ScheduleLambdaFunctionFailedCause {
   }
 }
 
-extension on String {
+extension ScheduleLambdaFunctionFailedCauseFromString on String {
   ScheduleLambdaFunctionFailedCause toScheduleLambdaFunctionFailedCause() {
     switch (this) {
       case 'ID_ALREADY_IN_USE':
@@ -9312,7 +9321,8 @@ enum SignalExternalWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on SignalExternalWorkflowExecutionFailedCause {
+extension SignalExternalWorkflowExecutionFailedCauseValue
+    on SignalExternalWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case SignalExternalWorkflowExecutionFailedCause
@@ -9327,7 +9337,7 @@ extension on SignalExternalWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension SignalExternalWorkflowExecutionFailedCauseFromString on String {
   SignalExternalWorkflowExecutionFailedCause
       toSignalExternalWorkflowExecutionFailedCause() {
     switch (this) {
@@ -9676,7 +9686,8 @@ enum StartChildWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension on StartChildWorkflowExecutionFailedCause {
+extension StartChildWorkflowExecutionFailedCauseValue
+    on StartChildWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
       case StartChildWorkflowExecutionFailedCause.workflowTypeDoesNotExist:
@@ -9707,7 +9718,7 @@ extension on StartChildWorkflowExecutionFailedCause {
   }
 }
 
-extension on String {
+extension StartChildWorkflowExecutionFailedCauseFromString on String {
   StartChildWorkflowExecutionFailedCause
       toStartChildWorkflowExecutionFailedCause() {
     switch (this) {
@@ -9933,7 +9944,8 @@ enum StartLambdaFunctionFailedCause {
   assumeRoleFailed,
 }
 
-extension on StartLambdaFunctionFailedCause {
+extension StartLambdaFunctionFailedCauseValue
+    on StartLambdaFunctionFailedCause {
   String toValue() {
     switch (this) {
       case StartLambdaFunctionFailedCause.assumeRoleFailed:
@@ -9942,7 +9954,7 @@ extension on StartLambdaFunctionFailedCause {
   }
 }
 
-extension on String {
+extension StartLambdaFunctionFailedCauseFromString on String {
   StartLambdaFunctionFailedCause toStartLambdaFunctionFailedCause() {
     switch (this) {
       case 'ASSUME_ROLE_FAILED':
@@ -10062,7 +10074,7 @@ enum StartTimerFailedCause {
   operationNotPermitted,
 }
 
-extension on StartTimerFailedCause {
+extension StartTimerFailedCauseValue on StartTimerFailedCause {
   String toValue() {
     switch (this) {
       case StartTimerFailedCause.timerIdAlreadyInUse:
@@ -10077,7 +10089,7 @@ extension on StartTimerFailedCause {
   }
 }
 
-extension on String {
+extension StartTimerFailedCauseFromString on String {
   StartTimerFailedCause toStartTimerFailedCause() {
     switch (this) {
       case 'TIMER_ID_ALREADY_IN_USE':
@@ -10294,7 +10306,8 @@ enum WorkflowExecutionCancelRequestedCause {
   childPolicyApplied,
 }
 
-extension on WorkflowExecutionCancelRequestedCause {
+extension WorkflowExecutionCancelRequestedCauseValue
+    on WorkflowExecutionCancelRequestedCause {
   String toValue() {
     switch (this) {
       case WorkflowExecutionCancelRequestedCause.childPolicyApplied:
@@ -10303,7 +10316,7 @@ extension on WorkflowExecutionCancelRequestedCause {
   }
 }
 
-extension on String {
+extension WorkflowExecutionCancelRequestedCauseFromString on String {
   WorkflowExecutionCancelRequestedCause
       toWorkflowExecutionCancelRequestedCause() {
     switch (this) {
@@ -11027,7 +11040,8 @@ enum WorkflowExecutionTerminatedCause {
   operatorInitiated,
 }
 
-extension on WorkflowExecutionTerminatedCause {
+extension WorkflowExecutionTerminatedCauseValue
+    on WorkflowExecutionTerminatedCause {
   String toValue() {
     switch (this) {
       case WorkflowExecutionTerminatedCause.childPolicyApplied:
@@ -11040,7 +11054,7 @@ extension on WorkflowExecutionTerminatedCause {
   }
 }
 
-extension on String {
+extension WorkflowExecutionTerminatedCauseFromString on String {
   WorkflowExecutionTerminatedCause toWorkflowExecutionTerminatedCause() {
     switch (this) {
       case 'CHILD_POLICY_APPLIED':
@@ -11153,7 +11167,7 @@ enum WorkflowExecutionTimeoutType {
   startToClose,
 }
 
-extension on WorkflowExecutionTimeoutType {
+extension WorkflowExecutionTimeoutTypeValue on WorkflowExecutionTimeoutType {
   String toValue() {
     switch (this) {
       case WorkflowExecutionTimeoutType.startToClose:
@@ -11162,7 +11176,7 @@ extension on WorkflowExecutionTimeoutType {
   }
 }
 
-extension on String {
+extension WorkflowExecutionTimeoutTypeFromString on String {
   WorkflowExecutionTimeoutType toWorkflowExecutionTimeoutType() {
     switch (this) {
       case 'START_TO_CLOSE':

--- a/generated/aws_swf_api/lib/swf-2012-01-25.dart
+++ b/generated/aws_swf_api/lib/swf-2012-01-25.dart
@@ -4563,7 +4563,7 @@ enum ActivityTaskTimeoutType {
   heartbeat,
 }
 
-extension ActivityTaskTimeoutTypeValue on ActivityTaskTimeoutType {
+extension ActivityTaskTimeoutTypeValueExtension on ActivityTaskTimeoutType {
   String toValue() {
     switch (this) {
       case ActivityTaskTimeoutType.startToClose:
@@ -4874,7 +4874,7 @@ enum CancelTimerFailedCause {
   operationNotPermitted,
 }
 
-extension CancelTimerFailedCauseValue on CancelTimerFailedCause {
+extension CancelTimerFailedCauseValueExtension on CancelTimerFailedCause {
   String toValue() {
     switch (this) {
       case CancelTimerFailedCause.timerIdUnknown:
@@ -4982,7 +4982,7 @@ enum CancelWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension CancelWorkflowExecutionFailedCauseValue
+extension CancelWorkflowExecutionFailedCauseValueExtension
     on CancelWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -5048,7 +5048,7 @@ enum ChildPolicy {
   abandon,
 }
 
-extension ChildPolicyValue on ChildPolicy {
+extension ChildPolicyValueExtension on ChildPolicy {
   String toValue() {
     switch (this) {
       case ChildPolicy.terminate:
@@ -5347,7 +5347,7 @@ enum CloseStatus {
   timedOut,
 }
 
-extension CloseStatusValue on CloseStatus {
+extension CloseStatusValueExtension on CloseStatus {
   String toValue() {
     switch (this) {
       case CloseStatus.completed:
@@ -5453,7 +5453,7 @@ enum CompleteWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension CompleteWorkflowExecutionFailedCauseValue
+extension CompleteWorkflowExecutionFailedCauseValueExtension
     on CompleteWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -5699,7 +5699,7 @@ enum ContinueAsNewWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension ContinueAsNewWorkflowExecutionFailedCauseValue
+extension ContinueAsNewWorkflowExecutionFailedCauseValueExtension
     on ContinueAsNewWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -6371,7 +6371,7 @@ enum DecisionTaskTimeoutType {
   startToClose,
 }
 
-extension DecisionTaskTimeoutTypeValue on DecisionTaskTimeoutType {
+extension DecisionTaskTimeoutTypeValueExtension on DecisionTaskTimeoutType {
   String toValue() {
     switch (this) {
       case DecisionTaskTimeoutType.startToClose:
@@ -6406,7 +6406,7 @@ enum DecisionType {
   scheduleLambdaFunction,
 }
 
-extension DecisionTypeValue on DecisionType {
+extension DecisionTypeValueExtension on DecisionType {
   String toValue() {
     switch (this) {
       case DecisionType.scheduleActivityTask:
@@ -6642,7 +6642,7 @@ enum EventType {
   startLambdaFunctionFailed,
 }
 
-extension EventTypeValue on EventType {
+extension EventTypeValueExtension on EventType {
   String toValue() {
     switch (this) {
       case EventType.workflowExecutionStarted:
@@ -6878,7 +6878,7 @@ enum ExecutionStatus {
   closed,
 }
 
-extension ExecutionStatusValue on ExecutionStatus {
+extension ExecutionStatusValueExtension on ExecutionStatus {
   String toValue() {
     switch (this) {
       case ExecutionStatus.open:
@@ -7035,7 +7035,7 @@ enum FailWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension FailWorkflowExecutionFailedCauseValue
+extension FailWorkflowExecutionFailedCauseValueExtension
     on FailWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -8210,7 +8210,7 @@ enum LambdaFunctionTimeoutType {
   startToClose,
 }
 
-extension LambdaFunctionTimeoutTypeValue on LambdaFunctionTimeoutType {
+extension LambdaFunctionTimeoutTypeValueExtension on LambdaFunctionTimeoutType {
   String toValue() {
     switch (this) {
       case LambdaFunctionTimeoutType.startToClose:
@@ -8348,7 +8348,7 @@ enum RecordMarkerFailedCause {
   operationNotPermitted,
 }
 
-extension RecordMarkerFailedCauseValue on RecordMarkerFailedCause {
+extension RecordMarkerFailedCauseValueExtension on RecordMarkerFailedCause {
   String toValue() {
     switch (this) {
       case RecordMarkerFailedCause.operationNotPermitted:
@@ -8410,7 +8410,7 @@ enum RegistrationStatus {
   deprecated,
 }
 
-extension RegistrationStatusValue on RegistrationStatus {
+extension RegistrationStatusValueExtension on RegistrationStatus {
   String toValue() {
     switch (this) {
       case RegistrationStatus.registered:
@@ -8481,7 +8481,7 @@ enum RequestCancelActivityTaskFailedCause {
   operationNotPermitted,
 }
 
-extension RequestCancelActivityTaskFailedCauseValue
+extension RequestCancelActivityTaskFailedCauseValueExtension
     on RequestCancelActivityTaskFailedCause {
   String toValue() {
     switch (this) {
@@ -8611,7 +8611,7 @@ enum RequestCancelExternalWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension RequestCancelExternalWorkflowExecutionFailedCauseValue
+extension RequestCancelExternalWorkflowExecutionFailedCauseValueExtension
     on RequestCancelExternalWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -8997,7 +8997,7 @@ enum ScheduleActivityTaskFailedCause {
   operationNotPermitted,
 }
 
-extension ScheduleActivityTaskFailedCauseValue
+extension ScheduleActivityTaskFailedCauseValueExtension
     on ScheduleActivityTaskFailedCause {
   String toValue() {
     switch (this) {
@@ -9163,7 +9163,7 @@ enum ScheduleLambdaFunctionFailedCause {
   lambdaServiceNotAvailableInRegion,
 }
 
-extension ScheduleLambdaFunctionFailedCauseValue
+extension ScheduleLambdaFunctionFailedCauseValueExtension
     on ScheduleLambdaFunctionFailedCause {
   String toValue() {
     switch (this) {
@@ -9321,7 +9321,7 @@ enum SignalExternalWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension SignalExternalWorkflowExecutionFailedCauseValue
+extension SignalExternalWorkflowExecutionFailedCauseValueExtension
     on SignalExternalWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -9686,7 +9686,7 @@ enum StartChildWorkflowExecutionFailedCause {
   operationNotPermitted,
 }
 
-extension StartChildWorkflowExecutionFailedCauseValue
+extension StartChildWorkflowExecutionFailedCauseValueExtension
     on StartChildWorkflowExecutionFailedCause {
   String toValue() {
     switch (this) {
@@ -9944,7 +9944,7 @@ enum StartLambdaFunctionFailedCause {
   assumeRoleFailed,
 }
 
-extension StartLambdaFunctionFailedCauseValue
+extension StartLambdaFunctionFailedCauseValueExtension
     on StartLambdaFunctionFailedCause {
   String toValue() {
     switch (this) {
@@ -10074,7 +10074,7 @@ enum StartTimerFailedCause {
   operationNotPermitted,
 }
 
-extension StartTimerFailedCauseValue on StartTimerFailedCause {
+extension StartTimerFailedCauseValueExtension on StartTimerFailedCause {
   String toValue() {
     switch (this) {
       case StartTimerFailedCause.timerIdAlreadyInUse:
@@ -10306,7 +10306,7 @@ enum WorkflowExecutionCancelRequestedCause {
   childPolicyApplied,
 }
 
-extension WorkflowExecutionCancelRequestedCauseValue
+extension WorkflowExecutionCancelRequestedCauseValueExtension
     on WorkflowExecutionCancelRequestedCause {
   String toValue() {
     switch (this) {
@@ -11040,7 +11040,7 @@ enum WorkflowExecutionTerminatedCause {
   operatorInitiated,
 }
 
-extension WorkflowExecutionTerminatedCauseValue
+extension WorkflowExecutionTerminatedCauseValueExtension
     on WorkflowExecutionTerminatedCause {
   String toValue() {
     switch (this) {
@@ -11167,7 +11167,8 @@ enum WorkflowExecutionTimeoutType {
   startToClose,
 }
 
-extension WorkflowExecutionTimeoutTypeValue on WorkflowExecutionTimeoutType {
+extension WorkflowExecutionTimeoutTypeValueExtension
+    on WorkflowExecutionTimeoutType {
   String toValue() {
     switch (this) {
       case WorkflowExecutionTimeoutType.startToClose:

--- a/generated/aws_textract_api/lib/textract-2018-06-27.dart
+++ b/generated/aws_textract_api/lib/textract-2018-06-27.dart
@@ -947,7 +947,7 @@ enum BlockType {
   selectionElement,
 }
 
-extension on BlockType {
+extension BlockTypeValue on BlockType {
   String toValue() {
     switch (this) {
       case BlockType.keyValueSet:
@@ -968,7 +968,7 @@ extension on BlockType {
   }
 }
 
-extension on String {
+extension BlockTypeFromString on String {
   BlockType toBlockType() {
     switch (this) {
       case 'KEY_VALUE_SET':
@@ -1043,7 +1043,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension on ContentClassifier {
+extension ContentClassifierValue on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -1054,7 +1054,7 @@ extension on ContentClassifier {
   }
 }
 
-extension on String {
+extension ContentClassifierFromString on String {
   ContentClassifier toContentClassifier() {
     switch (this) {
       case 'FreeOfPersonallyIdentifiableInformation':
@@ -1189,7 +1189,7 @@ enum EntityType {
   value,
 }
 
-extension on EntityType {
+extension EntityTypeValue on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.key:
@@ -1200,7 +1200,7 @@ extension on EntityType {
   }
 }
 
-extension on String {
+extension EntityTypeFromString on String {
   EntityType toEntityType() {
     switch (this) {
       case 'KEY':
@@ -1217,7 +1217,7 @@ enum FeatureType {
   forms,
 }
 
-extension on FeatureType {
+extension FeatureTypeValue on FeatureType {
   String toValue() {
     switch (this) {
       case FeatureType.tables:
@@ -1228,7 +1228,7 @@ extension on FeatureType {
   }
 }
 
-extension on String {
+extension FeatureTypeFromString on String {
   FeatureType toFeatureType() {
     switch (this) {
       case 'TABLES':
@@ -1480,7 +1480,7 @@ enum JobStatus {
   partialSuccess,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.inProgress:
@@ -1495,7 +1495,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -1630,7 +1630,7 @@ enum RelationshipType {
   complexFeatures,
 }
 
-extension on RelationshipType {
+extension RelationshipTypeValue on RelationshipType {
   String toValue() {
     switch (this) {
       case RelationshipType.value:
@@ -1643,7 +1643,7 @@ extension on RelationshipType {
   }
 }
 
-extension on String {
+extension RelationshipTypeFromString on String {
   RelationshipType toRelationshipType() {
     switch (this) {
       case 'VALUE':
@@ -1698,7 +1698,7 @@ enum SelectionStatus {
   notSelected,
 }
 
-extension on SelectionStatus {
+extension SelectionStatusValue on SelectionStatus {
   String toValue() {
     switch (this) {
       case SelectionStatus.selected:
@@ -1709,7 +1709,7 @@ extension on SelectionStatus {
   }
 }
 
-extension on String {
+extension SelectionStatusFromString on String {
   SelectionStatus toSelectionStatus() {
     switch (this) {
       case 'SELECTED':
@@ -1761,7 +1761,7 @@ enum TextType {
   printed,
 }
 
-extension on TextType {
+extension TextTypeValue on TextType {
   String toValue() {
     switch (this) {
       case TextType.handwriting:
@@ -1772,7 +1772,7 @@ extension on TextType {
   }
 }
 
-extension on String {
+extension TextTypeFromString on String {
   TextType toTextType() {
     switch (this) {
       case 'HANDWRITING':

--- a/generated/aws_textract_api/lib/textract-2018-06-27.dart
+++ b/generated/aws_textract_api/lib/textract-2018-06-27.dart
@@ -947,7 +947,7 @@ enum BlockType {
   selectionElement,
 }
 
-extension BlockTypeValue on BlockType {
+extension BlockTypeValueExtension on BlockType {
   String toValue() {
     switch (this) {
       case BlockType.keyValueSet:
@@ -1043,7 +1043,7 @@ enum ContentClassifier {
   freeOfAdultContent,
 }
 
-extension ContentClassifierValue on ContentClassifier {
+extension ContentClassifierValueExtension on ContentClassifier {
   String toValue() {
     switch (this) {
       case ContentClassifier.freeOfPersonallyIdentifiableInformation:
@@ -1189,7 +1189,7 @@ enum EntityType {
   value,
 }
 
-extension EntityTypeValue on EntityType {
+extension EntityTypeValueExtension on EntityType {
   String toValue() {
     switch (this) {
       case EntityType.key:
@@ -1217,7 +1217,7 @@ enum FeatureType {
   forms,
 }
 
-extension FeatureTypeValue on FeatureType {
+extension FeatureTypeValueExtension on FeatureType {
   String toValue() {
     switch (this) {
       case FeatureType.tables:
@@ -1480,7 +1480,7 @@ enum JobStatus {
   partialSuccess,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.inProgress:
@@ -1630,7 +1630,7 @@ enum RelationshipType {
   complexFeatures,
 }
 
-extension RelationshipTypeValue on RelationshipType {
+extension RelationshipTypeValueExtension on RelationshipType {
   String toValue() {
     switch (this) {
       case RelationshipType.value:
@@ -1698,7 +1698,7 @@ enum SelectionStatus {
   notSelected,
 }
 
-extension SelectionStatusValue on SelectionStatus {
+extension SelectionStatusValueExtension on SelectionStatus {
   String toValue() {
     switch (this) {
       case SelectionStatus.selected:
@@ -1761,7 +1761,7 @@ enum TextType {
   printed,
 }
 
-extension TextTypeValue on TextType {
+extension TextTypeValueExtension on TextType {
   String toValue() {
     switch (this) {
       case TextType.handwriting:

--- a/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
+++ b/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
@@ -1895,7 +1895,7 @@ enum BaseModelName {
   wideBand,
 }
 
-extension BaseModelNameValue on BaseModelName {
+extension BaseModelNameValueExtension on BaseModelName {
   String toValue() {
     switch (this) {
       case BaseModelName.narrowBand:
@@ -1922,7 +1922,7 @@ enum CLMLanguageCode {
   enUs,
 }
 
-extension CLMLanguageCodeValue on CLMLanguageCode {
+extension CLMLanguageCodeValueExtension on CLMLanguageCode {
   String toValue() {
     switch (this) {
       case CLMLanguageCode.enUs:
@@ -2416,7 +2416,7 @@ enum LanguageCode {
   zhCn,
 }
 
-extension LanguageCodeValue on LanguageCode {
+extension LanguageCodeValueExtension on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.afZa:
@@ -2871,7 +2871,7 @@ enum MediaFormat {
   webm,
 }
 
-extension MediaFormatValue on MediaFormat {
+extension MediaFormatValueExtension on MediaFormat {
   String toValue() {
     switch (this) {
       case MediaFormat.mp3:
@@ -3273,7 +3273,7 @@ enum ModelStatus {
   completed,
 }
 
-extension ModelStatusValue on ModelStatus {
+extension ModelStatusValueExtension on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.inProgress:
@@ -3305,7 +3305,7 @@ enum OutputLocationType {
   serviceBucket,
 }
 
-extension OutputLocationTypeValue on OutputLocationType {
+extension OutputLocationTypeValueExtension on OutputLocationType {
   String toValue() {
     switch (this) {
       case OutputLocationType.customerBucket:
@@ -3333,7 +3333,7 @@ enum RedactionOutput {
   redactedAndUnredacted,
 }
 
-extension RedactionOutputValue on RedactionOutput {
+extension RedactionOutputValueExtension on RedactionOutput {
   String toValue() {
     switch (this) {
       case RedactionOutput.redacted:
@@ -3360,7 +3360,7 @@ enum RedactionType {
   pii,
 }
 
-extension RedactionTypeValue on RedactionType {
+extension RedactionTypeValueExtension on RedactionType {
   String toValue() {
     switch (this) {
       case RedactionType.pii:
@@ -3492,7 +3492,7 @@ enum Specialty {
   primarycare,
 }
 
-extension SpecialtyValue on Specialty {
+extension SpecialtyValueExtension on Specialty {
   String toValue() {
     switch (this) {
       case Specialty.primarycare:
@@ -3758,7 +3758,7 @@ enum TranscriptionJobStatus {
   completed,
 }
 
-extension TranscriptionJobStatusValue on TranscriptionJobStatus {
+extension TranscriptionJobStatusValueExtension on TranscriptionJobStatus {
   String toValue() {
     switch (this) {
       case TranscriptionJobStatus.queued:
@@ -3886,7 +3886,7 @@ enum Type {
   dictation,
 }
 
-extension TypeValue on Type {
+extension TypeValueExtension on Type {
   String toValue() {
     switch (this) {
       case Type.conversation:
@@ -4031,7 +4031,7 @@ enum VocabularyFilterMethod {
   mask,
 }
 
-extension VocabularyFilterMethodValue on VocabularyFilterMethod {
+extension VocabularyFilterMethodValueExtension on VocabularyFilterMethod {
   String toValue() {
     switch (this) {
       case VocabularyFilterMethod.remove:
@@ -4092,7 +4092,7 @@ enum VocabularyState {
   failed,
 }
 
-extension VocabularyStateValue on VocabularyState {
+extension VocabularyStateValueExtension on VocabularyState {
   String toValue() {
     switch (this) {
       case VocabularyState.pending:

--- a/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
+++ b/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
@@ -1895,7 +1895,7 @@ enum BaseModelName {
   wideBand,
 }
 
-extension on BaseModelName {
+extension BaseModelNameValue on BaseModelName {
   String toValue() {
     switch (this) {
       case BaseModelName.narrowBand:
@@ -1906,7 +1906,7 @@ extension on BaseModelName {
   }
 }
 
-extension on String {
+extension BaseModelNameFromString on String {
   BaseModelName toBaseModelName() {
     switch (this) {
       case 'NarrowBand':
@@ -1922,7 +1922,7 @@ enum CLMLanguageCode {
   enUs,
 }
 
-extension on CLMLanguageCode {
+extension CLMLanguageCodeValue on CLMLanguageCode {
   String toValue() {
     switch (this) {
       case CLMLanguageCode.enUs:
@@ -1931,7 +1931,7 @@ extension on CLMLanguageCode {
   }
 }
 
-extension on String {
+extension CLMLanguageCodeFromString on String {
   CLMLanguageCode toCLMLanguageCode() {
     switch (this) {
       case 'en-US':
@@ -2416,7 +2416,7 @@ enum LanguageCode {
   zhCn,
 }
 
-extension on LanguageCode {
+extension LanguageCodeValue on LanguageCode {
   String toValue() {
     switch (this) {
       case LanguageCode.afZa:
@@ -2495,7 +2495,7 @@ extension on LanguageCode {
   }
 }
 
-extension on String {
+extension LanguageCodeFromString on String {
   LanguageCode toLanguageCode() {
     switch (this) {
       case 'af-ZA':
@@ -2871,7 +2871,7 @@ enum MediaFormat {
   webm,
 }
 
-extension on MediaFormat {
+extension MediaFormatValue on MediaFormat {
   String toValue() {
     switch (this) {
       case MediaFormat.mp3:
@@ -2892,7 +2892,7 @@ extension on MediaFormat {
   }
 }
 
-extension on String {
+extension MediaFormatFromString on String {
   MediaFormat toMediaFormat() {
     switch (this) {
       case 'mp3':
@@ -3273,7 +3273,7 @@ enum ModelStatus {
   completed,
 }
 
-extension on ModelStatus {
+extension ModelStatusValue on ModelStatus {
   String toValue() {
     switch (this) {
       case ModelStatus.inProgress:
@@ -3286,7 +3286,7 @@ extension on ModelStatus {
   }
 }
 
-extension on String {
+extension ModelStatusFromString on String {
   ModelStatus toModelStatus() {
     switch (this) {
       case 'IN_PROGRESS':
@@ -3305,7 +3305,7 @@ enum OutputLocationType {
   serviceBucket,
 }
 
-extension on OutputLocationType {
+extension OutputLocationTypeValue on OutputLocationType {
   String toValue() {
     switch (this) {
       case OutputLocationType.customerBucket:
@@ -3316,7 +3316,7 @@ extension on OutputLocationType {
   }
 }
 
-extension on String {
+extension OutputLocationTypeFromString on String {
   OutputLocationType toOutputLocationType() {
     switch (this) {
       case 'CUSTOMER_BUCKET':
@@ -3333,7 +3333,7 @@ enum RedactionOutput {
   redactedAndUnredacted,
 }
 
-extension on RedactionOutput {
+extension RedactionOutputValue on RedactionOutput {
   String toValue() {
     switch (this) {
       case RedactionOutput.redacted:
@@ -3344,7 +3344,7 @@ extension on RedactionOutput {
   }
 }
 
-extension on String {
+extension RedactionOutputFromString on String {
   RedactionOutput toRedactionOutput() {
     switch (this) {
       case 'redacted':
@@ -3360,7 +3360,7 @@ enum RedactionType {
   pii,
 }
 
-extension on RedactionType {
+extension RedactionTypeValue on RedactionType {
   String toValue() {
     switch (this) {
       case RedactionType.pii:
@@ -3369,7 +3369,7 @@ extension on RedactionType {
   }
 }
 
-extension on String {
+extension RedactionTypeFromString on String {
   RedactionType toRedactionType() {
     switch (this) {
       case 'PII':
@@ -3492,7 +3492,7 @@ enum Specialty {
   primarycare,
 }
 
-extension on Specialty {
+extension SpecialtyValue on Specialty {
   String toValue() {
     switch (this) {
       case Specialty.primarycare:
@@ -3501,7 +3501,7 @@ extension on Specialty {
   }
 }
 
-extension on String {
+extension SpecialtyFromString on String {
   Specialty toSpecialty() {
     switch (this) {
       case 'PRIMARYCARE':
@@ -3758,7 +3758,7 @@ enum TranscriptionJobStatus {
   completed,
 }
 
-extension on TranscriptionJobStatus {
+extension TranscriptionJobStatusValue on TranscriptionJobStatus {
   String toValue() {
     switch (this) {
       case TranscriptionJobStatus.queued:
@@ -3773,7 +3773,7 @@ extension on TranscriptionJobStatus {
   }
 }
 
-extension on String {
+extension TranscriptionJobStatusFromString on String {
   TranscriptionJobStatus toTranscriptionJobStatus() {
     switch (this) {
       case 'QUEUED':
@@ -3886,7 +3886,7 @@ enum Type {
   dictation,
 }
 
-extension on Type {
+extension TypeValue on Type {
   String toValue() {
     switch (this) {
       case Type.conversation:
@@ -3897,7 +3897,7 @@ extension on Type {
   }
 }
 
-extension on String {
+extension TypeFromString on String {
   Type toType() {
     switch (this) {
       case 'CONVERSATION':
@@ -4031,7 +4031,7 @@ enum VocabularyFilterMethod {
   mask,
 }
 
-extension on VocabularyFilterMethod {
+extension VocabularyFilterMethodValue on VocabularyFilterMethod {
   String toValue() {
     switch (this) {
       case VocabularyFilterMethod.remove:
@@ -4042,7 +4042,7 @@ extension on VocabularyFilterMethod {
   }
 }
 
-extension on String {
+extension VocabularyFilterMethodFromString on String {
   VocabularyFilterMethod toVocabularyFilterMethod() {
     switch (this) {
       case 'remove':
@@ -4092,7 +4092,7 @@ enum VocabularyState {
   failed,
 }
 
-extension on VocabularyState {
+extension VocabularyStateValue on VocabularyState {
   String toValue() {
     switch (this) {
       case VocabularyState.pending:
@@ -4105,7 +4105,7 @@ extension on VocabularyState {
   }
 }
 
-extension on String {
+extension VocabularyStateFromString on String {
   VocabularyState toVocabularyState() {
     switch (this) {
       case 'PENDING':

--- a/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
+++ b/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
@@ -2230,7 +2230,7 @@ enum EndpointType {
   vpcEndpoint,
 }
 
-extension EndpointTypeValue on EndpointType {
+extension EndpointTypeValueExtension on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.public:
@@ -2293,7 +2293,7 @@ enum HomeDirectoryType {
   logical,
 }
 
-extension HomeDirectoryTypeValue on HomeDirectoryType {
+extension HomeDirectoryTypeValueExtension on HomeDirectoryType {
   String toValue() {
     switch (this) {
       case HomeDirectoryType.path:
@@ -2360,7 +2360,7 @@ enum IdentityProviderType {
   apiGateway,
 }
 
-extension IdentityProviderTypeValue on IdentityProviderType {
+extension IdentityProviderTypeValueExtension on IdentityProviderType {
   String toValue() {
     switch (this) {
       case IdentityProviderType.serviceManaged:
@@ -2645,7 +2645,7 @@ enum Protocol {
   ftps,
 }
 
-extension ProtocolValue on Protocol {
+extension ProtocolValueExtension on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.sftp:
@@ -2727,7 +2727,7 @@ enum State {
   stopFailed,
 }
 
-extension StateValue on State {
+extension StateValueExtension on State {
   String toValue() {
     switch (this) {
       case State.offline:

--- a/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
+++ b/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
@@ -2230,7 +2230,7 @@ enum EndpointType {
   vpcEndpoint,
 }
 
-extension on EndpointType {
+extension EndpointTypeValue on EndpointType {
   String toValue() {
     switch (this) {
       case EndpointType.public:
@@ -2243,7 +2243,7 @@ extension on EndpointType {
   }
 }
 
-extension on String {
+extension EndpointTypeFromString on String {
   EndpointType toEndpointType() {
     switch (this) {
       case 'PUBLIC':
@@ -2293,7 +2293,7 @@ enum HomeDirectoryType {
   logical,
 }
 
-extension on HomeDirectoryType {
+extension HomeDirectoryTypeValue on HomeDirectoryType {
   String toValue() {
     switch (this) {
       case HomeDirectoryType.path:
@@ -2304,7 +2304,7 @@ extension on HomeDirectoryType {
   }
 }
 
-extension on String {
+extension HomeDirectoryTypeFromString on String {
   HomeDirectoryType toHomeDirectoryType() {
     switch (this) {
       case 'PATH':
@@ -2360,7 +2360,7 @@ enum IdentityProviderType {
   apiGateway,
 }
 
-extension on IdentityProviderType {
+extension IdentityProviderTypeValue on IdentityProviderType {
   String toValue() {
     switch (this) {
       case IdentityProviderType.serviceManaged:
@@ -2371,7 +2371,7 @@ extension on IdentityProviderType {
   }
 }
 
-extension on String {
+extension IdentityProviderTypeFromString on String {
   IdentityProviderType toIdentityProviderType() {
     switch (this) {
       case 'SERVICE_MANAGED':
@@ -2645,7 +2645,7 @@ enum Protocol {
   ftps,
 }
 
-extension on Protocol {
+extension ProtocolValue on Protocol {
   String toValue() {
     switch (this) {
       case Protocol.sftp:
@@ -2658,7 +2658,7 @@ extension on Protocol {
   }
 }
 
-extension on String {
+extension ProtocolFromString on String {
   Protocol toProtocol() {
     switch (this) {
       case 'SFTP':
@@ -2727,7 +2727,7 @@ enum State {
   stopFailed,
 }
 
-extension on State {
+extension StateValue on State {
   String toValue() {
     switch (this) {
       case State.offline:
@@ -2746,7 +2746,7 @@ extension on State {
   }
 }
 
-extension on String {
+extension StateFromString on String {
   State toState() {
     switch (this) {
       case 'OFFLINE':

--- a/generated/aws_translate_api/lib/translate-2017-07-01.dart
+++ b/generated/aws_translate_api/lib/translate-2017-07-01.dart
@@ -1009,7 +1009,7 @@ enum EncryptionKeyType {
   kms,
 }
 
-extension on EncryptionKeyType {
+extension EncryptionKeyTypeValue on EncryptionKeyType {
   String toValue() {
     switch (this) {
       case EncryptionKeyType.kms:
@@ -1018,7 +1018,7 @@ extension on EncryptionKeyType {
   }
 }
 
-extension on String {
+extension EncryptionKeyTypeFromString on String {
   EncryptionKeyType toEncryptionKeyType() {
     switch (this) {
       case 'KMS':
@@ -1224,7 +1224,7 @@ enum JobStatus {
   stopped,
 }
 
-extension on JobStatus {
+extension JobStatusValue on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -1245,7 +1245,7 @@ extension on JobStatus {
   }
 }
 
-extension on String {
+extension JobStatusFromString on String {
   JobStatus toJobStatus() {
     switch (this) {
       case 'SUBMITTED':
@@ -1344,7 +1344,7 @@ enum MergeStrategy {
   overwrite,
 }
 
-extension on MergeStrategy {
+extension MergeStrategyValue on MergeStrategy {
   String toValue() {
     switch (this) {
       case MergeStrategy.overwrite:
@@ -1353,7 +1353,7 @@ extension on MergeStrategy {
   }
 }
 
-extension on String {
+extension MergeStrategyFromString on String {
   MergeStrategy toMergeStrategy() {
     switch (this) {
       case 'OVERWRITE':
@@ -1444,7 +1444,7 @@ enum ParallelDataFormat {
   tmx,
 }
 
-extension on ParallelDataFormat {
+extension ParallelDataFormatValue on ParallelDataFormat {
   String toValue() {
     switch (this) {
       case ParallelDataFormat.tsv:
@@ -1457,7 +1457,7 @@ extension on ParallelDataFormat {
   }
 }
 
-extension on String {
+extension ParallelDataFormatFromString on String {
   ParallelDataFormat toParallelDataFormat() {
     switch (this) {
       case 'TSV':
@@ -1593,7 +1593,7 @@ enum ParallelDataStatus {
   failed,
 }
 
-extension on ParallelDataStatus {
+extension ParallelDataStatusValue on ParallelDataStatus {
   String toValue() {
     switch (this) {
       case ParallelDataStatus.creating:
@@ -1610,7 +1610,7 @@ extension on ParallelDataStatus {
   }
 }
 
-extension on String {
+extension ParallelDataStatusFromString on String {
   ParallelDataStatus toParallelDataStatus() {
     switch (this) {
       case 'CREATING':
@@ -1746,7 +1746,7 @@ enum TerminologyDataFormat {
   tmx,
 }
 
-extension on TerminologyDataFormat {
+extension TerminologyDataFormatValue on TerminologyDataFormat {
   String toValue() {
     switch (this) {
       case TerminologyDataFormat.csv:
@@ -1757,7 +1757,7 @@ extension on TerminologyDataFormat {
   }
 }
 
-extension on String {
+extension TerminologyDataFormatFromString on String {
   TerminologyDataFormat toTerminologyDataFormat() {
     switch (this) {
       case 'CSV':

--- a/generated/aws_translate_api/lib/translate-2017-07-01.dart
+++ b/generated/aws_translate_api/lib/translate-2017-07-01.dart
@@ -1009,7 +1009,7 @@ enum EncryptionKeyType {
   kms,
 }
 
-extension EncryptionKeyTypeValue on EncryptionKeyType {
+extension EncryptionKeyTypeValueExtension on EncryptionKeyType {
   String toValue() {
     switch (this) {
       case EncryptionKeyType.kms:
@@ -1224,7 +1224,7 @@ enum JobStatus {
   stopped,
 }
 
-extension JobStatusValue on JobStatus {
+extension JobStatusValueExtension on JobStatus {
   String toValue() {
     switch (this) {
       case JobStatus.submitted:
@@ -1344,7 +1344,7 @@ enum MergeStrategy {
   overwrite,
 }
 
-extension MergeStrategyValue on MergeStrategy {
+extension MergeStrategyValueExtension on MergeStrategy {
   String toValue() {
     switch (this) {
       case MergeStrategy.overwrite:
@@ -1444,7 +1444,7 @@ enum ParallelDataFormat {
   tmx,
 }
 
-extension ParallelDataFormatValue on ParallelDataFormat {
+extension ParallelDataFormatValueExtension on ParallelDataFormat {
   String toValue() {
     switch (this) {
       case ParallelDataFormat.tsv:
@@ -1593,7 +1593,7 @@ enum ParallelDataStatus {
   failed,
 }
 
-extension ParallelDataStatusValue on ParallelDataStatus {
+extension ParallelDataStatusValueExtension on ParallelDataStatus {
   String toValue() {
     switch (this) {
       case ParallelDataStatus.creating:
@@ -1746,7 +1746,7 @@ enum TerminologyDataFormat {
   tmx,
 }
 
-extension TerminologyDataFormatValue on TerminologyDataFormat {
+extension TerminologyDataFormatValueExtension on TerminologyDataFormat {
   String toValue() {
     switch (this) {
       case TerminologyDataFormat.csv:

--- a/generated/aws_waf_api/lib/waf-2015-08-24.dart
+++ b/generated/aws_waf_api/lib/waf-2015-08-24.dart
@@ -7360,7 +7360,7 @@ enum ChangeAction {
   delete,
 }
 
-extension ChangeActionValue on ChangeAction {
+extension ChangeActionValueExtension on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.insert:
@@ -7389,7 +7389,7 @@ enum ChangeTokenStatus {
   insync,
 }
 
-extension ChangeTokenStatusValue on ChangeTokenStatus {
+extension ChangeTokenStatusValueExtension on ChangeTokenStatus {
   String toValue() {
     switch (this) {
       case ChangeTokenStatus.provisioned:
@@ -7425,7 +7425,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -8179,7 +8179,7 @@ enum GeoMatchConstraintType {
   country,
 }
 
-extension GeoMatchConstraintTypeValue on GeoMatchConstraintType {
+extension GeoMatchConstraintTypeValueExtension on GeoMatchConstraintType {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintType.country:
@@ -8450,7 +8450,7 @@ enum GeoMatchConstraintValue {
   zw,
 }
 
-extension GeoMatchConstraintValueValue on GeoMatchConstraintValue {
+extension GeoMatchConstraintValueValueExtension on GeoMatchConstraintValue {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintValue.af:
@@ -10288,7 +10288,7 @@ enum IPSetDescriptorType {
   ipv6,
 }
 
-extension IPSetDescriptorTypeValue on IPSetDescriptorType {
+extension IPSetDescriptorTypeValueExtension on IPSetDescriptorType {
   String toValue() {
     switch (this) {
       case IPSetDescriptorType.ipv4:
@@ -10882,7 +10882,7 @@ enum MatchFieldType {
   allQueryArgs,
 }
 
-extension MatchFieldTypeValue on MatchFieldType {
+extension MatchFieldTypeValueExtension on MatchFieldType {
   String toValue() {
     switch (this) {
       case MatchFieldType.uri:
@@ -10933,7 +10933,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension PositionalConstraintValue on PositionalConstraint {
+extension PositionalConstraintValueExtension on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -11047,7 +11047,7 @@ enum PredicateType {
   regexMatch,
 }
 
-extension PredicateTypeValue on PredicateType {
+extension PredicateTypeValueExtension on PredicateType {
   String toValue() {
     switch (this) {
       case PredicateType.iPMatch:
@@ -11214,7 +11214,7 @@ enum RateKey {
   ip,
 }
 
-extension RateKeyValue on RateKey {
+extension RateKeyValueExtension on RateKey {
   String toValue() {
     switch (this) {
       case RateKey.ip:
@@ -12830,7 +12830,7 @@ enum TextTransformation {
   urlDecode,
 }
 
-extension TextTransformationValue on TextTransformation {
+extension TextTransformationValueExtension on TextTransformation {
   String toValue() {
     switch (this) {
       case TextTransformation.none:
@@ -13208,7 +13208,7 @@ enum WafActionType {
   count,
 }
 
-extension WafActionTypeValue on WafActionType {
+extension WafActionTypeValueExtension on WafActionType {
   String toValue() {
     switch (this) {
       case WafActionType.block:
@@ -13276,7 +13276,7 @@ enum WafOverrideActionType {
   count,
 }
 
-extension WafOverrideActionTypeValue on WafOverrideActionType {
+extension WafOverrideActionTypeValueExtension on WafOverrideActionType {
   String toValue() {
     switch (this) {
       case WafOverrideActionType.none:
@@ -13305,7 +13305,7 @@ enum WafRuleType {
   group,
 }
 
-extension WafRuleTypeValue on WafRuleType {
+extension WafRuleTypeValueExtension on WafRuleType {
   String toValue() {
     switch (this) {
       case WafRuleType.regular:

--- a/generated/aws_waf_api/lib/waf-2015-08-24.dart
+++ b/generated/aws_waf_api/lib/waf-2015-08-24.dart
@@ -7360,7 +7360,7 @@ enum ChangeAction {
   delete,
 }
 
-extension on ChangeAction {
+extension ChangeActionValue on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.insert:
@@ -7371,7 +7371,7 @@ extension on ChangeAction {
   }
 }
 
-extension on String {
+extension ChangeActionFromString on String {
   ChangeAction toChangeAction() {
     switch (this) {
       case 'INSERT':
@@ -7389,7 +7389,7 @@ enum ChangeTokenStatus {
   insync,
 }
 
-extension on ChangeTokenStatus {
+extension ChangeTokenStatusValue on ChangeTokenStatus {
   String toValue() {
     switch (this) {
       case ChangeTokenStatus.provisioned:
@@ -7402,7 +7402,7 @@ extension on ChangeTokenStatus {
   }
 }
 
-extension on String {
+extension ChangeTokenStatusFromString on String {
   ChangeTokenStatus toChangeTokenStatus() {
     switch (this) {
       case 'PROVISIONED':
@@ -7425,7 +7425,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -7444,7 +7444,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -8179,7 +8179,7 @@ enum GeoMatchConstraintType {
   country,
 }
 
-extension on GeoMatchConstraintType {
+extension GeoMatchConstraintTypeValue on GeoMatchConstraintType {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintType.country:
@@ -8188,7 +8188,7 @@ extension on GeoMatchConstraintType {
   }
 }
 
-extension on String {
+extension GeoMatchConstraintTypeFromString on String {
   GeoMatchConstraintType toGeoMatchConstraintType() {
     switch (this) {
       case 'Country':
@@ -8450,7 +8450,7 @@ enum GeoMatchConstraintValue {
   zw,
 }
 
-extension on GeoMatchConstraintValue {
+extension GeoMatchConstraintValueValue on GeoMatchConstraintValue {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintValue.af:
@@ -8955,7 +8955,7 @@ extension on GeoMatchConstraintValue {
   }
 }
 
-extension on String {
+extension GeoMatchConstraintValueFromString on String {
   GeoMatchConstraintValue toGeoMatchConstraintValue() {
     switch (this) {
       case 'AF':
@@ -10288,7 +10288,7 @@ enum IPSetDescriptorType {
   ipv6,
 }
 
-extension on IPSetDescriptorType {
+extension IPSetDescriptorTypeValue on IPSetDescriptorType {
   String toValue() {
     switch (this) {
       case IPSetDescriptorType.ipv4:
@@ -10299,7 +10299,7 @@ extension on IPSetDescriptorType {
   }
 }
 
-extension on String {
+extension IPSetDescriptorTypeFromString on String {
   IPSetDescriptorType toIPSetDescriptorType() {
     switch (this) {
       case 'IPV4':
@@ -10882,7 +10882,7 @@ enum MatchFieldType {
   allQueryArgs,
 }
 
-extension on MatchFieldType {
+extension MatchFieldTypeValue on MatchFieldType {
   String toValue() {
     switch (this) {
       case MatchFieldType.uri:
@@ -10903,7 +10903,7 @@ extension on MatchFieldType {
   }
 }
 
-extension on String {
+extension MatchFieldTypeFromString on String {
   MatchFieldType toMatchFieldType() {
     switch (this) {
       case 'URI':
@@ -10933,7 +10933,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension on PositionalConstraint {
+extension PositionalConstraintValue on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -10950,7 +10950,7 @@ extension on PositionalConstraint {
   }
 }
 
-extension on String {
+extension PositionalConstraintFromString on String {
   PositionalConstraint toPositionalConstraint() {
     switch (this) {
       case 'EXACTLY':
@@ -11047,7 +11047,7 @@ enum PredicateType {
   regexMatch,
 }
 
-extension on PredicateType {
+extension PredicateTypeValue on PredicateType {
   String toValue() {
     switch (this) {
       case PredicateType.iPMatch:
@@ -11068,7 +11068,7 @@ extension on PredicateType {
   }
 }
 
-extension on String {
+extension PredicateTypeFromString on String {
   PredicateType toPredicateType() {
     switch (this) {
       case 'IPMatch':
@@ -11214,7 +11214,7 @@ enum RateKey {
   ip,
 }
 
-extension on RateKey {
+extension RateKeyValue on RateKey {
   String toValue() {
     switch (this) {
       case RateKey.ip:
@@ -11223,7 +11223,7 @@ extension on RateKey {
   }
 }
 
-extension on String {
+extension RateKeyFromString on String {
   RateKey toRateKey() {
     switch (this) {
       case 'IP':
@@ -12830,7 +12830,7 @@ enum TextTransformation {
   urlDecode,
 }
 
-extension on TextTransformation {
+extension TextTransformationValue on TextTransformation {
   String toValue() {
     switch (this) {
       case TextTransformation.none:
@@ -12849,7 +12849,7 @@ extension on TextTransformation {
   }
 }
 
-extension on String {
+extension TextTransformationFromString on String {
   TextTransformation toTextTransformation() {
     switch (this) {
       case 'NONE':
@@ -13208,7 +13208,7 @@ enum WafActionType {
   count,
 }
 
-extension on WafActionType {
+extension WafActionTypeValue on WafActionType {
   String toValue() {
     switch (this) {
       case WafActionType.block:
@@ -13221,7 +13221,7 @@ extension on WafActionType {
   }
 }
 
-extension on String {
+extension WafActionTypeFromString on String {
   WafActionType toWafActionType() {
     switch (this) {
       case 'BLOCK':
@@ -13276,7 +13276,7 @@ enum WafOverrideActionType {
   count,
 }
 
-extension on WafOverrideActionType {
+extension WafOverrideActionTypeValue on WafOverrideActionType {
   String toValue() {
     switch (this) {
       case WafOverrideActionType.none:
@@ -13287,7 +13287,7 @@ extension on WafOverrideActionType {
   }
 }
 
-extension on String {
+extension WafOverrideActionTypeFromString on String {
   WafOverrideActionType toWafOverrideActionType() {
     switch (this) {
       case 'NONE':
@@ -13305,7 +13305,7 @@ enum WafRuleType {
   group,
 }
 
-extension on WafRuleType {
+extension WafRuleTypeValue on WafRuleType {
   String toValue() {
     switch (this) {
       case WafRuleType.regular:
@@ -13318,7 +13318,7 @@ extension on WafRuleType {
   }
 }
 
-extension on String {
+extension WafRuleTypeFromString on String {
   WafRuleType toWafRuleType() {
     switch (this) {
       case 'REGULAR':

--- a/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
+++ b/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
@@ -7641,7 +7641,7 @@ enum ChangeAction {
   delete,
 }
 
-extension ChangeActionValue on ChangeAction {
+extension ChangeActionValueExtension on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.insert:
@@ -7670,7 +7670,7 @@ enum ChangeTokenStatus {
   insync,
 }
 
-extension ChangeTokenStatusValue on ChangeTokenStatus {
+extension ChangeTokenStatusValueExtension on ChangeTokenStatus {
   String toValue() {
     switch (this) {
       case ChangeTokenStatus.provisioned:
@@ -7706,7 +7706,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -8467,7 +8467,7 @@ enum GeoMatchConstraintType {
   country,
 }
 
-extension GeoMatchConstraintTypeValue on GeoMatchConstraintType {
+extension GeoMatchConstraintTypeValueExtension on GeoMatchConstraintType {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintType.country:
@@ -8738,7 +8738,7 @@ enum GeoMatchConstraintValue {
   zw,
 }
 
-extension GeoMatchConstraintValueValue on GeoMatchConstraintValue {
+extension GeoMatchConstraintValueValueExtension on GeoMatchConstraintValue {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintValue.af:
@@ -10595,7 +10595,7 @@ enum IPSetDescriptorType {
   ipv6,
 }
 
-extension IPSetDescriptorTypeValue on IPSetDescriptorType {
+extension IPSetDescriptorTypeValueExtension on IPSetDescriptorType {
   String toValue() {
     switch (this) {
       case IPSetDescriptorType.ipv4:
@@ -11208,7 +11208,7 @@ enum MatchFieldType {
   allQueryArgs,
 }
 
-extension MatchFieldTypeValue on MatchFieldType {
+extension MatchFieldTypeValueExtension on MatchFieldType {
   String toValue() {
     switch (this) {
       case MatchFieldType.uri:
@@ -11259,7 +11259,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension PositionalConstraintValue on PositionalConstraint {
+extension PositionalConstraintValueExtension on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -11373,7 +11373,7 @@ enum PredicateType {
   regexMatch,
 }
 
-extension PredicateTypeValue on PredicateType {
+extension PredicateTypeValueExtension on PredicateType {
   String toValue() {
     switch (this) {
       case PredicateType.iPMatch:
@@ -11540,7 +11540,7 @@ enum RateKey {
   ip,
 }
 
-extension RateKeyValue on RateKey {
+extension RateKeyValueExtension on RateKey {
   String toValue() {
     switch (this) {
       case RateKey.ip:
@@ -12024,7 +12024,7 @@ enum ResourceType {
   apiGateway,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.applicationLoadBalancer:
@@ -13184,7 +13184,7 @@ enum TextTransformation {
   urlDecode,
 }
 
-extension TextTransformationValue on TextTransformation {
+extension TextTransformationValueExtension on TextTransformation {
   String toValue() {
     switch (this) {
       case TextTransformation.none:
@@ -13562,7 +13562,7 @@ enum WafActionType {
   count,
 }
 
-extension WafActionTypeValue on WafActionType {
+extension WafActionTypeValueExtension on WafActionType {
   String toValue() {
     switch (this) {
       case WafActionType.block:
@@ -13630,7 +13630,7 @@ enum WafOverrideActionType {
   count,
 }
 
-extension WafOverrideActionTypeValue on WafOverrideActionType {
+extension WafOverrideActionTypeValueExtension on WafOverrideActionType {
   String toValue() {
     switch (this) {
       case WafOverrideActionType.none:
@@ -13659,7 +13659,7 @@ enum WafRuleType {
   group,
 }
 
-extension WafRuleTypeValue on WafRuleType {
+extension WafRuleTypeValueExtension on WafRuleType {
   String toValue() {
     switch (this) {
       case WafRuleType.regular:

--- a/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
+++ b/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
@@ -7641,7 +7641,7 @@ enum ChangeAction {
   delete,
 }
 
-extension on ChangeAction {
+extension ChangeActionValue on ChangeAction {
   String toValue() {
     switch (this) {
       case ChangeAction.insert:
@@ -7652,7 +7652,7 @@ extension on ChangeAction {
   }
 }
 
-extension on String {
+extension ChangeActionFromString on String {
   ChangeAction toChangeAction() {
     switch (this) {
       case 'INSERT':
@@ -7670,7 +7670,7 @@ enum ChangeTokenStatus {
   insync,
 }
 
-extension on ChangeTokenStatus {
+extension ChangeTokenStatusValue on ChangeTokenStatus {
   String toValue() {
     switch (this) {
       case ChangeTokenStatus.provisioned:
@@ -7683,7 +7683,7 @@ extension on ChangeTokenStatus {
   }
 }
 
-extension on String {
+extension ChangeTokenStatusFromString on String {
   ChangeTokenStatus toChangeTokenStatus() {
     switch (this) {
       case 'PROVISIONED':
@@ -7706,7 +7706,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -7725,7 +7725,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -8467,7 +8467,7 @@ enum GeoMatchConstraintType {
   country,
 }
 
-extension on GeoMatchConstraintType {
+extension GeoMatchConstraintTypeValue on GeoMatchConstraintType {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintType.country:
@@ -8476,7 +8476,7 @@ extension on GeoMatchConstraintType {
   }
 }
 
-extension on String {
+extension GeoMatchConstraintTypeFromString on String {
   GeoMatchConstraintType toGeoMatchConstraintType() {
     switch (this) {
       case 'Country':
@@ -8738,7 +8738,7 @@ enum GeoMatchConstraintValue {
   zw,
 }
 
-extension on GeoMatchConstraintValue {
+extension GeoMatchConstraintValueValue on GeoMatchConstraintValue {
   String toValue() {
     switch (this) {
       case GeoMatchConstraintValue.af:
@@ -9243,7 +9243,7 @@ extension on GeoMatchConstraintValue {
   }
 }
 
-extension on String {
+extension GeoMatchConstraintValueFromString on String {
   GeoMatchConstraintValue toGeoMatchConstraintValue() {
     switch (this) {
       case 'AF':
@@ -10595,7 +10595,7 @@ enum IPSetDescriptorType {
   ipv6,
 }
 
-extension on IPSetDescriptorType {
+extension IPSetDescriptorTypeValue on IPSetDescriptorType {
   String toValue() {
     switch (this) {
       case IPSetDescriptorType.ipv4:
@@ -10606,7 +10606,7 @@ extension on IPSetDescriptorType {
   }
 }
 
-extension on String {
+extension IPSetDescriptorTypeFromString on String {
   IPSetDescriptorType toIPSetDescriptorType() {
     switch (this) {
       case 'IPV4':
@@ -11208,7 +11208,7 @@ enum MatchFieldType {
   allQueryArgs,
 }
 
-extension on MatchFieldType {
+extension MatchFieldTypeValue on MatchFieldType {
   String toValue() {
     switch (this) {
       case MatchFieldType.uri:
@@ -11229,7 +11229,7 @@ extension on MatchFieldType {
   }
 }
 
-extension on String {
+extension MatchFieldTypeFromString on String {
   MatchFieldType toMatchFieldType() {
     switch (this) {
       case 'URI':
@@ -11259,7 +11259,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension on PositionalConstraint {
+extension PositionalConstraintValue on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -11276,7 +11276,7 @@ extension on PositionalConstraint {
   }
 }
 
-extension on String {
+extension PositionalConstraintFromString on String {
   PositionalConstraint toPositionalConstraint() {
     switch (this) {
       case 'EXACTLY':
@@ -11373,7 +11373,7 @@ enum PredicateType {
   regexMatch,
 }
 
-extension on PredicateType {
+extension PredicateTypeValue on PredicateType {
   String toValue() {
     switch (this) {
       case PredicateType.iPMatch:
@@ -11394,7 +11394,7 @@ extension on PredicateType {
   }
 }
 
-extension on String {
+extension PredicateTypeFromString on String {
   PredicateType toPredicateType() {
     switch (this) {
       case 'IPMatch':
@@ -11540,7 +11540,7 @@ enum RateKey {
   ip,
 }
 
-extension on RateKey {
+extension RateKeyValue on RateKey {
   String toValue() {
     switch (this) {
       case RateKey.ip:
@@ -11549,7 +11549,7 @@ extension on RateKey {
   }
 }
 
-extension on String {
+extension RateKeyFromString on String {
   RateKey toRateKey() {
     switch (this) {
       case 'IP':
@@ -12024,7 +12024,7 @@ enum ResourceType {
   apiGateway,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.applicationLoadBalancer:
@@ -12035,7 +12035,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'APPLICATION_LOAD_BALANCER':
@@ -13184,7 +13184,7 @@ enum TextTransformation {
   urlDecode,
 }
 
-extension on TextTransformation {
+extension TextTransformationValue on TextTransformation {
   String toValue() {
     switch (this) {
       case TextTransformation.none:
@@ -13203,7 +13203,7 @@ extension on TextTransformation {
   }
 }
 
-extension on String {
+extension TextTransformationFromString on String {
   TextTransformation toTextTransformation() {
     switch (this) {
       case 'NONE':
@@ -13562,7 +13562,7 @@ enum WafActionType {
   count,
 }
 
-extension on WafActionType {
+extension WafActionTypeValue on WafActionType {
   String toValue() {
     switch (this) {
       case WafActionType.block:
@@ -13575,7 +13575,7 @@ extension on WafActionType {
   }
 }
 
-extension on String {
+extension WafActionTypeFromString on String {
   WafActionType toWafActionType() {
     switch (this) {
       case 'BLOCK':
@@ -13630,7 +13630,7 @@ enum WafOverrideActionType {
   count,
 }
 
-extension on WafOverrideActionType {
+extension WafOverrideActionTypeValue on WafOverrideActionType {
   String toValue() {
     switch (this) {
       case WafOverrideActionType.none:
@@ -13641,7 +13641,7 @@ extension on WafOverrideActionType {
   }
 }
 
-extension on String {
+extension WafOverrideActionTypeFromString on String {
   WafOverrideActionType toWafOverrideActionType() {
     switch (this) {
       case 'NONE':
@@ -13659,7 +13659,7 @@ enum WafRuleType {
   group,
 }
 
-extension on WafRuleType {
+extension WafRuleTypeValue on WafRuleType {
   String toValue() {
     switch (this) {
       case WafRuleType.regular:
@@ -13672,7 +13672,7 @@ extension on WafRuleType {
   }
 }
 
-extension on String {
+extension WafRuleTypeFromString on String {
   WafRuleType toWafRuleType() {
     switch (this) {
       case 'REGULAR':

--- a/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
+++ b/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
@@ -3951,7 +3951,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension ComparisonOperatorValue on ComparisonOperator {
+extension ComparisonOperatorValueExtension on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -4264,7 +4264,7 @@ enum CountryCode {
   zw,
 }
 
-extension CountryCodeValue on CountryCode {
+extension CountryCodeValueExtension on CountryCode {
   String toValue() {
     switch (this) {
       case CountryCode.af:
@@ -5532,7 +5532,7 @@ enum FallbackBehavior {
   noMatch,
 }
 
-extension FallbackBehaviorValue on FallbackBehavior {
+extension FallbackBehaviorValueExtension on FallbackBehavior {
   String toValue() {
     switch (this) {
       case FallbackBehavior.match:
@@ -5806,7 +5806,7 @@ enum ForwardedIPPosition {
   any,
 }
 
-extension ForwardedIPPositionValue on ForwardedIPPosition {
+extension ForwardedIPPositionValueExtension on ForwardedIPPosition {
   String toValue() {
     switch (this) {
       case ForwardedIPPosition.first:
@@ -6217,7 +6217,7 @@ enum IPAddressVersion {
   ipv6,
 }
 
-extension IPAddressVersionValue on IPAddressVersion {
+extension IPAddressVersionValueExtension on IPAddressVersion {
   String toValue() {
     switch (this) {
       case IPAddressVersion.ipv4:
@@ -7080,7 +7080,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension PositionalConstraintValue on PositionalConstraint {
+extension PositionalConstraintValueExtension on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -7282,7 +7282,7 @@ enum RateBasedStatementAggregateKeyType {
   forwardedIp,
 }
 
-extension RateBasedStatementAggregateKeyTypeValue
+extension RateBasedStatementAggregateKeyTypeValueExtension
     on RateBasedStatementAggregateKeyType {
   String toValue() {
     switch (this) {
@@ -7547,7 +7547,7 @@ enum ResourceType {
   appsync,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.applicationLoadBalancer:
@@ -8022,7 +8022,7 @@ enum Scope {
   regional,
 }
 
-extension ScopeValue on Scope {
+extension ScopeValueExtension on Scope {
   String toValue() {
     switch (this) {
       case Scope.cloudfront:
@@ -8734,7 +8734,7 @@ enum TextTransformationType {
   urlDecode,
 }
 
-extension TextTransformationTypeValue on TextTransformationType {
+extension TextTransformationTypeValueExtension on TextTransformationType {
   String toValue() {
     switch (this) {
       case TextTransformationType.none:

--- a/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
+++ b/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
@@ -3951,7 +3951,7 @@ enum ComparisonOperator {
   gt,
 }
 
-extension on ComparisonOperator {
+extension ComparisonOperatorValue on ComparisonOperator {
   String toValue() {
     switch (this) {
       case ComparisonOperator.eq:
@@ -3970,7 +3970,7 @@ extension on ComparisonOperator {
   }
 }
 
-extension on String {
+extension ComparisonOperatorFromString on String {
   ComparisonOperator toComparisonOperator() {
     switch (this) {
       case 'EQ':
@@ -4264,7 +4264,7 @@ enum CountryCode {
   zw,
 }
 
-extension on CountryCode {
+extension CountryCodeValue on CountryCode {
   String toValue() {
     switch (this) {
       case CountryCode.af:
@@ -4769,7 +4769,7 @@ extension on CountryCode {
   }
 }
 
-extension on String {
+extension CountryCodeFromString on String {
   CountryCode toCountryCode() {
     switch (this) {
       case 'AF':
@@ -5532,7 +5532,7 @@ enum FallbackBehavior {
   noMatch,
 }
 
-extension on FallbackBehavior {
+extension FallbackBehaviorValue on FallbackBehavior {
   String toValue() {
     switch (this) {
       case FallbackBehavior.match:
@@ -5543,7 +5543,7 @@ extension on FallbackBehavior {
   }
 }
 
-extension on String {
+extension FallbackBehaviorFromString on String {
   FallbackBehavior toFallbackBehavior() {
     switch (this) {
       case 'MATCH':
@@ -5806,7 +5806,7 @@ enum ForwardedIPPosition {
   any,
 }
 
-extension on ForwardedIPPosition {
+extension ForwardedIPPositionValue on ForwardedIPPosition {
   String toValue() {
     switch (this) {
       case ForwardedIPPosition.first:
@@ -5819,7 +5819,7 @@ extension on ForwardedIPPosition {
   }
 }
 
-extension on String {
+extension ForwardedIPPositionFromString on String {
   ForwardedIPPosition toForwardedIPPosition() {
     switch (this) {
       case 'FIRST':
@@ -6217,7 +6217,7 @@ enum IPAddressVersion {
   ipv6,
 }
 
-extension on IPAddressVersion {
+extension IPAddressVersionValue on IPAddressVersion {
   String toValue() {
     switch (this) {
       case IPAddressVersion.ipv4:
@@ -6228,7 +6228,7 @@ extension on IPAddressVersion {
   }
 }
 
-extension on String {
+extension IPAddressVersionFromString on String {
   IPAddressVersion toIPAddressVersion() {
     switch (this) {
       case 'IPV4':
@@ -7080,7 +7080,7 @@ enum PositionalConstraint {
   containsWord,
 }
 
-extension on PositionalConstraint {
+extension PositionalConstraintValue on PositionalConstraint {
   String toValue() {
     switch (this) {
       case PositionalConstraint.exactly:
@@ -7097,7 +7097,7 @@ extension on PositionalConstraint {
   }
 }
 
-extension on String {
+extension PositionalConstraintFromString on String {
   PositionalConstraint toPositionalConstraint() {
     switch (this) {
       case 'EXACTLY':
@@ -7282,7 +7282,8 @@ enum RateBasedStatementAggregateKeyType {
   forwardedIp,
 }
 
-extension on RateBasedStatementAggregateKeyType {
+extension RateBasedStatementAggregateKeyTypeValue
+    on RateBasedStatementAggregateKeyType {
   String toValue() {
     switch (this) {
       case RateBasedStatementAggregateKeyType.ip:
@@ -7293,7 +7294,7 @@ extension on RateBasedStatementAggregateKeyType {
   }
 }
 
-extension on String {
+extension RateBasedStatementAggregateKeyTypeFromString on String {
   RateBasedStatementAggregateKeyType toRateBasedStatementAggregateKeyType() {
     switch (this) {
       case 'IP':
@@ -7546,7 +7547,7 @@ enum ResourceType {
   appsync,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.applicationLoadBalancer:
@@ -7559,7 +7560,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'APPLICATION_LOAD_BALANCER':
@@ -8021,7 +8022,7 @@ enum Scope {
   regional,
 }
 
-extension on Scope {
+extension ScopeValue on Scope {
   String toValue() {
     switch (this) {
       case Scope.cloudfront:
@@ -8032,7 +8033,7 @@ extension on Scope {
   }
 }
 
-extension on String {
+extension ScopeFromString on String {
   Scope toScope() {
     switch (this) {
       case 'CLOUDFRONT':
@@ -8733,7 +8734,7 @@ enum TextTransformationType {
   urlDecode,
 }
 
-extension on TextTransformationType {
+extension TextTransformationTypeValue on TextTransformationType {
   String toValue() {
     switch (this) {
       case TextTransformationType.none:
@@ -8752,7 +8753,7 @@ extension on TextTransformationType {
   }
 }
 
-extension on String {
+extension TextTransformationTypeFromString on String {
   TextTransformationType toTextTransformationType() {
     switch (this) {
       case 'NONE':

--- a/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
+++ b/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
@@ -3259,7 +3259,7 @@ enum ActivityType {
   folderMoved,
 }
 
-extension on ActivityType {
+extension ActivityTypeValue on ActivityType {
   String toValue() {
     switch (this) {
       case ActivityType.documentCheckedIn:
@@ -3332,7 +3332,7 @@ extension on ActivityType {
   }
 }
 
-extension on String {
+extension ActivityTypeFromString on String {
   ActivityType toActivityType() {
     switch (this) {
       case 'DOCUMENT_CHECKED_IN':
@@ -3428,7 +3428,7 @@ enum BooleanEnumType {
   $false,
 }
 
-extension on BooleanEnumType {
+extension BooleanEnumTypeValue on BooleanEnumType {
   String toValue() {
     switch (this) {
       case BooleanEnumType.$true:
@@ -3439,7 +3439,7 @@ extension on BooleanEnumType {
   }
 }
 
-extension on String {
+extension BooleanEnumTypeFromString on String {
   BooleanEnumType toBooleanEnumType() {
     switch (this) {
       case 'TRUE':
@@ -3555,7 +3555,7 @@ enum CommentStatusType {
   deleted,
 }
 
-extension on CommentStatusType {
+extension CommentStatusTypeValue on CommentStatusType {
   String toValue() {
     switch (this) {
       case CommentStatusType.draft:
@@ -3568,7 +3568,7 @@ extension on CommentStatusType {
   }
 }
 
-extension on String {
+extension CommentStatusTypeFromString on String {
   CommentStatusType toCommentStatusType() {
     switch (this) {
       case 'DRAFT':
@@ -3587,7 +3587,7 @@ enum CommentVisibilityType {
   private,
 }
 
-extension on CommentVisibilityType {
+extension CommentVisibilityTypeValue on CommentVisibilityType {
   String toValue() {
     switch (this) {
       case CommentVisibilityType.public:
@@ -3598,7 +3598,7 @@ extension on CommentVisibilityType {
   }
 }
 
-extension on String {
+extension CommentVisibilityTypeFromString on String {
   CommentVisibilityType toCommentVisibilityType() {
     switch (this) {
       case 'PUBLIC':
@@ -3985,7 +3985,7 @@ enum DocumentSourceType {
   withComments,
 }
 
-extension on DocumentSourceType {
+extension DocumentSourceTypeValue on DocumentSourceType {
   String toValue() {
     switch (this) {
       case DocumentSourceType.original:
@@ -3996,7 +3996,7 @@ extension on DocumentSourceType {
   }
 }
 
-extension on String {
+extension DocumentSourceTypeFromString on String {
   DocumentSourceType toDocumentSourceType() {
     switch (this) {
       case 'ORIGINAL':
@@ -4013,7 +4013,7 @@ enum DocumentStatusType {
   active,
 }
 
-extension on DocumentStatusType {
+extension DocumentStatusTypeValue on DocumentStatusType {
   String toValue() {
     switch (this) {
       case DocumentStatusType.initialized:
@@ -4024,7 +4024,7 @@ extension on DocumentStatusType {
   }
 }
 
-extension on String {
+extension DocumentStatusTypeFromString on String {
   DocumentStatusType toDocumentStatusType() {
     switch (this) {
       case 'INITIALIZED':
@@ -4042,7 +4042,7 @@ enum DocumentThumbnailType {
   large,
 }
 
-extension on DocumentThumbnailType {
+extension DocumentThumbnailTypeValue on DocumentThumbnailType {
   String toValue() {
     switch (this) {
       case DocumentThumbnailType.small:
@@ -4055,7 +4055,7 @@ extension on DocumentThumbnailType {
   }
 }
 
-extension on String {
+extension DocumentThumbnailTypeFromString on String {
   DocumentThumbnailType toDocumentThumbnailType() {
     switch (this) {
       case 'SMALL':
@@ -4152,7 +4152,7 @@ enum DocumentVersionStatus {
   active,
 }
 
-extension on DocumentVersionStatus {
+extension DocumentVersionStatusValue on DocumentVersionStatus {
   String toValue() {
     switch (this) {
       case DocumentVersionStatus.active:
@@ -4161,7 +4161,7 @@ extension on DocumentVersionStatus {
   }
 }
 
-extension on String {
+extension DocumentVersionStatusFromString on String {
   DocumentVersionStatus toDocumentVersionStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -4177,7 +4177,7 @@ enum FolderContentType {
   folder,
 }
 
-extension on FolderContentType {
+extension FolderContentTypeValue on FolderContentType {
   String toValue() {
     switch (this) {
       case FolderContentType.all:
@@ -4190,7 +4190,7 @@ extension on FolderContentType {
   }
 }
 
-extension on String {
+extension FolderContentTypeFromString on String {
   FolderContentType toFolderContentType() {
     switch (this) {
       case 'ALL':
@@ -4478,7 +4478,7 @@ enum LocaleType {
   $default,
 }
 
-extension on LocaleType {
+extension LocaleTypeValue on LocaleType {
   String toValue() {
     switch (this) {
       case LocaleType.en:
@@ -4507,7 +4507,7 @@ extension on LocaleType {
   }
 }
 
-extension on String {
+extension LocaleTypeFromString on String {
   LocaleType toLocaleType() {
     switch (this) {
       case 'en':
@@ -4565,7 +4565,7 @@ enum OrderType {
   descending,
 }
 
-extension on OrderType {
+extension OrderTypeValue on OrderType {
   String toValue() {
     switch (this) {
       case OrderType.ascending:
@@ -4576,7 +4576,7 @@ extension on OrderType {
   }
 }
 
-extension on String {
+extension OrderTypeFromString on String {
   OrderType toOrderType() {
     switch (this) {
       case 'ASCENDING':
@@ -4670,7 +4670,7 @@ enum PrincipalType {
   organization,
 }
 
-extension on PrincipalType {
+extension PrincipalTypeValue on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -4687,7 +4687,7 @@ extension on PrincipalType {
   }
 }
 
-extension on String {
+extension PrincipalTypeFromString on String {
   PrincipalType toPrincipalType() {
     switch (this) {
       case 'USER':
@@ -4709,7 +4709,7 @@ enum ResourceCollectionType {
   sharedWithMe,
 }
 
-extension on ResourceCollectionType {
+extension ResourceCollectionTypeValue on ResourceCollectionType {
   String toValue() {
     switch (this) {
       case ResourceCollectionType.sharedWithMe:
@@ -4718,7 +4718,7 @@ extension on ResourceCollectionType {
   }
 }
 
-extension on String {
+extension ResourceCollectionTypeFromString on String {
   ResourceCollectionType toResourceCollectionType() {
     switch (this) {
       case 'SHARED_WITH_ME':
@@ -4819,7 +4819,7 @@ enum ResourceSortType {
   name,
 }
 
-extension on ResourceSortType {
+extension ResourceSortTypeValue on ResourceSortType {
   String toValue() {
     switch (this) {
       case ResourceSortType.date:
@@ -4830,7 +4830,7 @@ extension on ResourceSortType {
   }
 }
 
-extension on String {
+extension ResourceSortTypeFromString on String {
   ResourceSortType toResourceSortType() {
     switch (this) {
       case 'DATE':
@@ -4849,7 +4849,7 @@ enum ResourceStateType {
   recycled,
 }
 
-extension on ResourceStateType {
+extension ResourceStateTypeValue on ResourceStateType {
   String toValue() {
     switch (this) {
       case ResourceStateType.active:
@@ -4864,7 +4864,7 @@ extension on ResourceStateType {
   }
 }
 
-extension on String {
+extension ResourceStateTypeFromString on String {
   ResourceStateType toResourceStateType() {
     switch (this) {
       case 'ACTIVE':
@@ -4885,7 +4885,7 @@ enum ResourceType {
   document,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.folder:
@@ -4896,7 +4896,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'FOLDER':
@@ -4913,7 +4913,7 @@ enum RolePermissionType {
   inherited,
 }
 
-extension on RolePermissionType {
+extension RolePermissionTypeValue on RolePermissionType {
   String toValue() {
     switch (this) {
       case RolePermissionType.direct:
@@ -4924,7 +4924,7 @@ extension on RolePermissionType {
   }
 }
 
-extension on String {
+extension RolePermissionTypeFromString on String {
   RolePermissionType toRolePermissionType() {
     switch (this) {
       case 'DIRECT':
@@ -4943,7 +4943,7 @@ enum RoleType {
   coowner,
 }
 
-extension on RoleType {
+extension RoleTypeValue on RoleType {
   String toValue() {
     switch (this) {
       case RoleType.viewer:
@@ -4958,7 +4958,7 @@ extension on RoleType {
   }
 }
 
-extension on String {
+extension RoleTypeFromString on String {
   RoleType toRoleType() {
     switch (this) {
       case 'VIEWER':
@@ -5047,7 +5047,7 @@ enum ShareStatusType {
   failure,
 }
 
-extension on ShareStatusType {
+extension ShareStatusTypeValue on ShareStatusType {
   String toValue() {
     switch (this) {
       case ShareStatusType.success:
@@ -5058,7 +5058,7 @@ extension on ShareStatusType {
   }
 }
 
-extension on String {
+extension ShareStatusTypeFromString on String {
   ShareStatusType toShareStatusType() {
     switch (this) {
       case 'SUCCESS':
@@ -5105,7 +5105,7 @@ enum StorageType {
   quota,
 }
 
-extension on StorageType {
+extension StorageTypeValue on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.unlimited:
@@ -5116,7 +5116,7 @@ extension on StorageType {
   }
 }
 
-extension on String {
+extension StorageTypeFromString on String {
   StorageType toStorageType() {
     switch (this) {
       case 'UNLIMITED':
@@ -5157,7 +5157,7 @@ enum SubscriptionProtocolType {
   https,
 }
 
-extension on SubscriptionProtocolType {
+extension SubscriptionProtocolTypeValue on SubscriptionProtocolType {
   String toValue() {
     switch (this) {
       case SubscriptionProtocolType.https:
@@ -5166,7 +5166,7 @@ extension on SubscriptionProtocolType {
   }
 }
 
-extension on String {
+extension SubscriptionProtocolTypeFromString on String {
   SubscriptionProtocolType toSubscriptionProtocolType() {
     switch (this) {
       case 'HTTPS':
@@ -5180,7 +5180,7 @@ enum SubscriptionType {
   all,
 }
 
-extension on SubscriptionType {
+extension SubscriptionTypeValue on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.all:
@@ -5189,7 +5189,7 @@ extension on SubscriptionType {
   }
 }
 
-extension on String {
+extension SubscriptionTypeFromString on String {
   SubscriptionType toSubscriptionType() {
     switch (this) {
       case 'ALL':
@@ -5329,7 +5329,7 @@ enum UserFilterType {
   activePending,
 }
 
-extension on UserFilterType {
+extension UserFilterTypeValue on UserFilterType {
   String toValue() {
     switch (this) {
       case UserFilterType.all:
@@ -5340,7 +5340,7 @@ extension on UserFilterType {
   }
 }
 
-extension on String {
+extension UserFilterTypeFromString on String {
   UserFilterType toUserFilterType() {
     switch (this) {
       case 'ALL':
@@ -5395,7 +5395,7 @@ enum UserSortType {
   storageUsed,
 }
 
-extension on UserSortType {
+extension UserSortTypeValue on UserSortType {
   String toValue() {
     switch (this) {
       case UserSortType.userName:
@@ -5412,7 +5412,7 @@ extension on UserSortType {
   }
 }
 
-extension on String {
+extension UserSortTypeFromString on String {
   UserSortType toUserSortType() {
     switch (this) {
       case 'USER_NAME':
@@ -5436,7 +5436,7 @@ enum UserStatusType {
   pending,
 }
 
-extension on UserStatusType {
+extension UserStatusTypeValue on UserStatusType {
   String toValue() {
     switch (this) {
       case UserStatusType.active:
@@ -5449,7 +5449,7 @@ extension on UserStatusType {
   }
 }
 
-extension on String {
+extension UserStatusTypeFromString on String {
   UserStatusType toUserStatusType() {
     switch (this) {
       case 'ACTIVE':
@@ -5494,7 +5494,7 @@ enum UserType {
   workspacesuser,
 }
 
-extension on UserType {
+extension UserTypeValue on UserType {
   String toValue() {
     switch (this) {
       case UserType.user:
@@ -5511,7 +5511,7 @@ extension on UserType {
   }
 }
 
-extension on String {
+extension UserTypeFromString on String {
   UserType toUserType() {
     switch (this) {
       case 'USER':

--- a/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
+++ b/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
@@ -3259,7 +3259,7 @@ enum ActivityType {
   folderMoved,
 }
 
-extension ActivityTypeValue on ActivityType {
+extension ActivityTypeValueExtension on ActivityType {
   String toValue() {
     switch (this) {
       case ActivityType.documentCheckedIn:
@@ -3428,7 +3428,7 @@ enum BooleanEnumType {
   $false,
 }
 
-extension BooleanEnumTypeValue on BooleanEnumType {
+extension BooleanEnumTypeValueExtension on BooleanEnumType {
   String toValue() {
     switch (this) {
       case BooleanEnumType.$true:
@@ -3555,7 +3555,7 @@ enum CommentStatusType {
   deleted,
 }
 
-extension CommentStatusTypeValue on CommentStatusType {
+extension CommentStatusTypeValueExtension on CommentStatusType {
   String toValue() {
     switch (this) {
       case CommentStatusType.draft:
@@ -3587,7 +3587,7 @@ enum CommentVisibilityType {
   private,
 }
 
-extension CommentVisibilityTypeValue on CommentVisibilityType {
+extension CommentVisibilityTypeValueExtension on CommentVisibilityType {
   String toValue() {
     switch (this) {
       case CommentVisibilityType.public:
@@ -3985,7 +3985,7 @@ enum DocumentSourceType {
   withComments,
 }
 
-extension DocumentSourceTypeValue on DocumentSourceType {
+extension DocumentSourceTypeValueExtension on DocumentSourceType {
   String toValue() {
     switch (this) {
       case DocumentSourceType.original:
@@ -4013,7 +4013,7 @@ enum DocumentStatusType {
   active,
 }
 
-extension DocumentStatusTypeValue on DocumentStatusType {
+extension DocumentStatusTypeValueExtension on DocumentStatusType {
   String toValue() {
     switch (this) {
       case DocumentStatusType.initialized:
@@ -4042,7 +4042,7 @@ enum DocumentThumbnailType {
   large,
 }
 
-extension DocumentThumbnailTypeValue on DocumentThumbnailType {
+extension DocumentThumbnailTypeValueExtension on DocumentThumbnailType {
   String toValue() {
     switch (this) {
       case DocumentThumbnailType.small:
@@ -4152,7 +4152,7 @@ enum DocumentVersionStatus {
   active,
 }
 
-extension DocumentVersionStatusValue on DocumentVersionStatus {
+extension DocumentVersionStatusValueExtension on DocumentVersionStatus {
   String toValue() {
     switch (this) {
       case DocumentVersionStatus.active:
@@ -4177,7 +4177,7 @@ enum FolderContentType {
   folder,
 }
 
-extension FolderContentTypeValue on FolderContentType {
+extension FolderContentTypeValueExtension on FolderContentType {
   String toValue() {
     switch (this) {
       case FolderContentType.all:
@@ -4478,7 +4478,7 @@ enum LocaleType {
   $default,
 }
 
-extension LocaleTypeValue on LocaleType {
+extension LocaleTypeValueExtension on LocaleType {
   String toValue() {
     switch (this) {
       case LocaleType.en:
@@ -4565,7 +4565,7 @@ enum OrderType {
   descending,
 }
 
-extension OrderTypeValue on OrderType {
+extension OrderTypeValueExtension on OrderType {
   String toValue() {
     switch (this) {
       case OrderType.ascending:
@@ -4670,7 +4670,7 @@ enum PrincipalType {
   organization,
 }
 
-extension PrincipalTypeValue on PrincipalType {
+extension PrincipalTypeValueExtension on PrincipalType {
   String toValue() {
     switch (this) {
       case PrincipalType.user:
@@ -4709,7 +4709,7 @@ enum ResourceCollectionType {
   sharedWithMe,
 }
 
-extension ResourceCollectionTypeValue on ResourceCollectionType {
+extension ResourceCollectionTypeValueExtension on ResourceCollectionType {
   String toValue() {
     switch (this) {
       case ResourceCollectionType.sharedWithMe:
@@ -4819,7 +4819,7 @@ enum ResourceSortType {
   name,
 }
 
-extension ResourceSortTypeValue on ResourceSortType {
+extension ResourceSortTypeValueExtension on ResourceSortType {
   String toValue() {
     switch (this) {
       case ResourceSortType.date:
@@ -4849,7 +4849,7 @@ enum ResourceStateType {
   recycled,
 }
 
-extension ResourceStateTypeValue on ResourceStateType {
+extension ResourceStateTypeValueExtension on ResourceStateType {
   String toValue() {
     switch (this) {
       case ResourceStateType.active:
@@ -4885,7 +4885,7 @@ enum ResourceType {
   document,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.folder:
@@ -4913,7 +4913,7 @@ enum RolePermissionType {
   inherited,
 }
 
-extension RolePermissionTypeValue on RolePermissionType {
+extension RolePermissionTypeValueExtension on RolePermissionType {
   String toValue() {
     switch (this) {
       case RolePermissionType.direct:
@@ -4943,7 +4943,7 @@ enum RoleType {
   coowner,
 }
 
-extension RoleTypeValue on RoleType {
+extension RoleTypeValueExtension on RoleType {
   String toValue() {
     switch (this) {
       case RoleType.viewer:
@@ -5047,7 +5047,7 @@ enum ShareStatusType {
   failure,
 }
 
-extension ShareStatusTypeValue on ShareStatusType {
+extension ShareStatusTypeValueExtension on ShareStatusType {
   String toValue() {
     switch (this) {
       case ShareStatusType.success:
@@ -5105,7 +5105,7 @@ enum StorageType {
   quota,
 }
 
-extension StorageTypeValue on StorageType {
+extension StorageTypeValueExtension on StorageType {
   String toValue() {
     switch (this) {
       case StorageType.unlimited:
@@ -5157,7 +5157,7 @@ enum SubscriptionProtocolType {
   https,
 }
 
-extension SubscriptionProtocolTypeValue on SubscriptionProtocolType {
+extension SubscriptionProtocolTypeValueExtension on SubscriptionProtocolType {
   String toValue() {
     switch (this) {
       case SubscriptionProtocolType.https:
@@ -5180,7 +5180,7 @@ enum SubscriptionType {
   all,
 }
 
-extension SubscriptionTypeValue on SubscriptionType {
+extension SubscriptionTypeValueExtension on SubscriptionType {
   String toValue() {
     switch (this) {
       case SubscriptionType.all:
@@ -5329,7 +5329,7 @@ enum UserFilterType {
   activePending,
 }
 
-extension UserFilterTypeValue on UserFilterType {
+extension UserFilterTypeValueExtension on UserFilterType {
   String toValue() {
     switch (this) {
       case UserFilterType.all:
@@ -5395,7 +5395,7 @@ enum UserSortType {
   storageUsed,
 }
 
-extension UserSortTypeValue on UserSortType {
+extension UserSortTypeValueExtension on UserSortType {
   String toValue() {
     switch (this) {
       case UserSortType.userName:
@@ -5436,7 +5436,7 @@ enum UserStatusType {
   pending,
 }
 
-extension UserStatusTypeValue on UserStatusType {
+extension UserStatusTypeValueExtension on UserStatusType {
   String toValue() {
     switch (this) {
       case UserStatusType.active:
@@ -5494,7 +5494,7 @@ enum UserType {
   workspacesuser,
 }
 
-extension UserTypeValue on UserType {
+extension UserTypeValueExtension on UserType {
   String toValue() {
     switch (this) {
       case UserType.user:

--- a/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
+++ b/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
@@ -1613,7 +1613,7 @@ enum AuthorizationProviderType {
   saml,
 }
 
-extension AuthorizationProviderTypeValue on AuthorizationProviderType {
+extension AuthorizationProviderTypeValueExtension on AuthorizationProviderType {
   String toValue() {
     switch (this) {
       case AuthorizationProviderType.saml:
@@ -1915,7 +1915,7 @@ enum DeviceStatus {
   signedOut,
 }
 
-extension DeviceStatusValue on DeviceStatus {
+extension DeviceStatusValueExtension on DeviceStatus {
   String toValue() {
     switch (this) {
       case DeviceStatus.active:
@@ -1992,7 +1992,7 @@ enum DomainStatus {
   failedToDisassociate,
 }
 
-extension DomainStatusValue on DomainStatus {
+extension DomainStatusValueExtension on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingValidation:
@@ -2078,7 +2078,7 @@ enum FleetStatus {
   failedToDelete,
 }
 
-extension FleetStatusValue on FleetStatus {
+extension FleetStatusValueExtension on FleetStatus {
   String toValue() {
     switch (this) {
       case FleetStatus.creating:
@@ -2172,7 +2172,7 @@ enum IdentityProviderType {
   saml,
 }
 
-extension IdentityProviderTypeValue on IdentityProviderType {
+extension IdentityProviderTypeValueExtension on IdentityProviderType {
   String toValue() {
     switch (this) {
       case IdentityProviderType.saml:

--- a/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
+++ b/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
@@ -1613,7 +1613,7 @@ enum AuthorizationProviderType {
   saml,
 }
 
-extension on AuthorizationProviderType {
+extension AuthorizationProviderTypeValue on AuthorizationProviderType {
   String toValue() {
     switch (this) {
       case AuthorizationProviderType.saml:
@@ -1622,7 +1622,7 @@ extension on AuthorizationProviderType {
   }
 }
 
-extension on String {
+extension AuthorizationProviderTypeFromString on String {
   AuthorizationProviderType toAuthorizationProviderType() {
     switch (this) {
       case 'SAML':
@@ -1915,7 +1915,7 @@ enum DeviceStatus {
   signedOut,
 }
 
-extension on DeviceStatus {
+extension DeviceStatusValue on DeviceStatus {
   String toValue() {
     switch (this) {
       case DeviceStatus.active:
@@ -1926,7 +1926,7 @@ extension on DeviceStatus {
   }
 }
 
-extension on String {
+extension DeviceStatusFromString on String {
   DeviceStatus toDeviceStatus() {
     switch (this) {
       case 'ACTIVE':
@@ -1992,7 +1992,7 @@ enum DomainStatus {
   failedToDisassociate,
 }
 
-extension on DomainStatus {
+extension DomainStatusValue on DomainStatus {
   String toValue() {
     switch (this) {
       case DomainStatus.pendingValidation:
@@ -2015,7 +2015,7 @@ extension on DomainStatus {
   }
 }
 
-extension on String {
+extension DomainStatusFromString on String {
   DomainStatus toDomainStatus() {
     switch (this) {
       case 'PENDING_VALIDATION':
@@ -2078,7 +2078,7 @@ enum FleetStatus {
   failedToDelete,
 }
 
-extension on FleetStatus {
+extension FleetStatusValue on FleetStatus {
   String toValue() {
     switch (this) {
       case FleetStatus.creating:
@@ -2097,7 +2097,7 @@ extension on FleetStatus {
   }
 }
 
-extension on String {
+extension FleetStatusFromString on String {
   FleetStatus toFleetStatus() {
     switch (this) {
       case 'CREATING':
@@ -2172,7 +2172,7 @@ enum IdentityProviderType {
   saml,
 }
 
-extension on IdentityProviderType {
+extension IdentityProviderTypeValue on IdentityProviderType {
   String toValue() {
     switch (this) {
       case IdentityProviderType.saml:
@@ -2181,7 +2181,7 @@ extension on IdentityProviderType {
   }
 }
 
-extension on String {
+extension IdentityProviderTypeFromString on String {
   IdentityProviderType toIdentityProviderType() {
     switch (this) {
       case 'SAML':

--- a/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
+++ b/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
@@ -3295,7 +3295,7 @@ enum AccessControlRuleEffect {
   deny,
 }
 
-extension on AccessControlRuleEffect {
+extension AccessControlRuleEffectValue on AccessControlRuleEffect {
   String toValue() {
     switch (this) {
       case AccessControlRuleEffect.allow:
@@ -3306,7 +3306,7 @@ extension on AccessControlRuleEffect {
   }
 }
 
-extension on String {
+extension AccessControlRuleEffectFromString on String {
   AccessControlRuleEffect toAccessControlRuleEffect() {
     switch (this) {
       case 'ALLOW':
@@ -3873,7 +3873,7 @@ enum EntityState {
   deleted,
 }
 
-extension on EntityState {
+extension EntityStateValue on EntityState {
   String toValue() {
     switch (this) {
       case EntityState.enabled:
@@ -3886,7 +3886,7 @@ extension on EntityState {
   }
 }
 
-extension on String {
+extension EntityStateFromString on String {
   EntityState toEntityState() {
     switch (this) {
       case 'ENABLED':
@@ -3946,7 +3946,7 @@ enum FolderName {
   junkEmail,
 }
 
-extension on FolderName {
+extension FolderNameValue on FolderName {
   String toValue() {
     switch (this) {
       case FolderName.inbox:
@@ -3963,7 +3963,7 @@ extension on FolderName {
   }
 }
 
-extension on String {
+extension FolderNameFromString on String {
   FolderName toFolderName() {
     switch (this) {
       case 'INBOX':
@@ -4402,7 +4402,7 @@ enum MailboxExportJobState {
   cancelled,
 }
 
-extension on MailboxExportJobState {
+extension MailboxExportJobStateValue on MailboxExportJobState {
   String toValue() {
     switch (this) {
       case MailboxExportJobState.running:
@@ -4417,7 +4417,7 @@ extension on MailboxExportJobState {
   }
 }
 
-extension on String {
+extension MailboxExportJobStateFromString on String {
   MailboxExportJobState toMailboxExportJobState() {
     switch (this) {
       case 'RUNNING':
@@ -4478,7 +4478,7 @@ enum MemberType {
   user,
 }
 
-extension on MemberType {
+extension MemberTypeValue on MemberType {
   String toValue() {
     switch (this) {
       case MemberType.group:
@@ -4489,7 +4489,7 @@ extension on MemberType {
   }
 }
 
-extension on String {
+extension MemberTypeFromString on String {
   MemberType toMemberType() {
     switch (this) {
       case 'GROUP':
@@ -4579,7 +4579,7 @@ enum PermissionType {
   sendOnBehalf,
 }
 
-extension on PermissionType {
+extension PermissionTypeValue on PermissionType {
   String toValue() {
     switch (this) {
       case PermissionType.fullAccess:
@@ -4592,7 +4592,7 @@ extension on PermissionType {
   }
 }
 
-extension on String {
+extension PermissionTypeFromString on String {
   PermissionType toPermissionType() {
     switch (this) {
       case 'FULL_ACCESS':
@@ -4691,7 +4691,7 @@ enum ResourceType {
   equipment,
 }
 
-extension on ResourceType {
+extension ResourceTypeValue on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.room:
@@ -4702,7 +4702,7 @@ extension on ResourceType {
   }
 }
 
-extension on String {
+extension ResourceTypeFromString on String {
   ResourceType toResourceType() {
     switch (this) {
       case 'ROOM':
@@ -4720,7 +4720,7 @@ enum RetentionAction {
   permanentlyDelete,
 }
 
-extension on RetentionAction {
+extension RetentionActionValue on RetentionAction {
   String toValue() {
     switch (this) {
       case RetentionAction.none:
@@ -4733,7 +4733,7 @@ extension on RetentionAction {
   }
 }
 
-extension on String {
+extension RetentionActionFromString on String {
   RetentionAction toRetentionAction() {
     switch (this) {
       case 'NONE':
@@ -4881,7 +4881,7 @@ enum UserRole {
   systemUser,
 }
 
-extension on UserRole {
+extension UserRoleValue on UserRole {
   String toValue() {
     switch (this) {
       case UserRole.user:
@@ -4894,7 +4894,7 @@ extension on UserRole {
   }
 }
 
-extension on String {
+extension UserRoleFromString on String {
   UserRole toUserRole() {
     switch (this) {
       case 'USER':

--- a/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
+++ b/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
@@ -3295,7 +3295,7 @@ enum AccessControlRuleEffect {
   deny,
 }
 
-extension AccessControlRuleEffectValue on AccessControlRuleEffect {
+extension AccessControlRuleEffectValueExtension on AccessControlRuleEffect {
   String toValue() {
     switch (this) {
       case AccessControlRuleEffect.allow:
@@ -3873,7 +3873,7 @@ enum EntityState {
   deleted,
 }
 
-extension EntityStateValue on EntityState {
+extension EntityStateValueExtension on EntityState {
   String toValue() {
     switch (this) {
       case EntityState.enabled:
@@ -3946,7 +3946,7 @@ enum FolderName {
   junkEmail,
 }
 
-extension FolderNameValue on FolderName {
+extension FolderNameValueExtension on FolderName {
   String toValue() {
     switch (this) {
       case FolderName.inbox:
@@ -4402,7 +4402,7 @@ enum MailboxExportJobState {
   cancelled,
 }
 
-extension MailboxExportJobStateValue on MailboxExportJobState {
+extension MailboxExportJobStateValueExtension on MailboxExportJobState {
   String toValue() {
     switch (this) {
       case MailboxExportJobState.running:
@@ -4478,7 +4478,7 @@ enum MemberType {
   user,
 }
 
-extension MemberTypeValue on MemberType {
+extension MemberTypeValueExtension on MemberType {
   String toValue() {
     switch (this) {
       case MemberType.group:
@@ -4579,7 +4579,7 @@ enum PermissionType {
   sendOnBehalf,
 }
 
-extension PermissionTypeValue on PermissionType {
+extension PermissionTypeValueExtension on PermissionType {
   String toValue() {
     switch (this) {
       case PermissionType.fullAccess:
@@ -4691,7 +4691,7 @@ enum ResourceType {
   equipment,
 }
 
-extension ResourceTypeValue on ResourceType {
+extension ResourceTypeValueExtension on ResourceType {
   String toValue() {
     switch (this) {
       case ResourceType.room:
@@ -4720,7 +4720,7 @@ enum RetentionAction {
   permanentlyDelete,
 }
 
-extension RetentionActionValue on RetentionAction {
+extension RetentionActionValueExtension on RetentionAction {
   String toValue() {
     switch (this) {
       case RetentionAction.none:
@@ -4881,7 +4881,7 @@ enum UserRole {
   systemUser,
 }
 
-extension UserRoleValue on UserRole {
+extension UserRoleValueExtension on UserRole {
   String toValue() {
     switch (this) {
       case UserRole.user:

--- a/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
+++ b/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
@@ -2529,7 +2529,7 @@ enum AccessPropertyValue {
   deny,
 }
 
-extension AccessPropertyValueValue on AccessPropertyValue {
+extension AccessPropertyValueValueExtension on AccessPropertyValue {
   String toValue() {
     switch (this) {
       case AccessPropertyValue.allow:
@@ -2604,7 +2604,7 @@ enum Application {
   microsoftOffice_2019,
 }
 
-extension ApplicationValue on Application {
+extension ApplicationValueExtension on Application {
   String toValue() {
     switch (this) {
       case Application.microsoftOffice_2016:
@@ -2658,7 +2658,7 @@ enum AssociationStatus {
   pendingDisassociation,
 }
 
-extension AssociationStatusValue on AssociationStatus {
+extension AssociationStatusValueExtension on AssociationStatus {
   String toValue() {
     switch (this) {
       case AssociationStatus.notAssociated:
@@ -2759,7 +2759,7 @@ enum Compute {
   graphicspro,
 }
 
-extension ComputeValue on Compute {
+extension ComputeValueExtension on Compute {
   String toValue() {
     switch (this) {
       case Compute.value:
@@ -2937,7 +2937,7 @@ enum ConnectionAliasState {
   deleting,
 }
 
-extension ConnectionAliasStateValue on ConnectionAliasState {
+extension ConnectionAliasStateValueExtension on ConnectionAliasState {
   String toValue() {
     switch (this) {
       case ConnectionAliasState.creating:
@@ -2970,7 +2970,7 @@ enum ConnectionState {
   unknown,
 }
 
-extension ConnectionStateValue on ConnectionState {
+extension ConnectionStateValueExtension on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.connected:
@@ -3083,7 +3083,7 @@ enum DedicatedTenancyModificationStateEnum {
   failed,
 }
 
-extension DedicatedTenancyModificationStateEnumValue
+extension DedicatedTenancyModificationStateEnumValueExtension
     on DedicatedTenancyModificationStateEnum {
   String toValue() {
     switch (this) {
@@ -3117,7 +3117,8 @@ enum DedicatedTenancySupportEnum {
   enabled,
 }
 
-extension DedicatedTenancySupportEnumValue on DedicatedTenancySupportEnum {
+extension DedicatedTenancySupportEnumValueExtension
+    on DedicatedTenancySupportEnum {
   String toValue() {
     switch (this) {
       case DedicatedTenancySupportEnum.enabled:
@@ -3141,7 +3142,7 @@ enum DedicatedTenancySupportResultEnum {
   disabled,
 }
 
-extension DedicatedTenancySupportResultEnumValue
+extension DedicatedTenancySupportResultEnumValueExtension
     on DedicatedTenancySupportResultEnum {
   String toValue() {
     switch (this) {
@@ -3699,7 +3700,7 @@ enum ImageType {
   shared,
 }
 
-extension ImageTypeValue on ImageType {
+extension ImageTypeValueExtension on ImageType {
   String toValue() {
     switch (this) {
       case ImageType.owned:
@@ -3816,7 +3817,7 @@ enum ModificationResourceEnum {
   computeType,
 }
 
-extension ModificationResourceEnumValue on ModificationResourceEnum {
+extension ModificationResourceEnumValueExtension on ModificationResourceEnum {
   String toValue() {
     switch (this) {
       case ModificationResourceEnum.rootVolume:
@@ -3868,7 +3869,7 @@ enum ModificationStateEnum {
   updateInProgress,
 }
 
-extension ModificationStateEnumValue on ModificationStateEnum {
+extension ModificationStateEnumValueExtension on ModificationStateEnum {
   String toValue() {
     switch (this) {
       case ModificationStateEnum.updateInitiated:
@@ -3962,7 +3963,7 @@ enum OperatingSystemType {
   linux,
 }
 
-extension OperatingSystemTypeValue on OperatingSystemType {
+extension OperatingSystemTypeValueExtension on OperatingSystemType {
   String toValue() {
     switch (this) {
       case OperatingSystemType.windows:
@@ -4058,7 +4059,7 @@ enum ReconnectEnum {
   disabled,
 }
 
-extension ReconnectEnumValue on ReconnectEnum {
+extension ReconnectEnumValueExtension on ReconnectEnum {
   String toValue() {
     switch (this) {
       case ReconnectEnum.enabled:
@@ -4122,7 +4123,7 @@ enum RunningMode {
   alwaysOn,
 }
 
-extension RunningModeValue on RunningMode {
+extension RunningModeValueExtension on RunningMode {
   String toValue() {
     switch (this) {
       case RunningMode.autoStop:
@@ -4328,7 +4329,7 @@ enum TargetWorkspaceState {
   adminMaintenance,
 }
 
-extension TargetWorkspaceStateValue on TargetWorkspaceState {
+extension TargetWorkspaceStateValueExtension on TargetWorkspaceState {
   String toValue() {
     switch (this) {
       case TargetWorkspaceState.available:
@@ -4356,7 +4357,7 @@ enum Tenancy {
   shared,
 }
 
-extension TenancyValue on Tenancy {
+extension TenancyValueExtension on Tenancy {
   String toValue() {
     switch (this) {
       case Tenancy.dedicated:
@@ -4966,7 +4967,7 @@ enum WorkspaceDirectoryState {
   error,
 }
 
-extension WorkspaceDirectoryStateValue on WorkspaceDirectoryState {
+extension WorkspaceDirectoryStateValueExtension on WorkspaceDirectoryState {
   String toValue() {
     switch (this) {
       case WorkspaceDirectoryState.registering:
@@ -5006,7 +5007,7 @@ enum WorkspaceDirectoryType {
   adConnector,
 }
 
-extension WorkspaceDirectoryTypeValue on WorkspaceDirectoryType {
+extension WorkspaceDirectoryTypeValueExtension on WorkspaceDirectoryType {
   String toValue() {
     switch (this) {
       case WorkspaceDirectoryType.simpleAd:
@@ -5106,7 +5107,7 @@ enum WorkspaceImageIngestionProcess {
   byolRegularWsp,
 }
 
-extension WorkspaceImageIngestionProcessValue
+extension WorkspaceImageIngestionProcessValueExtension
     on WorkspaceImageIngestionProcess {
   String toValue() {
     switch (this) {
@@ -5144,7 +5145,8 @@ enum WorkspaceImageRequiredTenancy {
   dedicated,
 }
 
-extension WorkspaceImageRequiredTenancyValue on WorkspaceImageRequiredTenancy {
+extension WorkspaceImageRequiredTenancyValueExtension
+    on WorkspaceImageRequiredTenancy {
   String toValue() {
     switch (this) {
       case WorkspaceImageRequiredTenancy.$default:
@@ -5173,7 +5175,7 @@ enum WorkspaceImageState {
   error,
 }
 
-extension WorkspaceImageStateValue on WorkspaceImageState {
+extension WorkspaceImageStateValueExtension on WorkspaceImageState {
   String toValue() {
     switch (this) {
       case WorkspaceImageState.available:
@@ -5371,7 +5373,7 @@ enum WorkspaceState {
   error,
 }
 
-extension WorkspaceStateValue on WorkspaceState {
+extension WorkspaceStateValueExtension on WorkspaceState {
   String toValue() {
     switch (this) {
       case WorkspaceState.pending:

--- a/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
+++ b/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
@@ -2529,7 +2529,7 @@ enum AccessPropertyValue {
   deny,
 }
 
-extension on AccessPropertyValue {
+extension AccessPropertyValueValue on AccessPropertyValue {
   String toValue() {
     switch (this) {
       case AccessPropertyValue.allow:
@@ -2540,7 +2540,7 @@ extension on AccessPropertyValue {
   }
 }
 
-extension on String {
+extension AccessPropertyValueFromString on String {
   AccessPropertyValue toAccessPropertyValue() {
     switch (this) {
       case 'ALLOW':
@@ -2604,7 +2604,7 @@ enum Application {
   microsoftOffice_2019,
 }
 
-extension on Application {
+extension ApplicationValue on Application {
   String toValue() {
     switch (this) {
       case Application.microsoftOffice_2016:
@@ -2615,7 +2615,7 @@ extension on Application {
   }
 }
 
-extension on String {
+extension ApplicationFromString on String {
   Application toApplication() {
     switch (this) {
       case 'Microsoft_Office_2016':
@@ -2658,7 +2658,7 @@ enum AssociationStatus {
   pendingDisassociation,
 }
 
-extension on AssociationStatus {
+extension AssociationStatusValue on AssociationStatus {
   String toValue() {
     switch (this) {
       case AssociationStatus.notAssociated:
@@ -2675,7 +2675,7 @@ extension on AssociationStatus {
   }
 }
 
-extension on String {
+extension AssociationStatusFromString on String {
   AssociationStatus toAssociationStatus() {
     switch (this) {
       case 'NOT_ASSOCIATED':
@@ -2759,7 +2759,7 @@ enum Compute {
   graphicspro,
 }
 
-extension on Compute {
+extension ComputeValue on Compute {
   String toValue() {
     switch (this) {
       case Compute.value:
@@ -2780,7 +2780,7 @@ extension on Compute {
   }
 }
 
-extension on String {
+extension ComputeFromString on String {
   Compute toCompute() {
     switch (this) {
       case 'VALUE':
@@ -2937,7 +2937,7 @@ enum ConnectionAliasState {
   deleting,
 }
 
-extension on ConnectionAliasState {
+extension ConnectionAliasStateValue on ConnectionAliasState {
   String toValue() {
     switch (this) {
       case ConnectionAliasState.creating:
@@ -2950,7 +2950,7 @@ extension on ConnectionAliasState {
   }
 }
 
-extension on String {
+extension ConnectionAliasStateFromString on String {
   ConnectionAliasState toConnectionAliasState() {
     switch (this) {
       case 'CREATING':
@@ -2970,7 +2970,7 @@ enum ConnectionState {
   unknown,
 }
 
-extension on ConnectionState {
+extension ConnectionStateValue on ConnectionState {
   String toValue() {
     switch (this) {
       case ConnectionState.connected:
@@ -2983,7 +2983,7 @@ extension on ConnectionState {
   }
 }
 
-extension on String {
+extension ConnectionStateFromString on String {
   ConnectionState toConnectionState() {
     switch (this) {
       case 'CONNECTED':
@@ -3083,7 +3083,8 @@ enum DedicatedTenancyModificationStateEnum {
   failed,
 }
 
-extension on DedicatedTenancyModificationStateEnum {
+extension DedicatedTenancyModificationStateEnumValue
+    on DedicatedTenancyModificationStateEnum {
   String toValue() {
     switch (this) {
       case DedicatedTenancyModificationStateEnum.pending:
@@ -3096,7 +3097,7 @@ extension on DedicatedTenancyModificationStateEnum {
   }
 }
 
-extension on String {
+extension DedicatedTenancyModificationStateEnumFromString on String {
   DedicatedTenancyModificationStateEnum
       toDedicatedTenancyModificationStateEnum() {
     switch (this) {
@@ -3116,7 +3117,7 @@ enum DedicatedTenancySupportEnum {
   enabled,
 }
 
-extension on DedicatedTenancySupportEnum {
+extension DedicatedTenancySupportEnumValue on DedicatedTenancySupportEnum {
   String toValue() {
     switch (this) {
       case DedicatedTenancySupportEnum.enabled:
@@ -3125,7 +3126,7 @@ extension on DedicatedTenancySupportEnum {
   }
 }
 
-extension on String {
+extension DedicatedTenancySupportEnumFromString on String {
   DedicatedTenancySupportEnum toDedicatedTenancySupportEnum() {
     switch (this) {
       case 'ENABLED':
@@ -3140,7 +3141,8 @@ enum DedicatedTenancySupportResultEnum {
   disabled,
 }
 
-extension on DedicatedTenancySupportResultEnum {
+extension DedicatedTenancySupportResultEnumValue
+    on DedicatedTenancySupportResultEnum {
   String toValue() {
     switch (this) {
       case DedicatedTenancySupportResultEnum.enabled:
@@ -3151,7 +3153,7 @@ extension on DedicatedTenancySupportResultEnum {
   }
 }
 
-extension on String {
+extension DedicatedTenancySupportResultEnumFromString on String {
   DedicatedTenancySupportResultEnum toDedicatedTenancySupportResultEnum() {
     switch (this) {
       case 'ENABLED':
@@ -3697,7 +3699,7 @@ enum ImageType {
   shared,
 }
 
-extension on ImageType {
+extension ImageTypeValue on ImageType {
   String toValue() {
     switch (this) {
       case ImageType.owned:
@@ -3708,7 +3710,7 @@ extension on ImageType {
   }
 }
 
-extension on String {
+extension ImageTypeFromString on String {
   ImageType toImageType() {
     switch (this) {
       case 'OWNED':
@@ -3814,7 +3816,7 @@ enum ModificationResourceEnum {
   computeType,
 }
 
-extension on ModificationResourceEnum {
+extension ModificationResourceEnumValue on ModificationResourceEnum {
   String toValue() {
     switch (this) {
       case ModificationResourceEnum.rootVolume:
@@ -3827,7 +3829,7 @@ extension on ModificationResourceEnum {
   }
 }
 
-extension on String {
+extension ModificationResourceEnumFromString on String {
   ModificationResourceEnum toModificationResourceEnum() {
     switch (this) {
       case 'ROOT_VOLUME':
@@ -3866,7 +3868,7 @@ enum ModificationStateEnum {
   updateInProgress,
 }
 
-extension on ModificationStateEnum {
+extension ModificationStateEnumValue on ModificationStateEnum {
   String toValue() {
     switch (this) {
       case ModificationStateEnum.updateInitiated:
@@ -3877,7 +3879,7 @@ extension on ModificationStateEnum {
   }
 }
 
-extension on String {
+extension ModificationStateEnumFromString on String {
   ModificationStateEnum toModificationStateEnum() {
     switch (this) {
       case 'UPDATE_INITIATED':
@@ -3960,7 +3962,7 @@ enum OperatingSystemType {
   linux,
 }
 
-extension on OperatingSystemType {
+extension OperatingSystemTypeValue on OperatingSystemType {
   String toValue() {
     switch (this) {
       case OperatingSystemType.windows:
@@ -3971,7 +3973,7 @@ extension on OperatingSystemType {
   }
 }
 
-extension on String {
+extension OperatingSystemTypeFromString on String {
   OperatingSystemType toOperatingSystemType() {
     switch (this) {
       case 'WINDOWS':
@@ -4056,7 +4058,7 @@ enum ReconnectEnum {
   disabled,
 }
 
-extension on ReconnectEnum {
+extension ReconnectEnumValue on ReconnectEnum {
   String toValue() {
     switch (this) {
       case ReconnectEnum.enabled:
@@ -4067,7 +4069,7 @@ extension on ReconnectEnum {
   }
 }
 
-extension on String {
+extension ReconnectEnumFromString on String {
   ReconnectEnum toReconnectEnum() {
     switch (this) {
       case 'ENABLED':
@@ -4120,7 +4122,7 @@ enum RunningMode {
   alwaysOn,
 }
 
-extension on RunningMode {
+extension RunningModeValue on RunningMode {
   String toValue() {
     switch (this) {
       case RunningMode.autoStop:
@@ -4131,7 +4133,7 @@ extension on RunningMode {
   }
 }
 
-extension on String {
+extension RunningModeFromString on String {
   RunningMode toRunningMode() {
     switch (this) {
       case 'AUTO_STOP':
@@ -4326,7 +4328,7 @@ enum TargetWorkspaceState {
   adminMaintenance,
 }
 
-extension on TargetWorkspaceState {
+extension TargetWorkspaceStateValue on TargetWorkspaceState {
   String toValue() {
     switch (this) {
       case TargetWorkspaceState.available:
@@ -4337,7 +4339,7 @@ extension on TargetWorkspaceState {
   }
 }
 
-extension on String {
+extension TargetWorkspaceStateFromString on String {
   TargetWorkspaceState toTargetWorkspaceState() {
     switch (this) {
       case 'AVAILABLE':
@@ -4354,7 +4356,7 @@ enum Tenancy {
   shared,
 }
 
-extension on Tenancy {
+extension TenancyValue on Tenancy {
   String toValue() {
     switch (this) {
       case Tenancy.dedicated:
@@ -4365,7 +4367,7 @@ extension on Tenancy {
   }
 }
 
-extension on String {
+extension TenancyFromString on String {
   Tenancy toTenancy() {
     switch (this) {
       case 'DEDICATED':
@@ -4964,7 +4966,7 @@ enum WorkspaceDirectoryState {
   error,
 }
 
-extension on WorkspaceDirectoryState {
+extension WorkspaceDirectoryStateValue on WorkspaceDirectoryState {
   String toValue() {
     switch (this) {
       case WorkspaceDirectoryState.registering:
@@ -4981,7 +4983,7 @@ extension on WorkspaceDirectoryState {
   }
 }
 
-extension on String {
+extension WorkspaceDirectoryStateFromString on String {
   WorkspaceDirectoryState toWorkspaceDirectoryState() {
     switch (this) {
       case 'REGISTERING':
@@ -5004,7 +5006,7 @@ enum WorkspaceDirectoryType {
   adConnector,
 }
 
-extension on WorkspaceDirectoryType {
+extension WorkspaceDirectoryTypeValue on WorkspaceDirectoryType {
   String toValue() {
     switch (this) {
       case WorkspaceDirectoryType.simpleAd:
@@ -5015,7 +5017,7 @@ extension on WorkspaceDirectoryType {
   }
 }
 
-extension on String {
+extension WorkspaceDirectoryTypeFromString on String {
   WorkspaceDirectoryType toWorkspaceDirectoryType() {
     switch (this) {
       case 'SIMPLE_AD':
@@ -5104,7 +5106,8 @@ enum WorkspaceImageIngestionProcess {
   byolRegularWsp,
 }
 
-extension on WorkspaceImageIngestionProcess {
+extension WorkspaceImageIngestionProcessValue
+    on WorkspaceImageIngestionProcess {
   String toValue() {
     switch (this) {
       case WorkspaceImageIngestionProcess.byolRegular:
@@ -5119,7 +5122,7 @@ extension on WorkspaceImageIngestionProcess {
   }
 }
 
-extension on String {
+extension WorkspaceImageIngestionProcessFromString on String {
   WorkspaceImageIngestionProcess toWorkspaceImageIngestionProcess() {
     switch (this) {
       case 'BYOL_REGULAR':
@@ -5141,7 +5144,7 @@ enum WorkspaceImageRequiredTenancy {
   dedicated,
 }
 
-extension on WorkspaceImageRequiredTenancy {
+extension WorkspaceImageRequiredTenancyValue on WorkspaceImageRequiredTenancy {
   String toValue() {
     switch (this) {
       case WorkspaceImageRequiredTenancy.$default:
@@ -5152,7 +5155,7 @@ extension on WorkspaceImageRequiredTenancy {
   }
 }
 
-extension on String {
+extension WorkspaceImageRequiredTenancyFromString on String {
   WorkspaceImageRequiredTenancy toWorkspaceImageRequiredTenancy() {
     switch (this) {
       case 'DEFAULT':
@@ -5170,7 +5173,7 @@ enum WorkspaceImageState {
   error,
 }
 
-extension on WorkspaceImageState {
+extension WorkspaceImageStateValue on WorkspaceImageState {
   String toValue() {
     switch (this) {
       case WorkspaceImageState.available:
@@ -5183,7 +5186,7 @@ extension on WorkspaceImageState {
   }
 }
 
-extension on String {
+extension WorkspaceImageStateFromString on String {
   WorkspaceImageState toWorkspaceImageState() {
     switch (this) {
       case 'AVAILABLE':
@@ -5368,7 +5371,7 @@ enum WorkspaceState {
   error,
 }
 
-extension on WorkspaceState {
+extension WorkspaceStateValue on WorkspaceState {
   String toValue() {
     switch (this) {
       case WorkspaceState.pending:
@@ -5409,7 +5412,7 @@ extension on WorkspaceState {
   }
 }
 
-extension on String {
+extension WorkspaceStateFromString on String {
   WorkspaceState toWorkspaceState() {
     switch (this) {
       case 'PENDING':

--- a/generated/aws_xray_api/lib/xray-2016-04-12.dart
+++ b/generated/aws_xray_api/lib/xray-2016-04-12.dart
@@ -1674,7 +1674,7 @@ enum EncryptionStatus {
   active,
 }
 
-extension EncryptionStatusValue on EncryptionStatus {
+extension EncryptionStatusValueExtension on EncryptionStatus {
   String toValue() {
     switch (this) {
       case EncryptionStatus.updating:
@@ -1702,7 +1702,7 @@ enum EncryptionType {
   kms,
 }
 
-extension EncryptionTypeValue on EncryptionType {
+extension EncryptionTypeValueExtension on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.none:
@@ -2615,7 +2615,7 @@ enum InsightCategory {
   fault,
 }
 
-extension InsightCategoryValue on InsightCategory {
+extension InsightCategoryValueExtension on InsightCategory {
   String toValue() {
     switch (this) {
       case InsightCategory.fault:
@@ -2774,7 +2774,7 @@ enum InsightState {
   closed,
 }
 
-extension InsightStateValue on InsightState {
+extension InsightStateValueExtension on InsightState {
   String toValue() {
     switch (this) {
       case InsightState.active:
@@ -3507,7 +3507,7 @@ enum SamplingStrategyName {
   fixedRate,
 }
 
-extension SamplingStrategyNameValue on SamplingStrategyName {
+extension SamplingStrategyNameValueExtension on SamplingStrategyName {
   String toValue() {
     switch (this) {
       case SamplingStrategyName.partialScan:
@@ -3900,7 +3900,7 @@ enum TimeRangeType {
   event,
 }
 
-extension TimeRangeTypeValue on TimeRangeType {
+extension TimeRangeTypeValueExtension on TimeRangeType {
   String toValue() {
     switch (this) {
       case TimeRangeType.traceId:

--- a/generated/aws_xray_api/lib/xray-2016-04-12.dart
+++ b/generated/aws_xray_api/lib/xray-2016-04-12.dart
@@ -1674,7 +1674,7 @@ enum EncryptionStatus {
   active,
 }
 
-extension on EncryptionStatus {
+extension EncryptionStatusValue on EncryptionStatus {
   String toValue() {
     switch (this) {
       case EncryptionStatus.updating:
@@ -1685,7 +1685,7 @@ extension on EncryptionStatus {
   }
 }
 
-extension on String {
+extension EncryptionStatusFromString on String {
   EncryptionStatus toEncryptionStatus() {
     switch (this) {
       case 'UPDATING':
@@ -1702,7 +1702,7 @@ enum EncryptionType {
   kms,
 }
 
-extension on EncryptionType {
+extension EncryptionTypeValue on EncryptionType {
   String toValue() {
     switch (this) {
       case EncryptionType.none:
@@ -1713,7 +1713,7 @@ extension on EncryptionType {
   }
 }
 
-extension on String {
+extension EncryptionTypeFromString on String {
   EncryptionType toEncryptionType() {
     switch (this) {
       case 'NONE':
@@ -2615,7 +2615,7 @@ enum InsightCategory {
   fault,
 }
 
-extension on InsightCategory {
+extension InsightCategoryValue on InsightCategory {
   String toValue() {
     switch (this) {
       case InsightCategory.fault:
@@ -2624,7 +2624,7 @@ extension on InsightCategory {
   }
 }
 
-extension on String {
+extension InsightCategoryFromString on String {
   InsightCategory toInsightCategory() {
     switch (this) {
       case 'FAULT':
@@ -2774,7 +2774,7 @@ enum InsightState {
   closed,
 }
 
-extension on InsightState {
+extension InsightStateValue on InsightState {
   String toValue() {
     switch (this) {
       case InsightState.active:
@@ -2785,7 +2785,7 @@ extension on InsightState {
   }
 }
 
-extension on String {
+extension InsightStateFromString on String {
   InsightState toInsightState() {
     switch (this) {
       case 'ACTIVE':
@@ -3507,7 +3507,7 @@ enum SamplingStrategyName {
   fixedRate,
 }
 
-extension on SamplingStrategyName {
+extension SamplingStrategyNameValue on SamplingStrategyName {
   String toValue() {
     switch (this) {
       case SamplingStrategyName.partialScan:
@@ -3518,7 +3518,7 @@ extension on SamplingStrategyName {
   }
 }
 
-extension on String {
+extension SamplingStrategyNameFromString on String {
   SamplingStrategyName toSamplingStrategyName() {
     switch (this) {
       case 'PartialScan':
@@ -3900,7 +3900,7 @@ enum TimeRangeType {
   event,
 }
 
-extension on TimeRangeType {
+extension TimeRangeTypeValue on TimeRangeType {
   String toValue() {
     switch (this) {
       case TimeRangeType.traceId:
@@ -3911,7 +3911,7 @@ extension on TimeRangeType {
   }
 }
 
-extension on String {
+extension TimeRangeTypeFromString on String {
   TimeRangeType toTimeRangeType() {
     switch (this) {
       case 'TraceId':

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -202,7 +202,7 @@ ${builder.constructor()}
       }).toList();
       writeln('}');
 
-      writeln("""extension on $name {
+      writeln("""extension ${name}Value on $name {
   String toValue() {
     switch (this) {
     ${shape.enumeration!.mapIndexed<String, String>((index, value) => ''' case $name.${enumFieldNames[index]}:
@@ -213,7 +213,7 @@ ${builder.constructor()}
 }
         """);
 
-      writeln("""extension on String {
+      writeln("""extension ${name}FromString on String {
   $name to$name() {
     switch (this) {
     ${shape.enumeration!.mapIndexed<String, String>((index, value) => ''' case '$value':

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -202,7 +202,7 @@ ${builder.constructor()}
       }).toList();
       writeln('}');
 
-      writeln("""extension ${name}Value on $name {
+      writeln("""extension ${name}ValueExtension on $name {
   String toValue() {
     switch (this) {
     ${shape.enumeration!.mapIndexed<String, String>((index, value) => ''' case $name.${enumFieldNames[index]}:

--- a/generator/lib/builders/pubspec_builder.dart
+++ b/generator/lib/builders/pubspec_builder.dart
@@ -7,8 +7,20 @@ String buildPubspecYaml(
   required bool isDevMode,
   required ProtocolConfig protocolConfig,
 }) {
+  /// This si requiredin DevMode becuase if we depend on any generated S3 package
+  /// such as aws_s3_api and then that in turn depends on the local copy of aws_shared_api
+  /// then the top level app would although pick the locla aws_s3_api package but
+  /// for some reason, the aws_shared_api is always picked up from dart packge hub
+  var dependencies = '''
+dependencies:
+  shared_aws_api: ${protocolConfig.shared}''';
   var dependenciesOverride = '';
+
   if (isDevMode) {
+    dependencies = '''
+dependencies:
+  shared_aws_api:
+    path: ../../shared_aws_api''';
     dependenciesOverride = '''
 dependency_overrides:
   shared_aws_api:
@@ -27,8 +39,7 @@ protocol: ${api.metadata.protocol}
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
-dependencies:
-  shared_aws_api: ${protocolConfig.shared}
+$dependencies
 
 $dependenciesOverride
 ''';

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -79,6 +79,9 @@ class GenericAwsException implements AwsException {
 typedef AwsExceptionFn = AwsException Function(String type, String message);
 
 XmlElement? extractXmlChild(XmlElement elem, String name) {
+  if (name == elem.localName) {
+    return elem;
+  }
   return elem.findElements(name).firstOrNull;
 }
 

--- a/shared_aws_api/test/generated/input/json/enum.dart
+++ b/shared_aws_api/test/generated/input/json/enum.dart
@@ -97,7 +97,7 @@ enum EnumType {
   bar,
 }
 
-extension on EnumType {
+extension EnumTypeValue on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:
@@ -108,7 +108,7 @@ extension on EnumType {
   }
 }
 
-extension on String {
+extension EnumTypeFromString on String {
   EnumType toEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/input/json/enum.dart
+++ b/shared_aws_api/test/generated/input/json/enum.dart
@@ -97,7 +97,7 @@ enum EnumType {
   bar,
 }
 
-extension EnumTypeValue on EnumType {
+extension EnumTypeValueExtension on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:

--- a/shared_aws_api/test/generated/input/query/enum.dart
+++ b/shared_aws_api/test/generated/input/query/enum.dart
@@ -118,7 +118,7 @@ enum EnumType {
   bar,
 }
 
-extension on EnumType {
+extension EnumTypeValue on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:
@@ -129,7 +129,7 @@ extension on EnumType {
   }
 }
 
-extension on String {
+extension EnumTypeFromString on String {
   EnumType toEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/input/query/enum.dart
+++ b/shared_aws_api/test/generated/input/query/enum.dart
@@ -118,7 +118,7 @@ enum EnumType {
   bar,
 }
 
-extension EnumTypeValue on EnumType {
+extension EnumTypeValueExtension on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:

--- a/shared_aws_api/test/generated/input/query/map_with_enum_key.dart
+++ b/shared_aws_api/test/generated/input/query/map_with_enum_key.dart
@@ -79,7 +79,7 @@ enum QueueAttributeName {
   policy,
 }
 
-extension on QueueAttributeName {
+extension QueueAttributeNameValueExtension on QueueAttributeName {
   String toValue() {
     switch (this) {
       case QueueAttributeName.all:
@@ -90,7 +90,7 @@ extension on QueueAttributeName {
   }
 }
 
-extension on String {
+extension QueueAttributeNameFromString on String {
   QueueAttributeName toQueueAttributeName() {
     switch (this) {
       case 'All':

--- a/shared_aws_api/test/generated/input/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-json/enum.dart
@@ -116,7 +116,7 @@ enum EnumType {
   $1,
 }
 
-extension EnumTypeValue on EnumType {
+extension EnumTypeValueExtension on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:

--- a/shared_aws_api/test/generated/input/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-json/enum.dart
@@ -116,7 +116,7 @@ enum EnumType {
   $1,
 }
 
-extension on EnumType {
+extension EnumTypeValue on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:
@@ -133,7 +133,7 @@ extension on EnumType {
   }
 }
 
-extension on String {
+extension EnumTypeFromString on String {
   EnumType toEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -159,7 +159,7 @@ enum EnumType {
   $1,
 }
 
-extension EnumTypeValue on EnumType {
+extension EnumTypeValueExtension on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -159,7 +159,7 @@ enum EnumType {
   $1,
 }
 
-extension on EnumType {
+extension EnumTypeValue on EnumType {
   String toValue() {
     switch (this) {
       case EnumType.foo:
@@ -176,7 +176,7 @@ extension on EnumType {
   }
 }
 
-extension on String {
+extension EnumTypeFromString on String {
   EnumType toEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/output/json/enum_output.dart
+++ b/shared_aws_api/test/generated/output/json/enum_output.dart
@@ -88,7 +88,7 @@ enum JSONEnumType {
   bar,
 }
 
-extension on JSONEnumType {
+extension JSONEnumTypeValue on JSONEnumType {
   String toValue() {
     switch (this) {
       case JSONEnumType.foo:
@@ -99,7 +99,7 @@ extension on JSONEnumType {
   }
 }
 
-extension on String {
+extension JSONEnumTypeFromString on String {
   JSONEnumType toJSONEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/output/json/enum_output.dart
+++ b/shared_aws_api/test/generated/output/json/enum_output.dart
@@ -88,7 +88,7 @@ enum JSONEnumType {
   bar,
 }
 
-extension JSONEnumTypeValue on JSONEnumType {
+extension JSONEnumTypeValueExtension on JSONEnumType {
   String toValue() {
     switch (this) {
       case JSONEnumType.foo:

--- a/shared_aws_api/test/generated/output/query/enum_output.dart
+++ b/shared_aws_api/test/generated/output/query/enum_output.dart
@@ -91,7 +91,7 @@ enum EC2EnumType {
   bar,
 }
 
-extension on EC2EnumType {
+extension EC2EnumTypeValue on EC2EnumType {
   String toValue() {
     switch (this) {
       case EC2EnumType.foo:
@@ -102,7 +102,7 @@ extension on EC2EnumType {
   }
 }
 
-extension on String {
+extension EC2EnumTypeFromString on String {
   EC2EnumType toEC2EnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/output/query/enum_output.dart
+++ b/shared_aws_api/test/generated/output/query/enum_output.dart
@@ -91,7 +91,7 @@ enum EC2EnumType {
   bar,
 }
 
-extension EC2EnumTypeValue on EC2EnumType {
+extension EC2EnumTypeValueExtension on EC2EnumType {
   String toValue() {
     switch (this) {
       case EC2EnumType.foo:

--- a/shared_aws_api/test/generated/output/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-json/enum.dart
@@ -110,7 +110,7 @@ enum RESTJSONEnumType {
   $1,
 }
 
-extension RESTJSONEnumTypeValue on RESTJSONEnumType {
+extension RESTJSONEnumTypeValueExtension on RESTJSONEnumType {
   String toValue() {
     switch (this) {
       case RESTJSONEnumType.foo:

--- a/shared_aws_api/test/generated/output/rest-json/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-json/enum.dart
@@ -110,7 +110,7 @@ enum RESTJSONEnumType {
   $1,
 }
 
-extension on RESTJSONEnumType {
+extension RESTJSONEnumTypeValue on RESTJSONEnumType {
   String toValue() {
     switch (this) {
       case RESTJSONEnumType.foo:
@@ -127,7 +127,7 @@ extension on RESTJSONEnumType {
   }
 }
 
-extension on String {
+extension RESTJSONEnumTypeFromString on String {
   RESTJSONEnumType toRESTJSONEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/output/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/enum.dart
@@ -129,7 +129,7 @@ enum RESTJSONEnumType {
   $1,
 }
 
-extension RESTJSONEnumTypeValue on RESTJSONEnumType {
+extension RESTJSONEnumTypeValueExtension on RESTJSONEnumType {
   String toValue() {
     switch (this) {
       case RESTJSONEnumType.foo:

--- a/shared_aws_api/test/generated/output/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/enum.dart
@@ -129,7 +129,7 @@ enum RESTJSONEnumType {
   $1,
 }
 
-extension on RESTJSONEnumType {
+extension RESTJSONEnumTypeValue on RESTJSONEnumType {
   String toValue() {
     switch (this) {
       case RESTJSONEnumType.foo:
@@ -146,7 +146,7 @@ extension on RESTJSONEnumType {
   }
 }
 
-extension on String {
+extension RESTJSONEnumTypeFromString on String {
   RESTJSONEnumType toRESTJSONEnumType() {
     switch (this) {
       case 'foo':

--- a/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
@@ -108,7 +108,7 @@ enum ItemType {
   type3,
 }
 
-extension on ItemType {
+extension ItemTypeValue on ItemType {
   String toValue() {
     switch (this) {
       case ItemType.type1:
@@ -121,7 +121,7 @@ extension on ItemType {
   }
 }
 
-extension on String {
+extension ItemTypeFromString on String {
   ItemType toItemType() {
     switch (this) {
       case 'Type1':

--- a/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
+++ b/shared_aws_api/test/generated/output/rest-xml/xml_attributes.dart
@@ -108,7 +108,7 @@ enum ItemType {
   type3,
 }
 
-extension ItemTypeValue on ItemType {
+extension ItemTypeValueExtension on ItemType {
   String toValue() {
     switch (this) {
       case ItemType.type1:


### PR DESCRIPTION
Fixes following things:

### In Shared API 

- The `extractXmlChild()` returns the element itself if the name of the element matches with the name given as parameter.

Without it, the calls such as [GetBucketLocation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLocation.html) fail as they have the root element as their output:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">eu-central-1</LocationConstraint>
```         

### In generator

- The dart extensions are named so that they are publicly visible as well. Without it, the `toValue()` and `toSomeEnum()` on the String do not work.
- The `isdevMode` in package manifest building simply adds the `shared_aws_api` as path directly to the `dependencies` as well as `dependency_overrides`. This is done because when depending on some specific package (such as `aws_s3_api`) from an app, by pointing to the local copy of this package still fetches the `shared_aws_api` from the dart package registry even if the `dependency_overrides` stanza is present.

All generated packages are regenerated after the above changes.

FYI @isoos happy to make adjustments.