### PR TITLE
Modify to specify endpoint value in constructor for endpoint custom

### DIFF
--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -32,6 +32,7 @@ class AutoScaling {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -40,6 +41,7 @@ class AutoScaling {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -35,6 +35,7 @@ class CloudFormation {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -43,6 +44,7 @@ class CloudFormation {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -32,6 +32,7 @@ class CloudSearch {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -40,6 +41,7 @@ class CloudSearch {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -32,6 +32,7 @@ class CloudSearch {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -40,6 +41,7 @@ class CloudSearch {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -44,6 +44,7 @@ class CloudWatch {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -52,6 +53,7 @@ class CloudWatch {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -29,6 +29,7 @@ class DocDB {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -38,6 +39,7 @@ class DocDB {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -30,6 +30,7 @@ class ElastiCache {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -38,6 +39,7 @@ class ElastiCache {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -31,6 +31,7 @@ class ElasticBeanstalk {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -39,6 +40,7 @@ class ElasticBeanstalk {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
+++ b/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
@@ -36,6 +36,7 @@ class ElasticLoadBalancing {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -44,6 +45,7 @@ class ElasticLoadBalancing {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -38,6 +38,7 @@ class ElasticLoadBalancingv2 {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -46,6 +47,7 @@ class ElasticLoadBalancingv2 {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -36,6 +36,7 @@ class IAM {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -44,6 +45,7 @@ class IAM {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -34,6 +34,7 @@ class ImportExport {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -42,6 +43,7 @@ class ImportExport {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -39,6 +39,7 @@ class Neptune {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -48,6 +49,7 @@ class Neptune {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -28,6 +28,7 @@ class RDS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -36,6 +37,7 @@ class RDS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -28,6 +28,7 @@ class RDS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -36,6 +37,7 @@ class RDS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -28,6 +28,7 @@ class RDS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -36,6 +37,7 @@ class RDS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -28,6 +28,7 @@ class RDS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -36,6 +37,7 @@ class RDS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -34,6 +34,7 @@ class RDS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -42,6 +43,7 @@ class RDS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -39,6 +39,7 @@ class Redshift {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -47,6 +48,7 @@ class Redshift {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
+++ b/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
@@ -45,6 +45,7 @@ class SimpleDB {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -53,6 +54,7 @@ class SimpleDB {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -41,6 +41,7 @@ class SES {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -50,6 +51,7 @@ class SES {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sns_api/lib/sns-2010-03-31.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.dart
@@ -37,6 +37,7 @@ class SNS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -45,6 +46,7 @@ class SNS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -97,6 +97,7 @@ class SQS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -105,6 +106,7 @@ class SQS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generated/aws_sts_api/lib/sts-2011-06-15.dart
+++ b/generated/aws_sts_api/lib/sts-2011-06-15.dart
@@ -35,6 +35,7 @@ class STS {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -43,6 +44,7 @@ class STS {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/generator/lib/builders/protocols/query_builder.dart
+++ b/generator/lib/builders/protocols/query_builder.dart
@@ -20,7 +20,7 @@ class QueryServiceBuilder extends ServiceBuilder {
     ${isRegionRequired ? 'required String' : 'String?'} region,
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
-    _s.Client? client,
+    _s.Client? client, String? endpointUrl,
     })
   : _protocol = _s.QueryProtocol(
       client: client,
@@ -28,6 +28,7 @@ class QueryServiceBuilder extends ServiceBuilder {
       region: region,
       credentials: credentials,
       credentialsProvider: credentialsProvider,
+      endpointUrl: endpointUrl,
     ),
   shapes = shapesJson.map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));
   ''';

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs.dart
@@ -29,6 +29,7 @@ class Base64EncodedBlobs {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class Base64EncodedBlobs {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
+++ b/shared_aws_api/test/generated/input/query/base64_encoded_blobs_nested.dart
@@ -29,6 +29,7 @@ class Base64EncodedBlobsNested {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class Base64EncodedBlobsNested {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
+++ b/shared_aws_api/test/generated/input/query/endpoint_host_trait.dart
@@ -29,6 +29,7 @@ class EndpointHostTrait {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class EndpointHostTrait {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/enum.dart
+++ b/shared_aws_api/test/generated/input/query/enum.dart
@@ -29,6 +29,7 @@ class Enum {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class Enum {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list.dart
@@ -29,6 +29,7 @@ class FlattenedList {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedList {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/flattened_list_with_locationname.dart
@@ -29,6 +29,7 @@ class FlattenedListWithLocationName {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedListWithLocationName {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
+++ b/shared_aws_api/test/generated/input/query/idempotency_token_auto_fill.dart
@@ -29,6 +29,7 @@ class IdempotencyTokenAutoFill {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class IdempotencyTokenAutoFill {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/list_types.dart
+++ b/shared_aws_api/test/generated/input/query/list_types.dart
@@ -29,6 +29,7 @@ class ListTypes {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class ListTypes {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/nested_structure_members.dart
+++ b/shared_aws_api/test/generated/input/query/nested_structure_members.dart
@@ -29,6 +29,7 @@ class NestedStructureMembers {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class NestedStructureMembers {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/non_flattened_list_with_locationname.dart
@@ -29,6 +29,7 @@ class NonFlattenedListWithLocationName {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class NonFlattenedListWithLocationName {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/recursive_shapes.dart
+++ b/shared_aws_api/test/generated/input/query/recursive_shapes.dart
@@ -29,6 +29,7 @@ class RecursiveShapes {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class RecursiveShapes {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/input/query/scalar_members.dart
@@ -29,6 +29,7 @@ class ScalarMembers {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class ScalarMembers {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_flattened_map_type.dart
@@ -29,6 +29,7 @@ class SerializeFlattenedMapType {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class SerializeFlattenedMapType {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_map_type.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type.dart
@@ -29,6 +29,7 @@ class SerializeMapType {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class SerializeMapType {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
+++ b/shared_aws_api/test/generated/input/query/serialize_map_type_with_locationname.dart
@@ -29,6 +29,7 @@ class SerializeMapTypeWithLocationName {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class SerializeMapTypeWithLocationName {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/input/query/timestamp_values.dart
+++ b/shared_aws_api/test/generated/input/query/timestamp_values.dart
@@ -29,6 +29,7 @@ class TimestampValues {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class TimestampValues {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/blob.dart
+++ b/shared_aws_api/test/generated/output/query/blob.dart
@@ -29,6 +29,7 @@ class Blob {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class Blob {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/empty_string.dart
+++ b/shared_aws_api/test/generated/output/query/empty_string.dart
@@ -29,6 +29,7 @@ class EmptyString {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class EmptyString {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/enum_output.dart
+++ b/shared_aws_api/test/generated/output/query/enum_output.dart
@@ -29,6 +29,7 @@ class EnumOutput {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class EnumOutput {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list.dart
@@ -29,6 +29,7 @@ class FlattenedList {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedList {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_of_structures.dart
@@ -29,6 +29,7 @@ class FlattenedListOfStructures {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedListOfStructures {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_list_with_location_name.dart
@@ -29,6 +29,7 @@ class FlattenedListWithLocationName {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedListWithLocationName {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_map.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map.dart
@@ -29,6 +29,7 @@ class FlattenedMap {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedMap {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_map_in_shape_definition.dart
@@ -29,6 +29,7 @@ class FlattenedMapInShapeDefinition {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedMapInShapeDefinition {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
+++ b/shared_aws_api/test/generated/output/query/flattened_single_element_list.dart
@@ -29,6 +29,7 @@ class FlattenedSingleElementList {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class FlattenedSingleElementList {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/list_of_structures.dart
+++ b/shared_aws_api/test/generated/output/query/list_of_structures.dart
@@ -29,6 +29,7 @@ class ListOfStructures {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class ListOfStructures {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
+++ b/shared_aws_api/test/generated/output/query/list_with_custom_member_name.dart
@@ -29,6 +29,7 @@ class ListWithCustomMemberName {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class ListWithCustomMemberName {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/lists.dart
+++ b/shared_aws_api/test/generated/output/query/lists.dart
@@ -29,6 +29,7 @@ class Lists {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class Lists {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/named_map.dart
+++ b/shared_aws_api/test/generated/output/query/named_map.dart
@@ -29,6 +29,7 @@ class NamedMap {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class NamedMap {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/normal_map.dart
+++ b/shared_aws_api/test/generated/output/query/normal_map.dart
@@ -29,6 +29,7 @@ class NormalMap {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class NormalMap {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
+++ b/shared_aws_api/test/generated/output/query/not_all_members_in_response.dart
@@ -29,6 +29,7 @@ class NotAllMembersInResponse {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class NotAllMembersInResponse {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/scalar_members.dart
+++ b/shared_aws_api/test/generated/output/query/scalar_members.dart
@@ -29,6 +29,7 @@ class ScalarMembers {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class ScalarMembers {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));

--- a/shared_aws_api/test/generated/output/query/timestamp_members.dart
+++ b/shared_aws_api/test/generated/output/query/timestamp_members.dart
@@ -29,6 +29,7 @@ class TimestampMembers {
     _s.AwsClientCredentials? credentials,
     _s.AwsClientCredentialsProvider? credentialsProvider,
     _s.Client? client,
+    String? endpointUrl,
   })  : _protocol = _s.QueryProtocol(
           client: client,
           service: _s.ServiceMetadata(
@@ -37,6 +38,7 @@ class TimestampMembers {
           region: region,
           credentials: credentials,
           credentialsProvider: credentialsProvider,
+          endpointUrl: endpointUrl,
         ),
         shapes = shapesJson
             .map((key, value) => MapEntry(key, _s.Shape.fromJson(value)));


### PR DESCRIPTION
hi, I am using it to personally create and use a dashboard for localstack.

While implementing `SQS`, it was not possible to specify and use `endpointUrl`, so the corresponding part was modified.

