### PR TITLE
Include x-amz-security-token in set of signed headers

### DIFF
--- a/shared_aws_api/lib/src/protocol/_sign.dart
+++ b/shared_aws_api/lib/src/protocol/_sign.dart
@@ -18,6 +18,9 @@ void signAws4HmacSha256({
   rq.headers['Host'] = rq.url.host;
   rq.headers['x-amz-content-sha256'] ??=
       sha256.convert(rq.bodyBytes).toString();
+  if (credentials.sessionToken != null) {
+    rq.headers['X-Amz-Security-Token'] = credentials.sessionToken!;
+  }
 
   // sorted list of key:value header entries
   final canonicalHeaders = rq.headers.keys
@@ -61,9 +64,6 @@ void signAws4HmacSha256({
   });
   final signature =
       Hmac(sha256, signingKey).convert(utf8.encode(toSign)).toString();
-  if (credentials.sessionToken != null) {
-    rq.headers['X-Amz-Security-Token'] = credentials.sessionToken!;
-  }
 
   final auth = '$_aws4HmacSha256 '
       'Credential=${credentials.accessKey}/${credentialList.join('/')}, '


### PR DESCRIPTION
When sending a request using this signing scheme from ECS tasks on fargate, I get the following response:

```xml
<Error><Code>AccessDenied</Code><Message>There were headers present in the request which were not signed</Message><HeadersNotSigned>x-amz-security-token</HeadersNotSigned>
```

Moving the addition of the `X-Amz-Security-Token` header before the canonicalization of headers resolved this error for me.