### PR TITLE
more expressive exception

### DIFF
--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -99,7 +99,7 @@ class RestXmlProtocol {
         final message = elem.findElements('Message').first.text;
         throw GenericAwsException(code: code, message: message);
       } else {
-        throw AmazonServiceException(request: rq, response: rs, body: body);
+        throwException(rs, body, exceptionFnMap);
       }
     }
     return rs;

--- a/shared_aws_api/lib/src/protocol/rest-xml.dart
+++ b/shared_aws_api/lib/src/protocol/rest-xml.dart
@@ -99,7 +99,7 @@ class RestXmlProtocol {
         final message = elem.findElements('Message').first.text;
         throw GenericAwsException(code: code, message: message);
       } else {
-        throw Exception('$body');
+        throw AmazonServiceException(request: rq, response: rs, body: body);
       }
     }
     return rs;

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -76,20 +76,6 @@ class GenericAwsException implements AwsException {
       };
 }
 
-class AmazonServiceException implements AwsException {
-  // refer to https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonServiceException.java
-  final Request? request;
-  final BaseResponse? response;
-  final String? body;
-
-  AmazonServiceException({this.request, this.response, this.body});
-
-  int? get statusCode => response?.statusCode;
-
-  @override
-  String toString() => 'AWS request failed with status $statusCode';
-}
-
 typedef AwsExceptionFn = AwsException Function(String type, String message);
 
 XmlElement? extractXmlChild(XmlElement elem, String name) {

--- a/shared_aws_api/lib/src/protocol/shared.dart
+++ b/shared_aws_api/lib/src/protocol/shared.dart
@@ -76,6 +76,20 @@ class GenericAwsException implements AwsException {
       };
 }
 
+class AmazonServiceException implements AwsException {
+  // refer to https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonServiceException.java
+  final Request? request;
+  final BaseResponse? response;
+  final String? body;
+
+  AmazonServiceException({this.request, this.response, this.body});
+
+  int? get statusCode => response?.statusCode;
+
+  @override
+  String toString() => 'AWS request failed with status $statusCode';
+}
+
 typedef AwsExceptionFn = AwsException Function(String type, String message);
 
 XmlElement? extractXmlChild(XmlElement elem, String name) {

--- a/shared_aws_api/test/protocol/json_test.dart
+++ b/shared_aws_api/test/protocol/json_test.dart
@@ -1,0 +1,33 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/protocol/endpoint.dart';
+import 'package:shared_aws_api/src/protocol/json.dart';
+import 'package:shared_aws_api/src/protocol/shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('JsonProtocol.sendRaw', () {
+    test('throws an exception with a status code upon request failure status',
+        () async {
+      final client = MockClient((request) async {
+        return Response('', 500);
+      });
+      final protocol = JsonProtocol(
+        client: client,
+        endpointUrl: 'endpointUrl',
+        service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
+        region: 'us-west-2',
+      );
+      GenericAwsException? theError;
+      try {
+        await protocol
+            .send(method: 'POST', requestUri: 'requestUri', exceptionFnMap: {});
+      } catch (error) {
+        theError = error as GenericAwsException;
+      }
+      expect(theError!.code, '500');
+      expect(theError!.type, 'UnknownError');
+      expect(theError!.message, '500');
+    });
+  });
+}

--- a/shared_aws_api/test/protocol/json_test.dart
+++ b/shared_aws_api/test/protocol/json_test.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/credentials.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
 import 'package:shared_aws_api/src/protocol/json.dart';
 import 'package:shared_aws_api/src/protocol/shared.dart';
@@ -17,6 +18,7 @@ void main() {
         endpointUrl: 'endpointUrl',
         service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
         region: 'us-west-2',
+        credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
       );
       GenericAwsException? theError;
       try {

--- a/shared_aws_api/test/protocol/json_test.dart
+++ b/shared_aws_api/test/protocol/json_test.dart
@@ -23,6 +23,7 @@ void main() {
         await protocol
             .send(method: 'POST', requestUri: 'requestUri', exceptionFnMap: {});
       } catch (error) {
+        expect(error.toString(), '500 UnknownError: 500');
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');

--- a/shared_aws_api/test/protocol/json_test.dart
+++ b/shared_aws_api/test/protocol/json_test.dart
@@ -26,8 +26,8 @@ void main() {
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');
-      expect(theError!.type, 'UnknownError');
-      expect(theError!.message, '500');
+      expect(theError.type, 'UnknownError');
+      expect(theError.message, '500');
     });
   });
 }

--- a/shared_aws_api/test/protocol/query_test.dart
+++ b/shared_aws_api/test/protocol/query_test.dart
@@ -1,0 +1,37 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/protocol/endpoint.dart';
+import 'package:shared_aws_api/src/protocol/query.dart';
+import 'package:shared_aws_api/src/protocol/shared.dart';
+import 'package:test/test.dart';
+import 'package:xml/xml.dart';
+
+void main() {
+  group('QueryProtocol.sendRaw', () {
+    test('throws an exception with a status code upon request failure status',
+        () async {
+      final client = MockClient((request) async {
+        return Response('', 500);
+      });
+      final protocol = QueryProtocol(
+        client: client,
+        endpointUrl: 'endpointUrl',
+        service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
+        region: 'us-west-2',
+      );
+      Object? theError;
+      try {
+        await protocol.send({},
+            action: 'action',
+            version: 'version',
+            shapes: {},
+            method: 'POST',
+            requestUri: 'requestUri',
+            exceptionFnMap: {});
+      } catch (error) {
+        theError = error;
+      }
+      expect(theError, isA<XmlParserException>());
+    });
+  });
+}

--- a/shared_aws_api/test/protocol/query_test.dart
+++ b/shared_aws_api/test/protocol/query_test.dart
@@ -2,7 +2,6 @@ import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
 import 'package:shared_aws_api/src/protocol/query.dart';
-import 'package:shared_aws_api/src/protocol/shared.dart';
 import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 

--- a/shared_aws_api/test/protocol/query_test.dart
+++ b/shared_aws_api/test/protocol/query_test.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/credentials.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
 import 'package:shared_aws_api/src/protocol/query.dart';
 import 'package:test/test.dart';
@@ -17,6 +18,7 @@ void main() {
         endpointUrl: 'endpointUrl',
         service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
         region: 'us-west-2',
+        credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
       );
       Object? theError;
       try {

--- a/shared_aws_api/test/protocol/query_test.dart
+++ b/shared_aws_api/test/protocol/query_test.dart
@@ -28,6 +28,7 @@ void main() {
             requestUri: 'requestUri',
             exceptionFnMap: {});
       } catch (error) {
+        expect(error.toString(), 'XmlParserException: "<" expected at 1:1');
         theError = error;
       }
       expect(theError, isA<XmlParserException>());

--- a/shared_aws_api/test/protocol/rest-json_test.dart
+++ b/shared_aws_api/test/protocol/rest-json_test.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/credentials.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
 import 'package:shared_aws_api/src/protocol/rest-json.dart';
 import 'package:shared_aws_api/src/protocol/shared.dart';
@@ -17,6 +18,7 @@ void main() {
         endpointUrl: 'endpointUrl',
         service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
         region: 'us-west-2',
+        credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
       );
       GenericAwsException? theError;
       try {

--- a/shared_aws_api/test/protocol/rest-json_test.dart
+++ b/shared_aws_api/test/protocol/rest-json_test.dart
@@ -23,6 +23,7 @@ void main() {
         await protocol.sendRaw(
             method: 'POST', requestUri: 'requestUri', exceptionFnMap: {});
       } catch (error) {
+        expect(error.toString(), '500 UnknownError: 500');
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');

--- a/shared_aws_api/test/protocol/rest-json_test.dart
+++ b/shared_aws_api/test/protocol/rest-json_test.dart
@@ -1,18 +1,18 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
-import 'package:shared_aws_api/src/protocol/rest-xml.dart';
+import 'package:shared_aws_api/src/protocol/rest-json.dart';
 import 'package:shared_aws_api/src/protocol/shared.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('RestXmlProtocol.sendRaw', () {
+  group('RestJsonProtocol.sendRaw', () {
     test('throws an exception with a status code upon request failure status',
         () async {
       final client = MockClient((request) async {
         return Response('', 500);
       });
-      final protocol = RestXmlProtocol(
+      final protocol = RestJsonProtocol(
         client: client,
         endpointUrl: 'endpointUrl',
         service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),

--- a/shared_aws_api/test/protocol/rest-json_test.dart
+++ b/shared_aws_api/test/protocol/rest-json_test.dart
@@ -26,8 +26,8 @@ void main() {
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');
-      expect(theError!.type, 'UnknownError');
-      expect(theError!.message, '500');
+      expect(theError.type, 'UnknownError');
+      expect(theError.message, '500');
     });
   });
 }

--- a/shared_aws_api/test/protocol/rest-xml_test.dart
+++ b/shared_aws_api/test/protocol/rest-xml_test.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/credentials.dart';
 import 'package:shared_aws_api/src/protocol/endpoint.dart';
 import 'package:shared_aws_api/src/protocol/rest-xml.dart';
 import 'package:shared_aws_api/src/protocol/shared.dart';
@@ -17,6 +18,7 @@ void main() {
         endpointUrl: 'endpointUrl',
         service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
         region: 'us-west-2',
+        credentials: AwsClientCredentials(accessKey: '', secretKey: ''),
       );
       GenericAwsException? theError;
       try {

--- a/shared_aws_api/test/protocol/rest-xml_test.dart
+++ b/shared_aws_api/test/protocol/rest-xml_test.dart
@@ -23,6 +23,7 @@ void main() {
         await protocol.sendRaw(
             method: 'POST', requestUri: 'requestUri', exceptionFnMap: {});
       } catch (error) {
+        expect(error.toString(), '500 UnknownError: 500');
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');

--- a/shared_aws_api/test/protocol/rest-xml_test.dart
+++ b/shared_aws_api/test/protocol/rest-xml_test.dart
@@ -1,0 +1,32 @@
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:shared_aws_api/src/protocol/endpoint.dart';
+import 'package:shared_aws_api/src/protocol/rest-xml.dart';
+import 'package:shared_aws_api/src/protocol/shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RestXmlProtocol.sendRaw', () {
+    test('throws an exception with a status code upon request failure status',
+        () async {
+      final client = MockClient((request) async {
+        return Response('', 500);
+      });
+      final protocol = RestXmlProtocol(
+        client: client,
+        endpointUrl: 'endpointUrl',
+        service: ServiceMetadata(endpointPrefix: 'endpointPrefix'),
+        region: 'us-west-2',
+      );
+      Object? theError;
+      try {
+        await protocol.sendRaw(
+            method: 'POST', requestUri: 'requestUri', exceptionFnMap: {});
+      } catch (error) {
+        theError = error;
+      }
+      expect(theError, isA<AmazonServiceException>());
+      expect((theError as AmazonServiceException).statusCode, 500);
+    });
+  });
+}

--- a/shared_aws_api/test/protocol/rest-xml_test.dart
+++ b/shared_aws_api/test/protocol/rest-xml_test.dart
@@ -26,8 +26,8 @@ void main() {
         theError = error as GenericAwsException;
       }
       expect(theError!.code, '500');
-      expect(theError!.type, 'UnknownError');
-      expect(theError!.message, '500');
+      expect(theError.type, 'UnknownError');
+      expect(theError.message, '500');
     });
   });
 }


### PR DESCRIPTION
Introduces `AmazonServiceException` as a more expressive exception for determining, in  particular, the `statusCode` of a failed request.

Addresses #366 

<details>
  <summary>dart format and test</summary>
  
```
shared_aws_api$ dart format .        
Formatted 314 files (0 changed) in 1.16 seconds.
shared_aws_api$ dart test -r expanded
00:00 +0: test/generated/input/rest-xml/flattened_lists_test.dart: Flattened lists 0
00:00 +1: test/generated/input/rest-xml/recursive_shapes_test.dart: Recursive shapes 0
00:00 +2: test/generated/input/rest-xml/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:00 +3: test/generated/input/rest-xml/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:00 +4: test/generated/input/rest-xml/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:00 +5: test/generated/input/rest-xml/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:00 +6: test/generated/input/rest-xml/list_of_structures_test.dart: List of structures 0
00:00 +7: test/generated/input/rest-xml/list_of_structures_test.dart: List of structures 0
00:00 +8: test/generated/input/rest-xml/list_of_structures_test.dart: List of structures 0
00:00 +9: test/generated/input/rest-xml/greedy_keys_test.dart: Greedy keys 0
00:00 +10: test/generated/input/rest-xml/basic_xml_serialization_test.dart: Basic XML serialization 0
00:00 +11: test/generated/input/rest-xml/timestamp_shapes_test.dart: Timestamp shapes 0
00:00 +12: test/generated/input/rest-xml/timestamp_shapes_test.dart: Timestamp shapes 0
00:00 +13: test/generated/input/rest-xml/timestamp_shapes_test.dart: Timestamp shapes 0
00:00 +14: test/generated/input/rest-xml/timestamp_shapes_test.dart: Timestamp shapes 0
00:01 +15: test/generated/input/rest-xml/header_maps_test.dart: Header maps 0
00:01 +16: test/generated/input/rest-xml/structure_payload_test.dart: Structure payload 0
00:01 +17: test/generated/input/rest-xml/endpoint_host_trait_test.dart: Endpoint host trait 0
00:01 +18: test/generated/input/rest-xml/endpoint_host_trait_test.dart: Endpoint host trait 0
00:01 +19: test/generated/input/rest-xml/endpoint_host_trait_test.dart: Endpoint host trait 0
00:01 +20: test/generated/input/rest-xml/endpoint_host_trait_test.dart: Endpoint host trait 0
00:01 +21: test/generated/input/rest-xml/string_payload_test.dart: String payload 0
00:01 +22: test/generated/input/rest-xml/string_payload_test.dart: String payload 0
00:01 +23: test/generated/input/rest-xml/blob_payload_test.dart: Blob payload 0
00:01 +24: test/generated/input/rest-xml/flattened_lists_with_locationname_test.dart: Flattened lists with locationName 0
00:01 +25: test/generated/input/rest-xml/flattened_lists_with_locationname_test.dart: Flattened lists with locationName 0
00:02 +26: test/generated/input/rest-xml/xml_attribute_test.dart: XML Attribute 0
00:02 +27: test/generated/input/rest-xml/blob_shapes_test.dart: Blob shapes 0
00:02 +28: test/generated/input/rest-xml/idempotency_token_auto_fill_test.dart: Idempotency token auto fill 0
00:02 +29: test/generated/input/rest-xml/serialize_other_scalar_types_test.dart: Serialize other scalar types 0
00:02 +30: test/generated/input/rest-xml/serialize_other_scalar_types_test.dart: Serialize other scalar types 0
00:02 +31: test/generated/input/rest-xml/string_to_string_list_maps_in_querystring_test.dart: String to string list maps in querystring 0
00:02 +32: test/generated/input/rest-xml/non_flattened_lists_test.dart: Non flattened lists 0
00:02 +33: test/generated/input/rest-xml/non_flattened_lists_with_locationname_test.dart: Non flattened lists with locationName 0
00:03 +34: test/generated/input/rest-xml/enum_test.dart: Enum 0
00:03 +35: test/generated/input/rest-xml/omits_null_query_params_but_serializes_empty_strings_test.dart: Omits null query params, but serializes empty strings 0
00:03 +36: test/generated/input/rest-xml/omits_null_query_params_but_serializes_empty_strings_test.dart: Omits null query params, but serializes empty strings 0
00:03 +37: test/generated/input/rest-xml/nested_structures_test.dart: Nested structures 0
00:03 +38: test/generated/input/rest-xml/nested_structures_test.dart: Nested structures 0
00:03 +39: test/generated/input/rest-xml/boolean_in_querystring_test.dart: Boolean in querystring 0
00:03 +40: test/generated/input/json/scalar_members_test.dart: Scalar members 0
00:03 +41: test/generated/input/json/scalar_members_test.dart: Scalar members 0
00:03 +42: test/generated/input/json/timestamp_values_test.dart: Timestamp values 0
00:03 +43: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 0
00:03 +44: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 1
00:03 +45: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 2
00:03 +46: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 3
00:03 +47: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 4
00:03 +48: test/generated/input/json/recursive_shapes_test.dart: Recursive shapes 5
00:03 +49: test/generated/input/json/nested_blobs_test.dart: Nested blobs 0
00:04 +50: test/generated/input/json/idempotency_token_auto_fill_test.dart: Idempotency token auto fill 0
00:04 +51: test/generated/input/json/empty_maps_test.dart: Empty maps 0
00:04 +52: test/generated/input/json/empty_maps_test.dart: Empty maps 0
00:04 +53: test/generated/input/json/endpoint_host_trait_static_prefix_test.dart: Endpoint host trait static prefix 0
00:04 +54: test/generated/input/json/endpoint_host_trait_static_prefix_test.dart: Endpoint host trait static prefix 1
00:04 +55: test/generated/input/json/enum_test.dart: Enum 0
00:04 +56: test/generated/input/json/base64_encoded_blobs_test.dart: Base64 encoded Blobs 0
00:04 +57: test/generated/input/json/base64_encoded_blobs_test.dart: Base64 encoded Blobs 0
00:04 +58: test/generated/input/rest-json/streaming_payload_test.dart: Streaming payload 0
00:04 +59: test/generated/input/rest-json/streaming_payload_test.dart: Streaming payload 0
00:04 +60: test/generated/input/rest-json/uri_parameter_only_with_location_name_test.dart: URI parameter only with location name 0
00:04 +61: test/generated/input/rest-json/timestamp_values_test.dart: Timestamp values 0
00:05 +62: test/generated/input/rest-json/recursive_shapes_test.dart: Recursive shapes 0
00:05 +63: test/generated/input/rest-json/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:05 +64: test/generated/input/rest-json/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:05 +65: test/generated/input/rest-json/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:05 +66: test/generated/input/rest-json/string_to_string_maps_in_querystring_test.dart: String to string maps in querystring 0
00:05 +67: test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body_test.dart: URI parameter, querystring params, headers and JSON body 0
00:05 +68: test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body_test.dart: URI parameter, querystring params, headers and JSON body 0
00:05 +69: test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body_test.dart: URI parameter, querystring params, headers and JSON body 0
00:05 +70: test/generated/input/rest-json/querystring_list_of_strings_test.dart: Querystring list of strings 0
00:05 +71: test/generated/input/rest-json/json_value_trait_test.dart: JSON value trait 0
00:05 +72: test/generated/input/rest-json/uri_parameter_and_querystring_params_test.dart: URI parameter and querystring params 0
00:05 +73: test/generated/input/rest-json/structure_payload_test.dart: Structure payload 0
00:05 +74: test/generated/input/rest-json/structure_payload_test.dart: Structure payload 0
00:05 +75: test/generated/input/rest-json/structure_payload_test.dart: Structure payload 0
00:05 +76: test/generated/input/rest-json/structure_payload_test.dart: Structure payload 1
00:05 +77: test/generated/input/rest-json/endpoint_host_trait_test.dart: Endpoint host trait 0
00:06 +78: test/generated/input/rest-json/no_parameters_test.dart: No parameters 0
00:06 +79: test/generated/input/rest-json/no_parameters_test.dart: No parameters 0
00:06 +80: test/generated/input/rest-json/string_payload_test.dart: String payload 0
00:06 +81: test/generated/input/rest-json/blob_payload_test.dart: Blob payload 0
00:06 +82: test/generated/input/rest-json/blob_payload_test.dart: Blob payload 1
00:06 +83: test/generated/input/rest-json/uri_parameter_only_with_no_location_name_test.dart: URI parameter only with no location name 0
00:06 +84: test/generated/input/rest-json/idempotency_token_auto_fill_test.dart: Idempotency token auto fill 0
00:06 +85: test/generated/input/rest-json/string_to_string_list_maps_in_querystring_test.dart: String to string list maps in querystring 0
00:06 +86: test/generated/input/rest-json/string_to_string_list_maps_in_querystring_test.dart: String to string list maps in querystring 0
00:06 +87: test/generated/input/rest-json/enum_test.dart: Enum 0
00:06 +88: test/generated/input/rest-json/enum_test.dart: Enum 1
00:06 +89: test/generated/input/rest-json/omits_null_query_params_but_serializes_empty_strings_test.dart: Omits null query params, but serializes empty strings 0
00:07 +90: test/generated/input/rest-json/serialize_blobs_in_body_test.dart: Serialize blobs in body 0
00:07 +91: test/generated/input/rest-json/serialize_blobs_in_body_test.dart: Serialize blobs in body 0
00:07 +92: test/generated/input/rest-json/uri_parameter_querystring_params_and_json_body_test.dart: URI parameter, querystring params and JSON body 0
00:07 +93: test/generated/input/rest-json/named_locations_in_json_body_test.dart: Named locations in JSON body 0
00:07 +94: test/generated/input/rest-json/boolean_in_querystring_test.dart: Boolean in querystring 0
00:07 +95: test/generated/input/query/scalar_members_test.dart: Scalar members 0
00:07 +96: test/generated/input/query/scalar_members_test.dart: Scalar members 0
00:07 +97: test/generated/input/query/serialize_flattened_map_type_test.dart: Serialize flattened map type 0
00:07 +98: test/generated/input/query/serialize_flattened_map_type_test.dart: Serialize flattened map type 0
00:07 +99: test/generated/input/query/serialize_flattened_map_type_test.dart: Serialize flattened map type 0
00:08 +100: test/generated/input/query/timestamp_values_test.dart: Timestamp values 0
00:08 +101: test/generated/input/query/recursive_shapes_test.dart: Recursive shapes 0
00:08 +102: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +103: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +104: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +105: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +106: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +107: test/generated/input/query/serialize_map_type_with_locationname_test.dart: Serialize map type with locationName 0
00:08 +108: test/generated/input/query/flattened_list_with_locationname_test.dart: Flattened list with LocationName 0
00:08 +109: test/generated/input/query/serialize_map_type_test.dart: Serialize map type 0
00:08 +110: test/generated/input/query/map_with_enum_key_test.dart: Map with enum key 0
00:09 +111: test/generated/input/query/flattened_list_test.dart: Flattened list 0
00:09 +112: test/generated/input/query/endpoint_host_trait_test.dart: Endpoint host trait 0
00:09 +113: test/generated/input/query/endpoint_host_trait_test.dart: Endpoint host trait 0
00:09 +114: test/generated/input/query/idempotency_token_auto_fill_test.dart: Idempotency token auto fill 0
00:09 +115: test/generated/input/query/idempotency_token_auto_fill_test.dart: Idempotency token auto fill 0
00:09 +116: test/generated/input/query/base64_encoded_blobs_nested_test.dart: Base64 encoded Blobs nested 0
00:09 +117: test/generated/input/query/base64_encoded_blobs_nested_test.dart: Base64 encoded Blobs nested 0
00:09 +118: test/generated/input/query/non_flattened_list_with_locationname_test.dart: Non flattened list with LocationName 0
00:09 +119: test/generated/input/query/nested_structure_members_test.dart: Nested structure members 0
00:09 +120: test/generated/input/query/enum_test.dart: Enum 0
00:10 +121: test/generated/input/query/base64_encoded_blobs_test.dart: Base64 encoded Blobs 0
00:10 +122: test/generated/input/query/base64_encoded_blobs_test.dart: Base64 encoded Blobs 0
00:10 +123: test/generated/input/query/base64_encoded_blobs_test.dart: Base64 encoded Blobs 0
00:10 +124: test/generated/input/query/list_types_test.dart: List types 0
00:10 +125: test/generated/input/query/list_types_test.dart: List types 0
00:10 +126: test/generated/output/rest-xml/scalar_members_test.dart: Scalar members 0
00:10 +127: test/generated/output/rest-xml/scalar_members_test.dart: Scalar members 0
00:10 +128: test/generated/output/rest-xml/empty_string_test.dart: Empty string 0
00:10 +129: test/generated/output/rest-xml/empty_string_test.dart: Empty string 0
00:10 +130: test/generated/output/rest-xml/blob_test.dart: Blob 0
00:11 +131: test/generated/output/rest-xml/normal_map_test.dart: Normal map 0
00:11 +132: test/generated/output/rest-xml/flattened_list_test.dart: Flattened List 0
00:11 +133: test/generated/output/rest-xml/xml_attributes_test.dart: XML Attributes 0
00:11 +134: test/generated/output/rest-xml/scalar_members_in_headers_test.dart: Scalar members in headers 0
00:11 +135: test/generated/output/rest-xml/list_with_custom_member_name_test.dart: List with custom member name 0
00:11 +136: test/generated/output/rest-xml/timestamp_members_test.dart: Timestamp members 0
00:12 +137: test/generated/output/rest-xml/named_map_test.dart: Named map 0
00:12 +138: test/generated/output/rest-xml/enum_test.dart: Enum 0
00:12 +139: test/generated/output/rest-xml/lists_test.dart: Lists 0
00:12 +140: test/generated/output/rest-xml/lists_test.dart: Lists 0
00:12 +141: test/generated/output/rest-xml/xml_payload_test.dart: XML payload 0
00:12 +142: test/generated/output/rest-xml/flattened_map_test.dart: Flattened map 0
00:12 +143: test/generated/output/json/scalar_members_test.dart: Scalar members 0
00:12 +144: test/generated/output/json/maps_test.dart: Maps 0
00:13 +145: test/generated/output/json/blob_members_test.dart: Blob members 0
00:13 +146: test/generated/output/json/timestamp_members_test.dart: Timestamp members 0
00:13 +147: test/generated/output/json/timestamp_members_test.dart: Timestamp members 0
00:13 +148: test/generated/output/json/lists_test.dart: Lists 0
00:13 +149: test/generated/output/json/lists_test.dart: Lists 1
00:13 +150: test/generated/output/json/ignores_extra_data_test.dart: Ignores extra data 0
00:13 +151: test/generated/output/rest-json/streaming_payload_test.dart: Streaming payload 0
00:13 +152: test/generated/output/rest-json/scalar_members_test.dart: Scalar members 0
00:13 +153: test/generated/output/rest-json/maps_test.dart: Maps 0
00:14 +154: test/generated/output/rest-json/complex_list_values_test.dart: Complex List Values 0
00:14 +155: test/generated/output/rest-json/json_payload_test.dart: JSON payload 0
00:14 +155: test/generated/output/rest-json/supports_header_maps_test.dart: Supports header maps 0
  Skip: Not supported (and no API actually needs this)
00:14 +155 ~1: test/generated/output/rest-json/json_payload_test.dart: JSON payload 0
00:14 +156 ~1: test/generated/output/rest-json/json_value_trait_test.dart: JSON value trait 0
00:14 +157 ~1: test/generated/output/rest-json/json_value_trait_test.dart: JSON value trait 1
00:14 +158 ~1: test/generated/output/rest-json/lists_with_structure_member_test.dart: Lists with structure member 0
00:14 +159 ~1: test/generated/output/rest-json/blob_members_test.dart: Blob members 0
00:14 +160 ~1: test/generated/output/rest-json/timestamp_members_test.dart: Timestamp members 0
00:15 +161 ~1: test/generated/output/rest-json/timestamp_members_test.dart: Timestamp members 0
00:15 +162 ~1: test/generated/output/rest-json/enum_test.dart: Enum 1
00:15 +163 ~1: test/generated/output/rest-json/lists_test.dart: Lists 0
00:15 +163 ~1: test/generated/output/rest-json/ignores_undefined_output_test.dart: Ignores undefined output 0
  Skip: Not implemented
00:15 +163 ~2: test/generated/output/rest-json/lists_test.dart: Lists 0
00:15 +164 ~2: test/generated/output/rest-json/ignores_extra_data_test.dart: Ignores extra data 0
00:15 +165 ~2: test/generated/output/query/scalar_members_test.dart: Scalar members 0
00:15 +166 ~2: test/generated/output/query/empty_string_test.dart: Empty string 0
00:15 +167 ~2: test/generated/output/query/blob_test.dart: Blob 0
00:16 +168 ~2: test/generated/output/query/normal_map_test.dart: Normal map 0
00:16 +169 ~2: test/generated/output/query/list_of_structures_test.dart: List of structures 0
00:16 +170 ~2: test/generated/output/query/flattened_list_test.dart: Flattened List 0
00:16 +171 ~2: test/generated/output/query/flattened_single_element_list_test.dart: Flattened single element list 0
00:16 +172 ~2: test/generated/output/query/not_all_members_in_response_test.dart: Not all members in response 0
00:16 +173 ~2: test/generated/output/query/flattened_map_in_shape_definition_test.dart: Flattened map in shape definition 0
00:17 +174 ~2: test/generated/output/query/list_with_custom_member_name_test.dart: List with custom member name 0
00:17 +175 ~2: test/generated/output/query/timestamp_members_test.dart: Timestamp members 0
00:17 +176 ~2: test/generated/output/query/named_map_test.dart: Named map 0
00:17 +177 ~2: test/generated/output/query/flattened_list_of_structures_test.dart: Flattened list of structures 0
00:17 +178 ~2: test/generated/output/query/flattened_list_with_location_name_test.dart: Flattened list with location name 0
00:17 +179 ~2: test/generated/output/query/enum_output_test.dart: Enum output 0
00:18 +180 ~2: test/generated/output/query/lists_test.dart: Lists 0
00:18 +181 ~2: test/generated/output/query/flattened_map_test.dart: Flattened map 0
00:18 +182 ~2: test/protocol/rest-xml_test.dart: RestXmlProtocol.sendRaw throws an exception with a status code upon request failure status
00:18 +183 ~2: test/protocol/endpoint_test.dart: Endpoint.fromConfig Create url for service
00:18 +184 ~2: test/protocol/endpoint_test.dart: Endpoint.fromConfig Throw if region is not provided when required
00:18 +185 ~2: test/protocol/endpoint_test.dart: Endpoint.fromConfig Infer signing region for global services
00:18 +186 ~2: test/protocol/endpoint_test.dart: Endpoint.fromConfig Use correct signing region for global services
00:18 +187 ~2: test/protocol/endpoint_test.dart: Endpoint.forProtocol Infer endpoint
00:18 +188 ~2: test/protocol/endpoint_test.dart: Endpoint.forProtocol Custom endpointUrl
00:18 +189 ~2: test/validation/number_validation_test.dart: validate number ranges null name is ok
00:18 +190 ~2: test/validation/number_validation_test.dart: validate number ranges null value is an ArgumentError
00:18 +191 ~2: test/validation/number_validation_test.dart: validate number ranges null min is an ArgumentError
00:18 +192 ~2: test/validation/number_validation_test.dart: validate number ranges null max is an ArgumentError
00:18 +193 ~2: test/validation/number_validation_test.dart: validate number ranges NaN is an ArgumentError
00:18 +194 ~2: test/validation/number_validation_test.dart: validate number ranges +inf is at most a RangeError
00:18 +195 ~2: test/validation/number_validation_test.dart: validate number ranges -inf is at most a RangeError
00:18 +196 ~2: test/validation/string_validation_test.dart: validate patterns null name is ok
  Skip: Pattern validation is inactivated due to faulty regexes in definitions
00:18 +196 ~3: test/validation/string_validation_test.dart: validate patterns null value is an ArgumentError
  Skip: Pattern validation is inactivated due to faulty regexes in definitions
00:18 +196 ~4: test/validation/string_validation_test.dart: validate string length null name is ok
00:18 +197 ~4: test/validation/string_validation_test.dart: validate string length null value is an ArgumentError
00:18 +198 ~4: test/validation/string_validation_test.dart: validate string length null min is an ArgumentError
00:18 +199 ~4: test/validation/string_validation_test.dart: validate string length null max is an ArgumentError
00:18 +200 ~4: All tests passed!
```

</details>
