### PR TITLE
Read `sessionToken` from credentials profile if available

### DIFF
--- a/shared_aws_api/lib/src/credentials/credentials_io.dart
+++ b/shared_aws_api/lib/src/credentials/credentials_io.dart
@@ -69,6 +69,10 @@ class CredentialsUtil {
       return null;
     }
 
-    return AwsClientCredentials(accessKey: accessKey, secretKey: secretKey);
+    return AwsClientCredentials(
+      accessKey: accessKey,
+      secretKey: secretKey,
+      sessionToken: config.get(profile, 'aws_session_token'),
+    );
   }
 }


### PR DESCRIPTION
The credentials helper is ignoring session token which may cause authentication issue in some environment.
This PR tries to read the token if it's configured.