### PR TITLE
Remove client-side String.length validation

### DIFF
--- a/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
+++ b/generated/aws_accessanalyzer_api/lib/accessanalyzer-2019-11-01.dart
@@ -81,15 +81,6 @@ class AccessAnalyzer {
     required String ruleName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'analyzerArn': analyzerArn,
       'ruleName': ruleName,
@@ -136,15 +127,6 @@ class AccessAnalyzer {
     String? clientToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'analyzerName': analyzerName,
       'type': type.toValue(),
@@ -190,23 +172,6 @@ class AccessAnalyzer {
     required String ruleName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filter, 'filter');
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'filter': filter,
       'ruleName': ruleName,
@@ -240,14 +205,6 @@ class AccessAnalyzer {
     required String analyzerName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (clientToken != null) 'clientToken': [clientToken],
     };
@@ -281,22 +238,6 @@ class AccessAnalyzer {
     required String ruleName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (clientToken != null) 'clientToken': [clientToken],
     };
@@ -327,8 +268,6 @@ class AccessAnalyzer {
     required String analyzerArn,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $query = <String, List<String>>{
       'analyzerArn': [analyzerArn],
       'resourceArn': [resourceArn],
@@ -356,14 +295,6 @@ class AccessAnalyzer {
   Future<GetAnalyzerResponse> getAnalyzer({
     required String analyzerName,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -395,22 +326,6 @@ class AccessAnalyzer {
     required String analyzerName,
     required String ruleName,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -438,8 +353,6 @@ class AccessAnalyzer {
     required String analyzerArn,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
-    ArgumentError.checkNotNull(id, 'id');
     final $query = <String, List<String>>{
       'analyzerArn': [analyzerArn],
     };
@@ -479,7 +392,6 @@ class AccessAnalyzer {
     String? nextToken,
     ResourceType? resourceType,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
     final $payload = <String, dynamic>{
       'analyzerArn': analyzerArn,
       if (maxResults != null) 'maxResults': maxResults,
@@ -550,14 +462,6 @@ class AccessAnalyzer {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -606,7 +510,6 @@ class AccessAnalyzer {
     String? nextToken,
     SortCriteria? sort,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
     final $payload = <String, dynamic>{
       'analyzerArn': analyzerArn,
       if (filter != null) 'filter': filter,
@@ -636,7 +539,6 @@ class AccessAnalyzer {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -665,8 +567,6 @@ class AccessAnalyzer {
     required String analyzerArn,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       'analyzerArn': analyzerArn,
       'resourceArn': resourceArn,
@@ -696,8 +596,6 @@ class AccessAnalyzer {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -726,8 +624,6 @@ class AccessAnalyzer {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -766,23 +662,6 @@ class AccessAnalyzer {
     required String ruleName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(analyzerName, 'analyzerName');
-    _s.validateStringLength(
-      'analyzerName',
-      analyzerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filter, 'filter');
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'filter': filter,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -828,8 +707,6 @@ class AccessAnalyzer {
     List<String>? ids,
     String? resourceArn,
   }) async {
-    ArgumentError.checkNotNull(analyzerArn, 'analyzerArn');
-    ArgumentError.checkNotNull(status, 'status');
     final $payload = <String, dynamic>{
       'analyzerArn': analyzerArn,
       'status': status.toValue(),

--- a/generated/aws_acm_api/lib/acm-2015-12-08.dart
+++ b/generated/aws_acm_api/lib/acm-2015-12-08.dart
@@ -91,15 +91,6 @@ class ACM {
     required String certificateArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.AddTagsToCertificate'
@@ -144,14 +135,6 @@ class ACM {
   Future<void> deleteCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.DeleteCertificate'
@@ -185,14 +168,6 @@ class ACM {
   Future<DescribeCertificateResponse> describeCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.DescribeCertificate'
@@ -242,15 +217,6 @@ class ACM {
     required String certificateArn,
     required Uint8List passphrase,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(passphrase, 'passphrase');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.ExportCertificate'
@@ -292,14 +258,6 @@ class ACM {
   Future<GetCertificateResponse> getCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.GetCertificate'
@@ -426,14 +384,6 @@ class ACM {
     Uint8List? certificateChain,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(certificate, 'certificate');
-    ArgumentError.checkNotNull(privateKey, 'privateKey');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.ImportCertificate'
@@ -495,12 +445,6 @@ class ACM {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.ListCertificates'
@@ -544,14 +488,6 @@ class ACM {
   Future<ListTagsForCertificateResponse> listTagsForCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.ListTagsForCertificate'
@@ -602,15 +538,6 @@ class ACM {
     required String certificateArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.RemoveTagsFromCertificate'
@@ -652,14 +579,6 @@ class ACM {
   Future<void> renewCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.RenewCertificate'
@@ -796,26 +715,6 @@ class ACM {
     List<Tag>? tags,
     ValidationMethod? validationMethod,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      32,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.RequestCertificate'
@@ -909,30 +808,6 @@ class ACM {
     required String domain,
     required String validationDomain,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(validationDomain, 'validationDomain');
-    _s.validateStringLength(
-      'validationDomain',
-      validationDomain,
-      1,
-      253,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.ResendValidationEmail'
@@ -978,15 +853,6 @@ class ACM {
     required String certificateArn,
     required CertificateOptions options,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(options, 'options');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CertificateManager.UpdateCertificateOptions'

--- a/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
+++ b/generated/aws_acm_pca_api/lib/acm-pca-2017-08-22.dart
@@ -130,16 +130,6 @@ class ACMPCA {
     RevocationConfiguration? revocationConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityConfiguration, 'certificateAuthorityConfiguration');
-    ArgumentError.checkNotNull(
-        certificateAuthorityType, 'certificateAuthorityType');
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.CreateCertificateAuthority'
@@ -209,25 +199,6 @@ class ACMPCA {
     required String certificateAuthorityArn,
     required String s3BucketName,
   }) async {
-    ArgumentError.checkNotNull(
-        auditReportResponseFormat, 'auditReportResponseFormat');
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    _s.validateStringLength(
-      's3BucketName',
-      s3BucketName,
-      3,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.CreateCertificateAuthorityAuditReport'
@@ -314,30 +285,6 @@ class ACMPCA {
     required String principal,
     String? sourceAccount,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
-    _s.validateStringLength(
-      'principal',
-      principal,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceAccount',
-      sourceAccount,
-      12,
-      12,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.CreatePermission'
@@ -412,15 +359,6 @@ class ACMPCA {
     required String certificateAuthorityArn,
     int? permanentDeletionTimeInDays,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'permanentDeletionTimeInDays',
       permanentDeletionTimeInDays,
@@ -505,29 +443,6 @@ class ACMPCA {
     required String principal,
     String? sourceAccount,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
-    _s.validateStringLength(
-      'principal',
-      principal,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceAccount',
-      sourceAccount,
-      12,
-      12,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.DeletePermission'
@@ -607,14 +522,6 @@ class ACMPCA {
   Future<void> deletePolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.DeletePolicy'
@@ -681,15 +588,6 @@ class ACMPCA {
   Future<DescribeCertificateAuthorityResponse> describeCertificateAuthority({
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.DescribeCertificateAuthority'
@@ -737,23 +635,6 @@ class ACMPCA {
     required String auditReportId,
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(auditReportId, 'auditReportId');
-    _s.validateStringLength(
-      'auditReportId',
-      auditReportId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.DescribeCertificateAuthorityAuditReport'
@@ -809,23 +690,6 @@ class ACMPCA {
     required String certificateArn,
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.GetCertificate'
@@ -864,15 +728,6 @@ class ACMPCA {
       getCertificateAuthorityCertificate({
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.GetCertificateAuthorityCertificate'
@@ -917,15 +772,6 @@ class ACMPCA {
   Future<GetCertificateAuthorityCsrResponse> getCertificateAuthorityCsr({
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.GetCertificateAuthorityCsr'
@@ -994,14 +840,6 @@ class ACMPCA {
   Future<GetPolicyResponse> getPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.GetPolicy'
@@ -1192,16 +1030,6 @@ class ACMPCA {
     required String certificateAuthorityArn,
     Uint8List? certificateChain,
   }) async {
-    ArgumentError.checkNotNull(certificate, 'certificate');
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.ImportCertificateAuthorityCertificate'
@@ -1367,30 +1195,6 @@ class ACMPCA {
     String? idempotencyToken,
     String? templateArn,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(csr, 'csr');
-    ArgumentError.checkNotNull(signingAlgorithm, 'signingAlgorithm');
-    ArgumentError.checkNotNull(validity, 'validity');
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'templateArn',
-      templateArn,
-      5,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.IssueCertificate'
@@ -1445,12 +1249,6 @@ class ACMPCA {
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      500,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1537,26 +1335,11 @@ class ACMPCA {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      500,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1615,26 +1398,11 @@ class ACMPCA {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      500,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1725,22 +1493,6 @@ class ACMPCA {
     required String policy,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      20480,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.PutPolicy'
@@ -1795,15 +1547,6 @@ class ACMPCA {
   Future<void> restoreCertificateAuthority({
     required String certificateAuthorityArn,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.RestoreCertificateAuthority'
@@ -1886,24 +1629,6 @@ class ACMPCA {
     required String certificateSerial,
     required RevocationReason revocationReason,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(certificateSerial, 'certificateSerial');
-    _s.validateStringLength(
-      'certificateSerial',
-      certificateSerial,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revocationReason, 'revocationReason');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.RevokeCertificate'
@@ -1955,16 +1680,6 @@ class ACMPCA {
     required String certificateAuthorityArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.TagCertificateAuthority'
@@ -2011,16 +1726,6 @@ class ACMPCA {
     required String certificateAuthorityArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.UntagCertificateAuthority'
@@ -2076,15 +1781,6 @@ class ACMPCA {
     RevocationConfiguration? revocationConfiguration,
     CertificateAuthorityStatus? status,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityArn, 'certificateAuthorityArn');
-    _s.validateStringLength(
-      'certificateAuthorityArn',
-      certificateAuthorityArn,
-      5,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ACMPrivateCA.UpdateCertificateAuthority'

--- a/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
+++ b/generated/aws_alexaforbusiness_api/lib/alexaforbusiness-2017-11-09.dart
@@ -69,7 +69,6 @@ class AlexaForBusiness {
   Future<void> approveSkill({
     required String skillId,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ApproveSkill'
@@ -99,8 +98,6 @@ class AlexaForBusiness {
     required String addressBookArn,
     required String contactArn,
   }) async {
-    ArgumentError.checkNotNull(addressBookArn, 'addressBookArn');
-    ArgumentError.checkNotNull(contactArn, 'contactArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.AssociateContactWithAddressBook'
@@ -133,8 +130,6 @@ class AlexaForBusiness {
     required String deviceArn,
     required String networkProfileArn,
   }) async {
-    ArgumentError.checkNotNull(deviceArn, 'deviceArn');
-    ArgumentError.checkNotNull(networkProfileArn, 'networkProfileArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.AssociateDeviceWithNetworkProfile'
@@ -233,7 +228,6 @@ class AlexaForBusiness {
     required String skillId,
     String? skillGroupArn,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.AssociateSkillWithSkillGroup'
@@ -262,7 +256,6 @@ class AlexaForBusiness {
   Future<void> associateSkillWithUsers({
     required String skillId,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.AssociateSkillWithUsers'
@@ -298,26 +291,6 @@ class AlexaForBusiness {
     String? clientRequestToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateAddressBook'
@@ -381,26 +354,6 @@ class AlexaForBusiness {
     String? scheduleName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(contentRange, 'contentRange');
-    ArgumentError.checkNotNull(format, 'format');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      's3KeyPrefix',
-      s3KeyPrefix,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'scheduleName',
-      scheduleName,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateBusinessReportSchedule'
@@ -456,24 +409,6 @@ class AlexaForBusiness {
     IPDialIn? iPDialIn,
     PSTNDialIn? pSTNDialIn,
   }) async {
-    ArgumentError.checkNotNull(
-        conferenceProviderName, 'conferenceProviderName');
-    _s.validateStringLength(
-      'conferenceProviderName',
-      conferenceProviderName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        conferenceProviderType, 'conferenceProviderType');
-    ArgumentError.checkNotNull(meetingSetting, 'meetingSetting');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateConferenceProvider'
@@ -538,38 +473,6 @@ class AlexaForBusiness {
     List<PhoneNumber>? phoneNumbers,
     List<SipAddress>? sipAddresses,
   }) async {
-    ArgumentError.checkNotNull(firstName, 'firstName');
-    _s.validateStringLength(
-      'firstName',
-      firstName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'lastName',
-      lastName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'phoneNumber',
-      phoneNumber,
-      0,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateContact'
@@ -614,26 +517,6 @@ class AlexaForBusiness {
     String? clientRequestToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateGatewayGroup'
@@ -709,47 +592,6 @@ class AlexaForBusiness {
     String? nextPassword,
     List<String>? trustAnchors,
   }) async {
-    ArgumentError.checkNotNull(networkProfileName, 'networkProfileName');
-    _s.validateStringLength(
-      'networkProfileName',
-      networkProfileName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(securityType, 'securityType');
-    ArgumentError.checkNotNull(ssid, 'ssid');
-    _s.validateStringLength(
-      'ssid',
-      ssid,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'currentPassword',
-      currentPassword,
-      5,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'nextPassword',
-      nextPassword,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateNetworkProfile'
@@ -839,45 +681,6 @@ class AlexaForBusiness {
     bool? setupModeDisabled,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(address, 'address');
-    _s.validateStringLength(
-      'address',
-      address,
-      1,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(distanceUnit, 'distanceUnit');
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(temperatureUnit, 'temperatureUnit');
-    ArgumentError.checkNotNull(timezone, 'timezone');
-    _s.validateStringLength(
-      'timezone',
-      timezone,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(wakeWord, 'wakeWord');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'locale',
-      locale,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateProfile'
@@ -941,32 +744,6 @@ class AlexaForBusiness {
     String? providerCalendarId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(roomName, 'roomName');
-    _s.validateStringLength(
-      'roomName',
-      roomName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'providerCalendarId',
-      providerCalendarId,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateRoom'
@@ -1016,26 +793,6 @@ class AlexaForBusiness {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(skillGroupName, 'skillGroupName');
-    _s.validateStringLength(
-      'skillGroupName',
-      skillGroupName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateSkillGroup'
@@ -1090,38 +847,6 @@ class AlexaForBusiness {
     String? lastName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
-    _s.validateStringLength(
-      'email',
-      email,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'firstName',
-      firstName,
-      0,
-      30,
-    );
-    _s.validateStringLength(
-      'lastName',
-      lastName,
-      0,
-      30,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.CreateUser'
@@ -1156,7 +881,6 @@ class AlexaForBusiness {
   Future<void> deleteAddressBook({
     required String addressBookArn,
   }) async {
-    ArgumentError.checkNotNull(addressBookArn, 'addressBookArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteAddressBook'
@@ -1184,7 +908,6 @@ class AlexaForBusiness {
   Future<void> deleteBusinessReportSchedule({
     required String scheduleArn,
   }) async {
-    ArgumentError.checkNotNull(scheduleArn, 'scheduleArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteBusinessReportSchedule'
@@ -1210,7 +933,6 @@ class AlexaForBusiness {
   Future<void> deleteConferenceProvider({
     required String conferenceProviderArn,
   }) async {
-    ArgumentError.checkNotNull(conferenceProviderArn, 'conferenceProviderArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteConferenceProvider'
@@ -1237,7 +959,6 @@ class AlexaForBusiness {
   Future<void> deleteContact({
     required String contactArn,
   }) async {
-    ArgumentError.checkNotNull(contactArn, 'contactArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteContact'
@@ -1265,7 +986,6 @@ class AlexaForBusiness {
   Future<void> deleteDevice({
     required String deviceArn,
   }) async {
-    ArgumentError.checkNotNull(deviceArn, 'deviceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteDevice'
@@ -1300,8 +1020,6 @@ class AlexaForBusiness {
     required String deviceArn,
     required DeviceUsageType deviceUsageType,
   }) async {
-    ArgumentError.checkNotNull(deviceArn, 'deviceArn');
-    ArgumentError.checkNotNull(deviceUsageType, 'deviceUsageType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteDeviceUsageData'
@@ -1328,7 +1046,6 @@ class AlexaForBusiness {
   Future<void> deleteGatewayGroup({
     required String gatewayGroupArn,
   }) async {
-    ArgumentError.checkNotNull(gatewayGroupArn, 'gatewayGroupArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteGatewayGroup'
@@ -1356,7 +1073,6 @@ class AlexaForBusiness {
   Future<void> deleteNetworkProfile({
     required String networkProfileArn,
   }) async {
-    ArgumentError.checkNotNull(networkProfileArn, 'networkProfileArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteNetworkProfile'
@@ -1442,15 +1158,6 @@ class AlexaForBusiness {
     required String skillId,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(parameterKey, 'parameterKey');
-    _s.validateStringLength(
-      'parameterKey',
-      parameterKey,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteRoomSkillParameter'
@@ -1483,7 +1190,6 @@ class AlexaForBusiness {
     required String skillId,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteSkillAuthorization'
@@ -1541,14 +1247,6 @@ class AlexaForBusiness {
     required String enrollmentId,
     String? userArn,
   }) async {
-    ArgumentError.checkNotNull(enrollmentId, 'enrollmentId');
-    _s.validateStringLength(
-      'enrollmentId',
-      enrollmentId,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DeleteUser'
@@ -1577,8 +1275,6 @@ class AlexaForBusiness {
     required String addressBookArn,
     required String contactArn,
   }) async {
-    ArgumentError.checkNotNull(addressBookArn, 'addressBookArn');
-    ArgumentError.checkNotNull(contactArn, 'contactArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DisassociateContactFromAddressBook'
@@ -1638,7 +1334,6 @@ class AlexaForBusiness {
     required String skillId,
     String? skillGroupArn,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DisassociateSkillFromSkillGroup'
@@ -1667,7 +1362,6 @@ class AlexaForBusiness {
   Future<void> disassociateSkillFromUsers({
     required String skillId,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.DisassociateSkillFromUsers'
@@ -1725,7 +1419,6 @@ class AlexaForBusiness {
   Future<void> forgetSmartHomeAppliances({
     required String roomArn,
   }) async {
-    ArgumentError.checkNotNull(roomArn, 'roomArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ForgetSmartHomeAppliances'
@@ -1751,7 +1444,6 @@ class AlexaForBusiness {
   Future<GetAddressBookResponse> getAddressBook({
     required String addressBookArn,
   }) async {
-    ArgumentError.checkNotNull(addressBookArn, 'addressBookArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetAddressBook'
@@ -1798,7 +1490,6 @@ class AlexaForBusiness {
   Future<GetConferenceProviderResponse> getConferenceProvider({
     required String conferenceProviderArn,
   }) async {
-    ArgumentError.checkNotNull(conferenceProviderArn, 'conferenceProviderArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetConferenceProvider'
@@ -1826,7 +1517,6 @@ class AlexaForBusiness {
   Future<GetContactResponse> getContact({
     required String contactArn,
   }) async {
-    ArgumentError.checkNotNull(contactArn, 'contactArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetContact'
@@ -1881,7 +1571,6 @@ class AlexaForBusiness {
   Future<GetGatewayResponse> getGateway({
     required String gatewayArn,
   }) async {
-    ArgumentError.checkNotNull(gatewayArn, 'gatewayArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetGateway'
@@ -1909,7 +1598,6 @@ class AlexaForBusiness {
   Future<GetGatewayGroupResponse> getGatewayGroup({
     required String gatewayGroupArn,
   }) async {
-    ArgumentError.checkNotNull(gatewayGroupArn, 'gatewayGroupArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetGatewayGroup'
@@ -1959,7 +1647,6 @@ class AlexaForBusiness {
   Future<GetNetworkProfileResponse> getNetworkProfile({
     required String networkProfileArn,
   }) async {
-    ArgumentError.checkNotNull(networkProfileArn, 'networkProfileArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetNetworkProfile'
@@ -2050,15 +1737,6 @@ class AlexaForBusiness {
     required String skillId,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(parameterKey, 'parameterKey');
-    _s.validateStringLength(
-      'parameterKey',
-      parameterKey,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.GetRoomSkillParameter'
@@ -2126,12 +1804,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ListBusinessReportSchedules'
@@ -2168,12 +1840,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2226,18 +1892,11 @@ class AlexaForBusiness {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deviceArn, 'deviceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2279,12 +1938,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2328,12 +1981,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2389,12 +2036,6 @@ class AlexaForBusiness {
       1,
       10,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ListSkills'
@@ -2434,12 +2075,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ListSkillsStoreCategories'
@@ -2476,7 +2111,6 @@ class AlexaForBusiness {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(categoryId, 'categoryId');
     _s.validateNumRange(
       'categoryId',
       categoryId,
@@ -2489,12 +2123,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2533,18 +2161,11 @@ class AlexaForBusiness {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(roomArn, 'roomArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2588,18 +2209,11 @@ class AlexaForBusiness {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2631,7 +2245,6 @@ class AlexaForBusiness {
   Future<void> putConferencePreference({
     required ConferencePreference conferencePreference,
   }) async {
-    ArgumentError.checkNotNull(conferencePreference, 'conferencePreference');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.PutConferencePreference'
@@ -2669,20 +2282,6 @@ class AlexaForBusiness {
     String? contactEmail,
     List<String>? privateSkillIds,
   }) async {
-    ArgumentError.checkNotNull(organizationName, 'organizationName');
-    _s.validateStringLength(
-      'organizationName',
-      organizationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'contactEmail',
-      contactEmail,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.PutInvitationConfiguration'
@@ -2719,8 +2318,6 @@ class AlexaForBusiness {
     required String skillId,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(roomSkillParameter, 'roomSkillParameter');
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.PutRoomSkillParameter'
@@ -2762,8 +2359,6 @@ class AlexaForBusiness {
     required String skillId,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(authorizationResult, 'authorizationResult');
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.PutSkillAuthorization'
@@ -2820,17 +2415,6 @@ class AlexaForBusiness {
     String? deviceSerialNumber,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(amazonId, 'amazonId');
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    ArgumentError.checkNotNull(productId, 'productId');
-    ArgumentError.checkNotNull(userCode, 'userCode');
-    _s.validateStringLength(
-      'userCode',
-      userCode,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.RegisterAVSDevice'
@@ -2868,7 +2452,6 @@ class AlexaForBusiness {
   Future<void> rejectSkill({
     required String skillId,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.RejectSkill'
@@ -2899,8 +2482,6 @@ class AlexaForBusiness {
     required String skillId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(skillId, 'skillId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.ResolveRoom'
@@ -2934,12 +2515,6 @@ class AlexaForBusiness {
     String? enrollmentId,
     String? userArn,
   }) async {
-    _s.validateStringLength(
-      'enrollmentId',
-      enrollmentId,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.RevokeInvitation'
@@ -2989,12 +2564,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3049,12 +2618,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3114,12 +2677,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.SearchDevices'
@@ -3173,12 +2730,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3234,12 +2785,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.SearchProfiles'
@@ -3294,12 +2839,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.SearchRooms'
@@ -3353,12 +2892,6 @@ class AlexaForBusiness {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3417,12 +2950,6 @@ class AlexaForBusiness {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.SearchUsers'
@@ -3472,14 +2999,6 @@ class AlexaForBusiness {
     String? clientRequestToken,
     int? timeToLiveInSeconds,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(roomFilters, 'roomFilters');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      10,
-      150,
-    );
     _s.validateNumRange(
       'timeToLiveInSeconds',
       timeToLiveInSeconds,
@@ -3577,7 +3096,6 @@ class AlexaForBusiness {
     String? deviceArn,
     String? roomArn,
   }) async {
-    ArgumentError.checkNotNull(features, 'features');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.StartDeviceSync'
@@ -3606,7 +3124,6 @@ class AlexaForBusiness {
   Future<void> startSmartHomeApplianceDiscovery({
     required String roomArn,
   }) async {
-    ArgumentError.checkNotNull(roomArn, 'roomArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.StartSmartHomeApplianceDiscovery'
@@ -3637,8 +3154,6 @@ class AlexaForBusiness {
     required String arn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.TagResource'
@@ -3670,8 +3185,6 @@ class AlexaForBusiness {
     required String arn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UntagResource'
@@ -3708,19 +3221,6 @@ class AlexaForBusiness {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(addressBookArn, 'addressBookArn');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateAddressBook'
@@ -3771,19 +3271,6 @@ class AlexaForBusiness {
     String? s3KeyPrefix,
     String? scheduleName,
   }) async {
-    ArgumentError.checkNotNull(scheduleArn, 'scheduleArn');
-    _s.validateStringLength(
-      's3KeyPrefix',
-      s3KeyPrefix,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'scheduleName',
-      scheduleName,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateBusinessReportSchedule'
@@ -3830,10 +3317,6 @@ class AlexaForBusiness {
     IPDialIn? iPDialIn,
     PSTNDialIn? pSTNDialIn,
   }) async {
-    ArgumentError.checkNotNull(conferenceProviderArn, 'conferenceProviderArn');
-    ArgumentError.checkNotNull(
-        conferenceProviderType, 'conferenceProviderType');
-    ArgumentError.checkNotNull(meetingSetting, 'meetingSetting');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateConferenceProvider'
@@ -3891,31 +3374,6 @@ class AlexaForBusiness {
     List<PhoneNumber>? phoneNumbers,
     List<SipAddress>? sipAddresses,
   }) async {
-    ArgumentError.checkNotNull(contactArn, 'contactArn');
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'firstName',
-      firstName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'lastName',
-      lastName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'phoneNumber',
-      phoneNumber,
-      0,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateContact'
@@ -3953,12 +3411,6 @@ class AlexaForBusiness {
     String? deviceArn,
     String? deviceName,
   }) async {
-    _s.validateStringLength(
-      'deviceName',
-      deviceName,
-      2,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateDevice'
@@ -4000,25 +3452,6 @@ class AlexaForBusiness {
     String? name,
     String? softwareVersion,
   }) async {
-    ArgumentError.checkNotNull(gatewayArn, 'gatewayArn');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      253,
-    );
-    _s.validateStringLength(
-      'softwareVersion',
-      softwareVersion,
-      1,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateGateway'
@@ -4057,19 +3490,6 @@ class AlexaForBusiness {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(gatewayGroupArn, 'gatewayGroupArn');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateGatewayGroup'
@@ -4131,31 +3551,6 @@ class AlexaForBusiness {
     String? nextPassword,
     List<String>? trustAnchors,
   }) async {
-    ArgumentError.checkNotNull(networkProfileArn, 'networkProfileArn');
-    _s.validateStringLength(
-      'currentPassword',
-      currentPassword,
-      5,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'networkProfileName',
-      networkProfileName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'nextPassword',
-      nextPassword,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateNetworkProfile'
@@ -4241,30 +3636,6 @@ class AlexaForBusiness {
     String? timezone,
     WakeWord? wakeWord,
   }) async {
-    _s.validateStringLength(
-      'address',
-      address,
-      1,
-      500,
-    );
-    _s.validateStringLength(
-      'locale',
-      locale,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'timezone',
-      timezone,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateProfile'
@@ -4321,24 +3692,6 @@ class AlexaForBusiness {
     String? roomArn,
     String? roomName,
   }) async {
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'providerCalendarId',
-      providerCalendarId,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'roomName',
-      roomName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateRoom'
@@ -4379,18 +3732,6 @@ class AlexaForBusiness {
     String? skillGroupArn,
     String? skillGroupName,
   }) async {
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'skillGroupName',
-      skillGroupName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AlexaForBusiness.UpdateSkillGroup'

--- a/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
+++ b/generated/aws_amplify_api/lib/amplify-2017-07-25.dart
@@ -147,62 +147,6 @@ class Amplify {
     String? repository,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accessToken',
-      accessToken,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'basicAuthCredentials',
-      basicAuthCredentials,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'buildSpec',
-      buildSpec,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'customHeaders',
-      customHeaders,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'iamServiceRoleArn',
-      iamServiceRoleArn,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'oauthToken',
-      oauthToken,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'repository',
-      repository,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'name': name,
       if (accessToken != null) 'accessToken': accessToken,
@@ -265,34 +209,6 @@ class Amplify {
     String? deploymentArtifacts,
     String? stackName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deploymentArtifacts',
-      deploymentArtifacts,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'environmentName': environmentName,
       if (deploymentArtifacts != null)
@@ -396,64 +312,6 @@ class Amplify {
     Map<String, String>? tags,
     String? ttl,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'backendEnvironmentArn',
-      backendEnvironmentArn,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'basicAuthCredentials',
-      basicAuthCredentials,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'buildSpec',
-      buildSpec,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'framework',
-      framework,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'pullRequestEnvironmentName',
-      pullRequestEnvironmentName,
-      0,
-      20,
-    );
     final $payload = <String, dynamic>{
       'branchName': branchName,
       if (backendEnvironmentArn != null)
@@ -512,22 +370,6 @@ class Amplify {
     required String branchName,
     Map<String, String>? fileMap,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (fileMap != null) 'fileMap': fileMap,
     };
@@ -577,29 +419,6 @@ class Amplify {
     String? autoSubDomainIAMRole,
     bool? enableAutoSubDomain,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subDomainSettings, 'subDomainSettings');
-    _s.validateStringLength(
-      'autoSubDomainIAMRole',
-      autoSubDomainIAMRole,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'domainName': domainName,
       'subDomainSettings': subDomainSettings,
@@ -641,28 +460,6 @@ class Amplify {
     required String branchName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'branchName': branchName,
       if (description != null) 'description': description,
@@ -689,14 +486,6 @@ class Amplify {
   Future<DeleteAppResult> deleteApp({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -723,22 +512,6 @@ class Amplify {
     required String appId,
     required String environmentName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -766,22 +539,6 @@ class Amplify {
     required String appId,
     required String branchName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -809,22 +566,6 @@ class Amplify {
     required String appId,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -856,30 +597,6 @@ class Amplify {
     required String branchName,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -903,14 +620,6 @@ class Amplify {
   Future<DeleteWebhookResult> deleteWebhook({
     required String webhookId,
   }) async {
-    ArgumentError.checkNotNull(webhookId, 'webhookId');
-    _s.validateStringLength(
-      'webhookId',
-      webhookId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -947,22 +656,6 @@ class Amplify {
     DateTime? endTime,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'domainName': domainName,
       if (endTime != null) 'endTime': unixTimestampToJson(endTime),
@@ -989,14 +682,6 @@ class Amplify {
   Future<GetAppResult> getApp({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1019,14 +704,6 @@ class Amplify {
   Future<GetArtifactUrlResult> getArtifactUrl({
     required String artifactId,
   }) async {
-    ArgumentError.checkNotNull(artifactId, 'artifactId');
-    _s.validateStringLength(
-      'artifactId',
-      artifactId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1052,22 +729,6 @@ class Amplify {
     required String appId,
     required String environmentName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1094,22 +755,6 @@ class Amplify {
     required String appId,
     required String branchName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1136,22 +781,6 @@ class Amplify {
     required String appId,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1183,30 +812,6 @@ class Amplify {
     required String branchName,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1231,14 +836,6 @@ class Amplify {
   Future<GetWebhookResult> getWebhook({
     required String webhookId,
   }) async {
-    ArgumentError.checkNotNull(webhookId, 'webhookId');
-    _s.validateStringLength(
-      'webhookId',
-      webhookId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1269,12 +866,6 @@ class Amplify {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1320,41 +911,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1396,31 +957,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (environmentName != null) 'environmentName': [environmentName],
@@ -1458,25 +999,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1513,25 +1040,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1573,33 +1086,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1627,7 +1118,6 @@ class Amplify {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1659,25 +1149,11 @@ class Amplify {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2000,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1722,34 +1198,6 @@ class Amplify {
     String? jobId,
     String? sourceUrl,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'sourceUrl',
-      sourceUrl,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       if (jobId != null) 'jobId': jobId,
       if (sourceUrl != null) 'sourceUrl': sourceUrl,
@@ -1810,47 +1258,6 @@ class Amplify {
     String? jobId,
     String? jobReason,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobType, 'jobType');
-    _s.validateStringLength(
-      'commitId',
-      commitId,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'commitMessage',
-      commitMessage,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'jobReason',
-      jobReason,
-      0,
-      255,
-    );
     final $payload = <String, dynamic>{
       'jobType': jobType.toValue(),
       if (commitId != null) 'commitId': commitId,
@@ -1890,30 +1297,6 @@ class Amplify {
     required String branchName,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      0,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1939,8 +1322,6 @@ class Amplify {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1967,8 +1348,6 @@ class Amplify {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2071,68 +1450,6 @@ class Amplify {
     Platform? platform,
     String? repository,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accessToken',
-      accessToken,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'basicAuthCredentials',
-      basicAuthCredentials,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'buildSpec',
-      buildSpec,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'customHeaders',
-      customHeaders,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'iamServiceRoleArn',
-      iamServiceRoleArn,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'oauthToken',
-      oauthToken,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'repository',
-      repository,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       if (accessToken != null) 'accessToken': accessToken,
       if (autoBranchCreationConfig != null)
@@ -2252,64 +1569,6 @@ class Amplify {
     Stage? stage,
     String? ttl,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'backendEnvironmentArn',
-      backendEnvironmentArn,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'basicAuthCredentials',
-      basicAuthCredentials,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'buildSpec',
-      buildSpec,
-      1,
-      25000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'framework',
-      framework,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'pullRequestEnvironmentName',
-      pullRequestEnvironmentName,
-      0,
-      20,
-    );
     final $payload = <String, dynamic>{
       if (backendEnvironmentArn != null)
         'backendEnvironmentArn': backendEnvironmentArn,
@@ -2377,29 +1636,6 @@ class Amplify {
     String? autoSubDomainIAMRole,
     bool? enableAutoSubDomain,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
-    _s.validateStringLength(
-      'appId',
-      appId,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subDomainSettings, 'subDomainSettings');
-    _s.validateStringLength(
-      'autoSubDomainIAMRole',
-      autoSubDomainIAMRole,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'subDomainSettings': subDomainSettings,
       if (autoSubDomainCreationPatterns != null)
@@ -2440,26 +1676,6 @@ class Amplify {
     String? branchName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(webhookId, 'webhookId');
-    _s.validateStringLength(
-      'webhookId',
-      webhookId,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       if (branchName != null) 'branchName': branchName,
       if (description != null) 'description': description,

--- a/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
+++ b/generated/aws_apigateway_api/lib/apigateway-2015-07-09.dart
@@ -229,9 +229,6 @@ class APIGateway {
     String? identityValidationExpression,
     List<String>? providerARNs,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'name': name,
       'type': type.toValue(),
@@ -286,8 +283,6 @@ class APIGateway {
     String? basePath,
     String? stage,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'restApiId': restApiId,
       if (basePath != null) 'basePath': basePath,
@@ -360,7 +355,6 @@ class APIGateway {
     bool? tracingEnabled,
     Map<String, String>? variables,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (cacheClusterEnabled != null)
         'cacheClusterEnabled': cacheClusterEnabled,
@@ -406,9 +400,6 @@ class APIGateway {
     required String properties,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(location, 'location');
-    ArgumentError.checkNotNull(properties, 'properties');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'location': location,
       'properties': properties,
@@ -448,8 +439,6 @@ class APIGateway {
     String? description,
     String? stageName,
   }) async {
-    ArgumentError.checkNotNull(documentationVersion, 'documentationVersion');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'documentationVersion': documentationVersion,
       if (description != null) 'description': description,
@@ -538,7 +527,6 @@ class APIGateway {
     SecurityPolicy? securityPolicy,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       'domainName': domainName,
       if (certificateArn != null) 'certificateArn': certificateArn,
@@ -600,9 +588,6 @@ class APIGateway {
     String? description,
     String? schema,
   }) async {
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'contentType': contentType,
       'name': name,
@@ -646,7 +631,6 @@ class APIGateway {
     bool? validateRequestBody,
     bool? validateRequestParameters,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (name != null) 'name': name,
       if (validateRequestBody != null)
@@ -686,9 +670,6 @@ class APIGateway {
     required String pathPart,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(parentId, 'parentId');
-    ArgumentError.checkNotNull(pathPart, 'pathPart');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'pathPart': pathPart,
     };
@@ -775,7 +756,6 @@ class APIGateway {
     Map<String, String>? tags,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (apiKeySource != null) 'apiKeySource': apiKeySource.toValue(),
@@ -864,9 +844,6 @@ class APIGateway {
     bool? tracingEnabled,
     Map<String, String>? variables,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final $payload = <String, dynamic>{
       'deploymentId': deploymentId,
       'stageName': stageName,
@@ -928,7 +905,6 @@ class APIGateway {
     Map<String, String>? tags,
     ThrottleSettings? throttle,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (apiStages != null) 'apiStages': apiStages,
@@ -970,9 +946,6 @@ class APIGateway {
     required String keyType,
     required String usagePlanId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    ArgumentError.checkNotNull(keyType, 'keyType');
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final $payload = <String, dynamic>{
       'keyId': keyId,
       'keyType': keyType,
@@ -1016,8 +989,6 @@ class APIGateway {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(targetArns, 'targetArns');
     final $payload = <String, dynamic>{
       'name': name,
       'targetArns': targetArns,
@@ -1044,7 +1015,6 @@ class APIGateway {
   Future<void> deleteApiKey({
     required String apiKey,
   }) async {
-    ArgumentError.checkNotNull(apiKey, 'apiKey');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1073,8 +1043,6 @@ class APIGateway {
     required String authorizerId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1106,8 +1074,6 @@ class APIGateway {
     required String basePath,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(basePath, 'basePath');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1130,7 +1096,6 @@ class APIGateway {
   Future<void> deleteClientCertificate({
     required String clientCertificateId,
   }) async {
-    ArgumentError.checkNotNull(clientCertificateId, 'clientCertificateId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1157,8 +1122,6 @@ class APIGateway {
     required String deploymentId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1184,8 +1147,6 @@ class APIGateway {
     required String documentationPartId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(documentationPartId, 'documentationPartId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1212,8 +1173,6 @@ class APIGateway {
     required String documentationVersion,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(documentationVersion, 'documentationVersion');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1235,7 +1194,6 @@ class APIGateway {
   Future<void> deleteDomainName({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1288,8 +1246,6 @@ class APIGateway {
     required GatewayResponseType responseType,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(responseType, 'responseType');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1319,9 +1275,6 @@ class APIGateway {
     required String resourceId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1357,10 +1310,6 @@ class APIGateway {
     required String restApiId,
     required String statusCode,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1390,9 +1339,6 @@ class APIGateway {
     required String resourceId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1429,10 +1375,6 @@ class APIGateway {
     required String restApiId,
     required String statusCode,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1459,8 +1401,6 @@ class APIGateway {
     required String modelName,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1487,8 +1427,6 @@ class APIGateway {
     required String requestValidatorId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(requestValidatorId, 'requestValidatorId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1515,8 +1453,6 @@ class APIGateway {
     required String resourceId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1538,7 +1474,6 @@ class APIGateway {
   Future<void> deleteRestApi({
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1563,8 +1498,6 @@ class APIGateway {
     required String restApiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1586,7 +1519,6 @@ class APIGateway {
   Future<void> deleteUsagePlan({
     required String usagePlanId,
   }) async {
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1615,8 +1547,6 @@ class APIGateway {
     required String keyId,
     required String usagePlanId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1639,7 +1569,6 @@ class APIGateway {
   Future<void> deleteVpcLink({
     required String vpcLinkId,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1664,8 +1593,6 @@ class APIGateway {
     required String restApiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1691,8 +1618,6 @@ class APIGateway {
     required String restApiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1763,7 +1688,6 @@ class APIGateway {
     required String apiKey,
     bool? includeValue,
   }) async {
-    ArgumentError.checkNotNull(apiKey, 'apiKey');
     final $query = <String, List<String>>{
       if (includeValue != null) 'includeValue': [includeValue.toString()],
     };
@@ -1842,8 +1766,6 @@ class APIGateway {
     required String authorizerId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1878,7 +1800,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -1912,8 +1833,6 @@ class APIGateway {
     required String basePath,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(basePath, 'basePath');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1944,7 +1863,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -1972,7 +1890,6 @@ class APIGateway {
   Future<ClientCertificate> getClientCertificate({
     required String clientCertificateId,
   }) async {
-    ArgumentError.checkNotNull(clientCertificateId, 'clientCertificateId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2044,8 +1961,6 @@ class APIGateway {
     required String restApiId,
     List<String>? embed,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (embed != null) 'embed': embed,
     };
@@ -2082,7 +1997,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -2111,8 +2025,6 @@ class APIGateway {
     required String documentationPartId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(documentationPartId, 'documentationPartId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2162,7 +2074,6 @@ class APIGateway {
     String? position,
     DocumentationPartType? type,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (locationStatus != null) 'locationStatus': [locationStatus.toValue()],
@@ -2197,8 +2108,6 @@ class APIGateway {
     required String documentationVersion,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(documentationVersion, 'documentationVersion');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2229,7 +2138,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -2258,7 +2166,6 @@ class APIGateway {
   Future<DomainName> getDomainName({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2342,9 +2249,6 @@ class APIGateway {
     String? accepts,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(exportType, 'exportType');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final headers = <String, String>{
       if (accepts != null) 'Accept': accepts.toString(),
     };
@@ -2411,8 +2315,6 @@ class APIGateway {
     required GatewayResponseType responseType,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(responseType, 'responseType');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2450,7 +2352,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -2485,9 +2386,6 @@ class APIGateway {
     required String resourceId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2522,10 +2420,6 @@ class APIGateway {
     required String restApiId,
     required String statusCode,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2555,9 +2449,6 @@ class APIGateway {
     required String resourceId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2592,10 +2483,6 @@ class APIGateway {
     required String restApiId,
     required String statusCode,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2628,8 +2515,6 @@ class APIGateway {
     required String restApiId,
     bool? flatten,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (flatten != null) 'flatten': [flatten.toString()],
     };
@@ -2661,8 +2546,6 @@ class APIGateway {
     required String modelName,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2694,7 +2577,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -2724,8 +2606,6 @@ class APIGateway {
     required String requestValidatorId,
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(requestValidatorId, 'requestValidatorId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2757,7 +2637,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -2799,8 +2678,6 @@ class APIGateway {
     required String restApiId,
     List<String>? embed,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (embed != null) 'embed': embed,
     };
@@ -2846,7 +2723,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (embed != null) 'embed': embed,
       if (limit != null) 'limit': [limit.toString()],
@@ -2873,7 +2749,6 @@ class APIGateway {
   Future<RestApi> getRestApi({
     required String restApiId,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2949,9 +2824,6 @@ class APIGateway {
     required String stageName,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(sdkType, 'sdkType');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final $query = <String, List<String>>{
       if (parameters != null)
         for (var e in parameters.entries) e.key: [e.value],
@@ -2983,7 +2855,6 @@ class APIGateway {
   Future<SdkType> getSdkType({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3036,8 +2907,6 @@ class APIGateway {
     required String restApiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3063,7 +2932,6 @@ class APIGateway {
     required String restApiId,
     String? deploymentId,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (deploymentId != null) 'deploymentId': [deploymentId],
     };
@@ -3100,7 +2968,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (position != null) 'position': [position],
@@ -3148,9 +3015,6 @@ class APIGateway {
     int? limit,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(endDate, 'endDate');
-    ArgumentError.checkNotNull(startDate, 'startDate');
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final $query = <String, List<String>>{
       'endDate': [endDate],
       'startDate': [startDate],
@@ -3181,7 +3045,6 @@ class APIGateway {
   Future<UsagePlan> getUsagePlan({
     required String usagePlanId,
   }) async {
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3210,8 +3073,6 @@ class APIGateway {
     required String keyId,
     required String usagePlanId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3251,7 +3112,6 @@ class APIGateway {
     String? nameQuery,
     String? position,
   }) async {
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (nameQuery != null) 'name': [nameQuery],
@@ -3316,7 +3176,6 @@ class APIGateway {
   Future<VpcLink> getVpcLink({
     required String vpcLinkId,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3385,8 +3244,6 @@ class APIGateway {
     required ApiKeysFormat format,
     bool? failOnWarnings,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
-    ArgumentError.checkNotNull(format, 'format');
     final $query = <String, List<String>>{
       'format': [format.toValue()],
       if (failOnWarnings != null) 'failonwarnings': [failOnWarnings.toString()],
@@ -3431,8 +3288,6 @@ class APIGateway {
     bool? failOnWarnings,
     PutMode? mode,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (failOnWarnings != null) 'failonwarnings': [failOnWarnings.toString()],
       if (mode != null) 'mode': [mode.toValue()],
@@ -3499,7 +3354,6 @@ class APIGateway {
     bool? failOnWarnings,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
     final $query = <String, List<String>>{
       if (failOnWarnings != null) 'failonwarnings': [failOnWarnings.toString()],
       if (parameters != null)
@@ -3576,8 +3430,6 @@ class APIGateway {
     Map<String, String>? responseTemplates,
     String? statusCode,
   }) async {
-    ArgumentError.checkNotNull(responseType, 'responseType');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (responseParameters != null) 'responseParameters': responseParameters,
       if (responseTemplates != null) 'responseTemplates': responseTemplates,
@@ -3766,10 +3618,6 @@ class APIGateway {
     TlsConfig? tlsConfig,
     String? uri,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'type': type.toValue(),
       if (cacheKeyParameters != null) 'cacheKeyParameters': cacheKeyParameters,
@@ -3869,10 +3717,6 @@ class APIGateway {
     Map<String, String>? responseTemplates,
     String? selectionPattern,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final $payload = <String, dynamic>{
       if (contentHandling != null) 'contentHandling': contentHandling.toValue(),
       if (responseParameters != null) 'responseParameters': responseParameters,
@@ -3971,10 +3815,6 @@ class APIGateway {
     Map<String, bool>? requestParameters,
     String? requestValidatorId,
   }) async {
-    ArgumentError.checkNotNull(authorizationType, 'authorizationType');
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       'authorizationType': authorizationType,
       if (apiKeyRequired != null) 'apiKeyRequired': apiKeyRequired,
@@ -4046,10 +3886,6 @@ class APIGateway {
     Map<String, String>? responseModels,
     Map<String, bool>? responseParameters,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final $payload = <String, dynamic>{
       if (responseModels != null) 'responseModels': responseModels,
       if (responseParameters != null) 'responseParameters': responseParameters,
@@ -4108,8 +3944,6 @@ class APIGateway {
     PutMode? mode,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $query = <String, List<String>>{
       if (failOnWarnings != null) 'failonwarnings': [failOnWarnings.toString()],
       if (mode != null) 'mode': [mode.toValue()],
@@ -4146,8 +3980,6 @@ class APIGateway {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -4213,8 +4045,6 @@ class APIGateway {
     String? pathWithQueryString,
     Map<String, String>? stageVariables,
   }) async {
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (additionalContext != null) 'additionalContext': additionalContext,
       if (body != null) 'body': body,
@@ -4284,9 +4114,6 @@ class APIGateway {
     String? pathWithQueryString,
     Map<String, String>? stageVariables,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (body != null) 'body': body,
       if (clientCertificateId != null)
@@ -4324,8 +4151,6 @@ class APIGateway {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -4381,7 +4206,6 @@ class APIGateway {
     required String apiKey,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(apiKey, 'apiKey');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4418,8 +4242,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4459,8 +4281,6 @@ class APIGateway {
     required String domainName,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(basePath, 'basePath');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4492,7 +4312,6 @@ class APIGateway {
     required String clientCertificateId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(clientCertificateId, 'clientCertificateId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4529,8 +4348,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4566,8 +4383,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(documentationPartId, 'documentationPartId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4603,8 +4418,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(documentationVersion, 'documentationVersion');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4636,7 +4449,6 @@ class APIGateway {
     required String domainName,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4696,8 +4508,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(responseType, 'responseType');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4737,9 +4547,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4784,10 +4591,6 @@ class APIGateway {
     required String statusCode,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4827,9 +4630,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4875,10 +4675,6 @@ class APIGateway {
     required String statusCode,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(httpMethod, 'httpMethod');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(statusCode, 'statusCode');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4914,8 +4710,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4950,8 +4744,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(requestValidatorId, 'requestValidatorId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -4987,8 +4779,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -5020,7 +4810,6 @@ class APIGateway {
     required String restApiId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -5056,8 +4845,6 @@ class APIGateway {
     required String stageName,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(restApiId, 'restApiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -5094,8 +4881,6 @@ class APIGateway {
     required String usagePlanId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -5127,7 +4912,6 @@ class APIGateway {
     required String usagePlanId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(usagePlanId, 'usagePlanId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };
@@ -5159,7 +4943,6 @@ class APIGateway {
     required String vpcLinkId,
     List<PatchOperation>? patchOperations,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     final $payload = <String, dynamic>{
       if (patchOperations != null) 'patchOperations': patchOperations,
     };

--- a/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
+++ b/generated/aws_apigatewaymanagementapi_api/lib/apigatewaymanagementapi-2018-11-29.dart
@@ -61,7 +61,6 @@ class ApiGatewayManagementApi {
   Future<void> deleteConnection({
     required String connectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -78,7 +77,6 @@ class ApiGatewayManagementApi {
   Future<GetConnectionResponse> getConnection({
     required String connectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -104,8 +102,6 @@ class ApiGatewayManagementApi {
     required String connectionId,
     required Uint8List data,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(data, 'data');
     await _protocol.send(
       payload: data,
       method: 'POST',

--- a/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
+++ b/generated/aws_apigatewayv2_api/lib/apigatewayv2-2018-11-29.dart
@@ -138,8 +138,6 @@ class ApiGatewayV2 {
     String? target,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(protocolType, 'protocolType');
     final $payload = <String, dynamic>{
       'name': name,
       'protocolType': protocolType.toValue(),
@@ -192,9 +190,6 @@ class ApiGatewayV2 {
     required String stage,
     String? apiMappingKey,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(stage, 'stage');
     final $payload = <String, dynamic>{
       'apiId': apiId,
       'stage': stage,
@@ -314,10 +309,6 @@ class ApiGatewayV2 {
     String? identityValidationExpression,
     JWTConfiguration? jwtConfiguration,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(authorizerType, 'authorizerType');
-    ArgumentError.checkNotNull(identitySource, 'identitySource');
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'authorizerResultTtlInSeconds',
       authorizerResultTtlInSeconds,
@@ -370,7 +361,6 @@ class ApiGatewayV2 {
     String? description,
     String? stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (stageName != null) 'stageName': stageName,
@@ -409,7 +399,6 @@ class ApiGatewayV2 {
     MutualTlsAuthenticationInput? mutualTlsAuthentication,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       'domainName': domainName,
       if (domainNameConfigurations != null)
@@ -627,8 +616,6 @@ class ApiGatewayV2 {
     int? timeoutInMillis,
     TlsConfigInput? tlsConfig,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationType, 'integrationType');
     _s.validateNumRange(
       'timeoutInMillis',
       timeoutInMillis,
@@ -729,10 +716,6 @@ class ApiGatewayV2 {
     Map<String, String>? responseTemplates,
     String? templateSelectionExpression,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
-    ArgumentError.checkNotNull(
-        integrationResponseKey, 'integrationResponseKey');
     final $payload = <String, dynamic>{
       'integrationResponseKey': integrationResponseKey,
       if (contentHandlingStrategy != null)
@@ -781,9 +764,6 @@ class ApiGatewayV2 {
     String? contentType,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schema, 'schema');
     final $payload = <String, dynamic>{
       'name': name,
       'schema': schema,
@@ -864,8 +844,6 @@ class ApiGatewayV2 {
     String? routeResponseSelectionExpression,
     String? target,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeKey, 'routeKey');
     final $payload = <String, dynamic>{
       'routeKey': routeKey,
       if (apiKeyRequired != null) 'apiKeyRequired': apiKeyRequired,
@@ -925,9 +903,6 @@ class ApiGatewayV2 {
     Map<String, String>? responseModels,
     Map<String, ParameterConstraints>? responseParameters,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
-    ArgumentError.checkNotNull(routeResponseKey, 'routeResponseKey');
     final $payload = <String, dynamic>{
       'routeResponseKey': routeResponseKey,
       if (modelSelectionExpression != null)
@@ -1002,8 +977,6 @@ class ApiGatewayV2 {
     Map<String, String>? stageVariables,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final $payload = <String, dynamic>{
       'stageName': stageName,
       if (accessLogSettings != null) 'accessLogSettings': accessLogSettings,
@@ -1049,8 +1022,6 @@ class ApiGatewayV2 {
     List<String>? securityGroupIds,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $payload = <String, dynamic>{
       'name': name,
       'subnetIds': subnetIds,
@@ -1082,8 +1053,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1103,7 +1072,6 @@ class ApiGatewayV2 {
   Future<void> deleteApi({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1127,8 +1095,6 @@ class ApiGatewayV2 {
     required String apiMappingId,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(apiMappingId, 'apiMappingId');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1152,8 +1118,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String authorizerId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1173,7 +1137,6 @@ class ApiGatewayV2 {
   Future<void> deleteCorsConfiguration({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1196,8 +1159,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String deploymentId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1217,7 +1178,6 @@ class ApiGatewayV2 {
   Future<void> deleteDomainName({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1240,8 +1200,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String integrationId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1269,9 +1227,6 @@ class ApiGatewayV2 {
     required String integrationId,
     required String integrationResponseId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
-    ArgumentError.checkNotNull(integrationResponseId, 'integrationResponseId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1295,8 +1250,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String modelId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(modelId, 'modelId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1320,8 +1273,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String routeId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1349,9 +1300,6 @@ class ApiGatewayV2 {
     required String requestParameterKey,
     required String routeId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(requestParameterKey, 'requestParameterKey');
-    ArgumentError.checkNotNull(routeId, 'routeId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1379,9 +1327,6 @@ class ApiGatewayV2 {
     required String routeId,
     required String routeResponseId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
-    ArgumentError.checkNotNull(routeResponseId, 'routeResponseId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1410,9 +1355,6 @@ class ApiGatewayV2 {
     required String routeKey,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeKey, 'routeKey');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1437,8 +1379,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1458,7 +1398,6 @@ class ApiGatewayV2 {
   Future<void> deleteVpcLink({
     required String vpcLinkId,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1504,9 +1443,6 @@ class ApiGatewayV2 {
     bool? includeExtensions,
     String? stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(outputType, 'outputType');
-    ArgumentError.checkNotNull(specification, 'specification');
     final $query = <String, List<String>>{
       'outputType': [outputType],
       if (exportVersion != null) 'exportVersion': [exportVersion],
@@ -1544,8 +1480,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1565,7 +1499,6 @@ class ApiGatewayV2 {
   Future<GetApiResponse> getApi({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1590,8 +1523,6 @@ class ApiGatewayV2 {
     required String apiMappingId,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(apiMappingId, 'apiMappingId');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1622,7 +1553,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1682,8 +1612,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String authorizerId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1714,7 +1642,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1743,8 +1670,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String deploymentId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1775,7 +1700,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1800,7 +1724,6 @@ class ApiGatewayV2 {
   Future<GetDomainNameResponse> getDomainName({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1854,8 +1777,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String integrationId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1884,9 +1805,6 @@ class ApiGatewayV2 {
     required String integrationId,
     required String integrationResponseId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
-    ArgumentError.checkNotNull(integrationResponseId, 'integrationResponseId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1921,8 +1839,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1958,7 +1874,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1987,8 +1902,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String modelId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(modelId, 'modelId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2013,8 +1926,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String modelId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(modelId, 'modelId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2045,7 +1956,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -2074,8 +1984,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String routeId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2104,9 +2012,6 @@ class ApiGatewayV2 {
     required String routeId,
     required String routeResponseId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
-    ArgumentError.checkNotNull(routeResponseId, 'routeResponseId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2141,8 +2046,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -2178,7 +2081,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -2208,8 +2110,6 @@ class ApiGatewayV2 {
     required String apiId,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2240,7 +2140,6 @@ class ApiGatewayV2 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -2267,7 +2166,6 @@ class ApiGatewayV2 {
   Future<GetTagsResponse> getTags({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2287,7 +2185,6 @@ class ApiGatewayV2 {
   Future<GetVpcLinkResponse> getVpcLink({
     required String vpcLinkId,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2352,7 +2249,6 @@ class ApiGatewayV2 {
     String? basepath,
     bool? failOnWarnings,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
     final $query = <String, List<String>>{
       if (basepath != null) 'basepath': [basepath],
       if (failOnWarnings != null) 'failOnWarnings': [failOnWarnings.toString()],
@@ -2400,8 +2296,6 @@ class ApiGatewayV2 {
     String? basepath,
     bool? failOnWarnings,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(body, 'body');
     final $query = <String, List<String>>{
       if (basepath != null) 'basepath': [basepath],
       if (failOnWarnings != null) 'failOnWarnings': [failOnWarnings.toString()],
@@ -2436,7 +2330,6 @@ class ApiGatewayV2 {
     required String resourceArn,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
     };
@@ -2464,8 +2357,6 @@ class ApiGatewayV2 {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2561,7 +2452,6 @@ class ApiGatewayV2 {
     String? target,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $payload = <String, dynamic>{
       if (apiKeySelectionExpression != null)
         'apiKeySelectionExpression': apiKeySelectionExpression,
@@ -2616,9 +2506,6 @@ class ApiGatewayV2 {
     String? apiMappingKey,
     String? stage,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(apiMappingId, 'apiMappingId');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       'apiId': apiId,
       if (apiMappingKey != null) 'apiMappingKey': apiMappingKey,
@@ -2741,8 +2628,6 @@ class ApiGatewayV2 {
     JWTConfiguration? jwtConfiguration,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(authorizerId, 'authorizerId');
     _s.validateNumRange(
       'authorizerResultTtlInSeconds',
       authorizerResultTtlInSeconds,
@@ -2796,8 +2681,6 @@ class ApiGatewayV2 {
     required String deploymentId,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
     };
@@ -2831,7 +2714,6 @@ class ApiGatewayV2 {
     List<DomainNameConfiguration>? domainNameConfigurations,
     MutualTlsAuthenticationInput? mutualTlsAuthentication,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $payload = <String, dynamic>{
       if (domainNameConfigurations != null)
         'domainNameConfigurations': domainNameConfigurations,
@@ -3051,8 +2933,6 @@ class ApiGatewayV2 {
     int? timeoutInMillis,
     TlsConfigInput? tlsConfig,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
     _s.validateNumRange(
       'timeoutInMillis',
       timeoutInMillis,
@@ -3162,9 +3042,6 @@ class ApiGatewayV2 {
     Map<String, String>? responseTemplates,
     String? templateSelectionExpression,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(integrationId, 'integrationId');
-    ArgumentError.checkNotNull(integrationResponseId, 'integrationResponseId');
     final $payload = <String, dynamic>{
       if (contentHandlingStrategy != null)
         'contentHandlingStrategy': contentHandlingStrategy.toValue(),
@@ -3218,8 +3095,6 @@ class ApiGatewayV2 {
     String? name,
     String? schema,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(modelId, 'modelId');
     final $payload = <String, dynamic>{
       if (contentType != null) 'contentType': contentType,
       if (description != null) 'description': description,
@@ -3305,8 +3180,6 @@ class ApiGatewayV2 {
     String? routeResponseSelectionExpression,
     String? target,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
     final $payload = <String, dynamic>{
       if (apiKeyRequired != null) 'apiKeyRequired': apiKeyRequired,
       if (authorizationScopes != null)
@@ -3371,9 +3244,6 @@ class ApiGatewayV2 {
     Map<String, ParameterConstraints>? responseParameters,
     String? routeResponseKey,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(routeId, 'routeId');
-    ArgumentError.checkNotNull(routeResponseId, 'routeResponseId');
     final $payload = <String, dynamic>{
       if (modelSelectionExpression != null)
         'modelSelectionExpression': modelSelectionExpression,
@@ -3445,8 +3315,6 @@ class ApiGatewayV2 {
     Map<String, RouteSettings>? routeSettings,
     Map<String, String>? stageVariables,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(stageName, 'stageName');
     final $payload = <String, dynamic>{
       if (accessLogSettings != null) 'accessLogSettings': accessLogSettings,
       if (autoDeploy != null) 'autoDeploy': autoDeploy,
@@ -3484,7 +3352,6 @@ class ApiGatewayV2 {
     required String vpcLinkId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(vpcLinkId, 'vpcLinkId');
     final $payload = <String, dynamic>{
       if (name != null) 'name': name,
     };

--- a/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
+++ b/generated/aws_appconfig_api/lib/appconfig-2019-10-09.dart
@@ -77,20 +77,6 @@ class AppConfig {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (description != null) 'Description': description,
@@ -172,35 +158,6 @@ class AppConfig {
     Map<String, String>? tags,
     List<Validator>? validators,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(locationUri, 'locationUri');
-    _s.validateStringLength(
-      'locationUri',
-      locationUri,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'retrievalRoleArn',
-      retrievalRoleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       'LocationUri': locationUri,
       'Name': name,
@@ -291,8 +248,6 @@ class AppConfig {
     GrowthType? growthType,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        deploymentDurationInMinutes, 'deploymentDurationInMinutes');
     _s.validateNumRange(
       'deploymentDurationInMinutes',
       deploymentDurationInMinutes,
@@ -300,28 +255,12 @@ class AppConfig {
       1440,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(growthFactor, 'growthFactor');
     _s.validateNumRange(
       'growthFactor',
       growthFactor,
       1,
       100,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(replicateTo, 'replicateTo');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
     );
     _s.validateNumRange(
       'finalBakeTimeInMinutes',
@@ -385,21 +324,6 @@ class AppConfig {
     List<Monitor>? monitors,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (description != null) 'Description': description,
@@ -456,24 +380,6 @@ class AppConfig {
     String? description,
     int? latestVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': contentType.toString(),
       if (description != null) 'Description': description.toString(),
@@ -514,7 +420,6 @@ class AppConfig {
   Future<void> deleteApplication({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -541,9 +446,6 @@ class AppConfig {
     required String applicationId,
     required String configurationProfileId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -565,7 +467,6 @@ class AppConfig {
   Future<void> deleteDeploymentStrategy({
     required String deploymentStrategyId,
   }) async {
-    ArgumentError.checkNotNull(deploymentStrategyId, 'deploymentStrategyId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -592,8 +493,6 @@ class AppConfig {
     required String applicationId,
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -623,10 +522,6 @@ class AppConfig {
     required String configurationProfileId,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -647,7 +542,6 @@ class AppConfig {
   Future<Application> getApplication({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -723,44 +617,6 @@ class AppConfig {
     required String environment,
     String? clientConfigurationVersion,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configuration, 'configuration');
-    _s.validateStringLength(
-      'configuration',
-      configuration,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(environment, 'environment');
-    _s.validateStringLength(
-      'environment',
-      environment,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientConfigurationVersion',
-      clientConfigurationVersion,
-      1,
-      1024,
-    );
     final $query = <String, List<String>>{
       'client_id': [clientId],
       if (clientConfigurationVersion != null)
@@ -799,9 +655,6 @@ class AppConfig {
     required String applicationId,
     required String configurationProfileId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -831,9 +684,6 @@ class AppConfig {
     required int deploymentNumber,
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(deploymentNumber, 'deploymentNumber');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -859,7 +709,6 @@ class AppConfig {
   Future<DeploymentStrategy> getDeploymentStrategy({
     required String deploymentStrategyId,
   }) async {
-    ArgumentError.checkNotNull(deploymentStrategyId, 'deploymentStrategyId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -891,8 +740,6 @@ class AppConfig {
     required String applicationId,
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -922,10 +769,6 @@ class AppConfig {
     required String configurationProfileId,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -969,12 +812,6 @@ class AppConfig {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
       if (nextToken != null) 'next_token': [nextToken],
@@ -1010,18 +847,11 @@ class AppConfig {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -1059,12 +889,6 @@ class AppConfig {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -1105,19 +929,11 @@ class AppConfig {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -1155,18 +971,11 @@ class AppConfig {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -1209,20 +1018,11 @@ class AppConfig {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -1250,14 +1050,6 @@ class AppConfig {
   Future<ResourceTags> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1305,25 +1097,6 @@ class AppConfig {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    ArgumentError.checkNotNull(configurationVersion, 'configurationVersion');
-    _s.validateStringLength(
-      'configurationVersion',
-      configurationVersion,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deploymentStrategyId, 'deploymentStrategyId');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'ConfigurationProfileId': configurationProfileId,
       'ConfigurationVersion': configurationVersion,
@@ -1362,9 +1135,6 @@ class AppConfig {
     required int deploymentNumber,
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(deploymentNumber, 'deploymentNumber');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1395,15 +1165,6 @@ class AppConfig {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1430,15 +1191,6 @@ class AppConfig {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1470,19 +1222,6 @@ class AppConfig {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -1528,27 +1267,6 @@ class AppConfig {
     String? retrievalRoleArn,
     List<Validator>? validators,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'retrievalRoleArn',
-      retrievalRoleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -1624,18 +1342,11 @@ class AppConfig {
     double? growthFactor,
     GrowthType? growthType,
   }) async {
-    ArgumentError.checkNotNull(deploymentStrategyId, 'deploymentStrategyId');
     _s.validateNumRange(
       'deploymentDurationInMinutes',
       deploymentDurationInMinutes,
       0,
       1440,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
     );
     _s.validateNumRange(
       'finalBakeTimeInMinutes',
@@ -1695,20 +1406,6 @@ class AppConfig {
     List<Monitor>? monitors,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (monitors != null) 'Monitors': monitors,
@@ -1744,17 +1441,6 @@ class AppConfig {
     required String configurationProfileId,
     required String configurationVersion,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        configurationProfileId, 'configurationProfileId');
-    ArgumentError.checkNotNull(configurationVersion, 'configurationVersion');
-    _s.validateStringLength(
-      'configurationVersion',
-      configurationVersion,
-      1,
-      1024,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'configuration_version': [configurationVersion],
     };

--- a/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
+++ b/generated/aws_application_autoscaling_api/lib/application-autoscaling-2016-02-06.dart
@@ -312,24 +312,6 @@ class ApplicationAutoScaling {
     required ScalableDimension scalableDimension,
     required ServiceNamespace serviceNamespace,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DeleteScalingPolicy'
@@ -534,24 +516,6 @@ class ApplicationAutoScaling {
     required String scheduledActionName,
     required ServiceNamespace serviceNamespace,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DeleteScheduledAction'
@@ -753,16 +717,6 @@ class ApplicationAutoScaling {
     required ScalableDimension scalableDimension,
     required ServiceNamespace serviceNamespace,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DeregisterScalableTarget'
@@ -978,7 +932,6 @@ class ApplicationAutoScaling {
     List<String>? resourceIds,
     ScalableDimension? scalableDimension,
   }) async {
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DescribeScalableTargets'
@@ -1200,13 +1153,6 @@ class ApplicationAutoScaling {
     String? resourceId,
     ScalableDimension? scalableDimension,
   }) async {
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DescribeScalingActivities'
@@ -1439,13 +1385,6 @@ class ApplicationAutoScaling {
     String? resourceId,
     ScalableDimension? scalableDimension,
   }) async {
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DescribeScalingPolicies'
@@ -1677,13 +1616,6 @@ class ApplicationAutoScaling {
     ScalableDimension? scalableDimension,
     List<String>? scheduledActionNames,
   }) async {
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.DescribeScheduledActions'
@@ -1961,24 +1893,6 @@ class ApplicationAutoScaling {
     TargetTrackingScalingPolicyConfiguration?
         targetTrackingScalingPolicyConfiguration,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.PutScalingPolicy'
@@ -2257,30 +2171,6 @@ class ApplicationAutoScaling {
     String? schedule,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'schedule',
-      schedule,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.PutScheduledAction'
@@ -2579,22 +2469,6 @@ class ApplicationAutoScaling {
     String? roleARN,
     SuspendedState? suspendedState,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleFrontendService.RegisterScalableTarget'

--- a/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
+++ b/generated/aws_application_insights_api/lib/application-insights-2018-11-25.dart
@@ -89,20 +89,6 @@ class ApplicationInsights {
     String? opsItemSNSTopicArn,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'opsItemSNSTopicArn',
-      opsItemSNSTopicArn,
-      20,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.CreateApplication'
@@ -147,23 +133,6 @@ class ApplicationInsights {
     required String resourceGroupName,
     required List<String> resourceList,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceList, 'resourceList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.CreateComponent'
@@ -222,39 +191,6 @@ class ApplicationInsights {
     required int rank,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(pattern, 'pattern');
-    _s.validateStringLength(
-      'pattern',
-      pattern,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patternName, 'patternName');
-    _s.validateStringLength(
-      'patternName',
-      patternName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patternSetName, 'patternSetName');
-    _s.validateStringLength(
-      'patternSetName',
-      patternSetName,
-      1,
-      30,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rank, 'rank');
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.CreateLogPattern'
@@ -290,14 +226,6 @@ class ApplicationInsights {
   Future<void> deleteApplication({
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DeleteApplication'
@@ -331,22 +259,6 @@ class ApplicationInsights {
     required String componentName,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DeleteComponent'
@@ -384,30 +296,6 @@ class ApplicationInsights {
     required String patternSetName,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(patternName, 'patternName');
-    _s.validateStringLength(
-      'patternName',
-      patternName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patternSetName, 'patternSetName');
-    _s.validateStringLength(
-      'patternSetName',
-      patternSetName,
-      1,
-      30,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DeleteLogPattern'
@@ -437,14 +325,6 @@ class ApplicationInsights {
   Future<DescribeApplicationResponse> describeApplication({
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeApplication'
@@ -479,22 +359,6 @@ class ApplicationInsights {
     required String componentName,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeComponent'
@@ -530,22 +394,6 @@ class ApplicationInsights {
     required String componentName,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeComponentConfiguration'
@@ -588,23 +436,6 @@ class ApplicationInsights {
     required String resourceGroupName,
     required Tier tier,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tier, 'tier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -646,30 +477,6 @@ class ApplicationInsights {
     required String patternSetName,
     required String resourceGroupName,
   }) async {
-    ArgumentError.checkNotNull(patternName, 'patternName');
-    _s.validateStringLength(
-      'patternName',
-      patternName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patternSetName, 'patternSetName');
-    _s.validateStringLength(
-      'patternSetName',
-      patternSetName,
-      1,
-      30,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeLogPattern'
@@ -701,14 +508,6 @@ class ApplicationInsights {
   Future<DescribeObservationResponse> describeObservation({
     required String observationId,
   }) async {
-    ArgumentError.checkNotNull(observationId, 'observationId');
-    _s.validateStringLength(
-      'observationId',
-      observationId,
-      38,
-      38,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeObservation'
@@ -738,14 +537,6 @@ class ApplicationInsights {
   Future<DescribeProblemResponse> describeProblem({
     required String problemId,
   }) async {
-    ArgumentError.checkNotNull(problemId, 'problemId');
-    _s.validateStringLength(
-      'problemId',
-      problemId,
-      38,
-      38,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeProblem'
@@ -775,14 +566,6 @@ class ApplicationInsights {
   Future<DescribeProblemObservationsResponse> describeProblemObservations({
     required String problemId,
   }) async {
-    ArgumentError.checkNotNull(problemId, 'problemId');
-    _s.validateStringLength(
-      'problemId',
-      problemId,
-      38,
-      38,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.DescribeProblemObservations'
@@ -822,12 +605,6 @@ class ApplicationInsights {
       maxResults,
       1,
       40,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -870,25 +647,11 @@ class ApplicationInsights {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       40,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -975,18 +738,6 @@ class ApplicationInsights {
       1,
       40,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.ListConfigurationHistory'
@@ -1031,25 +782,11 @@ class ApplicationInsights {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       40,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1096,31 +833,11 @@ class ApplicationInsights {
     String? nextToken,
     String? patternSetName,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       40,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'patternSetName',
-      patternSetName,
-      1,
-      30,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1181,18 +898,6 @@ class ApplicationInsights {
       1,
       40,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.ListProblems'
@@ -1231,14 +936,6 @@ class ApplicationInsights {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.ListTagsForResource'
@@ -1284,15 +981,6 @@ class ApplicationInsights {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.TagResource'
@@ -1331,15 +1019,6 @@ class ApplicationInsights {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.UntagResource'
@@ -1390,20 +1069,6 @@ class ApplicationInsights {
     String? opsItemSNSTopicArn,
     bool? removeSNSTopic,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'opsItemSNSTopicArn',
-      opsItemSNSTopicArn,
-      20,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.UpdateApplication'
@@ -1452,28 +1117,6 @@ class ApplicationInsights {
     String? newComponentName,
     List<String>? resourceList,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'newComponentName',
-      newComponentName,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.UpdateComponent'
@@ -1534,28 +1177,6 @@ class ApplicationInsights {
     bool? monitor,
     Tier? tier,
   }) async {
-    ArgumentError.checkNotNull(componentName, 'componentName');
-    _s.validateStringLength(
-      'componentName',
-      componentName,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'componentConfiguration',
-      componentConfiguration,
-      1,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.UpdateComponentConfiguration'
@@ -1617,36 +1238,6 @@ class ApplicationInsights {
     String? pattern,
     int? rank,
   }) async {
-    ArgumentError.checkNotNull(patternName, 'patternName');
-    _s.validateStringLength(
-      'patternName',
-      patternName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patternSetName, 'patternSetName');
-    _s.validateStringLength(
-      'patternSetName',
-      patternSetName,
-      1,
-      30,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceGroupName, 'resourceGroupName');
-    _s.validateStringLength(
-      'resourceGroupName',
-      resourceGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'pattern',
-      pattern,
-      1,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'EC2WindowsBarleyService.UpdateLogPattern'

--- a/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2018-10-01.dart
@@ -108,14 +108,6 @@ class AppMesh {
     required String meshName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'meshName': meshName,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -179,31 +171,6 @@ class AppMesh {
     required String virtualRouterName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'routeName': routeName,
       'spec': spec,
@@ -289,23 +256,6 @@ class AppMesh {
     required String virtualNodeName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'spec': spec,
       'virtualNodeName': virtualNodeName,
@@ -360,23 +310,6 @@ class AppMesh {
     required String virtualRouterName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'spec': spec,
       'virtualRouterName': virtualRouterName,
@@ -414,14 +347,6 @@ class AppMesh {
   Future<DeleteMeshOutput> deleteMesh({
     required String meshName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -457,30 +382,6 @@ class AppMesh {
     required String routeName,
     required String virtualRouterName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -513,22 +414,6 @@ class AppMesh {
     required String meshName,
     required String virtualNodeName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -566,22 +451,6 @@ class AppMesh {
     required String meshName,
     required String virtualRouterName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -609,14 +478,6 @@ class AppMesh {
   Future<DescribeMeshOutput> describeMesh({
     required String meshName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -651,30 +512,6 @@ class AppMesh {
     required String routeName,
     required String virtualRouterName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -706,22 +543,6 @@ class AppMesh {
     required String meshName,
     required String virtualNodeName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -753,22 +574,6 @@ class AppMesh {
     required String meshName,
     required String virtualRouterName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -883,22 +688,6 @@ class AppMesh {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -959,14 +748,6 @@ class AppMesh {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1026,14 +807,6 @@ class AppMesh {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1088,31 +861,6 @@ class AppMesh {
     required String virtualRouterName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'spec': spec,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -1161,23 +909,6 @@ class AppMesh {
     required String virtualNodeName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'spec': spec,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -1226,23 +957,6 @@ class AppMesh {
     required String virtualRouterName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'spec': spec,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),

--- a/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
+++ b/generated/aws_appmesh_api/lib/appmesh-2019-01-25.dart
@@ -127,37 +127,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(gatewayRouteName, 'gatewayRouteName');
-    _s.validateStringLength(
-      'gatewayRouteName',
-      gatewayRouteName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -225,14 +194,6 @@ class AppMesh {
     MeshSpec? spec,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'meshName': meshName,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -310,37 +271,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -422,29 +352,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -550,29 +457,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -654,29 +538,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -758,22 +619,6 @@ class AppMesh {
     String? meshOwner,
     List<TagRef>? tags,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualServiceName, 'virtualServiceName');
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -828,36 +673,6 @@ class AppMesh {
     required String virtualGatewayName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(gatewayRouteName, 'gatewayRouteName');
-    _s.validateStringLength(
-      'gatewayRouteName',
-      gatewayRouteName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -894,14 +709,6 @@ class AppMesh {
   Future<DeleteMeshOutput> deleteMesh({
     required String meshName,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -945,36 +752,6 @@ class AppMesh {
     required String virtualRouterName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1020,28 +797,6 @@ class AppMesh {
     required String virtualGatewayName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1089,28 +844,6 @@ class AppMesh {
     required String virtualNodeName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1158,28 +891,6 @@ class AppMesh {
     required String virtualRouterName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1224,21 +935,6 @@ class AppMesh {
     required String virtualServiceName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualServiceName, 'virtualServiceName');
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1286,36 +982,6 @@ class AppMesh {
     required String virtualGatewayName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(gatewayRouteName, 'gatewayRouteName');
-    _s.validateStringLength(
-      'gatewayRouteName',
-      gatewayRouteName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1355,20 +1021,6 @@ class AppMesh {
     required String meshName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1415,36 +1067,6 @@ class AppMesh {
     required String virtualRouterName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1488,28 +1110,6 @@ class AppMesh {
     required String virtualGatewayName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1553,28 +1153,6 @@ class AppMesh {
     required String virtualNodeName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1618,28 +1196,6 @@ class AppMesh {
     required String virtualRouterName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1683,21 +1239,6 @@ class AppMesh {
     required String virtualServiceName,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualServiceName, 'virtualServiceName');
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -1762,33 +1303,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -1906,33 +1425,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -1985,7 +1482,6 @@ class AppMesh {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2049,25 +1545,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -2127,25 +1609,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -2205,25 +1673,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -2283,25 +1737,11 @@ class AppMesh {
     String? meshOwner,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -2343,8 +1783,6 @@ class AppMesh {
     required String resourceArn,
     required List<TagRef> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -2378,8 +1816,6 @@ class AppMesh {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -2439,37 +1875,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(gatewayRouteName, 'gatewayRouteName');
-    _s.validateStringLength(
-      'gatewayRouteName',
-      gatewayRouteName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -2516,14 +1921,6 @@ class AppMesh {
     String? clientToken,
     MeshSpec? spec,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
       if (spec != null) 'spec': spec,
@@ -2582,37 +1979,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routeName, 'routeName');
-    _s.validateStringLength(
-      'routeName',
-      routeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -2673,29 +2039,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualGatewayName, 'virtualGatewayName');
-    _s.validateStringLength(
-      'virtualGatewayName',
-      virtualGatewayName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -2756,29 +2099,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualNodeName, 'virtualNodeName');
-    _s.validateStringLength(
-      'virtualNodeName',
-      virtualNodeName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -2839,29 +2159,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualRouterName, 'virtualRouterName');
-    _s.validateStringLength(
-      'virtualRouterName',
-      virtualRouterName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };
@@ -2922,22 +2219,6 @@ class AppMesh {
     String? clientToken,
     String? meshOwner,
   }) async {
-    ArgumentError.checkNotNull(meshName, 'meshName');
-    _s.validateStringLength(
-      'meshName',
-      meshName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(spec, 'spec');
-    ArgumentError.checkNotNull(virtualServiceName, 'virtualServiceName');
-    _s.validateStringLength(
-      'meshOwner',
-      meshOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (meshOwner != null) 'meshOwner': [meshOwner],
     };

--- a/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
+++ b/generated/aws_appstream_api/lib/appstream-2016-12-01.dart
@@ -80,22 +80,6 @@ class AppStream {
     required String fleetName,
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.AssociateFleet'
@@ -125,7 +109,6 @@ class AppStream {
   Future<BatchAssociateUserStackResult> batchAssociateUserStack({
     required List<UserStackAssociation> userStackAssociations,
   }) async {
-    ArgumentError.checkNotNull(userStackAssociations, 'userStackAssociations');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.BatchAssociateUserStack'
@@ -154,7 +137,6 @@ class AppStream {
   Future<BatchDisassociateUserStackResult> batchDisassociateUserStack({
     required List<UserStackAssociation> userStackAssociations,
   }) async {
-    ArgumentError.checkNotNull(userStackAssociations, 'userStackAssociations');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.BatchDisassociateUserStack'
@@ -202,22 +184,6 @@ class AppStream {
     required String sourceImageName,
     String? destinationImageDescription,
   }) async {
-    ArgumentError.checkNotNull(destinationImageName, 'destinationImageName');
-    ArgumentError.checkNotNull(destinationRegion, 'destinationRegion');
-    _s.validateStringLength(
-      'destinationRegion',
-      destinationRegion,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceImageName, 'sourceImageName');
-    _s.validateStringLength(
-      'destinationImageDescription',
-      destinationImageDescription,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CopyImage'
@@ -265,9 +231,6 @@ class AppStream {
     required List<String> organizationalUnitDistinguishedNames,
     ServiceAccountCredentials? serviceAccountCredentials,
   }) async {
-    ArgumentError.checkNotNull(directoryName, 'directoryName');
-    ArgumentError.checkNotNull(organizationalUnitDistinguishedNames,
-        'organizationalUnitDistinguishedNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateDirectoryConfig'
@@ -552,34 +515,6 @@ class AppStream {
     Map<String, String>? tags,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(computeCapacity, 'computeCapacity');
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateFleet'
@@ -819,39 +754,6 @@ class AppStream {
     Map<String, String>? tags,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'appstreamAgentVersion',
-      appstreamAgentVersion,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateImageBuilder'
@@ -899,14 +801,6 @@ class AppStream {
     required String name,
     int? validity,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateImageBuilderStreamingURL'
@@ -1005,31 +899,6 @@ class AppStream {
     Map<String, String>? tags,
     List<UserSetting>? userSettings,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'feedbackURL',
-      feedbackURL,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'redirectURL',
-      redirectURL,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateStack'
@@ -1097,42 +966,6 @@ class AppStream {
     String? sessionContext,
     int? validity,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationId',
-      applicationId,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'sessionContext',
-      sessionContext,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateStreamingURL'
@@ -1221,27 +1054,6 @@ class AppStream {
     String? lastName,
     MessageAction? messageAction,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'firstName',
-      firstName,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'lastName',
-      lastName,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.CreateUser'
@@ -1274,7 +1086,6 @@ class AppStream {
   Future<void> deleteDirectoryConfig({
     required String directoryName,
   }) async {
-    ArgumentError.checkNotNull(directoryName, 'directoryName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteDirectoryConfig'
@@ -1302,14 +1113,6 @@ class AppStream {
   Future<void> deleteFleet({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteFleet'
@@ -1340,7 +1143,6 @@ class AppStream {
   Future<DeleteImageResult> deleteImage({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteImage'
@@ -1370,7 +1172,6 @@ class AppStream {
   Future<DeleteImageBuilderResult> deleteImageBuilder({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteImageBuilder'
@@ -1406,8 +1207,6 @@ class AppStream {
     required String name,
     required String sharedAccountId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(sharedAccountId, 'sharedAccountId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteImagePermissions'
@@ -1439,14 +1238,6 @@ class AppStream {
   Future<void> deleteStack({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteStack'
@@ -1497,15 +1288,6 @@ class AppStream {
     required AuthenticationType authenticationType,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DeleteUser'
@@ -1548,12 +1330,6 @@ class AppStream {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeDirectoryConfigs'
@@ -1589,12 +1365,6 @@ class AppStream {
     List<String>? names,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeFleets'
@@ -1634,12 +1404,6 @@ class AppStream {
     List<String>? names,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeImageBuilders'
@@ -1685,18 +1449,11 @@ class AppStream {
     String? nextToken,
     List<String>? sharedAwsAccountIds,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1754,12 +1511,6 @@ class AppStream {
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1822,34 +1573,6 @@ class AppStream {
     String? nextToken,
     String? userId,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeSessions'
@@ -1889,12 +1612,6 @@ class AppStream {
     List<String>? names,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeStacks'
@@ -1930,12 +1647,6 @@ class AppStream {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeUsageReportSubscriptions'
@@ -2003,24 +1714,6 @@ class AppStream {
       0,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeUserStackAssociations'
@@ -2065,13 +1758,6 @@ class AppStream {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DescribeUsers'
@@ -2110,15 +1796,6 @@ class AppStream {
     required AuthenticationType authenticationType,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DisableUser'
@@ -2152,22 +1829,6 @@ class AppStream {
     required String fleetName,
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.DisassociateFleet'
@@ -2207,15 +1868,6 @@ class AppStream {
     required AuthenticationType authenticationType,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.EnableUser'
@@ -2240,14 +1892,6 @@ class AppStream {
   Future<void> expireSession({
     required String sessionId,
   }) async {
-    ArgumentError.checkNotNull(sessionId, 'sessionId');
-    _s.validateStringLength(
-      'sessionId',
-      sessionId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.ExpireSession'
@@ -2277,20 +1921,6 @@ class AppStream {
     required String stackName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.ListAssociatedFleets'
@@ -2323,20 +1953,6 @@ class AppStream {
     required String fleetName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.ListAssociatedStacks'
@@ -2371,7 +1987,6 @@ class AppStream {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.ListTagsForResource'
@@ -2406,14 +2021,6 @@ class AppStream {
   Future<void> startFleet({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.StartFleet'
@@ -2448,20 +2055,6 @@ class AppStream {
     required String name,
     String? appstreamAgentVersion,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'appstreamAgentVersion',
-      appstreamAgentVersion,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.StartImageBuilder'
@@ -2492,14 +2085,6 @@ class AppStream {
   Future<void> stopFleet({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.StopFleet'
@@ -2527,14 +2112,6 @@ class AppStream {
   Future<StopImageBuilderResult> stopImageBuilder({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.StopImageBuilder'
@@ -2591,8 +2168,6 @@ class AppStream {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.TagResource'
@@ -2632,8 +2207,6 @@ class AppStream {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.UntagResource'
@@ -2675,7 +2248,6 @@ class AppStream {
     List<String>? organizationalUnitDistinguishedNames,
     ServiceAccountCredentials? serviceAccountCredentials,
   }) async {
-    ArgumentError.checkNotNull(directoryName, 'directoryName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.UpdateDirectoryConfig'
@@ -2945,36 +2517,6 @@ class AppStream {
     StreamView? streamView,
     VpcConfig? vpcConfig,
   }) async {
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.UpdateFleet'
@@ -3035,9 +2577,6 @@ class AppStream {
     required String name,
     required String sharedAccountId,
   }) async {
-    ArgumentError.checkNotNull(imagePermissions, 'imagePermissions');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(sharedAccountId, 'sharedAccountId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.UpdateImagePermissions'
@@ -3126,38 +2665,6 @@ class AppStream {
     List<StorageConnector>? storageConnectors,
     List<UserSetting>? userSettings,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'feedbackURL',
-      feedbackURL,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'redirectURL',
-      redirectURL,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'PhotonAdminProxyService.UpdateStack'

--- a/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
+++ b/generated/aws_appsync_api/lib/appsync-2017-07-25.dart
@@ -153,10 +153,6 @@ class AppSync {
     bool? atRestEncryptionEnabled,
     bool? transitEncryptionEnabled,
   }) async {
-    ArgumentError.checkNotNull(apiCachingBehavior, 'apiCachingBehavior');
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(ttl, 'ttl');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'apiCachingBehavior': apiCachingBehavior.toValue(),
       'ttl': ttl,
@@ -203,7 +199,6 @@ class AppSync {
     String? description,
     int? expires,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (expires != null) 'expires': expires,
@@ -267,16 +262,6 @@ class AppSync {
     RelationalDatabaseDataSourceConfig? relationalDatabaseConfig,
     String? serviceRoleArn,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'name': name,
       'type': type.toValue(),
@@ -341,36 +326,6 @@ class AppSync {
     String? requestMappingTemplate,
     String? responseMappingTemplate,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(dataSourceName, 'dataSourceName');
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionVersion, 'functionVersion');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'requestMappingTemplate',
-      requestMappingTemplate,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'responseMappingTemplate',
-      responseMappingTemplate,
-      1,
-      65536,
-    );
     final $payload = <String, dynamic>{
       'dataSourceName': dataSourceName,
       'functionVersion': functionVersion,
@@ -435,8 +390,6 @@ class AppSync {
     UserPoolConfig? userPoolConfig,
     bool? xrayEnabled,
   }) async {
-    ArgumentError.checkNotNull(authenticationType, 'authenticationType');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'authenticationType': authenticationType.toValue(),
       'name': name,
@@ -532,41 +485,6 @@ class AppSync {
     String? responseMappingTemplate,
     SyncConfig? syncConfig,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(fieldName, 'fieldName');
-    _s.validateStringLength(
-      'fieldName',
-      fieldName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'requestMappingTemplate',
-      requestMappingTemplate,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'responseMappingTemplate',
-      responseMappingTemplate,
-      1,
-      65536,
-    );
     final $payload = <String, dynamic>{
       'fieldName': fieldName,
       if (cachingConfig != null) 'cachingConfig': cachingConfig,
@@ -613,9 +531,6 @@ class AppSync {
     required String definition,
     required TypeDefinitionFormat format,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(format, 'format');
     final $payload = <String, dynamic>{
       'definition': definition,
       'format': format.toValue(),
@@ -642,7 +557,6 @@ class AppSync {
   Future<void> deleteApiCache({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -667,8 +581,6 @@ class AppSync {
     required String apiId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -695,15 +607,6 @@ class AppSync {
     required String apiId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -729,15 +632,6 @@ class AppSync {
     required String apiId,
     required String functionId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(functionId, 'functionId');
-    _s.validateStringLength(
-      'functionId',
-      functionId,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -761,7 +655,6 @@ class AppSync {
   Future<void> deleteGraphqlApi({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -790,23 +683,6 @@ class AppSync {
     required String fieldName,
     required String typeName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(fieldName, 'fieldName');
-    _s.validateStringLength(
-      'fieldName',
-      fieldName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -833,15 +709,6 @@ class AppSync {
     required String apiId,
     required String typeName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -864,7 +731,6 @@ class AppSync {
   Future<void> flushApiCache({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -886,7 +752,6 @@ class AppSync {
   Future<GetApiCacheResponse> getApiCache({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -913,15 +778,6 @@ class AppSync {
     required String apiId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -947,15 +803,6 @@ class AppSync {
     required String apiId,
     required String functionId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(functionId, 'functionId');
-    _s.validateStringLength(
-      'functionId',
-      functionId,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -979,7 +826,6 @@ class AppSync {
   Future<GetGraphqlApiResponse> getGraphqlApi({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1010,8 +856,6 @@ class AppSync {
     required OutputType format,
     bool? includeDirectives,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(format, 'format');
     final $query = <String, List<String>>{
       'format': [format.toValue()],
       if (includeDirectives != null)
@@ -1048,23 +892,6 @@ class AppSync {
     required String fieldName,
     required String typeName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(fieldName, 'fieldName');
-    _s.validateStringLength(
-      'fieldName',
-      fieldName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1087,7 +914,6 @@ class AppSync {
   Future<GetSchemaCreationStatusResponse> getSchemaCreationStatus({
     required String apiId,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1118,16 +944,6 @@ class AppSync {
     required TypeDefinitionFormat format,
     required String typeName,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(format, 'format');
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'format': [format.toValue()],
     };
@@ -1169,18 +985,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1217,18 +1026,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1265,18 +1067,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1313,12 +1108,6 @@ class AppSync {
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1359,19 +1148,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(typeName, 'typeName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1413,19 +1194,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(functionId, 'functionId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1456,14 +1229,6 @@ class AppSync {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      70,
-      75,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1499,19 +1264,11 @@ class AppSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(format, 'format');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65536,
     );
     final $query = <String, List<String>>{
       'format': [format.toValue()],
@@ -1547,8 +1304,6 @@ class AppSync {
     required String apiId,
     required Uint8List definition,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(definition, 'definition');
     final $payload = <String, dynamic>{
       'definition': base64Encode(definition),
     };
@@ -1579,15 +1334,6 @@ class AppSync {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      70,
-      75,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1617,15 +1363,6 @@ class AppSync {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      70,
-      75,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1732,10 +1469,6 @@ class AppSync {
     required int ttl,
     required ApiCacheType type,
   }) async {
-    ArgumentError.checkNotNull(apiCachingBehavior, 'apiCachingBehavior');
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(ttl, 'ttl');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'apiCachingBehavior': apiCachingBehavior.toValue(),
       'ttl': ttl,
@@ -1777,8 +1510,6 @@ class AppSync {
     String? description,
     int? expires,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (expires != null) 'expires': expires,
@@ -1842,16 +1573,6 @@ class AppSync {
     RelationalDatabaseDataSourceConfig? relationalDatabaseConfig,
     String? serviceRoleArn,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'type': type.toValue(),
       if (description != null) 'description': description,
@@ -1916,44 +1637,6 @@ class AppSync {
     String? requestMappingTemplate,
     String? responseMappingTemplate,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(dataSourceName, 'dataSourceName');
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionId, 'functionId');
-    _s.validateStringLength(
-      'functionId',
-      functionId,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionVersion, 'functionVersion');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'requestMappingTemplate',
-      requestMappingTemplate,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'responseMappingTemplate',
-      responseMappingTemplate,
-      1,
-      65536,
-    );
     final $payload = <String, dynamic>{
       'dataSourceName': dataSourceName,
       'functionVersion': functionVersion,
@@ -2020,8 +1703,6 @@ class AppSync {
     UserPoolConfig? userPoolConfig,
     bool? xrayEnabled,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (additionalAuthenticationProviders != null)
@@ -2114,41 +1795,6 @@ class AppSync {
     String? responseMappingTemplate,
     SyncConfig? syncConfig,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(fieldName, 'fieldName');
-    _s.validateStringLength(
-      'fieldName',
-      fieldName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'requestMappingTemplate',
-      requestMappingTemplate,
-      1,
-      65536,
-    );
-    _s.validateStringLength(
-      'responseMappingTemplate',
-      responseMappingTemplate,
-      1,
-      65536,
-    );
     final $payload = <String, dynamic>{
       if (cachingConfig != null) 'cachingConfig': cachingConfig,
       if (dataSourceName != null) 'dataSourceName': dataSourceName,
@@ -2195,16 +1841,6 @@ class AppSync {
     required String typeName,
     String? definition,
   }) async {
-    ArgumentError.checkNotNull(apiId, 'apiId');
-    ArgumentError.checkNotNull(format, 'format');
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      65536,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'format': format.toValue(),
       if (definition != null) 'definition': definition,

--- a/generated/aws_athena_api/lib/athena-2017-05-18.dart
+++ b/generated/aws_athena_api/lib/athena-2017-05-18.dart
@@ -84,7 +84,6 @@ class Athena {
   Future<BatchGetNamedQueryOutput> batchGetNamedQuery({
     required List<String> namedQueryIds,
   }) async {
-    ArgumentError.checkNotNull(namedQueryIds, 'namedQueryIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.BatchGetNamedQuery'
@@ -119,7 +118,6 @@ class Athena {
   Future<BatchGetQueryExecutionOutput> batchGetQueryExecution({
     required List<String> queryExecutionIds,
   }) async {
-    ArgumentError.checkNotNull(queryExecutionIds, 'queryExecutionIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.BatchGetQueryExecution'
@@ -205,21 +203,6 @@ class Athena {
     Map<String, String>? parameters,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.CreateDataCatalog'
@@ -285,42 +268,6 @@ class Athena {
     String? description,
     String? workGroup,
   }) async {
-    ArgumentError.checkNotNull(database, 'database');
-    _s.validateStringLength(
-      'database',
-      database,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      262144,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.CreateNamedQuery'
@@ -374,13 +321,6 @@ class Athena {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.CreateWorkGroup'
@@ -410,14 +350,6 @@ class Athena {
   Future<void> deleteDataCatalog({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.DeleteDataCatalog'
@@ -481,7 +413,6 @@ class Athena {
     required String workGroup,
     bool? recursiveDeleteOption,
   }) async {
-    ArgumentError.checkNotNull(workGroup, 'workGroup');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.DeleteWorkGroup'
@@ -510,14 +441,6 @@ class Athena {
   Future<GetDataCatalogOutput> getDataCatalog({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetDataCatalog'
@@ -551,22 +474,6 @@ class Athena {
     required String catalogName,
     required String databaseName,
   }) async {
-    ArgumentError.checkNotNull(catalogName, 'catalogName');
-    _s.validateStringLength(
-      'catalogName',
-      catalogName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetDatabase'
@@ -597,7 +504,6 @@ class Athena {
   Future<GetNamedQueryOutput> getNamedQuery({
     required String namedQueryId,
   }) async {
-    ArgumentError.checkNotNull(namedQueryId, 'namedQueryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetNamedQuery'
@@ -628,7 +534,6 @@ class Athena {
   Future<GetQueryExecutionOutput> getQueryExecution({
     required String queryExecutionId,
   }) async {
-    ArgumentError.checkNotNull(queryExecutionId, 'queryExecutionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetQueryExecution'
@@ -685,18 +590,11 @@ class Athena {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(queryExecutionId, 'queryExecutionId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -738,30 +636,6 @@ class Athena {
     required String databaseName,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(catalogName, 'catalogName');
-    _s.validateStringLength(
-      'catalogName',
-      catalogName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetTableMetadata'
@@ -792,7 +666,6 @@ class Athena {
   Future<GetWorkGroupOutput> getWorkGroup({
     required String workGroup,
   }) async {
-    ArgumentError.checkNotNull(workGroup, 'workGroup');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.GetWorkGroup'
@@ -833,12 +706,6 @@ class Athena {
       maxResults,
       2,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -881,25 +748,11 @@ class Athena {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(catalogName, 'catalogName');
-    _s.validateStringLength(
-      'catalogName',
-      catalogName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -957,12 +810,6 @@ class Athena {
       0,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.ListNamedQueries'
@@ -1019,12 +866,6 @@ class Athena {
       0,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.ListQueryExecutions'
@@ -1076,39 +917,11 @@ class Athena {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(catalogName, 'catalogName');
-    _s.validateStringLength(
-      'catalogName',
-      catalogName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'expression',
-      expression,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1155,25 +968,11 @@ class Athena {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       75,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1217,12 +1016,6 @@ class Athena {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1291,20 +1084,6 @@ class Athena {
     ResultConfiguration? resultConfiguration,
     String? workGroup,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      262144,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.StartQueryExecution'
@@ -1391,15 +1170,6 @@ class Athena {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.TagResource'
@@ -1433,15 +1203,6 @@ class Athena {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.UntagResource'
@@ -1521,21 +1282,6 @@ class Athena {
     String? description,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.UpdateDataCatalog'
@@ -1578,13 +1324,6 @@ class Athena {
     String? description,
     WorkGroupState? state,
   }) async {
-    ArgumentError.checkNotNull(workGroup, 'workGroup');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonAthena.UpdateWorkGroup'

--- a/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
+++ b/generated/aws_autoscaling_api/lib/autoscaling-2011-01-01.dart
@@ -84,14 +84,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? instanceIds,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     instanceIds?.also((arg) => $request['InstanceIds'] = arg);
@@ -150,15 +142,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required List<String> targetGroupARNs,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetGroupARNs, 'targetGroupARNs');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['TargetGroupARNs'] = targetGroupARNs;
@@ -205,15 +188,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required List<String> loadBalancerNames,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(loadBalancerNames, 'loadBalancerNames');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LoadBalancerNames'] = loadBalancerNames;
@@ -245,15 +219,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required List<String> scheduledActionNames,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scheduledActionNames, 'scheduledActionNames');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ScheduledActionNames'] = scheduledActionNames;
@@ -290,16 +255,6 @@ class AutoScaling {
     required List<ScheduledUpdateGroupActionRequest>
         scheduledUpdateGroupActions,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        scheduledUpdateGroupActions, 'scheduledUpdateGroupActions');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ScheduledUpdateGroupActions'] = scheduledUpdateGroupActions;
@@ -334,14 +289,6 @@ class AutoScaling {
   Future<CancelInstanceRefreshAnswer> cancelInstanceRefresh({
     required String autoScalingGroupName,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     final $result = await _protocol.send(
@@ -418,35 +365,6 @@ class AutoScaling {
     String? instanceId,
     String? lifecycleActionToken,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecycleActionResult, 'lifecycleActionResult');
-    ArgumentError.checkNotNull(lifecycleHookName, 'lifecycleHookName');
-    _s.validateStringLength(
-      'lifecycleHookName',
-      lifecycleHookName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'lifecycleActionToken',
-      lifecycleActionToken,
-      36,
-      36,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LifecycleActionResult'] = lifecycleActionResult;
@@ -728,52 +646,6 @@ class AutoScaling {
     List<String>? terminationPolicies,
     String? vPCZoneIdentifier,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(maxSize, 'maxSize');
-    ArgumentError.checkNotNull(minSize, 'minSize');
-    _s.validateStringLength(
-      'healthCheckType',
-      healthCheckType,
-      1,
-      32,
-    );
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'launchConfigurationName',
-      launchConfigurationName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'placementGroup',
-      placementGroup,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'serviceLinkedRoleARN',
-      serviceLinkedRoleARN,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'vPCZoneIdentifier',
-      vPCZoneIdentifier,
-      1,
-      2047,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['MaxSize'] = maxSize;
@@ -1051,81 +923,6 @@ class AutoScaling {
     String? spotPrice,
     String? userData,
   }) async {
-    ArgumentError.checkNotNull(
-        launchConfigurationName, 'launchConfigurationName');
-    _s.validateStringLength(
-      'launchConfigurationName',
-      launchConfigurationName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'classicLinkVPCId',
-      classicLinkVPCId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'iamInstanceProfile',
-      iamInstanceProfile,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'imageId',
-      imageId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'kernelId',
-      kernelId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'keyName',
-      keyName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'placementTenancy',
-      placementTenancy,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'ramdiskId',
-      ramdiskId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'spotPrice',
-      spotPrice,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'userData',
-      userData,
-      0,
-      21847,
-    );
     final $request = <String, dynamic>{};
     $request['LaunchConfigurationName'] = launchConfigurationName;
     associatePublicIpAddress
@@ -1181,7 +978,6 @@ class AutoScaling {
   Future<void> createOrUpdateTags({
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['Tags'] = tags;
     await _protocol.send(
@@ -1230,14 +1026,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     bool? forceDelete,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     forceDelete?.also((arg) => $request['ForceDelete'] = arg);
@@ -1267,15 +1055,6 @@ class AutoScaling {
   Future<void> deleteLaunchConfiguration({
     required String launchConfigurationName,
   }) async {
-    ArgumentError.checkNotNull(
-        launchConfigurationName, 'launchConfigurationName');
-    _s.validateStringLength(
-      'launchConfigurationName',
-      launchConfigurationName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['LaunchConfigurationName'] = launchConfigurationName;
     await _protocol.send(
@@ -1307,22 +1086,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required String lifecycleHookName,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecycleHookName, 'lifecycleHookName');
-    _s.validateStringLength(
-      'lifecycleHookName',
-      lifecycleHookName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LifecycleHookName'] = lifecycleHookName;
@@ -1353,22 +1116,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required String topicARN,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(topicARN, 'topicARN');
-    _s.validateStringLength(
-      'topicARN',
-      topicARN,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['TopicARN'] = topicARN;
@@ -1406,20 +1153,6 @@ class AutoScaling {
     required String policyName,
     String? autoScalingGroupName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     autoScalingGroupName?.also((arg) => $request['AutoScalingGroupName'] = arg);
@@ -1448,22 +1181,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required String scheduledActionName,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ScheduledActionName'] = scheduledActionName;
@@ -1489,7 +1206,6 @@ class AutoScaling {
   Future<void> deleteTags({
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['Tags'] = tags;
     await _protocol.send(
@@ -1720,14 +1436,6 @@ class AutoScaling {
     int? maxRecords,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     instanceRefreshIds?.also((arg) => $request['InstanceRefreshIds'] = arg);
@@ -1830,14 +1538,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? lifecycleHookNames,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     lifecycleHookNames?.also((arg) => $request['LifecycleHookNames'] = arg);
@@ -1875,14 +1575,6 @@ class AutoScaling {
     int? maxRecords,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -1924,14 +1616,6 @@ class AutoScaling {
     int? maxRecords,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -2047,12 +1731,6 @@ class AutoScaling {
     List<String>? policyNames,
     List<String>? policyTypes,
   }) async {
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     autoScalingGroupName?.also((arg) => $request['AutoScalingGroupName'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -2102,12 +1780,6 @@ class AutoScaling {
     int? maxRecords,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     activityIds?.also((arg) => $request['ActivityIds'] = arg);
     autoScalingGroupName?.also((arg) => $request['AutoScalingGroupName'] = arg);
@@ -2184,12 +1856,6 @@ class AutoScaling {
     List<String>? scheduledActionNames,
     DateTime? startTime,
   }) async {
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     autoScalingGroupName?.also((arg) => $request['AutoScalingGroupName'] = arg);
     endTime?.also((arg) => $request['EndTime'] = _s.iso8601ToJson(arg));
@@ -2323,16 +1989,6 @@ class AutoScaling {
     required bool shouldDecrementDesiredCapacity,
     List<String>? instanceIds,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        shouldDecrementDesiredCapacity, 'shouldDecrementDesiredCapacity');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ShouldDecrementDesiredCapacity'] = shouldDecrementDesiredCapacity;
@@ -2365,15 +2021,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required List<String> targetGroupARNs,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetGroupARNs, 'targetGroupARNs');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['TargetGroupARNs'] = targetGroupARNs;
@@ -2413,15 +2060,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     required List<String> loadBalancerNames,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(loadBalancerNames, 'loadBalancerNames');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LoadBalancerNames'] = loadBalancerNames;
@@ -2494,14 +2132,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? metrics,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     metrics?.also((arg) => $request['Metrics'] = arg);
@@ -2587,22 +2217,6 @@ class AutoScaling {
     required String granularity,
     List<String>? metrics,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(granularity, 'granularity');
-    _s.validateStringLength(
-      'granularity',
-      granularity,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['Granularity'] = granularity;
@@ -2651,16 +2265,6 @@ class AutoScaling {
     required bool shouldDecrementDesiredCapacity,
     List<String>? instanceIds,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        shouldDecrementDesiredCapacity, 'shouldDecrementDesiredCapacity');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ShouldDecrementDesiredCapacity'] = shouldDecrementDesiredCapacity;
@@ -2726,20 +2330,6 @@ class AutoScaling {
     bool? honorCooldown,
     double? metricValue,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     autoScalingGroupName?.also((arg) => $request['AutoScalingGroupName'] = arg);
@@ -2779,14 +2369,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? instanceIds,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     instanceIds?.also((arg) => $request['InstanceIds'] = arg);
@@ -2925,40 +2507,6 @@ class AutoScaling {
     String? notificationTargetARN,
     String? roleARN,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecycleHookName, 'lifecycleHookName');
-    _s.validateStringLength(
-      'lifecycleHookName',
-      lifecycleHookName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'notificationMetadata',
-      notificationMetadata,
-      1,
-      1023,
-    );
-    _s.validateStringLength(
-      'notificationTargetARN',
-      notificationTargetARN,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LifecycleHookName'] = lifecycleHookName;
@@ -3016,23 +2564,6 @@ class AutoScaling {
     required List<String> notificationTypes,
     required String topicARN,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notificationTypes, 'notificationTypes');
-    ArgumentError.checkNotNull(topicARN, 'topicARN');
-    _s.validateStringLength(
-      'topicARN',
-      topicARN,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['NotificationTypes'] = notificationTypes;
@@ -3212,40 +2743,6 @@ class AutoScaling {
     List<StepAdjustment>? stepAdjustments,
     TargetTrackingConfiguration? targetTrackingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'adjustmentType',
-      adjustmentType,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'metricAggregationType',
-      metricAggregationType,
-      1,
-      32,
-    );
-    _s.validateStringLength(
-      'policyType',
-      policyType,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['PolicyName'] = policyName;
@@ -3347,28 +2844,6 @@ class AutoScaling {
     DateTime? startTime,
     DateTime? time,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'recurrence',
-      recurrence,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['ScheduledActionName'] = scheduledActionName;
@@ -3446,34 +2921,6 @@ class AutoScaling {
     String? instanceId,
     String? lifecycleActionToken,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecycleHookName, 'lifecycleHookName');
-    _s.validateStringLength(
-      'lifecycleHookName',
-      lifecycleHookName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'lifecycleActionToken',
-      lifecycleActionToken,
-      36,
-      36,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['LifecycleHookName'] = lifecycleHookName;
@@ -3543,14 +2990,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? scalingProcesses,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     scalingProcesses?.also((arg) => $request['ScalingProcesses'] = arg);
@@ -3597,15 +3036,6 @@ class AutoScaling {
     required int desiredCapacity,
     bool? honorCooldown,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(desiredCapacity, 'desiredCapacity');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['DesiredCapacity'] = desiredCapacity;
@@ -3654,22 +3084,6 @@ class AutoScaling {
     required String instanceId,
     bool? shouldRespectGracePeriod,
   }) async {
-    ArgumentError.checkNotNull(healthStatus, 'healthStatus');
-    _s.validateStringLength(
-      'healthStatus',
-      healthStatus,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['HealthStatus'] = healthStatus;
     $request['InstanceId'] = instanceId;
@@ -3714,16 +3128,6 @@ class AutoScaling {
     required List<String> instanceIds,
     required bool protectedFromScaleIn,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
-    ArgumentError.checkNotNull(protectedFromScaleIn, 'protectedFromScaleIn');
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     $request['InstanceIds'] = instanceIds;
@@ -3790,14 +3194,6 @@ class AutoScaling {
     RefreshPreferences? preferences,
     RefreshStrategy? strategy,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     preferences?.also((arg) => $request['Preferences'] = arg);
@@ -3872,14 +3268,6 @@ class AutoScaling {
     required String autoScalingGroupName,
     List<String>? scalingProcesses,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     scalingProcesses?.also((arg) => $request['ScalingProcesses'] = arg);
@@ -3928,16 +3316,6 @@ class AutoScaling {
     required String instanceId,
     required bool shouldDecrementDesiredCapacity,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        shouldDecrementDesiredCapacity, 'shouldDecrementDesiredCapacity');
     final $request = <String, dynamic>{};
     $request['InstanceId'] = instanceId;
     $request['ShouldDecrementDesiredCapacity'] = shouldDecrementDesiredCapacity;
@@ -4149,44 +3527,6 @@ class AutoScaling {
     List<String>? terminationPolicies,
     String? vPCZoneIdentifier,
   }) async {
-    ArgumentError.checkNotNull(autoScalingGroupName, 'autoScalingGroupName');
-    _s.validateStringLength(
-      'autoScalingGroupName',
-      autoScalingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'healthCheckType',
-      healthCheckType,
-      1,
-      32,
-    );
-    _s.validateStringLength(
-      'launchConfigurationName',
-      launchConfigurationName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'placementGroup',
-      placementGroup,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'serviceLinkedRoleARN',
-      serviceLinkedRoleARN,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'vPCZoneIdentifier',
-      vPCZoneIdentifier,
-      1,
-      2047,
-    );
     final $request = <String, dynamic>{};
     $request['AutoScalingGroupName'] = autoScalingGroupName;
     availabilityZones?.also((arg) => $request['AvailabilityZones'] = arg);

--- a/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
+++ b/generated/aws_autoscaling_plans_api/lib/autoscaling-plans-2018-01-06.dart
@@ -74,16 +74,6 @@ class AutoScalingPlans {
     required List<ScalingInstruction> scalingInstructions,
     required String scalingPlanName,
   }) async {
-    ArgumentError.checkNotNull(applicationSource, 'applicationSource');
-    ArgumentError.checkNotNull(scalingInstructions, 'scalingInstructions');
-    ArgumentError.checkNotNull(scalingPlanName, 'scalingPlanName');
-    _s.validateStringLength(
-      'scalingPlanName',
-      scalingPlanName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleScalingPlannerFrontendService.CreateScalingPlan'
@@ -126,15 +116,6 @@ class AutoScalingPlans {
     required String scalingPlanName,
     required int scalingPlanVersion,
   }) async {
-    ArgumentError.checkNotNull(scalingPlanName, 'scalingPlanName');
-    _s.validateStringLength(
-      'scalingPlanName',
-      scalingPlanName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalingPlanVersion, 'scalingPlanVersion');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleScalingPlannerFrontendService.DeleteScalingPlan'
@@ -177,15 +158,6 @@ class AutoScalingPlans {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(scalingPlanName, 'scalingPlanName');
-    _s.validateStringLength(
-      'scalingPlanName',
-      scalingPlanName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalingPlanVersion, 'scalingPlanVersion');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -368,21 +340,6 @@ class AutoScalingPlans {
     required ServiceNamespace serviceNamespace,
     required DateTime startTime,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(forecastDataType, 'forecastDataType');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(scalableDimension, 'scalableDimension');
-    ArgumentError.checkNotNull(scalingPlanName, 'scalingPlanName');
-    _s.validateStringLength(
-      'scalingPlanName',
-      scalingPlanName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalingPlanVersion, 'scalingPlanVersion');
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -437,15 +394,6 @@ class AutoScalingPlans {
     ApplicationSource? applicationSource,
     List<ScalingInstruction>? scalingInstructions,
   }) async {
-    ArgumentError.checkNotNull(scalingPlanName, 'scalingPlanName');
-    _s.validateStringLength(
-      'scalingPlanName',
-      scalingPlanName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalingPlanVersion, 'scalingPlanVersion');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AnyScaleScalingPlannerFrontendService.UpdateScalingPlan'

--- a/generated/aws_backup_api/lib/backup-2018-11-15.dart
+++ b/generated/aws_backup_api/lib/backup-2018-11-15.dart
@@ -82,7 +82,6 @@ class Backup {
     Map<String, String>? backupPlanTags,
     String? creatorRequestId,
   }) async {
-    ArgumentError.checkNotNull(backupPlan, 'backupPlan');
     final $payload = <String, dynamic>{
       'BackupPlan': backupPlan,
       if (backupPlanTags != null) 'BackupPlanTags': backupPlanTags,
@@ -155,8 +154,6 @@ class Backup {
     required BackupSelection backupSelection,
     String? creatorRequestId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
-    ArgumentError.checkNotNull(backupSelection, 'backupSelection');
     final $payload = <String, dynamic>{
       'BackupSelection': backupSelection,
       if (creatorRequestId != null) 'CreatorRequestId': creatorRequestId,
@@ -209,7 +206,6 @@ class Backup {
     String? creatorRequestId,
     String? encryptionKeyArn,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     final $payload = <String, dynamic>{
       if (backupVaultTags != null) 'BackupVaultTags': backupVaultTags,
       if (creatorRequestId != null) 'CreatorRequestId': creatorRequestId,
@@ -240,7 +236,6 @@ class Backup {
   Future<DeleteBackupPlanOutput> deleteBackupPlan({
     required String backupPlanId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -268,8 +263,6 @@ class Backup {
     required String backupPlanId,
     required String selectionId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
-    ArgumentError.checkNotNull(selectionId, 'selectionId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -296,7 +289,6 @@ class Backup {
   Future<void> deleteBackupVault({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -320,7 +312,6 @@ class Backup {
   Future<void> deleteBackupVaultAccessPolicy({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -345,7 +336,6 @@ class Backup {
   Future<void> deleteBackupVaultNotifications({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -377,8 +367,6 @@ class Backup {
     required String backupVaultName,
     required String recoveryPointArn,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -401,7 +389,6 @@ class Backup {
   Future<DescribeBackupJobOutput> describeBackupJob({
     required String backupJobId,
   }) async {
-    ArgumentError.checkNotNull(backupJobId, 'backupJobId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -426,7 +413,6 @@ class Backup {
   Future<DescribeBackupVaultOutput> describeBackupVault({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -448,7 +434,6 @@ class Backup {
   Future<DescribeCopyJobOutput> describeCopyJob({
     required String copyJobId,
   }) async {
-    ArgumentError.checkNotNull(copyJobId, 'copyJobId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -486,7 +471,6 @@ class Backup {
   Future<DescribeProtectedResourceOutput> describeProtectedResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -518,8 +502,6 @@ class Backup {
     required String backupVaultName,
     required String recoveryPointArn,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -562,7 +544,6 @@ class Backup {
   Future<DescribeRestoreJobOutput> describeRestoreJob({
     required String restoreJobId,
   }) async {
-    ArgumentError.checkNotNull(restoreJobId, 'restoreJobId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -585,7 +566,6 @@ class Backup {
   Future<ExportBackupPlanTemplateOutput> exportBackupPlanTemplate({
     required String backupPlanId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -615,7 +595,6 @@ class Backup {
     required String backupPlanId,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     final $query = <String, List<String>>{
       if (versionId != null) 'versionId': [versionId],
     };
@@ -642,8 +621,6 @@ class Backup {
   Future<GetBackupPlanFromJSONOutput> getBackupPlanFromJSON({
     required String backupPlanTemplateJson,
   }) async {
-    ArgumentError.checkNotNull(
-        backupPlanTemplateJson, 'backupPlanTemplateJson');
     final $payload = <String, dynamic>{
       'BackupPlanTemplateJson': backupPlanTemplateJson,
     };
@@ -669,7 +646,6 @@ class Backup {
   Future<GetBackupPlanFromTemplateOutput> getBackupPlanFromTemplate({
     required String backupPlanTemplateId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanTemplateId, 'backupPlanTemplateId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -698,8 +674,6 @@ class Backup {
     required String backupPlanId,
     required String selectionId,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
-    ArgumentError.checkNotNull(selectionId, 'selectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -726,7 +700,6 @@ class Backup {
   Future<GetBackupVaultAccessPolicyOutput> getBackupVaultAccessPolicy({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -752,7 +725,6 @@ class Backup {
   Future<GetBackupVaultNotificationsOutput> getBackupVaultNotifications({
     required String backupVaultName,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -786,8 +758,6 @@ class Backup {
     required String backupVaultName,
     required String recoveryPointArn,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -976,7 +946,6 @@ class Backup {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1071,7 +1040,6 @@ class Backup {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1323,7 +1291,6 @@ class Backup {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1377,7 +1344,6 @@ class Backup {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1493,7 +1459,6 @@ class Backup {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1535,7 +1500,6 @@ class Backup {
     required String backupVaultName,
     String? policy,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
     final $payload = <String, dynamic>{
       if (policy != null) 'Policy': policy,
     };
@@ -1575,9 +1539,6 @@ class Backup {
     required String backupVaultName,
     required String sNSTopicArn,
   }) async {
-    ArgumentError.checkNotNull(backupVaultEvents, 'backupVaultEvents');
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(sNSTopicArn, 'sNSTopicArn');
     final $payload = <String, dynamic>{
       'BackupVaultEvents': backupVaultEvents.map((e) => e.toValue()).toList(),
       'SNSTopicArn': sNSTopicArn,
@@ -1661,9 +1622,6 @@ class Backup {
     Map<String, String>? recoveryPointTags,
     int? startWindowMinutes,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       'BackupVaultName': backupVaultName,
       'IamRoleArn': iamRoleArn,
@@ -1724,11 +1682,6 @@ class Backup {
     String? idempotencyToken,
     Lifecycle? lifecycle,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationBackupVaultArn, 'destinationBackupVaultArn');
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
-    ArgumentError.checkNotNull(sourceBackupVaultName, 'sourceBackupVaultName');
     final $payload = <String, dynamic>{
       'DestinationBackupVaultArn': destinationBackupVaultArn,
       'IamRoleArn': iamRoleArn,
@@ -1847,9 +1800,6 @@ class Backup {
     String? idempotencyToken,
     String? resourceType,
   }) async {
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(metadata, 'metadata');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
     final $payload = <String, dynamic>{
       'IamRoleArn': iamRoleArn,
       'Metadata': metadata,
@@ -1879,7 +1829,6 @@ class Backup {
   Future<void> stopBackupJob({
     required String backupJobId,
   }) async {
-    ArgumentError.checkNotNull(backupJobId, 'backupJobId');
     await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1908,8 +1857,6 @@ class Backup {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1939,8 +1886,6 @@ class Backup {
     required String resourceArn,
     required List<String> tagKeyList,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeyList, 'tagKeyList');
     final $payload = <String, dynamic>{
       'TagKeyList': tagKeyList,
     };
@@ -1971,8 +1916,6 @@ class Backup {
     required BackupPlanInput backupPlan,
     required String backupPlanId,
   }) async {
-    ArgumentError.checkNotNull(backupPlan, 'backupPlan');
-    ArgumentError.checkNotNull(backupPlanId, 'backupPlanId');
     final $payload = <String, dynamic>{
       'BackupPlan': backupPlan,
     };
@@ -2052,8 +1995,6 @@ class Backup {
     required String recoveryPointArn,
     Lifecycle? lifecycle,
   }) async {
-    ArgumentError.checkNotNull(backupVaultName, 'backupVaultName');
-    ArgumentError.checkNotNull(recoveryPointArn, 'recoveryPointArn');
     final $payload = <String, dynamic>{
       if (lifecycle != null) 'Lifecycle': lifecycle,
     };

--- a/generated/aws_batch_api/lib/batch-2016-08-10.dart
+++ b/generated/aws_batch_api/lib/batch-2016-08-10.dart
@@ -83,8 +83,6 @@ class Batch {
     required String jobId,
     required String reason,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(reason, 'reason');
     final $payload = <String, dynamic>{
       'jobId': jobId,
       'reason': reason,
@@ -231,10 +229,6 @@ class Batch {
     CEState? state,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        computeEnvironmentName, 'computeEnvironmentName');
-    ArgumentError.checkNotNull(serviceRole, 'serviceRole');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'computeEnvironmentName': computeEnvironmentName,
       'serviceRole': serviceRole,
@@ -315,10 +309,6 @@ class Batch {
     JQState? state,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        computeEnvironmentOrder, 'computeEnvironmentOrder');
-    ArgumentError.checkNotNull(jobQueueName, 'jobQueueName');
-    ArgumentError.checkNotNull(priority, 'priority');
     final $payload = <String, dynamic>{
       'computeEnvironmentOrder': computeEnvironmentOrder,
       'jobQueueName': jobQueueName,
@@ -354,7 +344,6 @@ class Batch {
   Future<void> deleteComputeEnvironment({
     required String computeEnvironment,
   }) async {
-    ArgumentError.checkNotNull(computeEnvironment, 'computeEnvironment');
     final $payload = <String, dynamic>{
       'computeEnvironment': computeEnvironment,
     };
@@ -382,7 +371,6 @@ class Batch {
   Future<void> deleteJobQueue({
     required String jobQueue,
   }) async {
-    ArgumentError.checkNotNull(jobQueue, 'jobQueue');
     final $payload = <String, dynamic>{
       'jobQueue': jobQueue,
     };
@@ -406,7 +394,6 @@ class Batch {
   Future<void> deregisterJobDefinition({
     required String jobDefinition,
   }) async {
-    ArgumentError.checkNotNull(jobDefinition, 'jobDefinition');
     final $payload = <String, dynamic>{
       'jobDefinition': jobDefinition,
     };
@@ -599,7 +586,6 @@ class Batch {
   Future<DescribeJobsResponse> describeJobs({
     required List<String> jobs,
   }) async {
-    ArgumentError.checkNotNull(jobs, 'jobs');
     final $payload = <String, dynamic>{
       'jobs': jobs,
     };
@@ -714,7 +700,6 @@ class Batch {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -822,8 +807,6 @@ class Batch {
     Map<String, String>? tags,
     JobTimeout? timeout,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'jobDefinitionName': jobDefinitionName,
       'type': type.toValue(),
@@ -963,9 +946,6 @@ class Batch {
     Map<String, String>? tags,
     JobTimeout? timeout,
   }) async {
-    ArgumentError.checkNotNull(jobDefinition, 'jobDefinition');
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    ArgumentError.checkNotNull(jobQueue, 'jobQueue');
     final $payload = <String, dynamic>{
       'jobDefinition': jobDefinition,
       'jobName': jobName,
@@ -1016,8 +996,6 @@ class Batch {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1048,8 +1026,6 @@ class Batch {
     required String jobId,
     required String reason,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(reason, 'reason');
     final $payload = <String, dynamic>{
       'jobId': jobId,
       'reason': reason,
@@ -1079,8 +1055,6 @@ class Batch {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1150,7 +1124,6 @@ class Batch {
     String? serviceRole,
     CEState? state,
   }) async {
-    ArgumentError.checkNotNull(computeEnvironment, 'computeEnvironment');
     final $payload = <String, dynamic>{
       'computeEnvironment': computeEnvironment,
       if (computeResources != null) 'computeResources': computeResources,
@@ -1211,7 +1184,6 @@ class Batch {
     int? priority,
     JQState? state,
   }) async {
-    ArgumentError.checkNotNull(jobQueue, 'jobQueue');
     final $payload = <String, dynamic>{
       'jobQueue': jobQueue,
       if (computeEnvironmentOrder != null)

--- a/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
+++ b/generated/aws_budgets_api/lib/budgets-2016-10-20.dart
@@ -137,15 +137,6 @@ class Budgets {
     required Budget budget,
     List<NotificationWithSubscribers>? notificationsWithSubscribers,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budget, 'budget');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.CreateBudget'
@@ -195,36 +186,6 @@ class Budgets {
     required NotificationType notificationType,
     required List<Subscriber> subscribers,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionThreshold, 'actionThreshold');
-    ArgumentError.checkNotNull(actionType, 'actionType');
-    ArgumentError.checkNotNull(approvalModel, 'approvalModel');
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(executionRoleArn, 'executionRoleArn');
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      32,
-      618,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notificationType, 'notificationType');
-    ArgumentError.checkNotNull(subscribers, 'subscribers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.CreateBudgetAction'
@@ -282,24 +243,6 @@ class Budgets {
     required Notification notification,
     required List<Subscriber> subscribers,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notification, 'notification');
-    ArgumentError.checkNotNull(subscribers, 'subscribers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.CreateNotification'
@@ -348,24 +291,6 @@ class Budgets {
     required Notification notification,
     required Subscriber subscriber,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notification, 'notification');
-    ArgumentError.checkNotNull(subscriber, 'subscriber');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.CreateSubscriber'
@@ -406,22 +331,6 @@ class Budgets {
     required String accountId,
     required String budgetName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DeleteBudget'
@@ -454,30 +363,6 @@ class Budgets {
     required String actionId,
     required String budgetName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionId, 'actionId');
-    _s.validateStringLength(
-      'actionId',
-      actionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DeleteBudgetAction'
@@ -523,23 +408,6 @@ class Budgets {
     required String budgetName,
     required Notification notification,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notification, 'notification');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DeleteNotification'
@@ -587,24 +455,6 @@ class Budgets {
     required Notification notification,
     required Subscriber subscriber,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notification, 'notification');
-    ArgumentError.checkNotNull(subscriber, 'subscriber');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DeleteSubscriber'
@@ -647,22 +497,6 @@ class Budgets {
     required String accountId,
     required String budgetName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DescribeBudget'
@@ -696,30 +530,6 @@ class Budgets {
     required String actionId,
     required String budgetName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionId, 'actionId');
-    _s.validateStringLength(
-      'actionId',
-      actionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.DescribeBudgetAction'
@@ -758,41 +568,11 @@ class Budgets {
     String? nextToken,
     TimePeriod? timePeriod,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionId, 'actionId');
-    _s.validateStringLength(
-      'actionId',
-      actionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -829,25 +609,11 @@ class Budgets {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -883,33 +649,11 @@ class Budgets {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -954,33 +698,11 @@ class Budgets {
     String? nextToken,
     TimePeriod? timePeriod,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1035,25 +757,11 @@ class Budgets {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1105,33 +813,11 @@ class Budgets {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1188,34 +874,11 @@ class Budgets {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(notification, 'notification');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2147483647,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1260,31 +923,6 @@ class Budgets {
     required String budgetName,
     required ExecutionType executionType,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionId, 'actionId');
-    _s.validateStringLength(
-      'actionId',
-      actionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(executionType, 'executionType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.ExecuteBudgetAction'
@@ -1334,15 +972,6 @@ class Budgets {
     required String accountId,
     required Budget newBudget,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newBudget, 'newBudget');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.UpdateBudget'
@@ -1388,36 +1017,6 @@ class Budgets {
     NotificationType? notificationType,
     List<Subscriber>? subscribers,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionId, 'actionId');
-    _s.validateStringLength(
-      'actionId',
-      actionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      32,
-      618,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.UpdateBudgetAction'
@@ -1471,24 +1070,6 @@ class Budgets {
     required Notification newNotification,
     required Notification oldNotification,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newNotification, 'newNotification');
-    ArgumentError.checkNotNull(oldNotification, 'oldNotification');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.UpdateNotification'
@@ -1538,25 +1119,6 @@ class Budgets {
     required Notification notification,
     required Subscriber oldSubscriber,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newSubscriber, 'newSubscriber');
-    ArgumentError.checkNotNull(notification, 'notification');
-    ArgumentError.checkNotNull(oldSubscriber, 'oldSubscriber');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSBudgetServiceGateway.UpdateSubscriber'

--- a/generated/aws_ce_api/lib/ce-2017-10-25.dart
+++ b/generated/aws_ce_api/lib/ce-2017-10-25.dart
@@ -75,7 +75,6 @@ class CostExplorer {
   Future<CreateAnomalyMonitorResponse> createAnomalyMonitor({
     required AnomalyMonitor anomalyMonitor,
   }) async {
-    ArgumentError.checkNotNull(anomalyMonitor, 'anomalyMonitor');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.CreateAnomalyMonitor'
@@ -107,7 +106,6 @@ class CostExplorer {
   Future<CreateAnomalySubscriptionResponse> createAnomalySubscription({
     required AnomalySubscription anomalySubscription,
   }) async {
-    ArgumentError.checkNotNull(anomalySubscription, 'anomalySubscription');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.CreateAnomalySubscription'
@@ -140,16 +138,6 @@ class CostExplorer {
     required CostCategoryRuleVersion ruleVersion,
     required List<CostCategoryRule> rules,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleVersion, 'ruleVersion');
-    ArgumentError.checkNotNull(rules, 'rules');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.CreateCostCategoryDefinition'
@@ -180,14 +168,6 @@ class CostExplorer {
   Future<void> deleteAnomalyMonitor({
     required String monitorArn,
   }) async {
-    ArgumentError.checkNotNull(monitorArn, 'monitorArn');
-    _s.validateStringLength(
-      'monitorArn',
-      monitorArn,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.DeleteAnomalyMonitor'
@@ -215,14 +195,6 @@ class CostExplorer {
   Future<void> deleteAnomalySubscription({
     required String subscriptionArn,
   }) async {
-    ArgumentError.checkNotNull(subscriptionArn, 'subscriptionArn');
-    _s.validateStringLength(
-      'subscriptionArn',
-      subscriptionArn,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.DeleteAnomalySubscription'
@@ -250,14 +222,6 @@ class CostExplorer {
   Future<DeleteCostCategoryDefinitionResponse> deleteCostCategoryDefinition({
     required String costCategoryArn,
   }) async {
-    ArgumentError.checkNotNull(costCategoryArn, 'costCategoryArn');
-    _s.validateStringLength(
-      'costCategoryArn',
-      costCategoryArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.DeleteCostCategoryDefinition'
@@ -298,20 +262,6 @@ class CostExplorer {
     required String costCategoryArn,
     String? effectiveOn,
   }) async {
-    ArgumentError.checkNotNull(costCategoryArn, 'costCategoryArn');
-    _s.validateStringLength(
-      'costCategoryArn',
-      costCategoryArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'effectiveOn',
-      effectiveOn,
-      20,
-      25,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.DescribeCostCategoryDefinition'
@@ -369,19 +319,6 @@ class CostExplorer {
     String? nextPageToken,
     TotalImpactFilter? totalImpact,
   }) async {
-    ArgumentError.checkNotNull(dateInterval, 'dateInterval');
-    _s.validateStringLength(
-      'monitorArn',
-      monitorArn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetAnomalies'
@@ -427,12 +364,6 @@ class CostExplorer {
     List<String>? monitorArnList,
     String? nextPageToken,
   }) async {
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetAnomalyMonitors'
@@ -479,18 +410,6 @@ class CostExplorer {
     String? nextPageToken,
     List<String>? subscriptionArnList,
   }) async {
-    _s.validateStringLength(
-      'monitorArn',
-      monitorArn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetAnomalySubscriptions'
@@ -603,14 +522,6 @@ class CostExplorer {
     List<GroupDefinition>? groupBy,
     String? nextPageToken,
   }) async {
-    ArgumentError.checkNotNull(metrics, 'metrics');
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetCostAndUsage'
@@ -726,14 +637,6 @@ class CostExplorer {
     List<String>? metrics,
     String? nextPageToken,
   }) async {
-    ArgumentError.checkNotNull(filter, 'filter');
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetCostAndUsageWithResources'
@@ -820,9 +723,6 @@ class CostExplorer {
     Expression? filter,
     int? predictionIntervalLevel,
   }) async {
-    ArgumentError.checkNotNull(granularity, 'granularity');
-    ArgumentError.checkNotNull(metric, 'metric');
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
     _s.validateNumRange(
       'predictionIntervalLevel',
       predictionIntervalLevel,
@@ -1032,20 +932,6 @@ class CostExplorer {
     String? nextPageToken,
     String? searchString,
   }) async {
-    ArgumentError.checkNotNull(dimension, 'dimension');
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'searchString',
-      searchString,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetDimensionValues'
@@ -1250,13 +1136,6 @@ class CostExplorer {
     List<String>? metrics,
     String? nextPageToken,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetReservationCoverage'
@@ -1351,26 +1230,6 @@ class CostExplorer {
     ServiceSpecification? serviceSpecification,
     TermInYears? termInYears,
   }) async {
-    ArgumentError.checkNotNull(service, 'service');
-    _s.validateStringLength(
-      'service',
-      service,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -1495,13 +1354,6 @@ class CostExplorer {
     List<GroupDefinition>? groupBy,
     String? nextPageToken,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetReservationUtilization'
@@ -1563,20 +1415,6 @@ class CostExplorer {
     String? nextPageToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(service, 'service');
-    _s.validateStringLength(
-      'service',
-      service,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -1698,18 +1536,11 @@ class CostExplorer {
     List<String>? metrics,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1796,16 +1627,6 @@ class CostExplorer {
     String? nextPageToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(lookbackPeriodInDays, 'lookbackPeriodInDays');
-    ArgumentError.checkNotNull(paymentOption, 'paymentOption');
-    ArgumentError.checkNotNull(savingsPlansType, 'savingsPlansType');
-    ArgumentError.checkNotNull(termInYears, 'termInYears');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -1898,7 +1719,6 @@ class CostExplorer {
     Expression? filter,
     Granularity? granularity,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetSavingsPlansUtilization'
@@ -1983,18 +1803,11 @@ class CostExplorer {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2052,25 +1865,6 @@ class CostExplorer {
     String? searchString,
     String? tagKey,
   }) async {
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'searchString',
-      searchString,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'tagKey',
-      tagKey,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.GetTags'
@@ -2149,9 +1943,6 @@ class CostExplorer {
     Expression? filter,
     int? predictionIntervalLevel,
   }) async {
-    ArgumentError.checkNotNull(granularity, 'granularity');
-    ArgumentError.checkNotNull(metric, 'metric');
-    ArgumentError.checkNotNull(timePeriod, 'timePeriod');
     _s.validateNumRange(
       'predictionIntervalLevel',
       predictionIntervalLevel,
@@ -2208,23 +1999,11 @@ class CostExplorer {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'effectiveOn',
-      effectiveOn,
-      20,
-      25,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2260,15 +2039,6 @@ class CostExplorer {
     required String anomalyId,
     required AnomalyFeedbackType feedback,
   }) async {
-    ArgumentError.checkNotNull(anomalyId, 'anomalyId');
-    _s.validateStringLength(
-      'anomalyId',
-      anomalyId,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(feedback, 'feedback');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.ProvideAnomalyFeedback'
@@ -2303,20 +2073,6 @@ class CostExplorer {
     required String monitorArn,
     String? monitorName,
   }) async {
-    ArgumentError.checkNotNull(monitorArn, 'monitorArn');
-    _s.validateStringLength(
-      'monitorArn',
-      monitorArn,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'monitorName',
-      monitorName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.UpdateAnomalyMonitor'
@@ -2368,20 +2124,6 @@ class CostExplorer {
     String? subscriptionName,
     double? threshold,
   }) async {
-    ArgumentError.checkNotNull(subscriptionArn, 'subscriptionArn');
-    _s.validateStringLength(
-      'subscriptionArn',
-      subscriptionArn,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'subscriptionName',
-      subscriptionName,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'threshold',
       threshold,
@@ -2432,16 +2174,6 @@ class CostExplorer {
     required CostCategoryRuleVersion ruleVersion,
     required List<CostCategoryRule> rules,
   }) async {
-    ArgumentError.checkNotNull(costCategoryArn, 'costCategoryArn');
-    _s.validateStringLength(
-      'costCategoryArn',
-      costCategoryArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleVersion, 'ruleVersion');
-    ArgumentError.checkNotNull(rules, 'rules');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSInsightsIndexService.UpdateCostCategoryDefinition'

--- a/generated/aws_chime_api/lib/chime-2018-05-01.dart
+++ b/generated/aws_chime_api/lib/chime-2018-05-01.dart
@@ -113,9 +113,6 @@ class Chime {
     required String e164PhoneNumber,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(e164PhoneNumber, 'e164PhoneNumber');
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       'E164PhoneNumber': e164PhoneNumber,
     };
@@ -156,8 +153,6 @@ class Chime {
     required String voiceConnectorId,
     bool? forceAssociate,
   }) async {
-    ArgumentError.checkNotNull(e164PhoneNumbers, 'e164PhoneNumbers');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'E164PhoneNumbers': e164PhoneNumbers,
       if (forceAssociate != null) 'ForceAssociate': forceAssociate,
@@ -201,8 +196,6 @@ class Chime {
     required String voiceConnectorGroupId,
     bool? forceAssociate,
   }) async {
-    ArgumentError.checkNotNull(e164PhoneNumbers, 'e164PhoneNumbers');
-    ArgumentError.checkNotNull(voiceConnectorGroupId, 'voiceConnectorGroupId');
     final $payload = <String, dynamic>{
       'E164PhoneNumbers': e164PhoneNumbers,
       if (forceAssociate != null) 'ForceAssociate': forceAssociate,
@@ -238,8 +231,6 @@ class Chime {
     required String accountId,
     required List<SigninDelegateGroup> signinDelegateGroups,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(signinDelegateGroups, 'signinDelegateGroups');
     final $payload = <String, dynamic>{
       'SigninDelegateGroups': signinDelegateGroups,
     };
@@ -275,8 +266,6 @@ class Chime {
     required List<CreateAttendeeRequestItem> attendees,
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(attendees, 'attendees');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final $payload = <String, dynamic>{
       'Attendees': attendees,
     };
@@ -316,9 +305,6 @@ class Chime {
     required List<MembershipItem> membershipItemList,
     required String roomId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(membershipItemList, 'membershipItemList');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final $payload = <String, dynamic>{
       'MembershipItemList': membershipItemList,
     };
@@ -352,7 +338,6 @@ class Chime {
   Future<BatchDeletePhoneNumberResponse> batchDeletePhoneNumber({
     required List<String> phoneNumberIds,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberIds, 'phoneNumberIds');
     final $payload = <String, dynamic>{
       'PhoneNumberIds': phoneNumberIds,
     };
@@ -403,8 +388,6 @@ class Chime {
     required String accountId,
     required List<String> userIdList,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userIdList, 'userIdList');
     final $payload = <String, dynamic>{
       'UserIdList': userIdList,
     };
@@ -447,8 +430,6 @@ class Chime {
     required String accountId,
     required List<String> userIdList,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userIdList, 'userIdList');
     final $payload = <String, dynamic>{
       'UserIdList': userIdList,
     };
@@ -488,8 +469,6 @@ class Chime {
   Future<BatchUpdatePhoneNumberResponse> batchUpdatePhoneNumber({
     required List<UpdatePhoneNumberRequestItem> updatePhoneNumberRequestItems,
   }) async {
-    ArgumentError.checkNotNull(
-        updatePhoneNumberRequestItems, 'updatePhoneNumberRequestItems');
     final $payload = <String, dynamic>{
       'UpdatePhoneNumberRequestItems': updatePhoneNumberRequestItems,
     };
@@ -523,9 +502,6 @@ class Chime {
     required String accountId,
     required List<UpdateUserRequestItem> updateUserRequestItems,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(
-        updateUserRequestItems, 'updateUserRequestItems');
     final $payload = <String, dynamic>{
       'UpdateUserRequestItems': updateUserRequestItems,
     };
@@ -558,14 +534,6 @@ class Chime {
   Future<CreateAccountResponse> createAccount({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
     };
@@ -605,26 +573,6 @@ class Chime {
     String? clientRequestToken,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -673,22 +621,6 @@ class Chime {
     required String appInstanceAdminArn,
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceAdminArn, 'appInstanceAdminArn');
-    _s.validateStringLength(
-      'appInstanceAdminArn',
-      appInstanceAdminArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'AppInstanceAdminArn': appInstanceAdminArn,
     };
@@ -736,42 +668,6 @@ class Chime {
     String? clientRequestToken,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appInstanceUserId, 'appInstanceUserId');
-    _s.validateStringLength(
-      'appInstanceUserId',
-      appInstanceUserId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'AppInstanceArn': appInstanceArn,
       'AppInstanceUserId': appInstanceUserId,
@@ -818,15 +714,6 @@ class Chime {
     required String meetingId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(externalUserId, 'externalUserId');
-    _s.validateStringLength(
-      'externalUserId',
-      externalUserId,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final $payload = <String, dynamic>{
       'ExternalUserId': externalUserId,
       if (tags != null) 'Tags': tags,
@@ -864,8 +751,6 @@ class Chime {
     required String displayName,
     String? domain,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(displayName, 'displayName');
     final $payload = <String, dynamic>{
       'DisplayName': displayName,
       if (domain != null) 'Domain': domain,
@@ -923,34 +808,6 @@ class Chime {
     ChannelPrivacy? privacy,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'AppInstanceArn': appInstanceArn,
       'Name': name,
@@ -996,22 +853,6 @@ class Chime {
     required String channelArn,
     required String memberArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'MemberArn': memberArn,
     };
@@ -1083,23 +924,6 @@ class Chime {
     required String memberArn,
     required ChannelMembershipType type,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'MemberArn': memberArn,
       'Type': type.toValue(),
@@ -1151,22 +975,6 @@ class Chime {
     required String channelArn,
     required String channelModeratorArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(channelModeratorArn, 'channelModeratorArn');
-    _s.validateStringLength(
-      'channelModeratorArn',
-      channelModeratorArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ChannelModeratorArn': channelModeratorArn,
     };
@@ -1233,24 +1041,6 @@ class Chime {
     MeetingNotificationConfiguration? notificationsConfiguration,
     List<Tag>? tags,
   }) async {
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'externalMeetingId',
-      externalMeetingId,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'meetingHostId',
-      meetingHostId,
-      2,
-      64,
-    );
     final $payload = <String, dynamic>{
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
       if (externalMeetingId != null) 'ExternalMeetingId': externalMeetingId,
@@ -1311,17 +1101,6 @@ class Chime {
     required String meetingId,
     required String toPhoneNumber,
   }) async {
-    ArgumentError.checkNotNull(fromPhoneNumber, 'fromPhoneNumber');
-    ArgumentError.checkNotNull(joinToken, 'joinToken');
-    _s.validateStringLength(
-      'joinToken',
-      joinToken,
-      2,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
-    ArgumentError.checkNotNull(toPhoneNumber, 'toPhoneNumber');
     final $payload = <String, dynamic>{
       'FromPhoneNumber': fromPhoneNumber,
       'JoinToken': joinToken,
@@ -1389,24 +1168,6 @@ class Chime {
     MeetingNotificationConfiguration? notificationsConfiguration,
     List<Tag>? tags,
   }) async {
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'externalMeetingId',
-      externalMeetingId,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'meetingHostId',
-      meetingHostId,
-      2,
-      64,
-    );
     final $payload = <String, dynamic>{
       if (attendees != null) 'Attendees': attendees,
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -1449,8 +1210,6 @@ class Chime {
     required List<String> e164PhoneNumbers,
     required PhoneNumberProductType productType,
   }) async {
-    ArgumentError.checkNotNull(e164PhoneNumbers, 'e164PhoneNumbers');
-    ArgumentError.checkNotNull(productType, 'productType');
     final $payload = <String, dynamic>{
       'E164PhoneNumbers': e164PhoneNumbers,
       'ProductType': productType.toValue(),
@@ -1510,17 +1269,6 @@ class Chime {
     String? name,
     NumberSelectionBehavior? numberSelectionBehavior,
   }) async {
-    ArgumentError.checkNotNull(capabilities, 'capabilities');
-    ArgumentError.checkNotNull(
-        participantPhoneNumbers, 'participantPhoneNumbers');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'expiryMinutes',
       expiryMinutes,
@@ -1571,14 +1319,6 @@ class Chime {
     required String name,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -1623,9 +1363,6 @@ class Chime {
     required String roomId,
     RoomMembershipRole? role,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final $payload = <String, dynamic>{
       'MemberId': memberId,
       if (role != null) 'Role': role.toValue(),
@@ -1666,14 +1403,6 @@ class Chime {
     required List<SipMediaApplicationEndpoint> endpoints,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(awsRegion, 'awsRegion');
-    ArgumentError.checkNotNull(endpoints, 'endpoints');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'AwsRegion': awsRegion,
       'Endpoints': endpoints,
@@ -1713,7 +1442,6 @@ class Chime {
     String? fromPhoneNumber,
     String? toPhoneNumber,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
     final $payload = <String, dynamic>{
       if (fromPhoneNumber != null) 'FromPhoneNumber': fromPhoneNumber,
       if (toPhoneNumber != null) 'ToPhoneNumber': toPhoneNumber,
@@ -1776,17 +1504,6 @@ class Chime {
     required String triggerValue,
     bool? disabled,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetApplications, 'targetApplications');
-    ArgumentError.checkNotNull(triggerType, 'triggerType');
-    ArgumentError.checkNotNull(triggerValue, 'triggerValue');
     final $payload = <String, dynamic>{
       'Name': name,
       'TargetApplications': targetApplications,
@@ -1831,7 +1548,6 @@ class Chime {
     UserType? userType,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final $payload = <String, dynamic>{
       if (email != null) 'Email': email,
       if (userType != null) 'UserType': userType.toValue(),
@@ -1879,15 +1595,6 @@ class Chime {
     required bool requireEncryption,
     VoiceConnectorAwsRegion? awsRegion,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(requireEncryption, 'requireEncryption');
     final $payload = <String, dynamic>{
       'Name': name,
       'RequireEncryption': requireEncryption,
@@ -1929,14 +1636,6 @@ class Chime {
     required String name,
     List<VoiceConnectorItem>? voiceConnectorItems,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (voiceConnectorItems != null)
@@ -1981,7 +1680,6 @@ class Chime {
   Future<void> deleteAccount({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2005,14 +1703,6 @@ class Chime {
   Future<void> deleteAppInstance({
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2042,22 +1732,6 @@ class Chime {
     required String appInstanceAdminArn,
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceAdminArn, 'appInstanceAdminArn');
-    _s.validateStringLength(
-      'appInstanceAdminArn',
-      appInstanceAdminArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2082,14 +1756,6 @@ class Chime {
   Future<void> deleteAppInstanceStreamingConfigurations({
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2113,14 +1779,6 @@ class Chime {
   Future<void> deleteAppInstanceUser({
     required String appInstanceUserArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceUserArn, 'appInstanceUserArn');
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2154,8 +1812,6 @@ class Chime {
     required String attendeeId,
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(attendeeId, 'attendeeId');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2180,14 +1836,6 @@ class Chime {
   Future<void> deleteChannel({
     required String channelArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2214,22 +1862,6 @@ class Chime {
     required String channelArn,
     required String memberArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2257,22 +1889,6 @@ class Chime {
     required String channelArn,
     required String memberArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2302,22 +1918,6 @@ class Chime {
     required String channelArn,
     required String messageId,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    _s.validateStringLength(
-      'messageId',
-      messageId,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2345,22 +1945,6 @@ class Chime {
     required String channelArn,
     required String channelModeratorArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(channelModeratorArn, 'channelModeratorArn');
-    _s.validateStringLength(
-      'channelModeratorArn',
-      channelModeratorArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2389,8 +1973,6 @@ class Chime {
     required String accountId,
     required String botId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2419,7 +2001,6 @@ class Chime {
   Future<void> deleteMeeting({
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2448,7 +2029,6 @@ class Chime {
   Future<void> deletePhoneNumber({
     required String phoneNumberId,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberId, 'phoneNumberId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2477,22 +2057,6 @@ class Chime {
     required String proxySessionId,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(proxySessionId, 'proxySessionId');
-    _s.validateStringLength(
-      'proxySessionId',
-      proxySessionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2521,8 +2085,6 @@ class Chime {
     required String accountId,
     required String roomId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2555,9 +2117,6 @@ class Chime {
     required String memberId,
     required String roomId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2583,7 +2142,6 @@ class Chime {
   Future<void> deleteSipMediaApplication({
     required String sipMediaApplicationId,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2609,7 +2167,6 @@ class Chime {
   Future<void> deleteSipRule({
     required String sipRuleId,
   }) async {
-    ArgumentError.checkNotNull(sipRuleId, 'sipRuleId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2636,7 +2193,6 @@ class Chime {
   Future<void> deleteVoiceConnector({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2661,7 +2217,6 @@ class Chime {
   Future<void> deleteVoiceConnectorEmergencyCallingConfiguration({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2689,7 +2244,6 @@ class Chime {
   Future<void> deleteVoiceConnectorGroup({
     required String voiceConnectorGroupId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorGroupId, 'voiceConnectorGroupId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2719,7 +2273,6 @@ class Chime {
   Future<void> deleteVoiceConnectorOrigination({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2745,14 +2298,6 @@ class Chime {
   Future<void> deleteVoiceConnectorProxy({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2778,7 +2323,6 @@ class Chime {
   Future<void> deleteVoiceConnectorStreamingConfiguration({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2808,7 +2352,6 @@ class Chime {
   Future<void> deleteVoiceConnectorTermination({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2839,8 +2382,6 @@ class Chime {
     required List<String> usernames,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(usernames, 'usernames');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'Usernames': usernames,
     };
@@ -2867,14 +2408,6 @@ class Chime {
   Future<DescribeAppInstanceResponse> describeAppInstance({
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2902,22 +2435,6 @@ class Chime {
     required String appInstanceAdminArn,
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceAdminArn, 'appInstanceAdminArn');
-    _s.validateStringLength(
-      'appInstanceAdminArn',
-      appInstanceAdminArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2942,14 +2459,6 @@ class Chime {
   Future<DescribeAppInstanceUserResponse> describeAppInstanceUser({
     required String appInstanceUserArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceUserArn, 'appInstanceUserArn');
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2974,14 +2483,6 @@ class Chime {
   Future<DescribeChannelResponse> describeChannel({
     required String channelArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3010,22 +2511,6 @@ class Chime {
     required String channelArn,
     required String memberArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3055,22 +2540,6 @@ class Chime {
     required String channelArn,
     required String memberArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberArn, 'memberArn');
-    _s.validateStringLength(
-      'memberArn',
-      memberArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3101,22 +2570,6 @@ class Chime {
     required String appInstanceUserArn,
     required String channelArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceUserArn, 'appInstanceUserArn');
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'app-instance-user-arn': [appInstanceUserArn],
     };
@@ -3152,22 +2605,6 @@ class Chime {
     required String appInstanceUserArn,
     required String channelArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceUserArn, 'appInstanceUserArn');
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'app-instance-user-arn': [appInstanceUserArn],
     };
@@ -3201,22 +2638,6 @@ class Chime {
     required String channelArn,
     required String channelModeratorArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(channelModeratorArn, 'channelModeratorArn');
-    _s.validateStringLength(
-      'channelModeratorArn',
-      channelModeratorArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3247,8 +2668,6 @@ class Chime {
     required String accountId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -3279,8 +2698,6 @@ class Chime {
     required List<String> e164PhoneNumbers,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(e164PhoneNumbers, 'e164PhoneNumbers');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'E164PhoneNumbers': e164PhoneNumbers,
     };
@@ -3316,8 +2733,6 @@ class Chime {
     required List<String> e164PhoneNumbers,
     required String voiceConnectorGroupId,
   }) async {
-    ArgumentError.checkNotNull(e164PhoneNumbers, 'e164PhoneNumbers');
-    ArgumentError.checkNotNull(voiceConnectorGroupId, 'voiceConnectorGroupId');
     final $payload = <String, dynamic>{
       'E164PhoneNumbers': e164PhoneNumbers,
     };
@@ -3352,8 +2767,6 @@ class Chime {
     required String accountId,
     required List<String> groupNames,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(groupNames, 'groupNames');
     final $payload = <String, dynamic>{
       'GroupNames': groupNames,
     };
@@ -3382,7 +2795,6 @@ class Chime {
   Future<GetAccountResponse> getAccount({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3411,7 +2823,6 @@ class Chime {
   Future<GetAccountSettingsResponse> getAccountSettings({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3437,14 +2848,6 @@ class Chime {
       getAppInstanceRetentionSettings({
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3471,14 +2874,6 @@ class Chime {
       getAppInstanceStreamingConfigurations({
     required String appInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3511,8 +2906,6 @@ class Chime {
     required String attendeeId,
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(attendeeId, 'attendeeId');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3543,8 +2936,6 @@ class Chime {
     required String accountId,
     required String botId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3574,22 +2965,6 @@ class Chime {
     required String channelArn,
     required String messageId,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    _s.validateStringLength(
-      'messageId',
-      messageId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3620,8 +2995,6 @@ class Chime {
     required String accountId,
     required String botId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3669,7 +3042,6 @@ class Chime {
   Future<GetMeetingResponse> getMeeting({
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3713,7 +3085,6 @@ class Chime {
   Future<GetPhoneNumberResponse> getPhoneNumber({
     required String phoneNumberId,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberId, 'phoneNumberId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3740,7 +3111,6 @@ class Chime {
   Future<GetPhoneNumberOrderResponse> getPhoneNumberOrder({
     required String phoneNumberOrderId,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberOrderId, 'phoneNumberOrderId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3790,22 +3160,6 @@ class Chime {
     required String proxySessionId,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(proxySessionId, 'proxySessionId');
-    _s.validateStringLength(
-      'proxySessionId',
-      proxySessionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3835,7 +3189,6 @@ class Chime {
   Future<GetRetentionSettingsResponse> getRetentionSettings({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3866,8 +3219,6 @@ class Chime {
     required String accountId,
     required String roomId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3894,7 +3245,6 @@ class Chime {
   Future<GetSipMediaApplicationResponse> getSipMediaApplication({
     required String sipMediaApplicationId,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3921,7 +3271,6 @@ class Chime {
       getSipMediaApplicationLoggingConfiguration({
     required String sipMediaApplicationId,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3949,7 +3298,6 @@ class Chime {
   Future<GetSipRuleResponse> getSipRule({
     required String sipRuleId,
   }) async {
-    ArgumentError.checkNotNull(sipRuleId, 'sipRuleId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3982,8 +3330,6 @@ class Chime {
     required String accountId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4014,8 +3360,6 @@ class Chime {
     required String accountId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4042,7 +3386,6 @@ class Chime {
   Future<GetVoiceConnectorResponse> getVoiceConnector({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4069,7 +3412,6 @@ class Chime {
       getVoiceConnectorEmergencyCallingConfiguration({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4097,7 +3439,6 @@ class Chime {
   Future<GetVoiceConnectorGroupResponse> getVoiceConnectorGroup({
     required String voiceConnectorGroupId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorGroupId, 'voiceConnectorGroupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4126,7 +3467,6 @@ class Chime {
       getVoiceConnectorLoggingConfiguration({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4153,7 +3493,6 @@ class Chime {
   Future<GetVoiceConnectorOriginationResponse> getVoiceConnectorOrigination({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4180,14 +3519,6 @@ class Chime {
   Future<GetVoiceConnectorProxyResponse> getVoiceConnectorProxy({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4217,7 +3548,6 @@ class Chime {
       getVoiceConnectorStreamingConfiguration({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4244,7 +3574,6 @@ class Chime {
   Future<GetVoiceConnectorTerminationResponse> getVoiceConnectorTermination({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4273,7 +3602,6 @@ class Chime {
       getVoiceConnectorTerminationHealth({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4309,8 +3637,6 @@ class Chime {
     required List<String> userEmailList,
     UserType? userType,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userEmailList, 'userEmailList');
     final $payload = <String, dynamic>{
       'UserEmailList': userEmailList,
       if (userType != null) 'UserType': userType.toValue(),
@@ -4361,12 +3687,6 @@ class Chime {
       1,
       200,
     );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
       if (name != null) 'name': [name],
@@ -4407,25 +3727,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -4466,25 +3772,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       'app-instance-arn': [appInstanceArn],
@@ -4526,12 +3818,6 @@ class Chime {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -4565,8 +3851,6 @@ class Chime {
     required String attendeeId,
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(attendeeId, 'attendeeId');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4603,7 +3887,6 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4649,7 +3932,6 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4693,25 +3975,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -4758,25 +4026,11 @@ class Chime {
     String? nextToken,
     ChannelMembershipType? type,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -4819,23 +4073,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (appInstanceUserArn != null)
@@ -4896,25 +4138,11 @@ class Chime {
     DateTime? notBefore,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -4958,25 +4186,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -5034,25 +4248,11 @@ class Chime {
     String? nextToken,
     ChannelPrivacy? privacy,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       'app-instance-arn': [appInstanceArn],
@@ -5094,23 +4294,11 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final $query = <String, List<String>>{
       if (appInstanceUserArn != null)
@@ -5143,7 +4331,6 @@ class Chime {
   Future<ListMeetingTagsResponse> listMeetingTags({
     required String meetingId,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5320,25 +4507,11 @@ class Chime {
     String? nextToken,
     ProxySessionStatus? status,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       99,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
@@ -5384,8 +4557,6 @@ class Chime {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5436,7 +4607,6 @@ class Chime {
     String? memberId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5482,12 +4652,6 @@ class Chime {
       1,
       99,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -5530,12 +4694,6 @@ class Chime {
       1,
       99,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max-results': [maxResults.toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -5566,14 +4724,6 @@ class Chime {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'arn': [resourceARN],
     };
@@ -5620,7 +4770,6 @@ class Chime {
     String? userEmail,
     UserType? userType,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5698,7 +4847,6 @@ class Chime {
       listVoiceConnectorTerminationCredentials({
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5768,8 +4916,6 @@ class Chime {
     required String accountId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -5800,16 +4946,6 @@ class Chime {
     required String appInstanceArn,
     required AppInstanceRetentionSettings appInstanceRetentionSettings,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        appInstanceRetentionSettings, 'appInstanceRetentionSettings');
     final $payload = <String, dynamic>{
       'AppInstanceRetentionSettings': appInstanceRetentionSettings,
     };
@@ -5844,16 +4980,6 @@ class Chime {
     required List<AppInstanceStreamingConfiguration>
         appInstanceStreamingConfigurations,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appInstanceStreamingConfigurations,
-        'appInstanceStreamingConfigurations');
     final $payload = <String, dynamic>{
       'AppInstanceStreamingConfigurations': appInstanceStreamingConfigurations,
     };
@@ -5896,8 +5022,6 @@ class Chime {
     String? lambdaFunctionArn,
     String? outboundEventsHTTPSEndpoint,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     final $payload = <String, dynamic>{
       if (lambdaFunctionArn != null) 'LambdaFunctionArn': lambdaFunctionArn,
       if (outboundEventsHTTPSEndpoint != null)
@@ -5946,8 +5070,6 @@ class Chime {
     required String accountId,
     required RetentionSettings retentionSettings,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(retentionSettings, 'retentionSettings');
     final $payload = <String, dynamic>{
       'RetentionSettings': retentionSettings,
     };
@@ -5982,7 +5104,6 @@ class Chime {
     SipMediaApplicationLoggingConfiguration?
         sipMediaApplicationLoggingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
     final $payload = <String, dynamic>{
       if (sipMediaApplicationLoggingConfiguration != null)
         'SipMediaApplicationLoggingConfiguration':
@@ -6022,9 +5143,6 @@ class Chime {
     required EmergencyCallingConfiguration emergencyCallingConfiguration,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(
-        emergencyCallingConfiguration, 'emergencyCallingConfiguration');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'EmergencyCallingConfiguration': emergencyCallingConfiguration,
     };
@@ -6061,8 +5179,6 @@ class Chime {
     required LoggingConfiguration loggingConfiguration,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(loggingConfiguration, 'loggingConfiguration');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'LoggingConfiguration': loggingConfiguration,
     };
@@ -6099,8 +5215,6 @@ class Chime {
     required Origination origination,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(origination, 'origination');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'Origination': origination,
     };
@@ -6148,18 +5262,6 @@ class Chime {
     bool? disabled,
     String? fallBackPhoneNumber,
   }) async {
-    ArgumentError.checkNotNull(
-        defaultSessionExpiryMinutes, 'defaultSessionExpiryMinutes');
-    ArgumentError.checkNotNull(
-        phoneNumberPoolCountries, 'phoneNumberPoolCountries');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DefaultSessionExpiryMinutes': defaultSessionExpiryMinutes,
       'PhoneNumberPoolCountries': phoneNumberPoolCountries,
@@ -6200,9 +5302,6 @@ class Chime {
     required StreamingConfiguration streamingConfiguration,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingConfiguration, 'streamingConfiguration');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'StreamingConfiguration': streamingConfiguration,
     };
@@ -6240,8 +5339,6 @@ class Chime {
     required Termination termination,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(termination, 'termination');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'Termination': termination,
     };
@@ -6275,7 +5372,6 @@ class Chime {
     required String voiceConnectorId,
     List<Credential>? credentials,
   }) async {
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       if (credentials != null) 'Credentials': credentials,
     };
@@ -6307,22 +5403,6 @@ class Chime {
     required String channelArn,
     required String messageId,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    _s.validateStringLength(
-      'messageId',
-      messageId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6357,9 +5437,6 @@ class Chime {
     required String conversationId,
     required String messageId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(conversationId, 'conversationId');
-    ArgumentError.checkNotNull(messageId, 'messageId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6392,9 +5469,6 @@ class Chime {
     required String messageId,
     required String roomId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6423,8 +5497,6 @@ class Chime {
     required String accountId,
     required String botId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6456,8 +5528,6 @@ class Chime {
     required String accountId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6485,7 +5555,6 @@ class Chime {
   Future<RestorePhoneNumberResponse> restorePhoneNumber({
     required String phoneNumberId,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberId, 'phoneNumberId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -6540,12 +5609,6 @@ class Chime {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'tollFreePrefix',
-      tollFreePrefix,
-      3,
-      3,
     );
     final $query = <String, List<String>>{
       if (areaCode != null) 'area-code': [areaCode],
@@ -6607,36 +5670,6 @@ class Chime {
     String? clientRequestToken,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      4096,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(persistence, 'persistence');
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Content': content,
       'Persistence': persistence.toValue(),
@@ -6677,9 +5710,6 @@ class Chime {
     required String meetingId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(attendeeId, 'attendeeId');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -6712,8 +5742,6 @@ class Chime {
     required String meetingId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -6745,15 +5773,6 @@ class Chime {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'Tags': tags,
@@ -6789,9 +5808,6 @@ class Chime {
     required String meetingId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(attendeeId, 'attendeeId');
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'TagKeys': tagKeys,
     };
@@ -6823,8 +5839,6 @@ class Chime {
     required String meetingId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(meetingId, 'meetingId');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'TagKeys': tagKeys,
     };
@@ -6856,15 +5870,6 @@ class Chime {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'TagKeys': tagKeys,
@@ -6897,13 +5902,6 @@ class Chime {
     required String accountId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -6940,8 +5938,6 @@ class Chime {
     required String accountId,
     required AccountSettings accountSettings,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(accountSettings, 'accountSettings');
     final $payload = <String, dynamic>{
       'AccountSettings': accountSettings,
     };
@@ -6976,28 +5972,6 @@ class Chime {
     required String name,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(appInstanceArn, 'appInstanceArn');
-    _s.validateStringLength(
-      'appInstanceArn',
-      appInstanceArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (metadata != null) 'Metadata': metadata,
@@ -7035,28 +6009,6 @@ class Chime {
     required String name,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(appInstanceUserArn, 'appInstanceUserArn');
-    _s.validateStringLength(
-      'appInstanceUserArn',
-      appInstanceUserArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (metadata != null) 'Metadata': metadata,
@@ -7095,8 +6047,6 @@ class Chime {
     required String botId,
     bool? disabled,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(botId, 'botId');
     final $payload = <String, dynamic>{
       if (disabled != null) 'Disabled': disabled,
     };
@@ -7139,29 +6089,6 @@ class Chime {
     required String name,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mode, 'mode');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'Mode': mode.toValue(),
       'Name': name,
@@ -7203,34 +6130,6 @@ class Chime {
     String? content,
     String? metadata,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    _s.validateStringLength(
-      'messageId',
-      messageId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'content',
-      content,
-      0,
-      4096,
-    );
-    _s.validateStringLength(
-      'metadata',
-      metadata,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (content != null) 'Content': content,
       if (metadata != null) 'Metadata': metadata,
@@ -7261,14 +6160,6 @@ class Chime {
   Future<UpdateChannelReadMarkerResponse> updateChannelReadMarker({
     required String channelArn,
   }) async {
-    ArgumentError.checkNotNull(channelArn, 'channelArn');
-    _s.validateStringLength(
-      'channelArn',
-      channelArn,
-      5,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -7297,8 +6188,6 @@ class Chime {
     required BusinessCallingSettings businessCalling,
     required VoiceConnectorSettings voiceConnector,
   }) async {
-    ArgumentError.checkNotNull(businessCalling, 'businessCalling');
-    ArgumentError.checkNotNull(voiceConnector, 'voiceConnector');
     final $payload = <String, dynamic>{
       'BusinessCalling': businessCalling,
       'VoiceConnector': voiceConnector,
@@ -7344,7 +6233,6 @@ class Chime {
     String? callingName,
     PhoneNumberProductType? productType,
   }) async {
-    ArgumentError.checkNotNull(phoneNumberId, 'phoneNumberId');
     final $payload = <String, dynamic>{
       if (callingName != null) 'CallingName': callingName,
       if (productType != null) 'ProductType': productType.toValue(),
@@ -7375,7 +6263,6 @@ class Chime {
   Future<void> updatePhoneNumberSettings({
     required String callingName,
   }) async {
-    ArgumentError.checkNotNull(callingName, 'callingName');
     final $payload = <String, dynamic>{
       'CallingName': callingName,
     };
@@ -7415,23 +6302,6 @@ class Chime {
     required String voiceConnectorId,
     int? expiryMinutes,
   }) async {
-    ArgumentError.checkNotNull(capabilities, 'capabilities');
-    ArgumentError.checkNotNull(proxySessionId, 'proxySessionId');
-    _s.validateStringLength(
-      'proxySessionId',
-      proxySessionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
-    _s.validateStringLength(
-      'voiceConnectorId',
-      voiceConnectorId,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'expiryMinutes',
       expiryMinutes,
@@ -7476,8 +6346,6 @@ class Chime {
     required String roomId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -7521,9 +6389,6 @@ class Chime {
     required String roomId,
     RoomMembershipRole? role,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    ArgumentError.checkNotNull(roomId, 'roomId');
     final $payload = <String, dynamic>{
       if (role != null) 'Role': role.toValue(),
     };
@@ -7561,13 +6426,6 @@ class Chime {
     List<SipMediaApplicationEndpoint>? endpoints,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(sipMediaApplicationId, 'sipMediaApplicationId');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (endpoints != null) 'Endpoints': endpoints,
       if (name != null) 'Name': name,
@@ -7611,15 +6469,6 @@ class Chime {
     bool? disabled,
     List<SipRuleTargetApplication>? targetApplications,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sipRuleId, 'sipRuleId');
     final $payload = <String, dynamic>{
       'Name': name,
       if (disabled != null) 'Disabled': disabled,
@@ -7667,8 +6516,6 @@ class Chime {
     License? licenseType,
     UserType? userType,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       if (alexaForBusinessMetadata != null)
         'AlexaForBusinessMetadata': alexaForBusinessMetadata,
@@ -7709,9 +6556,6 @@ class Chime {
     required String userId,
     required UserSettings userSettings,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(userId, 'userId');
-    ArgumentError.checkNotNull(userSettings, 'userSettings');
     final $payload = <String, dynamic>{
       'UserSettings': userSettings,
     };
@@ -7747,16 +6591,6 @@ class Chime {
     required bool requireEncryption,
     required String voiceConnectorId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(requireEncryption, 'requireEncryption');
-    ArgumentError.checkNotNull(voiceConnectorId, 'voiceConnectorId');
     final $payload = <String, dynamic>{
       'Name': name,
       'RequireEncryption': requireEncryption,
@@ -7795,16 +6629,6 @@ class Chime {
     required String voiceConnectorGroupId,
     required List<VoiceConnectorItem> voiceConnectorItems,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(voiceConnectorGroupId, 'voiceConnectorGroupId');
-    ArgumentError.checkNotNull(voiceConnectorItems, 'voiceConnectorItems');
     final $payload = <String, dynamic>{
       'Name': name,
       'VoiceConnectorItems': voiceConnectorItems,

--- a/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
+++ b/generated/aws_cloud9_api/lib/cloud9-2017-09-23.dart
@@ -110,39 +110,11 @@ class Cloud9 {
     String? subnetId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      5,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      60,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'automaticStopTimeMinutes',
       automaticStopTimeMinutes,
       0,
       20160,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'subnetId',
-      subnetId,
-      5,
-      30,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -206,9 +178,6 @@ class Cloud9 {
     required MemberPermissions permissions,
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    ArgumentError.checkNotNull(permissions, 'permissions');
-    ArgumentError.checkNotNull(userArn, 'userArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -246,7 +215,6 @@ class Cloud9 {
   Future<void> deleteEnvironment({
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.DeleteEnvironment'
@@ -283,8 +251,6 @@ class Cloud9 {
     required String environmentId,
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    ArgumentError.checkNotNull(userArn, 'userArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -402,7 +368,6 @@ class Cloud9 {
   Future<DescribeEnvironmentStatusResult> describeEnvironmentStatus({
     required String environmentId,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -437,7 +402,6 @@ class Cloud9 {
   Future<DescribeEnvironmentsResult> describeEnvironments({
     required List<String> environmentIds,
   }) async {
-    ArgumentError.checkNotNull(environmentIds, 'environmentIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.DescribeEnvironments'
@@ -518,7 +482,6 @@ class Cloud9 {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.ListTagsForResource'
@@ -558,8 +521,6 @@ class Cloud9 {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.TagResource'
@@ -595,8 +556,6 @@ class Cloud9 {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.UntagResource'
@@ -637,19 +596,6 @@ class Cloud9 {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      60,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCloud9WorkspaceManagementService.UpdateEnvironment'
@@ -704,9 +650,6 @@ class Cloud9 {
     required MemberPermissions permissions,
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(environmentId, 'environmentId');
-    ArgumentError.checkNotNull(permissions, 'permissions');
-    ArgumentError.checkNotNull(userArn, 'userArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2016-05-10.dart
@@ -89,9 +89,6 @@ class CloudDirectory {
     required SchemaFacet schemaFacet,
     List<AttributeKeyAndValue>? objectAttributeList,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -135,8 +132,6 @@ class CloudDirectory {
     required String directoryArn,
     required String publishedSchemaArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -194,17 +189,6 @@ class CloudDirectory {
     required String linkName,
     required ObjectReference parentReference,
   }) async {
-    ArgumentError.checkNotNull(childReference, 'childReference');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(linkName, 'linkName');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parentReference, 'parentReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -252,9 +236,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required ObjectReference policyReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -300,9 +281,6 @@ class CloudDirectory {
     required ObjectReference indexReference,
     required ObjectReference targetReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -359,11 +337,6 @@ class CloudDirectory {
     required ObjectReference targetObjectReference,
     required TypedLinkSchemaAndFacetName typedLinkFacet,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(sourceObjectReference, 'sourceObjectReference');
-    ArgumentError.checkNotNull(targetObjectReference, 'targetObjectReference');
-    ArgumentError.checkNotNull(typedLinkFacet, 'typedLinkFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -409,8 +382,6 @@ class CloudDirectory {
     required List<BatchReadOperation> operations,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(operations, 'operations');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -451,8 +422,6 @@ class CloudDirectory {
     required String directoryArn,
     required List<BatchWriteOperation> operations,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(operations, 'operations');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -492,15 +461,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -573,16 +533,6 @@ class CloudDirectory {
     required String schemaArn,
     List<FacetAttribute>? attributes,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(objectType, 'objectType');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -639,16 +589,6 @@ class CloudDirectory {
     String? linkName,
     ObjectReference? parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(isUnique, 'isUnique');
-    ArgumentError.checkNotNull(
-        orderedIndexedAttributeList, 'orderedIndexedAttributeList');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -711,14 +651,6 @@ class CloudDirectory {
     List<AttributeKeyAndValue>? objectAttributeList,
     ObjectReference? parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(schemaFacets, 'schemaFacets');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -775,14 +707,6 @@ class CloudDirectory {
   Future<CreateSchemaResponse> createSchema({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
     };
@@ -820,8 +744,6 @@ class CloudDirectory {
     required TypedLinkFacet facet,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(facet, 'facet');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -856,7 +778,6 @@ class CloudDirectory {
   Future<DeleteDirectoryResponse> deleteDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -894,15 +815,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -942,8 +854,6 @@ class CloudDirectory {
     required String directoryArn,
     required ObjectReference objectReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -977,7 +887,6 @@ class CloudDirectory {
   Future<DeleteSchemaResponse> deleteSchema({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1014,8 +923,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1058,9 +965,6 @@ class CloudDirectory {
     required ObjectReference indexReference,
     required ObjectReference targetReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1107,16 +1011,6 @@ class CloudDirectory {
     required String linkName,
     required ObjectReference parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(linkName, 'linkName');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parentReference, 'parentReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1161,9 +1055,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required ObjectReference policyReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1205,8 +1096,6 @@ class CloudDirectory {
     required String directoryArn,
     required TypedLinkSpecifier typedLinkSpecifier,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1240,7 +1129,6 @@ class CloudDirectory {
   Future<DisableDirectoryResponse> disableDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1271,7 +1159,6 @@ class CloudDirectory {
   Future<EnableDirectoryResponse> enableDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1301,7 +1188,6 @@ class CloudDirectory {
   Future<GetAppliedSchemaVersionResponse> getAppliedSchemaVersion({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final $payload = <String, dynamic>{
       'SchemaArn': schemaArn,
     };
@@ -1328,7 +1214,6 @@ class CloudDirectory {
   Future<GetDirectoryResponse> getDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1365,15 +1250,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1422,9 +1298,6 @@ class CloudDirectory {
     required TypedLinkSpecifier typedLinkSpecifier,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(attributeNames, 'attributeNames');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1479,10 +1352,6 @@ class CloudDirectory {
     required SchemaFacet schemaFacet,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(attributeNames, 'attributeNames');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -1527,8 +1396,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -1565,7 +1432,6 @@ class CloudDirectory {
   Future<GetSchemaAsJsonResponse> getSchemaAsJson({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1604,8 +1470,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1652,7 +1516,6 @@ class CloudDirectory {
     String? nextToken,
     String? schemaArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1706,8 +1569,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1847,15 +1708,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1904,7 +1756,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1979,8 +1830,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2052,8 +1901,6 @@ class CloudDirectory {
     String? nextToken,
     List<ObjectAttributeRange>? rangesOnIndexedValues,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2126,8 +1973,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2196,8 +2041,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2266,8 +2109,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2333,8 +2174,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2399,8 +2238,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2478,8 +2315,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2549,8 +2384,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2654,7 +2487,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2708,8 +2540,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2762,7 +2592,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2825,8 +2654,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2885,27 +2712,6 @@ class CloudDirectory {
     String? minorVersion,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(developmentSchemaArn, 'developmentSchemaArn');
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      10,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'minorVersion',
-      minorVersion,
-      1,
-      10,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': developmentSchemaArn.toString(),
     };
@@ -2947,8 +2753,6 @@ class CloudDirectory {
     required String document,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -2990,9 +2794,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required SchemaFacet schemaFacet,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3030,8 +2831,6 @@ class CloudDirectory {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'Tags': tags,
@@ -3065,8 +2864,6 @@ class CloudDirectory {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'TagKeys': tagKeys,
@@ -3126,15 +2923,6 @@ class CloudDirectory {
     List<FacetAttributeUpdate>? attributeUpdates,
     ObjectType? objectType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3183,9 +2971,6 @@ class CloudDirectory {
     required String directoryArn,
     required TypedLinkSpecifier typedLinkSpecifier,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3231,9 +3016,6 @@ class CloudDirectory {
     required String directoryArn,
     required ObjectReference objectReference,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3272,15 +3054,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3341,11 +3114,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(
-        identityAttributeOrder, 'identityAttributeOrder');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3396,8 +3164,6 @@ class CloudDirectory {
     required String publishedSchemaArn,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final $payload = <String, dynamic>{
       'DirectoryArn': directoryArn,
       'PublishedSchemaArn': publishedSchemaArn,
@@ -3446,16 +3212,6 @@ class CloudDirectory {
     required String publishedSchemaArn,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(developmentSchemaArn, 'developmentSchemaArn');
-    ArgumentError.checkNotNull(minorVersion, 'minorVersion');
-    _s.validateStringLength(
-      'minorVersion',
-      minorVersion,
-      1,
-      10,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final $payload = <String, dynamic>{
       'DevelopmentSchemaArn': developmentSchemaArn,
       'MinorVersion': minorVersion,

--- a/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
+++ b/generated/aws_clouddirectory_api/lib/clouddirectory-2017-01-11.dart
@@ -89,9 +89,6 @@ class CloudDirectory {
     required SchemaFacet schemaFacet,
     List<AttributeKeyAndValue>? objectAttributeList,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -136,8 +133,6 @@ class CloudDirectory {
     required String directoryArn,
     required String publishedSchemaArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -195,17 +190,6 @@ class CloudDirectory {
     required String linkName,
     required ObjectReference parentReference,
   }) async {
-    ArgumentError.checkNotNull(childReference, 'childReference');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(linkName, 'linkName');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parentReference, 'parentReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -253,9 +237,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required ObjectReference policyReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -301,9 +282,6 @@ class CloudDirectory {
     required ObjectReference indexReference,
     required ObjectReference targetReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -360,11 +338,6 @@ class CloudDirectory {
     required ObjectReference targetObjectReference,
     required TypedLinkSchemaAndFacetName typedLinkFacet,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(sourceObjectReference, 'sourceObjectReference');
-    ArgumentError.checkNotNull(targetObjectReference, 'targetObjectReference');
-    ArgumentError.checkNotNull(typedLinkFacet, 'typedLinkFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -410,8 +383,6 @@ class CloudDirectory {
     required List<BatchReadOperation> operations,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(operations, 'operations');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -452,8 +423,6 @@ class CloudDirectory {
     required String directoryArn,
     required List<BatchWriteOperation> operations,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(operations, 'operations');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -498,15 +467,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -586,15 +546,6 @@ class CloudDirectory {
     FacetStyle? facetStyle,
     ObjectType? objectType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -652,16 +603,6 @@ class CloudDirectory {
     String? linkName,
     ObjectReference? parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(isUnique, 'isUnique');
-    ArgumentError.checkNotNull(
-        orderedIndexedAttributeList, 'orderedIndexedAttributeList');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -724,14 +665,6 @@ class CloudDirectory {
     List<AttributeKeyAndValue>? objectAttributeList,
     ObjectReference? parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(schemaFacets, 'schemaFacets');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -788,14 +721,6 @@ class CloudDirectory {
   Future<CreateSchemaResponse> createSchema({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
     };
@@ -833,8 +758,6 @@ class CloudDirectory {
     required TypedLinkFacet facet,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(facet, 'facet');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -869,7 +792,6 @@ class CloudDirectory {
   Future<DeleteDirectoryResponse> deleteDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -907,15 +829,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -959,8 +872,6 @@ class CloudDirectory {
     required String directoryArn,
     required ObjectReference objectReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -994,7 +905,6 @@ class CloudDirectory {
   Future<DeleteSchemaResponse> deleteSchema({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1031,8 +941,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1075,9 +983,6 @@ class CloudDirectory {
     required ObjectReference indexReference,
     required ObjectReference targetReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1124,16 +1029,6 @@ class CloudDirectory {
     required String linkName,
     required ObjectReference parentReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(linkName, 'linkName');
-    _s.validateStringLength(
-      'linkName',
-      linkName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parentReference, 'parentReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1178,9 +1073,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required ObjectReference policyReference,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1222,8 +1114,6 @@ class CloudDirectory {
     required String directoryArn,
     required TypedLinkSpecifier typedLinkSpecifier,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1257,7 +1147,6 @@ class CloudDirectory {
   Future<DisableDirectoryResponse> disableDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1288,7 +1177,6 @@ class CloudDirectory {
   Future<EnableDirectoryResponse> enableDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1318,7 +1206,6 @@ class CloudDirectory {
   Future<GetAppliedSchemaVersionResponse> getAppliedSchemaVersion({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final $payload = <String, dynamic>{
       'SchemaArn': schemaArn,
     };
@@ -1345,7 +1232,6 @@ class CloudDirectory {
   Future<GetDirectoryResponse> getDirectory({
     required String directoryArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1382,15 +1268,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1439,9 +1316,6 @@ class CloudDirectory {
     required TypedLinkSpecifier typedLinkSpecifier,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(attributeNames, 'attributeNames');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -1496,10 +1370,6 @@ class CloudDirectory {
     required SchemaFacet schemaFacet,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(attributeNames, 'attributeNames');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -1544,8 +1414,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     ConsistencyLevel? consistencyLevel,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
       if (consistencyLevel != null)
@@ -1582,7 +1450,6 @@ class CloudDirectory {
   Future<GetSchemaAsJsonResponse> getSchemaAsJson({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1621,8 +1488,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -1669,7 +1534,6 @@ class CloudDirectory {
     String? nextToken,
     String? schemaArn,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1723,8 +1587,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(targetReference, 'targetReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1864,15 +1726,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1921,7 +1774,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1996,8 +1848,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2069,8 +1919,6 @@ class CloudDirectory {
     String? nextToken,
     List<ObjectAttributeRange>? rangesOnIndexedValues,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(indexReference, 'indexReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2188,8 +2036,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2258,8 +2104,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2328,8 +2172,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2401,8 +2243,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2469,8 +2309,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2548,8 +2386,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2619,8 +2455,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(policyReference, 'policyReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2724,7 +2558,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2778,8 +2611,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2832,7 +2663,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2895,8 +2725,6 @@ class CloudDirectory {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2955,27 +2783,6 @@ class CloudDirectory {
     String? minorVersion,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(developmentSchemaArn, 'developmentSchemaArn');
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      10,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'minorVersion',
-      minorVersion,
-      1,
-      10,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-    );
     final headers = <String, String>{
       'x-amz-data-partition': developmentSchemaArn.toString(),
     };
@@ -3017,8 +2824,6 @@ class CloudDirectory {
     required String document,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3060,9 +2865,6 @@ class CloudDirectory {
     required ObjectReference objectReference,
     required SchemaFacet schemaFacet,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
-    ArgumentError.checkNotNull(schemaFacet, 'schemaFacet');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3100,8 +2902,6 @@ class CloudDirectory {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'Tags': tags,
@@ -3135,8 +2935,6 @@ class CloudDirectory {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'TagKeys': tagKeys,
@@ -3197,15 +2995,6 @@ class CloudDirectory {
     List<FacetAttributeUpdate>? attributeUpdates,
     ObjectType? objectType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3254,9 +3043,6 @@ class CloudDirectory {
     required String directoryArn,
     required TypedLinkSpecifier typedLinkSpecifier,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(typedLinkSpecifier, 'typedLinkSpecifier');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3302,9 +3088,6 @@ class CloudDirectory {
     required String directoryArn,
     required ObjectReference objectReference,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(objectReference, 'objectReference');
     final headers = <String, String>{
       'x-amz-data-partition': directoryArn.toString(),
     };
@@ -3343,15 +3126,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3412,11 +3186,6 @@ class CloudDirectory {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(
-        identityAttributeOrder, 'identityAttributeOrder');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
     final headers = <String, String>{
       'x-amz-data-partition': schemaArn.toString(),
     };
@@ -3468,8 +3237,6 @@ class CloudDirectory {
     required String publishedSchemaArn,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(directoryArn, 'directoryArn');
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final $payload = <String, dynamic>{
       'DirectoryArn': directoryArn,
       'PublishedSchemaArn': publishedSchemaArn,
@@ -3518,16 +3285,6 @@ class CloudDirectory {
     required String publishedSchemaArn,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(developmentSchemaArn, 'developmentSchemaArn');
-    ArgumentError.checkNotNull(minorVersion, 'minorVersion');
-    _s.validateStringLength(
-      'minorVersion',
-      minorVersion,
-      1,
-      10,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(publishedSchemaArn, 'publishedSchemaArn');
     final $payload = <String, dynamic>{
       'DevelopmentSchemaArn': developmentSchemaArn,
       'MinorVersion': minorVersion,

--- a/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
+++ b/generated/aws_cloudformation_api/lib/cloudformation-2010-05-15.dart
@@ -80,13 +80,6 @@ class CloudFormation {
     required String stackName,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     clientRequestToken?.also((arg) => $request['ClientRequestToken'] = arg);
@@ -200,26 +193,6 @@ class CloudFormation {
     List<String>? resourcesToSkip,
     String? roleARN,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      20,
-      2048,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     clientRequestToken?.also((arg) => $request['ClientRequestToken'] = arg);
@@ -514,52 +487,6 @@ class CloudFormation {
     String? templateURL,
     bool? usePreviousTemplate,
   }) async {
-    ArgumentError.checkNotNull(changeSetName, 'changeSetName');
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['ChangeSetName'] = changeSetName;
     $request['StackName'] = stackName;
@@ -882,43 +809,6 @@ class CloudFormation {
     String? templateURL,
     int? timeoutInMinutes,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'stackPolicyBody',
-      stackPolicyBody,
-      1,
-      16384,
-    );
-    _s.validateStringLength(
-      'stackPolicyURL',
-      stackPolicyURL,
-      1,
-      1350,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     _s.validateNumRange(
       'timeoutInMinutes',
       timeoutInMinutes,
@@ -1065,14 +955,6 @@ class CloudFormation {
     StackSetOperationPreferences? operationPreferences,
     List<Parameter>? parameterOverrides,
   }) async {
-    ArgumentError.checkNotNull(regions, 'regions');
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['Regions'] = regions;
     $request['StackSetName'] = stackSetName;
@@ -1315,43 +1197,6 @@ class CloudFormation {
     String? templateBody,
     String? templateURL,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'administrationRoleARN',
-      administrationRoleARN,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'executionRoleName',
-      executionRoleName,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
     administrationRoleARN
@@ -1407,20 +1252,6 @@ class CloudFormation {
     required String changeSetName,
     String? stackName,
   }) async {
-    ArgumentError.checkNotNull(changeSetName, 'changeSetName');
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-    );
     final $request = <String, dynamic>{};
     $request['ChangeSetName'] = changeSetName;
     stackName?.also((arg) => $request['StackName'] = arg);
@@ -1492,19 +1323,6 @@ class CloudFormation {
     List<String>? retainResources,
     String? roleARN,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      20,
-      2048,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     clientRequestToken?.also((arg) => $request['ClientRequestToken'] = arg);
@@ -1585,15 +1403,6 @@ class CloudFormation {
     String? operationId,
     StackSetOperationPreferences? operationPreferences,
   }) async {
-    ArgumentError.checkNotNull(regions, 'regions');
-    ArgumentError.checkNotNull(retainStacks, 'retainStacks');
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['Regions'] = regions;
     $request['RetainStacks'] = retainStacks;
@@ -1629,7 +1438,6 @@ class CloudFormation {
   Future<void> deleteStackSet({
     required String stackSetName,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
     await _protocol.send(
@@ -1690,24 +1498,6 @@ class CloudFormation {
     String? typeName,
     String? versionId,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     arn?.also((arg) => $request['Arn'] = arg);
     type?.also((arg) => $request['Type'] = arg.toValue());
@@ -1738,12 +1528,6 @@ class CloudFormation {
   Future<DescribeAccountLimitsOutput> describeAccountLimits({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     nextToken?.also((arg) => $request['NextToken'] = arg);
     final $result = await _protocol.send(
@@ -1784,26 +1568,6 @@ class CloudFormation {
     String? nextToken,
     String? stackName,
   }) async {
-    ArgumentError.checkNotNull(changeSetName, 'changeSetName');
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-    );
     final $request = <String, dynamic>{};
     $request['ChangeSetName'] = changeSetName;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -1849,14 +1613,6 @@ class CloudFormation {
       describeStackDriftDetectionStatus({
     required String stackDriftDetectionId,
   }) async {
-    ArgumentError.checkNotNull(stackDriftDetectionId, 'stackDriftDetectionId');
-    _s.validateStringLength(
-      'stackDriftDetectionId',
-      stackDriftDetectionId,
-      1,
-      36,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['StackDriftDetectionId'] = stackDriftDetectionId;
     final $result = await _protocol.send(
@@ -1905,12 +1661,6 @@ class CloudFormation {
     String? nextToken,
     String? stackName,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     nextToken?.also((arg) => $request['NextToken'] = arg);
     stackName?.also((arg) => $request['StackName'] = arg);
@@ -1951,9 +1701,6 @@ class CloudFormation {
     required String stackInstanceRegion,
     required String stackSetName,
   }) async {
-    ArgumentError.checkNotNull(stackInstanceAccount, 'stackInstanceAccount');
-    ArgumentError.checkNotNull(stackInstanceRegion, 'stackInstanceRegion');
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     final $request = <String, dynamic>{};
     $request['StackInstanceAccount'] = stackInstanceAccount;
     $request['StackInstanceRegion'] = stackInstanceRegion;
@@ -2000,8 +1747,6 @@ class CloudFormation {
     required String logicalResourceId,
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(logicalResourceId, 'logicalResourceId');
-    ArgumentError.checkNotNull(stackName, 'stackName');
     final $request = <String, dynamic>{};
     $request['LogicalResourceId'] = logicalResourceId;
     $request['StackName'] = stackName;
@@ -2076,25 +1821,11 @@ class CloudFormation {
     String? nextToken,
     List<StackResourceDriftStatus>? stackResourceDriftStatusFilters,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
@@ -2212,7 +1943,6 @@ class CloudFormation {
   Future<DescribeStackSetOutput> describeStackSet({
     required String stackSetName,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
     final $result = await _protocol.send(
@@ -2243,15 +1973,6 @@ class CloudFormation {
     required String operationId,
     required String stackSetName,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     final $request = <String, dynamic>{};
     $request['OperationId'] = operationId;
     $request['StackSetName'] = stackSetName;
@@ -2298,12 +2019,6 @@ class CloudFormation {
     String? nextToken,
     String? stackName,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     nextToken?.also((arg) => $request['NextToken'] = arg);
     stackName?.also((arg) => $request['StackName'] = arg);
@@ -2364,24 +2079,6 @@ class CloudFormation {
     String? typeName,
     String? versionId,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     arn?.also((arg) => $request['Arn'] = arg);
     type?.also((arg) => $request['Type'] = arg.toValue());
@@ -2421,14 +2118,6 @@ class CloudFormation {
   Future<DescribeTypeRegistrationOutput> describeTypeRegistration({
     required String registrationToken,
   }) async {
-    ArgumentError.checkNotNull(registrationToken, 'registrationToken');
-    _s.validateStringLength(
-      'registrationToken',
-      registrationToken,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['RegistrationToken'] = registrationToken;
     final $result = await _protocol.send(
@@ -2486,14 +2175,6 @@ class CloudFormation {
     required String stackName,
     List<String>? logicalResourceIds,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     logicalResourceIds?.also((arg) => $request['LogicalResourceIds'] = arg);
@@ -2539,15 +2220,6 @@ class CloudFormation {
     required String logicalResourceId,
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(logicalResourceId, 'logicalResourceId');
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['LogicalResourceId'] = logicalResourceId;
     $request['StackName'] = stackName;
@@ -2625,13 +2297,6 @@ class CloudFormation {
     String? operationId,
     StackSetOperationPreferences? operationPreferences,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
     $request['OperationId'] = operationId ?? _s.generateIdempotencyToken();
@@ -2682,18 +2347,6 @@ class CloudFormation {
     String? templateBody,
     String? templateURL,
   }) async {
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     parameters?.also((arg) => $request['Parameters'] = arg);
     templateBody?.also((arg) => $request['TemplateBody'] = arg);
@@ -2753,26 +2406,6 @@ class CloudFormation {
     String? clientRequestToken,
     String? stackName,
   }) async {
-    ArgumentError.checkNotNull(changeSetName, 'changeSetName');
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-    );
     final $request = <String, dynamic>{};
     $request['ChangeSetName'] = changeSetName;
     clientRequestToken?.also((arg) => $request['ClientRequestToken'] = arg);
@@ -2799,7 +2432,6 @@ class CloudFormation {
   Future<GetStackPolicyOutput> getStackPolicy({
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     final $result = await _protocol.send(
@@ -2862,12 +2494,6 @@ class CloudFormation {
     String? stackName,
     TemplateStage? templateStage,
   }) async {
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      1600,
-    );
     final $request = <String, dynamic>{};
     changeSetName?.also((arg) => $request['ChangeSetName'] = arg);
     stackName?.also((arg) => $request['StackName'] = arg);
@@ -2945,24 +2571,6 @@ class CloudFormation {
     String? templateBody,
     String? templateURL,
   }) async {
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     stackName?.also((arg) => $request['StackName'] = arg);
     stackSetName?.also((arg) => $request['StackSetName'] = arg);
@@ -2997,20 +2605,6 @@ class CloudFormation {
     required String stackName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -3045,12 +2639,6 @@ class CloudFormation {
   Future<ListExportsOutput> listExports({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     nextToken?.also((arg) => $request['NextToken'] = arg);
     final $result = await _protocol.send(
@@ -3088,13 +2676,6 @@ class CloudFormation {
     required String exportName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(exportName, 'exportName');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['ExportName'] = exportName;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -3153,18 +2734,11 @@ class CloudFormation {
     String? stackInstanceAccount,
     String? stackInstanceRegion,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
@@ -3214,13 +2788,6 @@ class CloudFormation {
     required String stackName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -3270,26 +2837,11 @@ class CloudFormation {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $request = <String, dynamic>{};
     $request['OperationId'] = operationId;
@@ -3337,18 +2889,11 @@ class CloudFormation {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
@@ -3400,12 +2945,6 @@ class CloudFormation {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     maxResults?.also((arg) => $request['MaxResults'] = arg);
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -3443,12 +2982,6 @@ class CloudFormation {
     String? nextToken,
     List<StackStatus>? stackStatusFilter,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     nextToken?.also((arg) => $request['NextToken'] = arg);
     stackStatusFilter?.also((arg) =>
@@ -3522,24 +3055,6 @@ class CloudFormation {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeArn',
-      typeArn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
     );
     final $request = <String, dynamic>{};
     maxResults?.also((arg) => $request['MaxResults'] = arg);
@@ -3628,29 +3143,11 @@ class CloudFormation {
     RegistryType? type,
     String? typeName,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
     );
     final $request = <String, dynamic>{};
     arn?.also((arg) => $request['Arn'] = arg);
@@ -3768,12 +3265,6 @@ class CloudFormation {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     deprecatedStatus
         ?.also((arg) => $request['DeprecatedStatus'] = arg.toValue());
@@ -3849,33 +3340,6 @@ class CloudFormation {
     String? resourceModel,
     String? statusMessage,
   }) async {
-    ArgumentError.checkNotNull(bearerToken, 'bearerToken');
-    _s.validateStringLength(
-      'bearerToken',
-      bearerToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(operationStatus, 'operationStatus');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'resourceModel',
-      resourceModel,
-      1,
-      16384,
-    );
-    _s.validateStringLength(
-      'statusMessage',
-      statusMessage,
-      0,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['BearerToken'] = bearerToken;
     $request['OperationStatus'] = operationStatus.toValue();
@@ -4013,34 +3477,6 @@ class CloudFormation {
     LoggingConfig? loggingConfig,
     RegistryType? type,
   }) async {
-    ArgumentError.checkNotNull(schemaHandlerPackage, 'schemaHandlerPackage');
-    _s.validateStringLength(
-      'schemaHandlerPackage',
-      schemaHandlerPackage,
-      1,
-      4096,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      1,
-      256,
-    );
     final $request = <String, dynamic>{};
     $request['SchemaHandlerPackage'] = schemaHandlerPackage;
     $request['TypeName'] = typeName;
@@ -4084,19 +3520,6 @@ class CloudFormation {
     String? stackPolicyBody,
     String? stackPolicyURL,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackPolicyBody',
-      stackPolicyBody,
-      1,
-      16384,
-    );
-    _s.validateStringLength(
-      'stackPolicyURL',
-      stackPolicyURL,
-      1,
-      1350,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     stackPolicyBody?.also((arg) => $request['StackPolicyBody'] = arg);
@@ -4148,24 +3571,6 @@ class CloudFormation {
     String? typeName,
     String? versionId,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      10,
-      204,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     arn?.also((arg) => $request['Arn'] = arg);
     type?.also((arg) => $request['Type'] = arg.toValue());
@@ -4216,24 +3621,6 @@ class CloudFormation {
     required ResourceSignalStatus status,
     required String uniqueId,
   }) async {
-    ArgumentError.checkNotNull(logicalResourceId, 'logicalResourceId');
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    ArgumentError.checkNotNull(uniqueId, 'uniqueId');
-    _s.validateStringLength(
-      'uniqueId',
-      uniqueId,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['LogicalResourceId'] = logicalResourceId;
     $request['StackName'] = stackName;
@@ -4268,15 +3655,6 @@ class CloudFormation {
     required String operationId,
     required String stackSetName,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
     final $request = <String, dynamic>{};
     $request['OperationId'] = operationId;
     $request['StackSetName'] = stackSetName;
@@ -4582,55 +3960,6 @@ class CloudFormation {
     String? templateURL,
     bool? usePreviousTemplate,
   }) async {
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'stackPolicyBody',
-      stackPolicyBody,
-      1,
-      16384,
-    );
-    _s.validateStringLength(
-      'stackPolicyDuringUpdateBody',
-      stackPolicyDuringUpdateBody,
-      1,
-      16384,
-    );
-    _s.validateStringLength(
-      'stackPolicyDuringUpdateURL',
-      stackPolicyDuringUpdateURL,
-      1,
-      1350,
-    );
-    _s.validateStringLength(
-      'stackPolicyURL',
-      stackPolicyURL,
-      1,
-      1350,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['StackName'] = stackName;
     capabilities?.also((arg) =>
@@ -4797,14 +4126,6 @@ class CloudFormation {
     StackSetOperationPreferences? operationPreferences,
     List<Parameter>? parameterOverrides,
   }) async {
-    ArgumentError.checkNotNull(regions, 'regions');
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['Regions'] = regions;
     $request['StackSetName'] = stackSetName;
@@ -5166,43 +4487,6 @@ class CloudFormation {
     String? templateURL,
     bool? usePreviousTemplate,
   }) async {
-    ArgumentError.checkNotNull(stackSetName, 'stackSetName');
-    _s.validateStringLength(
-      'administrationRoleARN',
-      administrationRoleARN,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'executionRoleName',
-      executionRoleName,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['StackSetName'] = stackSetName;
     accounts?.also((arg) => $request['Accounts'] = arg);
@@ -5259,16 +4543,6 @@ class CloudFormation {
     required bool enableTerminationProtection,
     required String stackName,
   }) async {
-    ArgumentError.checkNotNull(
-        enableTerminationProtection, 'enableTerminationProtection');
-    ArgumentError.checkNotNull(stackName, 'stackName');
-    _s.validateStringLength(
-      'stackName',
-      stackName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['EnableTerminationProtection'] = enableTerminationProtection;
     $request['StackName'] = stackName;
@@ -5315,18 +4589,6 @@ class CloudFormation {
     String? templateBody,
     String? templateURL,
   }) async {
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'templateURL',
-      templateURL,
-      1,
-      1024,
-    );
     final $request = <String, dynamic>{};
     templateBody?.also((arg) => $request['TemplateBody'] = arg);
     templateURL?.also((arg) => $request['TemplateURL'] = arg);

--- a/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2016-11-25.dart
@@ -72,8 +72,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2016-11-25/origin-access-identity/cloudfront',
@@ -138,7 +136,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2016_11_25({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2016-11-25/distribution',
@@ -201,8 +198,6 @@ class CloudFront {
       createDistributionWithTags2016_11_25({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2016-11-25/distribution?WithTags',
@@ -236,8 +231,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -304,8 +297,6 @@ class CloudFront {
       createStreamingDistribution2016_11_25({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2016-11-25/streaming-distribution',
@@ -343,8 +334,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2016-11-25/streaming-distribution?WithTags',
@@ -379,7 +368,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -410,7 +398,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -489,7 +476,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -513,7 +499,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -539,7 +524,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -564,7 +548,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2016-11-25/distribution/${Uri.encodeComponent(id)}',
@@ -587,7 +570,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2016-11-25/distribution/${Uri.encodeComponent(id)}/config',
@@ -616,8 +598,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -641,7 +621,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -666,7 +645,6 @@ class CloudFront {
       getStreamingDistributionConfig2016_11_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -779,7 +757,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -823,7 +800,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -884,7 +860,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2016_11_25({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -916,8 +891,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -946,8 +919,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -988,9 +959,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1067,8 +1035,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1118,9 +1084,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-03-25.dart
@@ -71,8 +71,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-03-25/origin-access-identity/cloudfront',
@@ -139,7 +137,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2017_03_25({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-03-25/distribution',
@@ -204,8 +201,6 @@ class CloudFront {
       createDistributionWithTags2017_03_25({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-03-25/distribution?WithTags',
@@ -239,8 +234,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -307,8 +300,6 @@ class CloudFront {
       createStreamingDistribution2017_03_25({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-03-25/streaming-distribution',
@@ -346,8 +337,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-03-25/streaming-distribution?WithTags',
@@ -382,7 +371,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -413,7 +401,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -433,7 +420,6 @@ class CloudFront {
   Future<void> deleteServiceLinkedRole2017_03_25({
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
     await _protocol.send(
       method: 'DELETE',
       requestUri:
@@ -509,7 +495,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -533,7 +518,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -559,7 +543,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -584,7 +567,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-03-25/distribution/${Uri.encodeComponent(id)}',
@@ -607,7 +589,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-03-25/distribution/${Uri.encodeComponent(id)}/config',
@@ -636,8 +617,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -661,7 +640,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -686,7 +664,6 @@ class CloudFront {
       getStreamingDistributionConfig2017_03_25({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -799,7 +776,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -843,7 +819,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -904,7 +879,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2017_03_25({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -936,8 +910,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -966,8 +938,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1008,9 +978,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1156,8 +1123,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1207,9 +1172,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2017-10-30.dart
@@ -71,8 +71,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/origin-access-identity/cloudfront',
@@ -142,7 +140,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2017_10_30({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/distribution',
@@ -210,8 +207,6 @@ class CloudFront {
       createDistributionWithTags2017_10_30({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/distribution?WithTags',
@@ -243,8 +238,6 @@ class CloudFront {
       createFieldLevelEncryptionConfig2017_10_30({
     required FieldLevelEncryptionConfig fieldLevelEncryptionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/field-level-encryption',
@@ -277,8 +270,6 @@ class CloudFront {
     required FieldLevelEncryptionProfileConfig
         fieldLevelEncryptionProfileConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/field-level-encryption-profile',
@@ -313,8 +304,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -341,7 +330,6 @@ class CloudFront {
   Future<CreatePublicKeyResult> createPublicKey2017_10_30({
     required PublicKeyConfig publicKeyConfig,
   }) async {
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/public-key',
@@ -408,8 +396,6 @@ class CloudFront {
       createStreamingDistribution2017_10_30({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/streaming-distribution',
@@ -447,8 +433,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2017-10-30/streaming-distribution?WithTags',
@@ -483,7 +467,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -514,7 +497,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -545,7 +527,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -577,7 +558,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -609,7 +589,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -688,7 +667,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -712,7 +690,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -738,7 +715,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -763,7 +739,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-10-30/distribution/${Uri.encodeComponent(id)}',
@@ -786,7 +761,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-10-30/distribution/${Uri.encodeComponent(id)}/config',
@@ -809,7 +783,6 @@ class CloudFront {
   Future<GetFieldLevelEncryptionResult> getFieldLevelEncryption2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -834,7 +807,6 @@ class CloudFront {
       getFieldLevelEncryptionConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -859,7 +831,6 @@ class CloudFront {
       getFieldLevelEncryptionProfile2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -885,7 +856,6 @@ class CloudFront {
       getFieldLevelEncryptionProfileConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -916,8 +886,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -940,7 +908,6 @@ class CloudFront {
   Future<GetPublicKeyResult> getPublicKey2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-10-30/public-key/${Uri.encodeComponent(id)}',
@@ -963,7 +930,6 @@ class CloudFront {
   Future<GetPublicKeyConfigResult> getPublicKeyConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2017-10-30/public-key/${Uri.encodeComponent(id)}/config',
@@ -987,7 +953,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1012,7 +977,6 @@ class CloudFront {
       getStreamingDistributionConfig2017_10_30({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1125,7 +1089,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1243,7 +1206,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1338,7 +1300,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2017_10_30({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1370,8 +1331,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1400,8 +1359,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1442,9 +1399,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1593,8 +1547,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1642,9 +1594,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1695,9 +1644,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1743,8 +1689,6 @@ class CloudFront {
     required PublicKeyConfig publicKeyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1794,9 +1738,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-06-18.dart
@@ -71,8 +71,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/origin-access-identity/cloudfront',
@@ -158,7 +156,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2018_06_18({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/distribution',
@@ -226,8 +223,6 @@ class CloudFront {
       createDistributionWithTags2018_06_18({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/distribution?WithTags',
@@ -259,8 +254,6 @@ class CloudFront {
       createFieldLevelEncryptionConfig2018_06_18({
     required FieldLevelEncryptionConfig fieldLevelEncryptionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/field-level-encryption',
@@ -293,8 +286,6 @@ class CloudFront {
     required FieldLevelEncryptionProfileConfig
         fieldLevelEncryptionProfileConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/field-level-encryption-profile',
@@ -329,8 +320,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -357,7 +346,6 @@ class CloudFront {
   Future<CreatePublicKeyResult> createPublicKey2018_06_18({
     required PublicKeyConfig publicKeyConfig,
   }) async {
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/public-key',
@@ -424,8 +412,6 @@ class CloudFront {
       createStreamingDistribution2018_06_18({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/streaming-distribution',
@@ -463,8 +449,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-06-18/streaming-distribution?WithTags',
@@ -499,7 +483,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -530,7 +513,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -561,7 +543,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -593,7 +574,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -625,7 +605,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -704,7 +683,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -728,7 +706,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -754,7 +731,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -779,7 +755,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-06-18/distribution/${Uri.encodeComponent(id)}',
@@ -802,7 +777,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-06-18/distribution/${Uri.encodeComponent(id)}/config',
@@ -825,7 +799,6 @@ class CloudFront {
   Future<GetFieldLevelEncryptionResult> getFieldLevelEncryption2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -850,7 +823,6 @@ class CloudFront {
       getFieldLevelEncryptionConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -875,7 +847,6 @@ class CloudFront {
       getFieldLevelEncryptionProfile2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -901,7 +872,6 @@ class CloudFront {
       getFieldLevelEncryptionProfileConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -932,8 +902,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -956,7 +924,6 @@ class CloudFront {
   Future<GetPublicKeyResult> getPublicKey2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-06-18/public-key/${Uri.encodeComponent(id)}',
@@ -979,7 +946,6 @@ class CloudFront {
   Future<GetPublicKeyConfigResult> getPublicKeyConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-06-18/public-key/${Uri.encodeComponent(id)}/config',
@@ -1003,7 +969,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1028,7 +993,6 @@ class CloudFront {
       getStreamingDistributionConfig2018_06_18({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1141,7 +1105,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1259,7 +1222,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1354,7 +1316,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2018_06_18({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1386,8 +1347,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1416,8 +1375,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1458,9 +1415,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1626,8 +1580,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1675,9 +1627,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1728,9 +1677,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1776,8 +1722,6 @@ class CloudFront {
     required PublicKeyConfig publicKeyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1827,9 +1771,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2018-11-05.dart
@@ -71,8 +71,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/origin-access-identity/cloudfront',
@@ -159,7 +157,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2018_11_05({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/distribution',
@@ -228,8 +225,6 @@ class CloudFront {
       createDistributionWithTags2018_11_05({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/distribution?WithTags',
@@ -261,8 +256,6 @@ class CloudFront {
       createFieldLevelEncryptionConfig2018_11_05({
     required FieldLevelEncryptionConfig fieldLevelEncryptionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/field-level-encryption',
@@ -295,8 +288,6 @@ class CloudFront {
     required FieldLevelEncryptionProfileConfig
         fieldLevelEncryptionProfileConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/field-level-encryption-profile',
@@ -331,8 +322,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -359,7 +348,6 @@ class CloudFront {
   Future<CreatePublicKeyResult> createPublicKey2018_11_05({
     required PublicKeyConfig publicKeyConfig,
   }) async {
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/public-key',
@@ -426,8 +414,6 @@ class CloudFront {
       createStreamingDistribution2018_11_05({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/streaming-distribution',
@@ -465,8 +451,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2018-11-05/streaming-distribution?WithTags',
@@ -501,7 +485,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -532,7 +515,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -563,7 +545,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -595,7 +576,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -627,7 +607,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -706,7 +685,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -730,7 +708,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -756,7 +733,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -781,7 +757,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-11-05/distribution/${Uri.encodeComponent(id)}',
@@ -804,7 +779,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-11-05/distribution/${Uri.encodeComponent(id)}/config',
@@ -827,7 +801,6 @@ class CloudFront {
   Future<GetFieldLevelEncryptionResult> getFieldLevelEncryption2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -852,7 +825,6 @@ class CloudFront {
       getFieldLevelEncryptionConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -877,7 +849,6 @@ class CloudFront {
       getFieldLevelEncryptionProfile2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -903,7 +874,6 @@ class CloudFront {
       getFieldLevelEncryptionProfileConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -934,8 +904,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -958,7 +926,6 @@ class CloudFront {
   Future<GetPublicKeyResult> getPublicKey2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-11-05/public-key/${Uri.encodeComponent(id)}',
@@ -981,7 +948,6 @@ class CloudFront {
   Future<GetPublicKeyConfigResult> getPublicKeyConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2018-11-05/public-key/${Uri.encodeComponent(id)}/config',
@@ -1005,7 +971,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1030,7 +995,6 @@ class CloudFront {
       getStreamingDistributionConfig2018_11_05({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1143,7 +1107,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1261,7 +1224,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1356,7 +1318,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2018_11_05({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1388,8 +1349,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1418,8 +1377,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1460,9 +1417,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1629,8 +1583,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1678,9 +1630,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1731,9 +1680,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1779,8 +1725,6 @@ class CloudFront {
     required PublicKeyConfig publicKeyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1830,9 +1774,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2019-03-26.dart
@@ -71,8 +71,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/origin-access-identity/cloudfront',
@@ -156,7 +154,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2019_03_26({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/distribution',
@@ -225,8 +222,6 @@ class CloudFront {
       createDistributionWithTags2019_03_26({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/distribution?WithTags',
@@ -258,8 +253,6 @@ class CloudFront {
       createFieldLevelEncryptionConfig2019_03_26({
     required FieldLevelEncryptionConfig fieldLevelEncryptionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/field-level-encryption',
@@ -292,8 +285,6 @@ class CloudFront {
     required FieldLevelEncryptionProfileConfig
         fieldLevelEncryptionProfileConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/field-level-encryption-profile',
@@ -328,8 +319,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -356,7 +345,6 @@ class CloudFront {
   Future<CreatePublicKeyResult> createPublicKey2019_03_26({
     required PublicKeyConfig publicKeyConfig,
   }) async {
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/public-key',
@@ -423,8 +411,6 @@ class CloudFront {
       createStreamingDistribution2019_03_26({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/streaming-distribution',
@@ -462,8 +448,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2019-03-26/streaming-distribution?WithTags',
@@ -498,7 +482,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -529,7 +512,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -560,7 +542,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -592,7 +573,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -624,7 +604,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -703,7 +682,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -727,7 +705,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -753,7 +730,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -779,7 +755,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2019-03-26/distribution/${Uri.encodeComponent(id)}',
@@ -803,7 +778,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2019-03-26/distribution/${Uri.encodeComponent(id)}/config',
@@ -826,7 +800,6 @@ class CloudFront {
   Future<GetFieldLevelEncryptionResult> getFieldLevelEncryption2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -851,7 +824,6 @@ class CloudFront {
       getFieldLevelEncryptionConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -876,7 +848,6 @@ class CloudFront {
       getFieldLevelEncryptionProfile2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -902,7 +873,6 @@ class CloudFront {
       getFieldLevelEncryptionProfileConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -933,8 +903,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -957,7 +925,6 @@ class CloudFront {
   Future<GetPublicKeyResult> getPublicKey2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2019-03-26/public-key/${Uri.encodeComponent(id)}',
@@ -980,7 +947,6 @@ class CloudFront {
   Future<GetPublicKeyConfigResult> getPublicKeyConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2019-03-26/public-key/${Uri.encodeComponent(id)}/config',
@@ -1004,7 +970,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1029,7 +994,6 @@ class CloudFront {
       getStreamingDistributionConfig2019_03_26({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1142,7 +1106,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1260,7 +1223,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1355,7 +1317,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2019_03_26({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1387,8 +1348,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1417,8 +1376,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -1459,9 +1416,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1631,8 +1585,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1680,9 +1632,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1733,9 +1682,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1781,8 +1727,6 @@ class CloudFront {
     required PublicKeyConfig publicKeyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1832,9 +1776,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
+++ b/generated/aws_cloudfront_api/lib/cloudfront-2020-05-31.dart
@@ -93,7 +93,6 @@ class CloudFront {
   Future<CreateCachePolicyResult> createCachePolicy2020_05_31({
     required CachePolicyConfig cachePolicyConfig,
   }) async {
-    ArgumentError.checkNotNull(cachePolicyConfig, 'cachePolicyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/cache-policy',
@@ -129,8 +128,6 @@ class CloudFront {
     required CloudFrontOriginAccessIdentityConfig
         cloudFrontOriginAccessIdentityConfig,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/origin-access-identity/cloudfront',
@@ -222,7 +219,6 @@ class CloudFront {
   Future<CreateDistributionResult> createDistribution2020_05_31({
     required DistributionConfig distributionConfig,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/distribution',
@@ -299,8 +295,6 @@ class CloudFront {
       createDistributionWithTags2020_05_31({
     required DistributionConfigWithTags distributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigWithTags, 'distributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/distribution?WithTags',
@@ -332,8 +326,6 @@ class CloudFront {
       createFieldLevelEncryptionConfig2020_05_31({
     required FieldLevelEncryptionConfig fieldLevelEncryptionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/field-level-encryption',
@@ -366,8 +358,6 @@ class CloudFront {
     required FieldLevelEncryptionProfileConfig
         fieldLevelEncryptionProfileConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/field-level-encryption-profile',
@@ -402,8 +392,6 @@ class CloudFront {
     required String distributionId,
     required InvalidationBatch invalidationBatch,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(invalidationBatch, 'invalidationBatch');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -443,7 +431,6 @@ class CloudFront {
   Future<CreateKeyGroupResult> createKeyGroup2020_05_31({
     required KeyGroupConfig keyGroupConfig,
   }) async {
-    ArgumentError.checkNotNull(keyGroupConfig, 'keyGroupConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/key-group',
@@ -481,9 +468,6 @@ class CloudFront {
     required String distributionId,
     required MonitoringSubscription monitoringSubscription,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(
-        monitoringSubscription, 'monitoringSubscription');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri:
@@ -544,8 +528,6 @@ class CloudFront {
   Future<CreateOriginRequestPolicyResult> createOriginRequestPolicy2020_05_31({
     required OriginRequestPolicyConfig originRequestPolicyConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        originRequestPolicyConfig, 'originRequestPolicyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/origin-request-policy',
@@ -575,7 +557,6 @@ class CloudFront {
   Future<CreatePublicKeyResult> createPublicKey2020_05_31({
     required PublicKeyConfig publicKeyConfig,
   }) async {
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/public-key',
@@ -631,10 +612,6 @@ class CloudFront {
     required String name,
     required int samplingRate,
   }) async {
-    ArgumentError.checkNotNull(endPoints, 'endPoints');
-    ArgumentError.checkNotNull(fields, 'fields');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(samplingRate, 'samplingRate');
     final $result = await _protocol.send(
       method: 'POST',
       requestUri: '/2020-05-31/realtime-log-config',
@@ -680,8 +657,6 @@ class CloudFront {
       createStreamingDistribution2020_05_31({
     required StreamingDistributionConfig streamingDistributionConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/streaming-distribution',
@@ -723,8 +698,6 @@ class CloudFront {
     required StreamingDistributionConfigWithTags
         streamingDistributionConfigWithTags,
   }) async {
-    ArgumentError.checkNotNull(streamingDistributionConfigWithTags,
-        'streamingDistributionConfigWithTags');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2020-05-31/streaming-distribution?WithTags',
@@ -770,7 +743,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -801,7 +773,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -832,7 +803,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -863,7 +833,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -895,7 +864,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -935,7 +903,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -958,7 +925,6 @@ class CloudFront {
   Future<void> deleteMonitoringSubscription2020_05_31({
     required String distributionId,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     await _protocol.send(
       method: 'DELETE',
       requestUri:
@@ -999,7 +965,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1031,7 +996,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1151,7 +1115,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -1194,7 +1157,6 @@ class CloudFront {
   Future<GetCachePolicyResult> getCachePolicy2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/cache-policy/${Uri.encodeComponent(id)}',
@@ -1229,7 +1191,6 @@ class CloudFront {
   Future<GetCachePolicyConfigResult> getCachePolicyConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/cache-policy/${Uri.encodeComponent(id)}/config',
@@ -1253,7 +1214,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentity2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1279,7 +1239,6 @@ class CloudFront {
       getCloudFrontOriginAccessIdentityConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1305,7 +1264,6 @@ class CloudFront {
   Future<GetDistributionResult> getDistribution2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/distribution/${Uri.encodeComponent(id)}',
@@ -1329,7 +1287,6 @@ class CloudFront {
   Future<GetDistributionConfigResult> getDistributionConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/distribution/${Uri.encodeComponent(id)}/config',
@@ -1352,7 +1309,6 @@ class CloudFront {
   Future<GetFieldLevelEncryptionResult> getFieldLevelEncryption2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1377,7 +1333,6 @@ class CloudFront {
       getFieldLevelEncryptionConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1402,7 +1357,6 @@ class CloudFront {
       getFieldLevelEncryptionProfile2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1428,7 +1382,6 @@ class CloudFront {
       getFieldLevelEncryptionProfileConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1459,8 +1412,6 @@ class CloudFront {
     required String distributionId,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1491,7 +1442,6 @@ class CloudFront {
   Future<GetKeyGroupResult> getKeyGroup2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/key-group/${Uri.encodeComponent(id)}',
@@ -1521,7 +1471,6 @@ class CloudFront {
   Future<GetKeyGroupConfigResult> getKeyGroupConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/key-group/${Uri.encodeComponent(id)}/config',
@@ -1545,7 +1494,6 @@ class CloudFront {
   Future<GetMonitoringSubscriptionResult> getMonitoringSubscription2020_05_31({
     required String distributionId,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1588,7 +1536,6 @@ class CloudFront {
   Future<GetOriginRequestPolicyResult> getOriginRequestPolicy2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1625,7 +1572,6 @@ class CloudFront {
       getOriginRequestPolicyConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1649,7 +1595,6 @@ class CloudFront {
   Future<GetPublicKeyResult> getPublicKey2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/public-key/${Uri.encodeComponent(id)}',
@@ -1672,7 +1617,6 @@ class CloudFront {
   Future<GetPublicKeyConfigResult> getPublicKeyConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri: '/2020-05-31/public-key/${Uri.encodeComponent(id)}/config',
@@ -1731,7 +1675,6 @@ class CloudFront {
   Future<GetStreamingDistributionResult> getStreamingDistribution2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1756,7 +1699,6 @@ class CloudFront {
       getStreamingDistributionConfig2020_05_31({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $result = await _protocol.sendRaw(
       method: 'GET',
       requestUri:
@@ -1935,7 +1877,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(cachePolicyId, 'cachePolicyId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -1984,7 +1925,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(keyGroupId, 'keyGroupId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -2035,7 +1975,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(originRequestPolicyId, 'originRequestPolicyId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -2145,7 +2084,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -2263,7 +2201,6 @@ class CloudFront {
     String? marker,
     String? maxItems,
   }) async {
-    ArgumentError.checkNotNull(distributionId, 'distributionId');
     final $query = <String, List<String>>{
       if (marker != null) 'Marker': [marker],
       if (maxItems != null) 'MaxItems': [maxItems],
@@ -2503,7 +2440,6 @@ class CloudFront {
   Future<ListTagsForResourceResult> listTagsForResource2020_05_31({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -2535,8 +2471,6 @@ class CloudFront {
     required String resource,
     required Tags tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -2565,8 +2499,6 @@ class CloudFront {
     required String resource,
     required TagKeys tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'Resource': [resource],
     };
@@ -2627,8 +2559,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cachePolicyConfig, 'cachePolicyConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -2674,9 +2604,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(cloudFrontOriginAccessIdentityConfig,
-        'cloudFrontOriginAccessIdentityConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -2854,8 +2781,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(distributionConfig, 'distributionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -2903,9 +2828,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionConfig, 'fieldLevelEncryptionConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -2956,9 +2878,6 @@ class CloudFront {
     required String id,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(
-        fieldLevelEncryptionProfileConfig, 'fieldLevelEncryptionProfileConfig');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -3018,8 +2937,6 @@ class CloudFront {
     required KeyGroupConfig keyGroupConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(keyGroupConfig, 'keyGroupConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -3088,9 +3005,6 @@ class CloudFront {
     required OriginRequestPolicyConfig originRequestPolicyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        originRequestPolicyConfig, 'originRequestPolicyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -3135,8 +3049,6 @@ class CloudFront {
     required PublicKeyConfig publicKeyConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(publicKeyConfig, 'publicKeyConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };
@@ -3263,9 +3175,6 @@ class CloudFront {
     required StreamingDistributionConfig streamingDistributionConfig,
     String? ifMatch,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        streamingDistributionConfig, 'streamingDistributionConfig');
     final headers = <String, String>{
       if (ifMatch != null) 'If-Match': ifMatch.toString(),
     };

--- a/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
+++ b/generated/aws_cloudhsm_api/lib/cloudhsm-2014-05-30.dart
@@ -88,8 +88,6 @@ class CloudHSM {
     required String resourceArn,
     required List<Tag> tagList,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagList, 'tagList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.AddTagsToResource'
@@ -137,7 +135,6 @@ class CloudHSM {
   Future<CreateHapgResponse> createHapg({
     required String label,
   }) async {
-    ArgumentError.checkNotNull(label, 'label');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.CreateHapg'
@@ -227,10 +224,6 @@ class CloudHSM {
     String? externalId,
     String? syslogIp,
   }) async {
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(sshKey, 'sshKey');
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
-    ArgumentError.checkNotNull(subscriptionType, 'subscriptionType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.CreateHsm'
@@ -288,14 +281,6 @@ class CloudHSM {
     required String certificate,
     String? label,
   }) async {
-    ArgumentError.checkNotNull(certificate, 'certificate');
-    _s.validateStringLength(
-      'certificate',
-      certificate,
-      600,
-      2400,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.CreateLunaClient'
@@ -342,7 +327,6 @@ class CloudHSM {
   Future<DeleteHapgResponse> deleteHapg({
     required String hapgArn,
   }) async {
-    ArgumentError.checkNotNull(hapgArn, 'hapgArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.DeleteHapg'
@@ -389,7 +373,6 @@ class CloudHSM {
   Future<DeleteHsmResponse> deleteHsm({
     required String hsmArn,
   }) async {
-    ArgumentError.checkNotNull(hsmArn, 'hsmArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.DeleteHsm'
@@ -435,7 +418,6 @@ class CloudHSM {
   Future<DeleteLunaClientResponse> deleteLunaClient({
     required String clientArn,
   }) async {
-    ArgumentError.checkNotNull(clientArn, 'clientArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.DeleteLunaClient'
@@ -481,7 +463,6 @@ class CloudHSM {
   Future<DescribeHapgResponse> describeHapg({
     required String hapgArn,
   }) async {
-    ArgumentError.checkNotNull(hapgArn, 'hapgArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.DescribeHapg'
@@ -641,9 +622,6 @@ class CloudHSM {
     required ClientVersion clientVersion,
     required List<String> hapgList,
   }) async {
-    ArgumentError.checkNotNull(clientArn, 'clientArn');
-    ArgumentError.checkNotNull(clientVersion, 'clientVersion');
-    ArgumentError.checkNotNull(hapgList, 'hapgList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.GetConfig'
@@ -885,7 +863,6 @@ class CloudHSM {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.ListTagsForResource'
@@ -940,7 +917,6 @@ class CloudHSM {
     String? label,
     List<String>? partitionSerialList,
   }) async {
-    ArgumentError.checkNotNull(hapgArn, 'hapgArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.ModifyHapg'
@@ -1023,7 +999,6 @@ class CloudHSM {
     String? subnetId,
     String? syslogIp,
   }) async {
-    ArgumentError.checkNotNull(hsmArn, 'hsmArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.ModifyHsm'
@@ -1079,15 +1054,6 @@ class CloudHSM {
     required String certificate,
     required String clientArn,
   }) async {
-    ArgumentError.checkNotNull(certificate, 'certificate');
-    _s.validateStringLength(
-      'certificate',
-      certificate,
-      600,
-      2400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(clientArn, 'clientArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.ModifyLunaClient'
@@ -1144,8 +1110,6 @@ class CloudHSM {
     required String resourceArn,
     required List<String> tagKeyList,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeyList, 'tagKeyList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CloudHsmFrontendService.RemoveTagsFromResource'

--- a/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
+++ b/generated/aws_cloudhsmv2_api/lib/cloudhsmv2-2017-04-28.dart
@@ -76,8 +76,6 @@ class CloudHSMV2 {
     required String destinationRegion,
     List<Tag>? tagList,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    ArgumentError.checkNotNull(destinationRegion, 'destinationRegion');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.CopyBackupToRegion'
@@ -142,8 +140,6 @@ class CloudHSMV2 {
     String? sourceBackupId,
     List<Tag>? tagList,
   }) async {
-    ArgumentError.checkNotNull(hsmType, 'hsmType');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.CreateCluster'
@@ -194,8 +190,6 @@ class CloudHSMV2 {
     required String clusterId,
     String? ipAddress,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.CreateHsm'
@@ -232,7 +226,6 @@ class CloudHSMV2 {
   Future<DeleteBackupResponse> deleteBackup({
     required String backupId,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.DeleteBackup'
@@ -269,7 +262,6 @@ class CloudHSMV2 {
   Future<DeleteClusterResponse> deleteCluster({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.DeleteCluster'
@@ -319,7 +311,6 @@ class CloudHSMV2 {
     String? eniIp,
     String? hsmId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.DeleteHsm'
@@ -403,12 +394,6 @@ class CloudHSMV2 {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.DescribeBackups'
@@ -477,12 +462,6 @@ class CloudHSMV2 {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.DescribeClusters'
@@ -535,23 +514,6 @@ class CloudHSMV2 {
     required String signedCert,
     required String trustAnchor,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(signedCert, 'signedCert');
-    _s.validateStringLength(
-      'signedCert',
-      signedCert,
-      0,
-      5000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trustAnchor, 'trustAnchor');
-    _s.validateStringLength(
-      'trustAnchor',
-      trustAnchor,
-      0,
-      5000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.InitializeCluster'
@@ -605,18 +567,11 @@ class CloudHSMV2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -659,8 +614,6 @@ class CloudHSMV2 {
     required String backupId,
     required bool neverExpires,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    ArgumentError.checkNotNull(neverExpires, 'neverExpires');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.ModifyBackupAttributes'
@@ -698,8 +651,6 @@ class CloudHSMV2 {
     required BackupRetentionPolicy backupRetentionPolicy,
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(backupRetentionPolicy, 'backupRetentionPolicy');
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.ModifyCluster'
@@ -735,7 +686,6 @@ class CloudHSMV2 {
   Future<RestoreBackupResponse> restoreBackup({
     required String backupId,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.RestoreBackup'
@@ -774,8 +724,6 @@ class CloudHSMV2 {
     required String resourceId,
     required List<Tag> tagList,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagList, 'tagList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.TagResource'
@@ -813,8 +761,6 @@ class CloudHSMV2 {
     required String resourceId,
     required List<String> tagKeyList,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagKeyList, 'tagKeyList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'BaldrApiService.UntagResource'

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2011-02-01.dart
@@ -63,14 +63,6 @@ class CloudSearch {
   Future<CreateDomainResponse> createDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -101,15 +93,6 @@ class CloudSearch {
     required String domainName,
     required IndexField indexField,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexField, 'indexField');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['IndexField'] = indexField;
@@ -141,15 +124,6 @@ class CloudSearch {
     required String domainName,
     required NamedRankExpression rankExpression,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rankExpression, 'rankExpression');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['RankExpression'] = rankExpression;
@@ -174,14 +148,6 @@ class CloudSearch {
   Future<DeleteDomainResponse> deleteDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -208,22 +174,6 @@ class CloudSearch {
     required String domainName,
     required String indexFieldName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexFieldName, 'indexFieldName');
-    _s.validateStringLength(
-      'indexFieldName',
-      indexFieldName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['IndexFieldName'] = indexFieldName;
@@ -254,22 +204,6 @@ class CloudSearch {
     required String domainName,
     required String rankName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rankName, 'rankName');
-    _s.validateStringLength(
-      'rankName',
-      rankName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['RankName'] = rankName;
@@ -307,14 +241,6 @@ class CloudSearch {
   Future<DescribeAvailabilityOptionsResponse> describeAvailabilityOptions({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -339,14 +265,6 @@ class CloudSearch {
   Future<DescribeDefaultSearchFieldResponse> describeDefaultSearchField({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -404,14 +322,6 @@ class CloudSearch {
     required String domainName,
     List<String>? fieldNames,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     fieldNames?.also((arg) => $request['FieldNames'] = arg);
@@ -444,14 +354,6 @@ class CloudSearch {
     required String domainName,
     List<String>? rankNames,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     rankNames?.also((arg) => $request['RankNames'] = arg);
@@ -478,14 +380,6 @@ class CloudSearch {
   Future<DescribeServiceAccessPoliciesResponse> describeServiceAccessPolicies({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -510,14 +404,6 @@ class CloudSearch {
   Future<DescribeStemmingOptionsResponse> describeStemmingOptions({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -542,14 +428,6 @@ class CloudSearch {
   Future<DescribeStopwordOptionsResponse> describeStopwordOptions({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -574,14 +452,6 @@ class CloudSearch {
   Future<DescribeSynonymOptionsResponse> describeSynonymOptions({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -610,14 +480,6 @@ class CloudSearch {
   Future<IndexDocumentsResponse> indexDocuments({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -659,15 +521,6 @@ class CloudSearch {
     required String domainName,
     required bool multiAZ,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(multiAZ, 'multiAZ');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['MultiAZ'] = multiAZ;
@@ -706,15 +559,6 @@ class CloudSearch {
     required String defaultSearchField,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(defaultSearchField, 'defaultSearchField');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DefaultSearchField'] = defaultSearchField;
     $request['DomainName'] = domainName;
@@ -744,15 +588,6 @@ class CloudSearch {
     required String accessPolicies,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(accessPolicies, 'accessPolicies');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccessPolicies'] = accessPolicies;
     $request['DomainName'] = domainName;
@@ -783,15 +618,6 @@ class CloudSearch {
     required String domainName,
     required String stems,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stems, 'stems');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Stems'] = stems;
@@ -822,15 +648,6 @@ class CloudSearch {
     required String domainName,
     required String stopwords,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stopwords, 'stopwords');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Stopwords'] = stopwords;
@@ -862,15 +679,6 @@ class CloudSearch {
     required String domainName,
     required String synonyms,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(synonyms, 'synonyms');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Synonyms'] = synonyms;

--- a/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
+++ b/generated/aws_cloudsearch_api/lib/cloudsearch-2013-01-01.dart
@@ -65,14 +65,6 @@ class CloudSearch {
   Future<BuildSuggestersResponse> buildSuggesters({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -105,14 +97,6 @@ class CloudSearch {
   Future<CreateDomainResponse> createDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -145,15 +129,6 @@ class CloudSearch {
     required AnalysisScheme analysisScheme,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(analysisScheme, 'analysisScheme');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AnalysisScheme'] = analysisScheme;
     $request['DomainName'] = domainName;
@@ -188,15 +163,6 @@ class CloudSearch {
     required String domainName,
     required Expression expression,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(expression, 'expression');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Expression'] = expression;
@@ -238,15 +204,6 @@ class CloudSearch {
     required String domainName,
     required IndexField indexField,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexField, 'indexField');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['IndexField'] = indexField;
@@ -282,15 +239,6 @@ class CloudSearch {
     required String domainName,
     required Suggester suggester,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(suggester, 'suggester');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Suggester'] = suggester;
@@ -324,22 +272,6 @@ class CloudSearch {
     required String analysisSchemeName,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(analysisSchemeName, 'analysisSchemeName');
-    _s.validateStringLength(
-      'analysisSchemeName',
-      analysisSchemeName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AnalysisSchemeName'] = analysisSchemeName;
     $request['DomainName'] = domainName;
@@ -371,14 +303,6 @@ class CloudSearch {
   Future<DeleteDomainResponse> deleteDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -412,22 +336,6 @@ class CloudSearch {
     required String domainName,
     required String expressionName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(expressionName, 'expressionName');
-    _s.validateStringLength(
-      'expressionName',
-      expressionName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['ExpressionName'] = expressionName;
@@ -463,22 +371,6 @@ class CloudSearch {
     required String domainName,
     required String indexFieldName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexFieldName, 'indexFieldName');
-    _s.validateStringLength(
-      'indexFieldName',
-      indexFieldName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['IndexFieldName'] = indexFieldName;
@@ -512,22 +404,6 @@ class CloudSearch {
     required String domainName,
     required String suggesterName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(suggesterName, 'suggesterName');
-    _s.validateStringLength(
-      'suggesterName',
-      suggesterName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['SuggesterName'] = suggesterName;
@@ -575,14 +451,6 @@ class CloudSearch {
     List<String>? analysisSchemeNames,
     bool? deployed,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     analysisSchemeNames?.also((arg) => $request['AnalysisSchemeNames'] = arg);
@@ -627,14 +495,6 @@ class CloudSearch {
     required String domainName,
     bool? deployed,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -675,14 +535,6 @@ class CloudSearch {
     required String domainName,
     bool? deployed,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -763,14 +615,6 @@ class CloudSearch {
     bool? deployed,
     List<String>? expressionNames,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -818,14 +662,6 @@ class CloudSearch {
     bool? deployed,
     List<String>? fieldNames,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -857,14 +693,6 @@ class CloudSearch {
   Future<DescribeScalingParametersResponse> describeScalingParameters({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -905,14 +733,6 @@ class CloudSearch {
     required String domainName,
     bool? deployed,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -959,14 +779,6 @@ class CloudSearch {
     bool? deployed,
     List<String>? suggesterNames,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     deployed?.also((arg) => $request['Deployed'] = arg);
@@ -995,14 +807,6 @@ class CloudSearch {
   Future<IndexDocumentsResponse> indexDocuments({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -1063,15 +867,6 @@ class CloudSearch {
     required String domainName,
     required bool multiAZ,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(multiAZ, 'multiAZ');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['MultiAZ'] = multiAZ;
@@ -1115,15 +910,6 @@ class CloudSearch {
     required DomainEndpointOptions domainEndpointOptions,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainEndpointOptions, 'domainEndpointOptions');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DomainEndpointOptions'] = domainEndpointOptions;
     $request['DomainName'] = domainName;
@@ -1160,15 +946,6 @@ class CloudSearch {
     required String domainName,
     required ScalingParameters scalingParameters,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scalingParameters, 'scalingParameters');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['ScalingParameters'] = scalingParameters;
@@ -1204,15 +981,6 @@ class CloudSearch {
     required String accessPolicies,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(accessPolicies, 'accessPolicies');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccessPolicies'] = accessPolicies;
     $request['DomainName'] = domainName;

--- a/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
+++ b/generated/aws_cloudsearchdomain_api/lib/cloudsearchdomain-2013-01-01.dart
@@ -472,7 +472,6 @@ class CloudSearchDomain {
     int? start,
     String? stats,
   }) async {
-    ArgumentError.checkNotNull(query, 'query');
     final $query = <String, List<String>>{
       'q': [query],
       if (cursor != null) 'cursor': [cursor],
@@ -534,8 +533,6 @@ class CloudSearchDomain {
     required String suggester,
     int? size,
   }) async {
-    ArgumentError.checkNotNull(query, 'query');
-    ArgumentError.checkNotNull(suggester, 'suggester');
     final $query = <String, List<String>>{
       'q': [query],
       'suggester': [suggester],
@@ -595,8 +592,6 @@ class CloudSearchDomain {
     required ContentType contentType,
     required Uint8List documents,
   }) async {
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    ArgumentError.checkNotNull(documents, 'documents');
     final headers = <String, String>{
       'Content-Type': contentType.toValue(),
     };

--- a/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
+++ b/generated/aws_cloudtrail_api/lib/cloudtrail-2013-11-01.dart
@@ -78,7 +78,6 @@ class CloudTrail {
     required String resourceId,
     List<Tag>? tagsList,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -245,8 +244,6 @@ class CloudTrail {
     String? snsTopicName,
     List<Tag>? tagsList,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -303,7 +300,6 @@ class CloudTrail {
   Future<void> deleteTrail({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -442,7 +438,6 @@ class CloudTrail {
   Future<GetEventSelectorsResponse> getEventSelectors({
     required String trailName,
   }) async {
-    ArgumentError.checkNotNull(trailName, 'trailName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -510,7 +505,6 @@ class CloudTrail {
   Future<GetInsightSelectorsResponse> getInsightSelectors({
     required String trailName,
   }) async {
-    ArgumentError.checkNotNull(trailName, 'trailName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -543,7 +537,6 @@ class CloudTrail {
   Future<GetTrailResponse> getTrail({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -584,7 +577,6 @@ class CloudTrail {
   Future<GetTrailStatusResponse> getTrailStatus({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -679,7 +671,6 @@ class CloudTrail {
     required List<String> resourceIdList,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceIdList, 'resourceIdList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -978,7 +969,6 @@ class CloudTrail {
     List<AdvancedEventSelector>? advancedEventSelectors,
     List<EventSelector>? eventSelectors,
   }) async {
-    ArgumentError.checkNotNull(trailName, 'trailName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1029,8 +1019,6 @@ class CloudTrail {
     required List<InsightSelector> insightSelectors,
     required String trailName,
   }) async {
-    ArgumentError.checkNotNull(insightSelectors, 'insightSelectors');
-    ArgumentError.checkNotNull(trailName, 'trailName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1074,7 +1062,6 @@ class CloudTrail {
     required String resourceId,
     List<Tag>? tagsList,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1115,7 +1102,6 @@ class CloudTrail {
   Future<void> startLogging({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1158,7 +1144,6 @@ class CloudTrail {
   Future<void> stopLogging({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1338,7 +1323,6 @@ class CloudTrail {
     String? s3KeyPrefix,
     String? snsTopicName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':

--- a/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
+++ b/generated/aws_cloudwatch_api/lib/monitoring-2010-08-01.dart
@@ -98,7 +98,6 @@ class CloudWatch {
   Future<void> deleteAlarms({
     required List<String> alarmNames,
   }) async {
-    ArgumentError.checkNotNull(alarmNames, 'alarmNames');
     final $request = <String, dynamic>{};
     $request['AlarmNames'] = alarmNames;
     await _protocol.send(
@@ -138,23 +137,6 @@ class CloudWatch {
     required String stat,
     List<Dimension>? dimensions,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stat, 'stat');
     final $request = <String, dynamic>{};
     $request['MetricName'] = metricName;
     $request['Namespace'] = namespace;
@@ -186,7 +168,6 @@ class CloudWatch {
   Future<void> deleteDashboards({
     required List<String> dashboardNames,
   }) async {
-    ArgumentError.checkNotNull(dashboardNames, 'dashboardNames');
     final $request = <String, dynamic>{};
     $request['DashboardNames'] = dashboardNames;
     await _protocol.send(
@@ -218,7 +199,6 @@ class CloudWatch {
   Future<DeleteInsightRulesOutput> deleteInsightRules({
     required List<String> ruleNames,
   }) async {
-    ArgumentError.checkNotNull(ruleNames, 'ruleNames');
     final $request = <String, dynamic>{};
     $request['RuleNames'] = ruleNames;
     final $result = await _protocol.send(
@@ -283,12 +263,6 @@ class CloudWatch {
     ScanBy? scanBy,
     DateTime? startDate,
   }) async {
-    _s.validateStringLength(
-      'alarmName',
-      alarmName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
@@ -404,35 +378,11 @@ class CloudWatch {
     String? parentsOfAlarmName,
     StateValue? stateValue,
   }) async {
-    _s.validateStringLength(
-      'actionPrefix',
-      actionPrefix,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'alarmNamePrefix',
-      alarmNamePrefix,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'childrenOfAlarmName',
-      childrenOfAlarmName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'parentsOfAlarmName',
-      parentsOfAlarmName,
-      1,
-      255,
     );
     final $request = <String, dynamic>{};
     actionPrefix?.also((arg) => $request['ActionPrefix'] = arg);
@@ -500,22 +450,6 @@ class CloudWatch {
     Statistic? statistic,
     StandardUnit? unit,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'period',
       period,
@@ -592,18 +526,6 @@ class CloudWatch {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     dimensions?.also((arg) => $request['Dimensions'] = arg);
     maxResults?.also((arg) => $request['MaxResults'] = arg);
@@ -674,7 +596,6 @@ class CloudWatch {
   Future<void> disableAlarmActions({
     required List<String> alarmNames,
   }) async {
-    ArgumentError.checkNotNull(alarmNames, 'alarmNames');
     final $request = <String, dynamic>{};
     $request['AlarmNames'] = alarmNames;
     await _protocol.send(
@@ -702,7 +623,6 @@ class CloudWatch {
   Future<DisableInsightRulesOutput> disableInsightRules({
     required List<String> ruleNames,
   }) async {
-    ArgumentError.checkNotNull(ruleNames, 'ruleNames');
     final $request = <String, dynamic>{};
     $request['RuleNames'] = ruleNames;
     final $result = await _protocol.send(
@@ -726,7 +646,6 @@ class CloudWatch {
   Future<void> enableAlarmActions({
     required List<String> alarmNames,
   }) async {
-    ArgumentError.checkNotNull(alarmNames, 'alarmNames');
     final $request = <String, dynamic>{};
     $request['AlarmNames'] = alarmNames;
     await _protocol.send(
@@ -755,7 +674,6 @@ class CloudWatch {
   Future<EnableInsightRulesOutput> enableInsightRules({
     required List<String> ruleNames,
   }) async {
-    ArgumentError.checkNotNull(ruleNames, 'ruleNames');
     final $request = <String, dynamic>{};
     $request['RuleNames'] = ruleNames;
     final $result = await _protocol.send(
@@ -788,7 +706,6 @@ class CloudWatch {
   Future<GetDashboardOutput> getDashboard({
     required String dashboardName,
   }) async {
-    ArgumentError.checkNotNull(dashboardName, 'dashboardName');
     final $request = <String, dynamic>{};
     $request['DashboardName'] = dashboardName;
     final $result = await _protocol.send(
@@ -927,29 +844,12 @@ class CloudWatch {
     List<String>? metrics,
     String? orderBy,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'orderBy',
-      orderBy,
-      1,
-      32,
     );
     final $request = <String, dynamic>{};
     $request['EndTime'] = _s.iso8601ToJson(endTime);
@@ -1109,9 +1009,6 @@ class CloudWatch {
     String? nextToken,
     ScanBy? scanBy,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(metricDataQueries, 'metricDataQueries');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $request = <String, dynamic>{};
     $request['EndTime'] = _s.iso8601ToJson(endTime);
     $request['MetricDataQueries'] = metricDataQueries;
@@ -1327,24 +1224,6 @@ class CloudWatch {
     List<Statistic>? statistics,
     StandardUnit? unit,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -1352,7 +1231,6 @@ class CloudWatch {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $request = <String, dynamic>{};
     $request['EndTime'] = _s.iso8601ToJson(endTime);
     $request['MetricName'] = metricName;
@@ -1453,7 +1331,6 @@ class CloudWatch {
     required String metricWidget,
     String? outputFormat,
   }) async {
-    ArgumentError.checkNotNull(metricWidget, 'metricWidget');
     final $request = <String, dynamic>{};
     $request['MetricWidget'] = metricWidget;
     outputFormat?.also((arg) => $request['OutputFormat'] = arg);
@@ -1571,18 +1448,6 @@ class CloudWatch {
     String? nextToken,
     RecentlyActive? recentlyActive,
   }) async {
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-    );
     final $request = <String, dynamic>{};
     dimensions?.also((arg) => $request['Dimensions'] = arg);
     metricName?.also((arg) => $request['MetricName'] = arg);
@@ -1628,14 +1493,6 @@ class CloudWatch {
   Future<ListTagsForResourceOutput> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ResourceARN'] = resourceARN;
     final $result = await _protocol.send(
@@ -1690,23 +1547,6 @@ class CloudWatch {
     AnomalyDetectorConfiguration? configuration,
     List<Dimension>? dimensions,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stat, 'stat');
     final $request = <String, dynamic>{};
     $request['MetricName'] = metricName;
     $request['Namespace'] = namespace;
@@ -1900,28 +1740,6 @@ class CloudWatch {
     List<String>? oKActions,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
-    _s.validateStringLength(
-      'alarmName',
-      alarmName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(alarmRule, 'alarmRule');
-    _s.validateStringLength(
-      'alarmRule',
-      alarmRule,
-      1,
-      10240,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'alarmDescription',
-      alarmDescription,
-      0,
-      1024,
-    );
     final $request = <String, dynamic>{};
     $request['AlarmName'] = alarmName;
     $request['AlarmRule'] = alarmRule;
@@ -1987,8 +1805,6 @@ class CloudWatch {
     required String dashboardBody,
     required String dashboardName,
   }) async {
-    ArgumentError.checkNotNull(dashboardBody, 'dashboardBody');
-    ArgumentError.checkNotNull(dashboardName, 'dashboardName');
     final $request = <String, dynamic>{};
     $request['DashboardBody'] = dashboardBody;
     $request['DashboardName'] = dashboardName;
@@ -2054,28 +1870,6 @@ class CloudWatch {
     String? ruleState,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(ruleDefinition, 'ruleDefinition');
-    _s.validateStringLength(
-      'ruleDefinition',
-      ruleDefinition,
-      1,
-      8192,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'ruleState',
-      ruleState,
-      1,
-      32,
-    );
     final $request = <String, dynamic>{};
     $request['RuleDefinition'] = ruleDefinition;
     $request['RuleName'] = ruleName;
@@ -2408,16 +2202,6 @@ class CloudWatch {
     String? treatMissingData,
     StandardUnit? unit,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
-    _s.validateStringLength(
-      'alarmName',
-      alarmName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(comparisonOperator, 'comparisonOperator');
-    ArgumentError.checkNotNull(evaluationPeriods, 'evaluationPeriods');
     _s.validateNumRange(
       'evaluationPeriods',
       evaluationPeriods,
@@ -2425,53 +2209,17 @@ class CloudWatch {
       1152921504606846976,
       isRequired: true,
     );
-    _s.validateStringLength(
-      'alarmDescription',
-      alarmDescription,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'datapointsToAlarm',
       datapointsToAlarm,
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'evaluateLowSampleCountPercentile',
-      evaluateLowSampleCountPercentile,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'period',
       period,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'thresholdMetricId',
-      thresholdMetricId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'treatMissingData',
-      treatMissingData,
-      1,
-      255,
     );
     final $request = <String, dynamic>{};
     $request['AlarmName'] = alarmName;
@@ -2590,15 +2338,6 @@ class CloudWatch {
     required List<MetricDatum> metricData,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(metricData, 'metricData');
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['MetricData'] = metricData;
     $request['Namespace'] = namespace;
@@ -2659,29 +2398,6 @@ class CloudWatch {
     required StateValue stateValue,
     String? stateReasonData,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
-    _s.validateStringLength(
-      'alarmName',
-      alarmName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stateReason, 'stateReason');
-    _s.validateStringLength(
-      'stateReason',
-      stateReason,
-      0,
-      1023,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stateValue, 'stateValue');
-    _s.validateStringLength(
-      'stateReasonData',
-      stateReasonData,
-      0,
-      4000,
-    );
     final $request = <String, dynamic>{};
     $request['AlarmName'] = alarmName;
     $request['StateReason'] = stateReason;
@@ -2745,15 +2461,6 @@ class CloudWatch {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceARN'] = resourceARN;
     $request['Tags'] = tags;
@@ -2799,15 +2506,6 @@ class CloudWatch {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceARN'] = resourceARN;
     $request['TagKeys'] = tagKeys;

--- a/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
+++ b/generated/aws_codebuild_api/lib/codebuild-2016-10-06.dart
@@ -66,7 +66,6 @@ class CodeBuild {
   Future<BatchDeleteBuildsOutput> batchDeleteBuilds({
     required List<String> ids,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchDeleteBuilds'
@@ -94,7 +93,6 @@ class CodeBuild {
   Future<BatchGetBuildBatchesOutput> batchGetBuildBatches({
     required List<String> ids,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchGetBuildBatches'
@@ -122,7 +120,6 @@ class CodeBuild {
   Future<BatchGetBuildsOutput> batchGetBuilds({
     required List<String> ids,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchGetBuilds'
@@ -152,7 +149,6 @@ class CodeBuild {
   Future<BatchGetProjectsOutput> batchGetProjects({
     required List<String> names,
   }) async {
-    ArgumentError.checkNotNull(names, 'names');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchGetProjects'
@@ -180,7 +176,6 @@ class CodeBuild {
   Future<BatchGetReportGroupsOutput> batchGetReportGroups({
     required List<String> reportGroupArns,
   }) async {
-    ArgumentError.checkNotNull(reportGroupArns, 'reportGroupArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchGetReportGroups'
@@ -208,7 +203,6 @@ class CodeBuild {
   Future<BatchGetReportsOutput> batchGetReports({
     required List<String> reportArns,
   }) async {
-    ArgumentError.checkNotNull(reportArns, 'reportArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.BatchGetReports'
@@ -372,37 +366,6 @@ class CodeBuild {
     int? timeoutInMinutes,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(artifacts, 'artifacts');
-    ArgumentError.checkNotNull(environment, 'environment');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceRole, 'serviceRole');
-    _s.validateStringLength(
-      'serviceRole',
-      serviceRole,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'encryptionKey',
-      encryptionKey,
-      1,
-      1152921504606846976,
-    );
     _s.validateNumRange(
       'queuedTimeoutInMinutes',
       queuedTimeoutInMinutes,
@@ -483,16 +446,6 @@ class CodeBuild {
     required ReportType type,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(exportConfig, 'exportConfig');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.CreateReportGroup'
@@ -565,14 +518,6 @@ class CodeBuild {
     WebhookBuildType? buildType,
     List<List<WebhookFilter>>? filterGroups,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      2,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.CreateWebhook'
@@ -603,14 +548,6 @@ class CodeBuild {
   Future<DeleteBuildBatchOutput> deleteBuildBatch({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteBuildBatch'
@@ -639,14 +576,6 @@ class CodeBuild {
   Future<void> deleteProject({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteProject'
@@ -672,14 +601,6 @@ class CodeBuild {
   Future<void> deleteReport({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteReport'
@@ -719,14 +640,6 @@ class CodeBuild {
     required String arn,
     bool? deleteReports,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteReportGroup'
@@ -753,14 +666,6 @@ class CodeBuild {
   Future<void> deleteResourcePolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteResourcePolicy'
@@ -788,14 +693,6 @@ class CodeBuild {
   Future<DeleteSourceCredentialsOutput> deleteSourceCredentials({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteSourceCredentials'
@@ -828,14 +725,6 @@ class CodeBuild {
   Future<void> deleteWebhook({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      2,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.DeleteWebhook'
@@ -892,14 +781,6 @@ class CodeBuild {
     ReportCodeCoverageSortByType? sortBy,
     SortOrderType? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(reportArn, 'reportArn');
-    _s.validateStringLength(
-      'reportArn',
-      reportArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxLineCoveragePercentage',
       maxLineCoveragePercentage,
@@ -974,7 +855,6 @@ class CodeBuild {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(reportArn, 'reportArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1010,15 +890,6 @@ class CodeBuild {
     required ReportGroupTrendFieldType trendField,
     int? numOfReports,
   }) async {
-    ArgumentError.checkNotNull(reportGroupArn, 'reportGroupArn');
-    _s.validateStringLength(
-      'reportGroupArn',
-      reportGroupArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trendField, 'trendField');
     _s.validateNumRange(
       'numOfReports',
       numOfReports,
@@ -1055,14 +926,6 @@ class CodeBuild {
   Future<GetResourcePolicyOutput> getResourcePolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.GetResourcePolicy'
@@ -1116,22 +979,6 @@ class CodeBuild {
     bool? shouldOverwrite,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(authType, 'authType');
-    ArgumentError.checkNotNull(serverType, 'serverType');
-    ArgumentError.checkNotNull(token, 'token');
-    _s.validateStringLength(
-      'token',
-      token,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.ImportSourceCredentials'
@@ -1164,14 +1011,6 @@ class CodeBuild {
   Future<void> invalidateProjectCache({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.InvalidateProjectCache'
@@ -1296,12 +1135,6 @@ class CodeBuild {
       1,
       100,
     );
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.ListBuildBatchesForProject'
@@ -1405,14 +1238,6 @@ class CodeBuild {
     String? nextToken,
     SortOrderType? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.ListBuildsForProject'
@@ -1502,12 +1327,6 @@ class CodeBuild {
     ProjectSortByType? sortBy,
     SortOrderType? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.ListProjects'
@@ -1704,7 +1523,6 @@ class CodeBuild {
     String? nextToken,
     SortOrderType? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(reportGroupArn, 'reportGroupArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1787,12 +1605,6 @@ class CodeBuild {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1931,22 +1743,6 @@ class CodeBuild {
     required String policy,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.PutResourcePolicy'
@@ -1985,12 +1781,6 @@ class CodeBuild {
     String? id,
     String? idempotencyToken,
   }) async {
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.RetryBuild'
@@ -2033,12 +1823,6 @@ class CodeBuild {
     String? idempotencyToken,
     RetryBuildBatchType? retryType,
   }) async {
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.RetryBuildBatch'
@@ -2289,30 +2073,10 @@ class CodeBuild {
     String? sourceVersion,
     int? timeoutInMinutesOverride,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'encryptionKeyOverride',
-      encryptionKeyOverride,
-      1,
-      1152921504606846976,
-    );
     _s.validateNumRange(
       'gitCloneDepthOverride',
       gitCloneDepthOverride,
       0,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'imageOverride',
-      imageOverride,
-      1,
       1152921504606846976,
     );
     _s.validateNumRange(
@@ -2320,12 +2084,6 @@ class CodeBuild {
       queuedTimeoutInMinutesOverride,
       5,
       480,
-    );
-    _s.validateStringLength(
-      'serviceRoleOverride',
-      serviceRoleOverride,
-      1,
-      1152921504606846976,
     );
     _s.validateNumRange(
       'timeoutInMinutesOverride',
@@ -2627,25 +2385,11 @@ class CodeBuild {
     SourceType? sourceTypeOverride,
     String? sourceVersion,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'buildTimeoutInMinutesOverride',
       buildTimeoutInMinutesOverride,
       5,
       480,
-    );
-    _s.validateStringLength(
-      'encryptionKeyOverride',
-      encryptionKeyOverride,
-      1,
-      1152921504606846976,
     );
     _s.validateNumRange(
       'gitCloneDepthOverride',
@@ -2653,23 +2397,11 @@ class CodeBuild {
       0,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'imageOverride',
-      imageOverride,
-      1,
-      1152921504606846976,
-    );
     _s.validateNumRange(
       'queuedTimeoutInMinutesOverride',
       queuedTimeoutInMinutesOverride,
       5,
       480,
-    );
-    _s.validateStringLength(
-      'serviceRoleOverride',
-      serviceRoleOverride,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2752,14 +2484,6 @@ class CodeBuild {
   Future<StopBuildOutput> stopBuild({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.StopBuild'
@@ -2788,14 +2512,6 @@ class CodeBuild {
   Future<StopBuildBatchOutput> stopBuildBatch({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.StopBuildBatch'
@@ -2961,37 +2677,11 @@ class CodeBuild {
     int? timeoutInMinutes,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'encryptionKey',
-      encryptionKey,
-      1,
-      1152921504606846976,
-    );
     _s.validateNumRange(
       'queuedTimeoutInMinutes',
       queuedTimeoutInMinutes,
       5,
       480,
-    );
-    _s.validateStringLength(
-      'serviceRole',
-      serviceRole,
-      1,
-      1152921504606846976,
     );
     _s.validateNumRange(
       'timeoutInMinutes',
@@ -3071,14 +2761,6 @@ class CodeBuild {
     ReportExportConfig? exportConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.UpdateReportGroup'
@@ -3141,14 +2823,6 @@ class CodeBuild {
     List<List<WebhookFilter>>? filterGroups,
     bool? rotateSecret,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      2,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeBuild_20161006.UpdateWebhook'

--- a/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
+++ b/generated/aws_codecommit_api/lib/codecommit-2015-04-13.dart
@@ -80,23 +80,6 @@ class CodeCommit {
     required String approvalRuleTemplateName,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -144,16 +127,6 @@ class CodeCommit {
     required String approvalRuleTemplateName,
     required List<String> repositoryNames,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryNames, 'repositoryNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -254,18 +227,6 @@ class CodeCommit {
     int? maxMergeHunks,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(mergeOption, 'mergeOption');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.BatchDescribeMergeConflicts'
@@ -325,16 +286,6 @@ class CodeCommit {
     required String approvalRuleTemplateName,
     required List<String> repositoryNames,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryNames, 'repositoryNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -383,15 +334,6 @@ class CodeCommit {
     required List<String> commitIds,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(commitIds, 'commitIds');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.BatchGetCommits'
@@ -439,7 +381,6 @@ class CodeCommit {
   Future<BatchGetRepositoriesOutput> batchGetRepositories({
     required List<String> repositoryNames,
   }) async {
-    ArgumentError.checkNotNull(repositoryNames, 'repositoryNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.BatchGetRepositories'
@@ -531,30 +472,6 @@ class CodeCommit {
     required String approvalRuleTemplateName,
     String? approvalRuleTemplateDescription,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateContent, 'approvalRuleTemplateContent');
-    _s.validateStringLength(
-      'approvalRuleTemplateContent',
-      approvalRuleTemplateContent,
-      1,
-      3000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'approvalRuleTemplateDescription',
-      approvalRuleTemplateDescription,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreateApprovalRuleTemplate'
@@ -610,23 +527,6 @@ class CodeCommit {
     required String commitId,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(commitId, 'commitId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreateBranch'
@@ -733,22 +633,6 @@ class CodeCommit {
     List<PutFileEntry>? putFiles,
     List<SetFileModeEntry>? setFileModes,
   }) async {
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreateCommit'
@@ -833,21 +717,6 @@ class CodeCommit {
     String? clientRequestToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(targets, 'targets');
-    ArgumentError.checkNotNull(title, 'title');
-    _s.validateStringLength(
-      'title',
-      title,
-      0,
-      150,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      10240,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreatePullRequest'
@@ -941,23 +810,6 @@ class CodeCommit {
     required String approvalRuleName,
     required String pullRequestId,
   }) async {
-    ArgumentError.checkNotNull(approvalRuleContent, 'approvalRuleContent');
-    _s.validateStringLength(
-      'approvalRuleContent',
-      approvalRuleContent,
-      1,
-      3000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(approvalRuleName, 'approvalRuleName');
-    _s.validateStringLength(
-      'approvalRuleName',
-      approvalRuleName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreatePullRequestApprovalRule'
@@ -1024,20 +876,6 @@ class CodeCommit {
     String? repositoryDescription,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'repositoryDescription',
-      repositoryDescription,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreateRepository'
@@ -1166,18 +1004,6 @@ class CodeCommit {
     String? email,
     bool? keepEmptyFolders,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(mergeOption, 'mergeOption');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.CreateUnreferencedMergeCommit'
@@ -1221,15 +1047,6 @@ class CodeCommit {
   Future<DeleteApprovalRuleTemplateOutput> deleteApprovalRuleTemplate({
     required String approvalRuleTemplateName,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeleteApprovalRuleTemplate'
@@ -1272,22 +1089,6 @@ class CodeCommit {
     required String branchName,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeleteBranch'
@@ -1321,7 +1122,6 @@ class CodeCommit {
   Future<DeleteCommentContentOutput> deleteCommentContent({
     required String commentId,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeleteCommentContent'
@@ -1414,24 +1214,6 @@ class CodeCommit {
     bool? keepEmptyFolders,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filePath, 'filePath');
-    ArgumentError.checkNotNull(parentCommitId, 'parentCommitId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeleteFile'
@@ -1487,15 +1269,6 @@ class CodeCommit {
     required String approvalRuleName,
     required String pullRequestId,
   }) async {
-    ArgumentError.checkNotNull(approvalRuleName, 'approvalRuleName');
-    _s.validateStringLength(
-      'approvalRuleName',
-      approvalRuleName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeletePullRequestApprovalRule'
@@ -1536,14 +1309,6 @@ class CodeCommit {
   Future<DeleteRepositoryOutput> deleteRepository({
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DeleteRepository'
@@ -1639,19 +1404,6 @@ class CodeCommit {
     int? maxMergeHunks,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(filePath, 'filePath');
-    ArgumentError.checkNotNull(mergeOption, 'mergeOption');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DescribeMergeConflicts'
@@ -1724,7 +1476,6 @@ class CodeCommit {
     String? nextToken,
     PullRequestEventType? pullRequestEventType,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.DescribePullRequestEvents'
@@ -1776,23 +1527,6 @@ class CodeCommit {
     required String approvalRuleTemplateName,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1837,8 +1571,6 @@ class CodeCommit {
     required String pullRequestId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.EvaluatePullRequestApprovalRules'
@@ -1870,15 +1602,6 @@ class CodeCommit {
   Future<GetApprovalRuleTemplateOutput> getApprovalRuleTemplate({
     required String approvalRuleTemplateName,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetApprovalRuleTemplate'
@@ -1921,15 +1644,6 @@ class CodeCommit {
     required String blobId,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(blobId, 'blobId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetBlob'
@@ -1974,18 +1688,6 @@ class CodeCommit {
     String? branchName,
     String? repositoryName,
   }) async {
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetBranch'
@@ -2029,7 +1731,6 @@ class CodeCommit {
   Future<GetCommentOutput> getComment({
     required String commentId,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetComment'
@@ -2079,7 +1780,6 @@ class CodeCommit {
     String? nextToken,
     String? reactionUserArn,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetCommentReactions'
@@ -2148,15 +1848,6 @@ class CodeCommit {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(afterCommitId, 'afterCommitId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetCommentsForComparedCommit'
@@ -2235,13 +1926,6 @@ class CodeCommit {
     String? nextToken,
     String? repositoryName,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetCommentsForPullRequest'
@@ -2289,15 +1973,6 @@ class CodeCommit {
     required String commitId,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(commitId, 'commitId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetCommit'
@@ -2380,15 +2055,6 @@ class CodeCommit {
     String? beforeCommitSpecifier,
     String? beforePath,
   }) async {
-    ArgumentError.checkNotNull(afterCommitSpecifier, 'afterCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetDifferences'
@@ -2449,15 +2115,6 @@ class CodeCommit {
     required String repositoryName,
     String? commitSpecifier,
   }) async {
-    ArgumentError.checkNotNull(filePath, 'filePath');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetFile'
@@ -2514,15 +2171,6 @@ class CodeCommit {
     required String repositoryName,
     String? commitSpecifier,
   }) async {
-    ArgumentError.checkNotNull(folderPath, 'folderPath');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetFolder'
@@ -2590,17 +2238,6 @@ class CodeCommit {
     ConflictDetailLevelTypeEnum? conflictDetailLevel,
     ConflictResolutionStrategyTypeEnum? conflictResolutionStrategy,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetMergeCommit'
@@ -2694,18 +2331,6 @@ class CodeCommit {
     int? maxConflictFiles,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(mergeOption, 'mergeOption');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetMergeConflicts'
@@ -2785,17 +2410,6 @@ class CodeCommit {
     ConflictDetailLevelTypeEnum? conflictDetailLevel,
     ConflictResolutionStrategyTypeEnum? conflictResolutionStrategy,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetMergeOptions'
@@ -2837,7 +2451,6 @@ class CodeCommit {
   Future<GetPullRequestOutput> getPullRequest({
     required String pullRequestId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetPullRequest'
@@ -2880,8 +2493,6 @@ class CodeCommit {
     required String pullRequestId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetPullRequestApprovalStates'
@@ -2928,8 +2539,6 @@ class CodeCommit {
     required String pullRequestId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetPullRequestOverrideState'
@@ -2973,14 +2582,6 @@ class CodeCommit {
   Future<GetRepositoryOutput> getRepository({
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetRepository'
@@ -3015,14 +2616,6 @@ class CodeCommit {
   Future<GetRepositoryTriggersOutput> getRepositoryTriggers({
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.GetRepositoryTriggers'
@@ -3109,14 +2702,6 @@ class CodeCommit {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3160,14 +2745,6 @@ class CodeCommit {
     required String repositoryName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.ListBranches'
@@ -3230,14 +2807,6 @@ class CodeCommit {
     String? nextToken,
     PullRequestStatusEnum? pullRequestStatus,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.ListPullRequests'
@@ -3334,15 +2903,6 @@ class CodeCommit {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3386,7 +2946,6 @@ class CodeCommit {
     required String resourceArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.ListTagsForResource'
@@ -3447,23 +3006,6 @@ class CodeCommit {
     required String sourceCommitSpecifier,
     String? targetBranch,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
-    _s.validateStringLength(
-      'targetBranch',
-      targetBranch,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergeBranchesByFastForward'
@@ -3586,23 +3128,6 @@ class CodeCommit {
     bool? keepEmptyFolders,
     String? targetBranch,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
-    _s.validateStringLength(
-      'targetBranch',
-      targetBranch,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergeBranchesBySquash'
@@ -3735,23 +3260,6 @@ class CodeCommit {
     bool? keepEmptyFolders,
     String? targetBranch,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationCommitSpecifier, 'destinationCommitSpecifier');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceCommitSpecifier, 'sourceCommitSpecifier');
-    _s.validateStringLength(
-      'targetBranch',
-      targetBranch,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergeBranchesByThreeWay'
@@ -3825,15 +3333,6 @@ class CodeCommit {
     required String repositoryName,
     String? sourceCommitId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergePullRequestByFastForward'
@@ -3955,15 +3454,6 @@ class CodeCommit {
     bool? keepEmptyFolders,
     String? sourceCommitId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergePullRequestBySquash'
@@ -4095,15 +3585,6 @@ class CodeCommit {
     bool? keepEmptyFolders,
     String? sourceCommitId,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.MergePullRequestByThreeWay'
@@ -4172,9 +3653,6 @@ class CodeCommit {
     required String pullRequestId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(overrideStatus, 'overrideStatus');
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.OverridePullRequestApprovalRules'
@@ -4253,16 +3731,6 @@ class CodeCommit {
     String? clientRequestToken,
     Location? location,
   }) async {
-    ArgumentError.checkNotNull(afterCommitId, 'afterCommitId');
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PostCommentForComparedCommit'
@@ -4358,18 +3826,6 @@ class CodeCommit {
     String? clientRequestToken,
     Location? location,
   }) async {
-    ArgumentError.checkNotNull(afterCommitId, 'afterCommitId');
-    ArgumentError.checkNotNull(beforeCommitId, 'beforeCommitId');
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PostCommentForPullRequest'
@@ -4426,8 +3882,6 @@ class CodeCommit {
     required String inReplyTo,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(inReplyTo, 'inReplyTo');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PostCommentReply'
@@ -4476,8 +3930,6 @@ class CodeCommit {
     required String commentId,
     required String reactionValue,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
-    ArgumentError.checkNotNull(reactionValue, 'reactionValue');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PutCommentReaction'
@@ -4582,24 +4034,6 @@ class CodeCommit {
     String? name,
     String? parentCommitId,
   }) async {
-    ArgumentError.checkNotNull(branchName, 'branchName');
-    _s.validateStringLength(
-      'branchName',
-      branchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fileContent, 'fileContent');
-    ArgumentError.checkNotNull(filePath, 'filePath');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PutFile'
@@ -4659,15 +4093,6 @@ class CodeCommit {
     required String repositoryName,
     required List<RepositoryTrigger> triggers,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(triggers, 'triggers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.PutRepositoryTriggers'
@@ -4712,8 +4137,6 @@ class CodeCommit {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.TagResource'
@@ -4767,15 +4190,6 @@ class CodeCommit {
     required String repositoryName,
     required List<RepositoryTrigger> triggers,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(triggers, 'triggers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.TestRepositoryTriggers'
@@ -4820,8 +4234,6 @@ class CodeCommit {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UntagResource'
@@ -4867,23 +4279,6 @@ class CodeCommit {
     required String newRuleContent,
     String? existingRuleContentSha256,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newRuleContent, 'newRuleContent');
-    _s.validateStringLength(
-      'newRuleContent',
-      newRuleContent,
-      1,
-      3000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateApprovalRuleTemplateContent'
@@ -4922,24 +4317,6 @@ class CodeCommit {
     required String approvalRuleTemplateDescription,
     required String approvalRuleTemplateName,
   }) async {
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateDescription, 'approvalRuleTemplateDescription');
-    _s.validateStringLength(
-      'approvalRuleTemplateDescription',
-      approvalRuleTemplateDescription,
-      0,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        approvalRuleTemplateName, 'approvalRuleTemplateName');
-    _s.validateStringLength(
-      'approvalRuleTemplateName',
-      approvalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4977,24 +4354,6 @@ class CodeCommit {
     required String newApprovalRuleTemplateName,
     required String oldApprovalRuleTemplateName,
   }) async {
-    ArgumentError.checkNotNull(
-        newApprovalRuleTemplateName, 'newApprovalRuleTemplateName');
-    _s.validateStringLength(
-      'newApprovalRuleTemplateName',
-      newApprovalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        oldApprovalRuleTemplateName, 'oldApprovalRuleTemplateName');
-    _s.validateStringLength(
-      'oldApprovalRuleTemplateName',
-      oldApprovalRuleTemplateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateApprovalRuleTemplateName'
@@ -5035,8 +4394,6 @@ class CodeCommit {
     required String commentId,
     required String content,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
-    ArgumentError.checkNotNull(content, 'content');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateComment'
@@ -5084,22 +4441,6 @@ class CodeCommit {
     required String defaultBranchName,
     required String repositoryName,
   }) async {
-    ArgumentError.checkNotNull(defaultBranchName, 'defaultBranchName');
-    _s.validateStringLength(
-      'defaultBranchName',
-      defaultBranchName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateDefaultBranch'
@@ -5194,23 +4535,6 @@ class CodeCommit {
     required String pullRequestId,
     String? existingRuleContentSha256,
   }) async {
-    ArgumentError.checkNotNull(approvalRuleName, 'approvalRuleName');
-    _s.validateStringLength(
-      'approvalRuleName',
-      approvalRuleName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newRuleContent, 'newRuleContent');
-    _s.validateStringLength(
-      'newRuleContent',
-      newRuleContent,
-      1,
-      3000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdatePullRequestApprovalRuleContent'
@@ -5267,9 +4591,6 @@ class CodeCommit {
     required String pullRequestId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(approvalState, 'approvalState');
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdatePullRequestApprovalState'
@@ -5307,15 +4628,6 @@ class CodeCommit {
     required String description,
     required String pullRequestId,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      10240,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdatePullRequestDescription'
@@ -5361,8 +4673,6 @@ class CodeCommit {
     required String pullRequestId,
     required PullRequestStatusEnum pullRequestStatus,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(pullRequestStatus, 'pullRequestStatus');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdatePullRequestStatus'
@@ -5401,15 +4711,6 @@ class CodeCommit {
     required String pullRequestId,
     required String title,
   }) async {
-    ArgumentError.checkNotNull(pullRequestId, 'pullRequestId');
-    ArgumentError.checkNotNull(title, 'title');
-    _s.validateStringLength(
-      'title',
-      title,
-      0,
-      150,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdatePullRequestTitle'
@@ -5460,20 +4761,6 @@ class CodeCommit {
     required String repositoryName,
     String? repositoryDescription,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'repositoryDescription',
-      repositoryDescription,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateRepositoryDescription'
@@ -5514,22 +4801,6 @@ class CodeCommit {
     required String newName,
     required String oldName,
   }) async {
-    ArgumentError.checkNotNull(newName, 'newName');
-    _s.validateStringLength(
-      'newName',
-      newName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(oldName, 'oldName');
-    _s.validateStringLength(
-      'oldName',
-      oldName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeCommit_20150413.UpdateRepositoryName'

--- a/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
+++ b/generated/aws_codeguru_reviewer_api/lib/codeguru-reviewer-2019-09-19.dart
@@ -130,13 +130,6 @@ class CodeGuruReviewer {
     String? clientRequestToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(repository, 'repository');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'Repository': repository,
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -196,30 +189,6 @@ class CodeGuruReviewer {
     required CodeReviewType type,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        repositoryAssociationArn, 'repositoryAssociationArn');
-    _s.validateStringLength(
-      'repositoryAssociationArn',
-      repositoryAssociationArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'RepositoryAssociationArn': repositoryAssociationArn,
@@ -251,14 +220,6 @@ class CodeGuruReviewer {
   Future<DescribeCodeReviewResponse> describeCodeReview({
     required String codeReviewArn,
   }) async {
-    ArgumentError.checkNotNull(codeReviewArn, 'codeReviewArn');
-    _s.validateStringLength(
-      'codeReviewArn',
-      codeReviewArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -301,28 +262,6 @@ class CodeGuruReviewer {
     required String recommendationId,
     String? userId,
   }) async {
-    ArgumentError.checkNotNull(codeReviewArn, 'codeReviewArn');
-    _s.validateStringLength(
-      'codeReviewArn',
-      codeReviewArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(recommendationId, 'recommendationId');
-    _s.validateStringLength(
-      'recommendationId',
-      recommendationId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-    );
     final $query = <String, List<String>>{
       'RecommendationId': [recommendationId],
       if (userId != null) 'UserId': [userId],
@@ -358,14 +297,6 @@ class CodeGuruReviewer {
   Future<DescribeRepositoryAssociationResponse> describeRepositoryAssociation({
     required String associationArn,
   }) async {
-    ArgumentError.checkNotNull(associationArn, 'associationArn');
-    _s.validateStringLength(
-      'associationArn',
-      associationArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -394,14 +325,6 @@ class CodeGuruReviewer {
   Future<DisassociateRepositoryResponse> disassociateRepository({
     required String associationArn,
   }) async {
-    ArgumentError.checkNotNull(associationArn, 'associationArn');
-    _s.validateStringLength(
-      'associationArn',
-      associationArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -471,18 +394,11 @@ class CodeGuruReviewer {
     List<String>? repositoryNames,
     List<JobState>? states,
   }) async {
-    ArgumentError.checkNotNull(type, 'type');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       'Type': [type.toValue()],
@@ -549,25 +465,11 @@ class CodeGuruReviewer {
     List<String>? recommendationIds,
     List<String>? userIds,
   }) async {
-    ArgumentError.checkNotNull(codeReviewArn, 'codeReviewArn');
-    _s.validateStringLength(
-      'codeReviewArn',
-      codeReviewArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
@@ -610,25 +512,11 @@ class CodeGuruReviewer {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(codeReviewArn, 'codeReviewArn');
-    _s.validateStringLength(
-      'codeReviewArn',
-      codeReviewArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
@@ -759,12 +647,6 @@ class CodeGuruReviewer {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
       if (names != null) 'Name': names,
@@ -801,14 +683,6 @@ class CodeGuruReviewer {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -845,23 +719,6 @@ class CodeGuruReviewer {
     required List<Reaction> reactions,
     required String recommendationId,
   }) async {
-    ArgumentError.checkNotNull(codeReviewArn, 'codeReviewArn');
-    _s.validateStringLength(
-      'codeReviewArn',
-      codeReviewArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reactions, 'reactions');
-    ArgumentError.checkNotNull(recommendationId, 'recommendationId');
-    _s.validateStringLength(
-      'recommendationId',
-      recommendationId,
-      1,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'CodeReviewArn': codeReviewArn,
       'Reactions': reactions.map((e) => e.toValue()).toList(),
@@ -910,15 +767,6 @@ class CodeGuruReviewer {
     required Map<String, String> tags,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(tags, 'tags');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -951,15 +799,6 @@ class CodeGuruReviewer {
     required List<String> tagKeys,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
+++ b/generated/aws_codeguruprofiler_api/lib/codeguruprofiler-2019-07-18.dart
@@ -85,15 +85,6 @@ class CodeGuruProfiler {
     required List<Channel> channels,
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(channels, 'channels');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'channels': channels,
     };
@@ -168,20 +159,6 @@ class CodeGuruProfiler {
     DateTime? startTime,
     AggregationPeriod? targetResolution,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'period',
-      period,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (endTime != null) 'endTime': [_s.iso8601ToJson(endTime).toString()],
       if (period != null) 'period': [period],
@@ -269,20 +246,6 @@ class CodeGuruProfiler {
     String? fleetInstanceId,
     Map<MetadataField, String>? metadata,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'fleetInstanceId',
-      fleetInstanceId,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       if (fleetInstanceId != null) 'fleetInstanceId': fleetInstanceId,
       if (metadata != null)
@@ -337,20 +300,6 @@ class CodeGuruProfiler {
     ComputePlatform? computePlatform,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (clientToken != null) 'clientToken': [clientToken],
     };
@@ -386,14 +335,6 @@ class CodeGuruProfiler {
   Future<void> deleteProfilingGroup({
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -417,14 +358,6 @@ class CodeGuruProfiler {
   Future<DescribeProfilingGroupResponse> describeProfilingGroup({
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -484,12 +417,6 @@ class CodeGuruProfiler {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (dailyReportsOnly != null)
         'dailyReportsOnly': [dailyReportsOnly.toString()],
@@ -520,14 +447,6 @@ class CodeGuruProfiler {
   Future<GetNotificationConfigurationResponse> getNotificationConfiguration({
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -549,14 +468,6 @@ class CodeGuruProfiler {
   Future<GetPolicyResponse> getPolicy({
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -669,25 +580,11 @@ class CodeGuruProfiler {
     String? period,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxDepth',
       maxDepth,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'period',
-      period,
-      1,
-      64,
     );
     final headers = <String, String>{
       if (accept != null) 'Accept': accept.toString(),
@@ -790,16 +687,6 @@ class CodeGuruProfiler {
     required DateTime startTime,
     String? locale,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $query = <String, List<String>>{
       'endTime': [_s.iso8601ToJson(endTime).toString()],
       'startTime': [_s.iso8601ToJson(startTime).toString()],
@@ -872,27 +759,11 @@ class CodeGuruProfiler {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      64,
     );
     final $query = <String, List<String>>{
       'endTime': [_s.iso8601ToJson(endTime).toString()],
@@ -979,28 +850,11 @@ class CodeGuruProfiler {
     String? nextToken,
     OrderBy? orderBy,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(period, 'period');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      64,
     );
     final $query = <String, List<String>>{
       'endTime': [_s.iso8601ToJson(endTime).toString()],
@@ -1068,12 +922,6 @@ class CodeGuruProfiler {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (includeDescription != null)
         'includeDescription': [includeDescription.toString()],
@@ -1102,7 +950,6 @@ class CodeGuruProfiler {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1151,22 +998,6 @@ class CodeGuruProfiler {
     required String profilingGroupName,
     String? profileToken,
   }) async {
-    ArgumentError.checkNotNull(agentProfile, 'agentProfile');
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'profileToken',
-      profileToken,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': contentType.toString(),
     };
@@ -1241,16 +1072,6 @@ class CodeGuruProfiler {
     required String profilingGroupName,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(actionGroup, 'actionGroup');
-    ArgumentError.checkNotNull(principals, 'principals');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'principals': principals,
       if (revisionId != null) 'revisionId': revisionId,
@@ -1282,15 +1103,6 @@ class CodeGuruProfiler {
     required String channelId,
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1337,16 +1149,6 @@ class CodeGuruProfiler {
     required String profilingGroupName,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(actionGroup, 'actionGroup');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final $query = <String, List<String>>{
       'revisionId': [revisionId],
     };
@@ -1390,16 +1192,6 @@ class CodeGuruProfiler {
     required FeedbackType type,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(anomalyInstanceId, 'anomalyInstanceId');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'type': type.toValue(),
       if (comment != null) 'comment': comment,
@@ -1428,8 +1220,6 @@ class CodeGuruProfiler {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1458,8 +1248,6 @@ class CodeGuruProfiler {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1489,16 +1277,6 @@ class CodeGuruProfiler {
     required AgentOrchestrationConfig agentOrchestrationConfig,
     required String profilingGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        agentOrchestrationConfig, 'agentOrchestrationConfig');
-    ArgumentError.checkNotNull(profilingGroupName, 'profilingGroupName');
-    _s.validateStringLength(
-      'profilingGroupName',
-      profilingGroupName,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'agentOrchestrationConfig': agentOrchestrationConfig,
     };

--- a/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
+++ b/generated/aws_codepipeline_api/lib/codepipeline-2015-07-09.dart
@@ -71,15 +71,6 @@ class CodePipeline {
     required String jobId,
     required String nonce,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(nonce, 'nonce');
-    _s.validateStringLength(
-      'nonce',
-      nonce,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.AcknowledgeJob'
@@ -124,30 +115,6 @@ class CodePipeline {
     required String jobId,
     required String nonce,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nonce, 'nonce');
-    _s.validateStringLength(
-      'nonce',
-      nonce,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.AcknowledgeThirdPartyJob'
@@ -220,25 +187,6 @@ class CodePipeline {
     ActionTypeSettings? settings,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(category, 'category');
-    ArgumentError.checkNotNull(inputArtifactDetails, 'inputArtifactDetails');
-    ArgumentError.checkNotNull(outputArtifactDetails, 'outputArtifactDetails');
-    ArgumentError.checkNotNull(provider, 'provider');
-    _s.validateStringLength(
-      'provider',
-      provider,
-      1,
-      25,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      9,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.CreateCustomActionType'
@@ -294,7 +242,6 @@ class CodePipeline {
     required PipelineDeclaration pipeline,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(pipeline, 'pipeline');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.CreatePipeline'
@@ -343,23 +290,6 @@ class CodePipeline {
     required String provider,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(category, 'category');
-    ArgumentError.checkNotNull(provider, 'provider');
-    _s.validateStringLength(
-      'provider',
-      provider,
-      1,
-      25,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      9,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.DeleteCustomActionType'
@@ -388,14 +318,6 @@ class CodePipeline {
   Future<void> deletePipeline({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.DeletePipeline'
@@ -426,14 +348,6 @@ class CodePipeline {
   Future<void> deleteWebhook({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.DeleteWebhook'
@@ -462,12 +376,6 @@ class CodePipeline {
   Future<void> deregisterWebhookWithThirdParty({
     String? webhookName,
   }) async {
-    _s.validateStringLength(
-      'webhookName',
-      webhookName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.DeregisterWebhookWithThirdParty'
@@ -515,31 +423,6 @@ class CodePipeline {
     required String stageName,
     required StageTransitionType transitionType,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reason, 'reason');
-    _s.validateStringLength(
-      'reason',
-      reason,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stageName, 'stageName');
-    _s.validateStringLength(
-      'stageName',
-      stageName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transitionType, 'transitionType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.DisableStageTransition'
@@ -584,23 +467,6 @@ class CodePipeline {
     required String stageName,
     required StageTransitionType transitionType,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stageName, 'stageName');
-    _s.validateStringLength(
-      'stageName',
-      stageName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transitionType, 'transitionType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.EnableStageTransition'
@@ -635,7 +501,6 @@ class CodePipeline {
   Future<GetJobDetailsOutput> getJobDetails({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.GetJobDetails'
@@ -674,14 +539,6 @@ class CodePipeline {
     required String name,
     int? version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'version',
       version,
@@ -725,15 +582,6 @@ class CodePipeline {
     required String pipelineExecutionId,
     required String pipelineName,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionId, 'pipelineExecutionId');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.GetPipelineExecution'
@@ -769,14 +617,6 @@ class CodePipeline {
   Future<GetPipelineStateOutput> getPipelineState({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.GetPipelineState'
@@ -820,22 +660,6 @@ class CodePipeline {
     required String clientToken,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.GetThirdPartyJobDetails'
@@ -889,25 +713,11 @@ class CodePipeline {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -946,12 +756,6 @@ class CodePipeline {
     ActionOwner? actionOwnerFilter,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.ListActionTypes'
@@ -997,25 +801,11 @@ class CodePipeline {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1048,12 +838,6 @@ class CodePipeline {
   Future<ListPipelinesOutput> listPipelines({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.ListPipelines'
@@ -1095,18 +879,11 @@ class CodePipeline {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1151,12 +928,6 @@ class CodePipeline {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1208,7 +979,6 @@ class CodePipeline {
     int? maxBatchSize,
     Map<String, String>? queryParam,
   }) async {
-    ArgumentError.checkNotNull(actionTypeId, 'actionTypeId');
     _s.validateNumRange(
       'maxBatchSize',
       maxBatchSize,
@@ -1255,7 +1025,6 @@ class CodePipeline {
     required ActionTypeId actionTypeId,
     int? maxBatchSize,
   }) async {
-    ArgumentError.checkNotNull(actionTypeId, 'actionTypeId');
     _s.validateNumRange(
       'maxBatchSize',
       maxBatchSize,
@@ -1306,31 +1075,6 @@ class CodePipeline {
     required String pipelineName,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionRevision, 'actionRevision');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stageName, 'stageName');
-    _s.validateStringLength(
-      'stageName',
-      stageName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutActionRevision'
@@ -1386,32 +1130,6 @@ class CodePipeline {
     required String stageName,
     required String token,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(result, 'result');
-    ArgumentError.checkNotNull(stageName, 'stageName');
-    _s.validateStringLength(
-      'stageName',
-      stageName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(token, 'token');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutApprovalResult'
@@ -1451,8 +1169,6 @@ class CodePipeline {
     required FailureDetails failureDetails,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(failureDetails, 'failureDetails');
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutJobFailureResult'
@@ -1510,13 +1226,6 @@ class CodePipeline {
     ExecutionDetails? executionDetails,
     Map<String, String>? outputVariables,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'continuationToken',
-      continuationToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutJobSuccessResult'
@@ -1561,23 +1270,6 @@ class CodePipeline {
     required FailureDetails failureDetails,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(failureDetails, 'failureDetails');
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutThirdPartyJobFailureResult'
@@ -1634,28 +1326,6 @@ class CodePipeline {
     CurrentRevision? currentRevision,
     ExecutionDetails? executionDetails,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'continuationToken',
-      continuationToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutThirdPartyJobSuccessResult'
@@ -1708,7 +1378,6 @@ class CodePipeline {
     required WebhookDefinition webhook,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(webhook, 'webhook');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.PutWebhook'
@@ -1740,12 +1409,6 @@ class CodePipeline {
   Future<void> registerWebhookWithThirdParty({
     String? webhookName,
   }) async {
-    _s.validateStringLength(
-      'webhookName',
-      webhookName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.RegisterWebhookWithThirdParty'
@@ -1794,24 +1457,6 @@ class CodePipeline {
     required StageRetryMode retryMode,
     required String stageName,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionId, 'pipelineExecutionId');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(retryMode, 'retryMode');
-    ArgumentError.checkNotNull(stageName, 'stageName');
-    _s.validateStringLength(
-      'stageName',
-      stageName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.RetryStageExecution'
@@ -1850,20 +1495,6 @@ class CodePipeline {
     required String name,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.StartPipelineExecution'
@@ -1921,21 +1552,6 @@ class CodePipeline {
     bool? abandon,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionId, 'pipelineExecutionId');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'reason',
-      reason,
-      0,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.StopPipelineExecution'
@@ -1976,8 +1592,6 @@ class CodePipeline {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.TagResource'
@@ -2012,8 +1626,6 @@ class CodePipeline {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.UntagResource'
@@ -2048,7 +1660,6 @@ class CodePipeline {
   Future<UpdatePipelineOutput> updatePipeline({
     required PipelineDeclaration pipeline,
   }) async {
-    ArgumentError.checkNotNull(pipeline, 'pipeline');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodePipeline_20150709.UpdatePipeline'

--- a/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
+++ b/generated/aws_codestar_api/lib/codestar-2017-04-19.dart
@@ -85,29 +85,6 @@ class CodeStar {
     String? clientRequestToken,
     bool? remoteAccessAllowed,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
-    _s.validateStringLength(
-      'projectId',
-      projectId,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectRole, 'projectRole');
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.AssociateTeamMember'
@@ -179,34 +156,6 @@ class CodeStar {
     Map<String, String>? tags,
     Toolchain? toolchain,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.CreateProject'
@@ -262,36 +211,6 @@ class CodeStar {
     required String userArn,
     String? sshPublicKey,
   }) async {
-    ArgumentError.checkNotNull(displayName, 'displayName');
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
-    _s.validateStringLength(
-      'emailAddress',
-      emailAddress,
-      3,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sshPublicKey',
-      sshPublicKey,
-      0,
-      16384,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.CreateUserProfile'
@@ -339,20 +258,6 @@ class CodeStar {
     String? clientRequestToken,
     bool? deleteStack,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.DeleteProject'
@@ -386,14 +291,6 @@ class CodeStar {
   Future<DeleteUserProfileResult> deleteUserProfile({
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.DeleteUserProfile'
@@ -425,14 +322,6 @@ class CodeStar {
   Future<DescribeProjectResult> describeProject({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.DescribeProject'
@@ -462,14 +351,6 @@ class CodeStar {
   Future<DescribeUserProfileResult> describeUserProfile({
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.DescribeUserProfile'
@@ -509,22 +390,6 @@ class CodeStar {
     required String projectId,
     required String userArn,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
-    _s.validateStringLength(
-      'projectId',
-      projectId,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.DisassociateTeamMember'
@@ -563,12 +428,6 @@ class CodeStar {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -610,25 +469,11 @@ class CodeStar {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
-    _s.validateStringLength(
-      'projectId',
-      projectId,
-      2,
-      15,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -669,25 +514,11 @@ class CodeStar {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -729,25 +560,11 @@ class CodeStar {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
-    _s.validateStringLength(
-      'projectId',
-      projectId,
-      2,
-      15,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -791,12 +608,6 @@ class CodeStar {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.ListUserProfiles'
@@ -832,15 +643,6 @@ class CodeStar {
     required String id,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.TagProject'
@@ -876,15 +678,6 @@ class CodeStar {
     required String id,
     required List<String> tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.UntagProject'
@@ -920,26 +713,6 @@ class CodeStar {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      2,
-      15,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.UpdateProject'
@@ -994,22 +767,6 @@ class CodeStar {
     String? projectRole,
     bool? remoteAccessAllowed,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
-    _s.validateStringLength(
-      'projectId',
-      projectId,
-      2,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.UpdateTeamMember'
@@ -1061,32 +818,6 @@ class CodeStar {
     String? emailAddress,
     String? sshPublicKey,
   }) async {
-    ArgumentError.checkNotNull(userArn, 'userArn');
-    _s.validateStringLength(
-      'userArn',
-      userArn,
-      32,
-      95,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'emailAddress',
-      emailAddress,
-      3,
-      128,
-    );
-    _s.validateStringLength(
-      'sshPublicKey',
-      sshPublicKey,
-      0,
-      16384,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeStar_20170419.UpdateUserProfile'

--- a/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
+++ b/generated/aws_codestar_connections_api/lib/codestar-connections-2019-12-01.dart
@@ -80,20 +80,6 @@ class CodeStarconnections {
     ProviderType? providerType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(connectionName, 'connectionName');
-    _s.validateStringLength(
-      'connectionName',
-      connectionName,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'hostArn',
-      hostArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -151,23 +137,6 @@ class CodeStarconnections {
     required ProviderType providerType,
     VpcConfiguration? vpcConfiguration,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(providerEndpoint, 'providerEndpoint');
-    _s.validateStringLength(
-      'providerEndpoint',
-      providerEndpoint,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(providerType, 'providerType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -202,14 +171,6 @@ class CodeStarconnections {
   Future<void> deleteConnection({
     required String connectionArn,
   }) async {
-    ArgumentError.checkNotNull(connectionArn, 'connectionArn');
-    _s.validateStringLength(
-      'connectionArn',
-      connectionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -242,14 +203,6 @@ class CodeStarconnections {
   Future<void> deleteHost({
     required String hostArn,
   }) async {
-    ArgumentError.checkNotNull(hostArn, 'hostArn');
-    _s.validateStringLength(
-      'hostArn',
-      hostArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -278,14 +231,6 @@ class CodeStarconnections {
   Future<GetConnectionOutput> getConnection({
     required String connectionArn,
   }) async {
-    ArgumentError.checkNotNull(connectionArn, 'connectionArn');
-    _s.validateStringLength(
-      'connectionArn',
-      connectionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -316,14 +261,6 @@ class CodeStarconnections {
   Future<GetHostOutput> getHost({
     required String hostArn,
   }) async {
-    ArgumentError.checkNotNull(hostArn, 'hostArn');
-    _s.validateStringLength(
-      'hostArn',
-      hostArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -366,23 +303,11 @@ class CodeStarconnections {
     String? nextToken,
     ProviderType? providerTypeFilter,
   }) async {
-    _s.validateStringLength(
-      'hostArnFilter',
-      hostArnFilter,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -427,12 +352,6 @@ class CodeStarconnections {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -464,14 +383,6 @@ class CodeStarconnections {
   Future<ListTagsForResourceOutput> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -507,15 +418,6 @@ class CodeStarconnections {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -547,15 +449,6 @@ class CodeStarconnections {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -596,20 +489,6 @@ class CodeStarconnections {
     String? providerEndpoint,
     VpcConfiguration? vpcConfiguration,
   }) async {
-    ArgumentError.checkNotNull(hostArn, 'hostArn');
-    _s.validateStringLength(
-      'hostArn',
-      hostArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'providerEndpoint',
-      providerEndpoint,
-      1,
-      512,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':

--- a/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
+++ b/generated/aws_codestar_notifications_api/lib/codestar-notifications-2019-10-15.dart
@@ -184,24 +184,6 @@ class CodeStarNotifications {
     NotificationRuleStatus? status,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(detailType, 'detailType');
-    ArgumentError.checkNotNull(eventTypeIds, 'eventTypeIds');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'DetailType': detailType.toValue(),
       'EventTypeIds': eventTypeIds,
@@ -233,7 +215,6 @@ class CodeStarNotifications {
   Future<DeleteNotificationRuleResult> deleteNotificationRule({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $payload = <String, dynamic>{
       'Arn': arn,
     };
@@ -262,14 +243,6 @@ class CodeStarNotifications {
     required String targetAddress,
     bool? forceUnsubscribeAll,
   }) async {
-    ArgumentError.checkNotNull(targetAddress, 'targetAddress');
-    _s.validateStringLength(
-      'targetAddress',
-      targetAddress,
-      1,
-      320,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'TargetAddress': targetAddress,
       if (forceUnsubscribeAll != null)
@@ -293,7 +266,6 @@ class CodeStarNotifications {
   Future<DescribeNotificationRuleResult> describeNotificationRule({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $payload = <String, dynamic>{
       'Arn': arn,
     };
@@ -404,7 +376,6 @@ class CodeStarNotifications {
   Future<ListTagsForResourceResult> listTagsForResource({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $payload = <String, dynamic>{
       'Arn': arn,
     };
@@ -482,14 +453,6 @@ class CodeStarNotifications {
     required Target target,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'Arn': arn,
       'Target': target,
@@ -520,8 +483,6 @@ class CodeStarNotifications {
     required String arn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Arn': arn,
       'Tags': tags,
@@ -550,15 +511,6 @@ class CodeStarNotifications {
     required String arn,
     required String targetAddress,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(targetAddress, 'targetAddress');
-    _s.validateStringLength(
-      'targetAddress',
-      targetAddress,
-      1,
-      320,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Arn': arn,
       'TargetAddress': targetAddress,
@@ -589,8 +541,6 @@ class CodeStarNotifications {
     required String arn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'Arn': arn,
       'TagKeys': tagKeys,
@@ -645,13 +595,6 @@ class CodeStarNotifications {
     NotificationRuleStatus? status,
     List<Target>? targets,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'Arn': arn,
       if (detailType != null) 'DetailType': detailType.toValue(),

--- a/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
+++ b/generated/aws_cognito_identity_api/lib/cognito-identity-2014-06-30.dart
@@ -131,22 +131,6 @@ class CognitoIdentity {
     List<String>? samlProviderARNs,
     Map<String, String>? supportedLoginProviders,
   }) async {
-    ArgumentError.checkNotNull(
-        allowUnauthenticatedIdentities, 'allowUnauthenticatedIdentities');
-    ArgumentError.checkNotNull(identityPoolName, 'identityPoolName');
-    _s.validateStringLength(
-      'identityPoolName',
-      identityPoolName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'developerProviderName',
-      developerProviderName,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.CreateIdentityPool'
@@ -191,7 +175,6 @@ class CognitoIdentity {
   Future<DeleteIdentitiesResponse> deleteIdentities({
     required List<String> identityIdsToDelete,
   }) async {
-    ArgumentError.checkNotNull(identityIdsToDelete, 'identityIdsToDelete');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.DeleteIdentities'
@@ -226,14 +209,6 @@ class CognitoIdentity {
   Future<void> deleteIdentityPool({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.DeleteIdentityPool'
@@ -266,14 +241,6 @@ class CognitoIdentity {
   Future<IdentityDescription> describeIdentity({
     required String identityId,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.DescribeIdentity'
@@ -308,14 +275,6 @@ class CognitoIdentity {
   Future<IdentityPool> describeIdentityPool({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.DescribeIdentityPool'
@@ -377,20 +336,6 @@ class CognitoIdentity {
     String? customRoleArn,
     Map<String, String>? logins,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'customRoleArn',
-      customRoleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.GetCredentialsForIdentity'
@@ -465,20 +410,6 @@ class CognitoIdentity {
     String? accountId,
     Map<String, String>? logins,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      1,
-      15,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.GetId'
@@ -516,14 +447,6 @@ class CognitoIdentity {
   Future<GetIdentityPoolRolesResponse> getIdentityPoolRoles({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.GetIdentityPoolRoles'
@@ -571,14 +494,6 @@ class CognitoIdentity {
     required String identityId,
     Map<String, String>? logins,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.GetOpenIdToken'
@@ -663,21 +578,6 @@ class CognitoIdentity {
     String? identityId,
     int? tokenDuration,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logins, 'logins');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-    );
     _s.validateNumRange(
       'tokenDuration',
       tokenDuration,
@@ -736,27 +636,12 @@ class CognitoIdentity {
     bool? hideDisabled,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -798,19 +683,12 @@ class CognitoIdentity {
     required int maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -851,14 +729,6 @@ class CognitoIdentity {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.ListTagsForResource'
@@ -934,37 +804,11 @@ class CognitoIdentity {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'developerUserIdentifier',
-      developerUserIdentifier,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1037,39 +881,6 @@ class CognitoIdentity {
     required String identityPoolId,
     required String sourceUserIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationUserIdentifier, 'destinationUserIdentifier');
-    _s.validateStringLength(
-      'destinationUserIdentifier',
-      destinationUserIdentifier,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(developerProviderName, 'developerProviderName');
-    _s.validateStringLength(
-      'developerProviderName',
-      developerProviderName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceUserIdentifier, 'sourceUserIdentifier');
-    _s.validateStringLength(
-      'sourceUserIdentifier',
-      sourceUserIdentifier,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.MergeDeveloperIdentities'
@@ -1124,15 +935,6 @@ class CognitoIdentity {
     required Map<String, String> roles,
     Map<String, RoleMapping>? roleMappings,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roles, 'roles');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.SetIdentityPoolRoles'
@@ -1186,15 +988,6 @@ class CognitoIdentity {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.TagResource'
@@ -1245,39 +1038,6 @@ class CognitoIdentity {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(developerProviderName, 'developerProviderName');
-    _s.validateStringLength(
-      'developerProviderName',
-      developerProviderName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        developerUserIdentifier, 'developerUserIdentifier');
-    _s.validateStringLength(
-      'developerUserIdentifier',
-      developerUserIdentifier,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.UnlinkDeveloperIdentity'
@@ -1325,16 +1085,6 @@ class CognitoIdentity {
     required Map<String, String> logins,
     required List<String> loginsToRemove,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logins, 'logins');
-    ArgumentError.checkNotNull(loginsToRemove, 'loginsToRemove');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.UnlinkIdentity'
@@ -1373,15 +1123,6 @@ class CognitoIdentity {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.UntagResource'
@@ -1460,30 +1201,6 @@ class CognitoIdentity {
     List<String>? samlProviderARNs,
     Map<String, String>? supportedLoginProviders,
   }) async {
-    ArgumentError.checkNotNull(
-        allowUnauthenticatedIdentities, 'allowUnauthenticatedIdentities');
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolName, 'identityPoolName');
-    _s.validateStringLength(
-      'identityPoolName',
-      identityPoolName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'developerProviderName',
-      developerProviderName,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityService.UpdateIdentityPool'

--- a/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
+++ b/generated/aws_cognito_idp_api/lib/cognito-idp-2016-04-18.dart
@@ -73,15 +73,6 @@ class CognitoIdentityProvider {
     required List<SchemaAttributeType> customAttributes,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(customAttributes, 'customAttributes');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AddCustomAttributes'
@@ -123,30 +114,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminAddUserToGroup'
@@ -230,22 +197,6 @@ class CognitoIdentityProvider {
     required String username,
     Map<String, String>? clientMetadata,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminConfirmSignUp'
@@ -453,28 +404,6 @@ class CognitoIdentityProvider {
     List<AttributeType>? userAttributes,
     List<AttributeType>? validationData,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'temporaryPassword',
-      temporaryPassword,
-      6,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminCreateUser'
@@ -524,22 +453,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminDeleteUser'
@@ -587,23 +500,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userAttributeNames, 'userAttributeNames');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -679,8 +575,6 @@ class CognitoIdentityProvider {
     required ProviderUserIdentifierType user,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(user, 'user');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -719,22 +613,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminDisableUser'
@@ -772,22 +650,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminEnableUser'
@@ -830,30 +692,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminForgetDevice'
@@ -896,30 +734,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminGetDevice'
@@ -962,22 +776,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminGetUser'
@@ -1201,23 +999,6 @@ class CognitoIdentityProvider {
     Map<String, String>? clientMetadata,
     ContextDataType? contextData,
   }) async {
-    ArgumentError.checkNotNull(authFlow, 'authFlow');
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminInitiateAuth'
@@ -1326,9 +1107,6 @@ class CognitoIdentityProvider {
     required ProviderUserIdentifierType sourceUser,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(destinationUser, 'destinationUser');
-    ArgumentError.checkNotNull(sourceUser, 'sourceUser');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1376,33 +1154,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? paginationToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1454,33 +1210,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1531,33 +1265,11 @@ class CognitoIdentityProvider {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1605,30 +1317,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1727,22 +1415,6 @@ class CognitoIdentityProvider {
     required String username,
     Map<String, String>? clientMetadata,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminResetUserPassword'
@@ -1897,29 +1569,6 @@ class CognitoIdentityProvider {
     ContextDataType? contextData,
     String? session,
   }) async {
-    ArgumentError.checkNotNull(challengeName, 'challengeName');
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'session',
-      session,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1979,22 +1628,6 @@ class CognitoIdentityProvider {
     SMSMfaSettingsType? sMSMfaSettings,
     SoftwareTokenMfaSettingsType? softwareTokenMfaSettings,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2056,30 +1689,6 @@ class CognitoIdentityProvider {
     required String username,
     bool? permanent,
   }) async {
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      6,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminSetUserPassword'
@@ -2126,23 +1735,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(mFAOptions, 'mFAOptions');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminSetUserSettings'
@@ -2190,31 +1782,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(eventId, 'eventId');
-    _s.validateStringLength(
-      'eventId',
-      eventId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(feedbackValue, 'feedbackValue');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2264,30 +1831,6 @@ class CognitoIdentityProvider {
     required String username,
     DeviceRememberedStatusType? deviceRememberedStatus,
   }) async {
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2391,23 +1934,6 @@ class CognitoIdentityProvider {
     required String username,
     Map<String, String>? clientMetadata,
   }) async {
-    ArgumentError.checkNotNull(userAttributes, 'userAttributes');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2451,22 +1977,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AdminUserGlobalSignOut'
@@ -2505,12 +2015,6 @@ class CognitoIdentityProvider {
     String? accessToken,
     String? session,
   }) async {
-    _s.validateStringLength(
-      'session',
-      session,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.AssociateSoftwareToken'
@@ -2556,23 +2060,6 @@ class CognitoIdentityProvider {
     required String previousPassword,
     required String proposedPassword,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(previousPassword, 'previousPassword');
-    _s.validateStringLength(
-      'previousPassword',
-      previousPassword,
-      6,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(proposedPassword, 'proposedPassword');
-    _s.validateStringLength(
-      'proposedPassword',
-      proposedPassword,
-      6,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ChangePassword'
@@ -2625,21 +2112,6 @@ class CognitoIdentityProvider {
     String? deviceName,
     DeviceSecretVerifierConfigType? deviceSecretVerifierConfig,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deviceName',
-      deviceName,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ConfirmDevice'
@@ -2757,44 +2229,6 @@ class CognitoIdentityProvider {
     String? secretHash,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(confirmationCode, 'confirmationCode');
-    _s.validateStringLength(
-      'confirmationCode',
-      confirmationCode,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      6,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretHash',
-      secretHash,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ConfirmForgotPassword'
@@ -2917,36 +2351,6 @@ class CognitoIdentityProvider {
     String? secretHash,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(confirmationCode, 'confirmationCode');
-    _s.validateStringLength(
-      'confirmationCode',
-      confirmationCode,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretHash',
-      secretHash,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ConfirmSignUp'
@@ -3021,39 +2425,11 @@ class CognitoIdentityProvider {
     int? precedence,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
     _s.validateNumRange(
       'precedence',
       precedence,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3215,24 +2591,6 @@ class CognitoIdentityProvider {
     Map<String, String>? attributeMapping,
     List<String>? idpIdentifiers,
   }) async {
-    ArgumentError.checkNotNull(providerDetails, 'providerDetails');
-    ArgumentError.checkNotNull(providerName, 'providerName');
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(providerType, 'providerType');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.CreateIdentityProvider'
@@ -3285,30 +2643,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     List<ResourceServerScopeType>? scopes,
   }) async {
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    _s.validateStringLength(
-      'identifier',
-      identifier,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.CreateResourceServer'
@@ -3354,30 +2688,6 @@ class CognitoIdentityProvider {
     required String jobName,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(cloudWatchLogsRoleArn, 'cloudWatchLogsRoleArn');
-    _s.validateStringLength(
-      'cloudWatchLogsRoleArn',
-      cloudWatchLogsRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.CreateUserImportJob'
@@ -3535,38 +2845,6 @@ class CognitoIdentityProvider {
     UsernameConfigurationType? usernameConfiguration,
     VerificationMessageTemplateType? verificationMessageTemplate,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
-    _s.validateStringLength(
-      'poolName',
-      poolName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'emailVerificationMessage',
-      emailVerificationMessage,
-      6,
-      20000,
-    );
-    _s.validateStringLength(
-      'emailVerificationSubject',
-      emailVerificationSubject,
-      1,
-      140,
-    );
-    _s.validateStringLength(
-      'smsAuthenticationMessage',
-      smsAuthenticationMessage,
-      6,
-      140,
-    );
-    _s.validateStringLength(
-      'smsVerificationMessage',
-      smsVerificationMessage,
-      6,
-      140,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.CreateUserPool'
@@ -3852,33 +3130,11 @@ class CognitoIdentityProvider {
     TokenValidityUnitsType? tokenValidityUnits,
     List<String>? writeAttributes,
   }) async {
-    ArgumentError.checkNotNull(clientName, 'clientName');
-    _s.validateStringLength(
-      'clientName',
-      clientName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'accessTokenValidity',
       accessTokenValidity,
       1,
       86400,
-    );
-    _s.validateStringLength(
-      'defaultRedirectURI',
-      defaultRedirectURI,
-      1,
-      1024,
     );
     _s.validateNumRange(
       'idTokenValidity',
@@ -3971,22 +3227,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     CustomDomainConfigType? customDomainConfig,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.CreateUserPoolDomain'
@@ -4027,22 +3267,6 @@ class CognitoIdentityProvider {
     required String groupName,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteGroup'
@@ -4078,22 +3302,6 @@ class CognitoIdentityProvider {
     required String providerName,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(providerName, 'providerName');
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteIdentityProvider'
@@ -4128,22 +3336,6 @@ class CognitoIdentityProvider {
     required String identifier,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    _s.validateStringLength(
-      'identifier',
-      identifier,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteResourceServer'
@@ -4177,7 +3369,6 @@ class CognitoIdentityProvider {
   Future<void> deleteUser({
     required String accessToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteUser'
@@ -4219,8 +3410,6 @@ class CognitoIdentityProvider {
     required String accessToken,
     required List<String> userAttributeNames,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(userAttributeNames, 'userAttributeNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteUserAttributes'
@@ -4253,14 +3442,6 @@ class CognitoIdentityProvider {
   Future<void> deleteUserPool({
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteUserPool'
@@ -4294,22 +3475,6 @@ class CognitoIdentityProvider {
     required String clientId,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteUserPoolClient'
@@ -4343,22 +3508,6 @@ class CognitoIdentityProvider {
     required String domain,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DeleteUserPoolDomain'
@@ -4393,22 +3542,6 @@ class CognitoIdentityProvider {
     required String providerName,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(providerName, 'providerName');
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4446,22 +3579,6 @@ class CognitoIdentityProvider {
     required String identifier,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    _s.validateStringLength(
-      'identifier',
-      identifier,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DescribeResourceServer'
@@ -4499,20 +3616,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     String? clientId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4550,22 +3653,6 @@ class CognitoIdentityProvider {
     required String jobId,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DescribeUserImportJob'
@@ -4600,14 +3687,6 @@ class CognitoIdentityProvider {
   Future<DescribeUserPoolResponse> describeUserPool({
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DescribeUserPool'
@@ -4644,22 +3723,6 @@ class CognitoIdentityProvider {
     required String clientId,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DescribeUserPoolClient'
@@ -4691,14 +3754,6 @@ class CognitoIdentityProvider {
   Future<DescribeUserPoolDomainResponse> describeUserPoolDomain({
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.DescribeUserPoolDomain'
@@ -4738,14 +3793,6 @@ class CognitoIdentityProvider {
     required String deviceKey,
     String? accessToken,
   }) async {
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ForgetDevice'
@@ -4859,28 +3906,6 @@ class CognitoIdentityProvider {
     String? secretHash,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretHash',
-      secretHash,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ForgotPassword'
@@ -4919,14 +3944,6 @@ class CognitoIdentityProvider {
   Future<GetCSVHeaderResponse> getCSVHeader({
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetCSVHeader'
@@ -4966,14 +3983,6 @@ class CognitoIdentityProvider {
     required String deviceKey,
     String? accessToken,
   }) async {
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetDevice'
@@ -5012,22 +4021,6 @@ class CognitoIdentityProvider {
     required String groupName,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetGroup'
@@ -5065,22 +4058,6 @@ class CognitoIdentityProvider {
     required String idpIdentifier,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(idpIdentifier, 'idpIdentifier');
-    _s.validateStringLength(
-      'idpIdentifier',
-      idpIdentifier,
-      1,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -5112,14 +4089,6 @@ class CognitoIdentityProvider {
   Future<GetSigningCertificateResponse> getSigningCertificate({
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetSigningCertificate'
@@ -5159,20 +4128,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     String? clientId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetUICustomization'
@@ -5209,7 +4164,6 @@ class CognitoIdentityProvider {
   Future<GetUserResponse> getUser({
     required String accessToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetUser'
@@ -5301,15 +4255,6 @@ class CognitoIdentityProvider {
     required String attributeName,
     Map<String, String>? clientMetadata,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    _s.validateStringLength(
-      'attributeName',
-      attributeName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -5345,14 +4290,6 @@ class CognitoIdentityProvider {
   Future<GetUserPoolMfaConfigResponse> getUserPoolMfaConfig({
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GetUserPoolMfaConfig'
@@ -5389,7 +4326,6 @@ class CognitoIdentityProvider {
   Future<void> globalSignOut({
     required String accessToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.GlobalSignOut'
@@ -5594,15 +4530,6 @@ class CognitoIdentityProvider {
     Map<String, String>? clientMetadata,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(authFlow, 'authFlow');
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.InitiateAuth'
@@ -5652,18 +4579,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? paginationToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5709,25 +4629,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5770,25 +4676,11 @@ class CognitoIdentityProvider {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5831,25 +4723,11 @@ class CognitoIdentityProvider {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5891,14 +4769,6 @@ class CognitoIdentityProvider {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ListTagsForResource'
@@ -5940,27 +4810,12 @@ class CognitoIdentityProvider {
     required String userPoolId,
     String? paginationToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6006,25 +4861,11 @@ class CognitoIdentityProvider {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6064,19 +4905,12 @@ class CognitoIdentityProvider {
     required int maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       60,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6196,31 +5030,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? paginationToken,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'filter',
-      filter,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6272,33 +5086,11 @@ class CognitoIdentityProvider {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       60,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6405,28 +5197,6 @@ class CognitoIdentityProvider {
     String? secretHash,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretHash',
-      secretHash,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.ResendConfirmationCode'
@@ -6584,21 +5354,6 @@ class CognitoIdentityProvider {
     String? session,
     UserContextDataType? userContextData,
   }) async {
-    ArgumentError.checkNotNull(challengeName, 'challengeName');
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'session',
-      session,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.RespondToAuthChallenge'
@@ -6671,20 +5426,6 @@ class CognitoIdentityProvider {
         compromisedCredentialsRiskConfiguration,
     RiskExceptionConfigurationType? riskExceptionConfiguration,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SetRiskConfiguration'
@@ -6749,20 +5490,6 @@ class CognitoIdentityProvider {
     String? clientId,
     Uint8List? imageFile,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SetUICustomization'
@@ -6817,7 +5544,6 @@ class CognitoIdentityProvider {
     SMSMfaSettingsType? sMSMfaSettings,
     SoftwareTokenMfaSettingsType? softwareTokenMfaSettings,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SetUserMFAPreference'
@@ -6877,14 +5603,6 @@ class CognitoIdentityProvider {
     SmsMfaConfigType? smsMfaConfiguration,
     SoftwareTokenMfaConfigType? softwareTokenMfaConfiguration,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SetUserPoolMfaConfig'
@@ -6933,8 +5651,6 @@ class CognitoIdentityProvider {
     required String accessToken,
     required List<MFAOptionType> mFAOptions,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(mFAOptions, 'mFAOptions');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SetUserSettings'
@@ -7053,36 +5769,6 @@ class CognitoIdentityProvider {
     UserContextDataType? userContextData,
     List<AttributeType>? validationData,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      6,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretHash',
-      secretHash,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.SignUp'
@@ -7128,22 +5814,6 @@ class CognitoIdentityProvider {
     required String jobId,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.StartUserImportJob'
@@ -7181,22 +5851,6 @@ class CognitoIdentityProvider {
     required String jobId,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.StopUserImportJob'
@@ -7251,15 +5905,6 @@ class CognitoIdentityProvider {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.TagResource'
@@ -7296,15 +5941,6 @@ class CognitoIdentityProvider {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UntagResource'
@@ -7355,32 +5991,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(eventId, 'eventId');
-    _s.validateStringLength(
-      'eventId',
-      eventId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(feedbackToken, 'feedbackToken');
-    ArgumentError.checkNotNull(feedbackValue, 'feedbackValue');
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -7427,15 +6037,6 @@ class CognitoIdentityProvider {
     required String deviceKey,
     DeviceRememberedStatusType? deviceRememberedStatus,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(deviceKey, 'deviceKey');
-    _s.validateStringLength(
-      'deviceKey',
-      deviceKey,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateDeviceStatus'
@@ -7494,39 +6095,11 @@ class CognitoIdentityProvider {
     int? precedence,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
     _s.validateNumRange(
       'precedence',
       precedence,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -7581,22 +6154,6 @@ class CognitoIdentityProvider {
     List<String>? idpIdentifiers,
     Map<String, String>? providerDetails,
   }) async {
-    ArgumentError.checkNotNull(providerName, 'providerName');
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateIdentityProvider'
@@ -7649,30 +6206,6 @@ class CognitoIdentityProvider {
     required String userPoolId,
     List<ResourceServerScopeType>? scopes,
   }) async {
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    _s.validateStringLength(
-      'identifier',
-      identifier,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateResourceServer'
@@ -7767,8 +6300,6 @@ class CognitoIdentityProvider {
     required List<AttributeType> userAttributes,
     Map<String, String>? clientMetadata,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(userAttributes, 'userAttributes');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateUserAttributes'
@@ -7905,38 +6436,6 @@ class CognitoIdentityProvider {
     Map<String, String>? userPoolTags,
     VerificationMessageTemplateType? verificationMessageTemplate,
   }) async {
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'emailVerificationMessage',
-      emailVerificationMessage,
-      6,
-      20000,
-    );
-    _s.validateStringLength(
-      'emailVerificationSubject',
-      emailVerificationSubject,
-      1,
-      140,
-    );
-    _s.validateStringLength(
-      'smsAuthenticationMessage',
-      smsAuthenticationMessage,
-      6,
-      140,
-    );
-    _s.validateStringLength(
-      'smsVerificationMessage',
-      smsVerificationMessage,
-      6,
-      140,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateUserPool'
@@ -8203,39 +6702,11 @@ class CognitoIdentityProvider {
     TokenValidityUnitsType? tokenValidityUnits,
     List<String>? writeAttributes,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'accessTokenValidity',
       accessTokenValidity,
       1,
       86400,
-    );
-    _s.validateStringLength(
-      'clientName',
-      clientName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'defaultRedirectURI',
-      defaultRedirectURI,
-      1,
-      1024,
     );
     _s.validateNumRange(
       'idTokenValidity',
@@ -8358,23 +6829,6 @@ class CognitoIdentityProvider {
     required String domain,
     required String userPoolId,
   }) async {
-    ArgumentError.checkNotNull(customDomainConfig, 'customDomainConfig');
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userPoolId, 'userPoolId');
-    _s.validateStringLength(
-      'userPoolId',
-      userPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.UpdateUserPoolDomain'
@@ -8432,20 +6886,6 @@ class CognitoIdentityProvider {
     String? friendlyDeviceName,
     String? session,
   }) async {
-    ArgumentError.checkNotNull(userCode, 'userCode');
-    _s.validateStringLength(
-      'userCode',
-      userCode,
-      6,
-      6,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'session',
-      session,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.VerifySoftwareToken'
@@ -8495,23 +6935,6 @@ class CognitoIdentityProvider {
     required String attributeName,
     required String code,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    _s.validateStringLength(
-      'attributeName',
-      attributeName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(code, 'code');
-    _s.validateStringLength(
-      'code',
-      code,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSCognitoIdentityProviderService.VerifyUserAttribute'

--- a/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
+++ b/generated/aws_cognito_sync_api/lib/cognito-sync-2014-06-30.dart
@@ -77,14 +77,6 @@ class CognitoSync {
   Future<BulkPublishResponse> bulkPublish({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -128,30 +120,6 @@ class CognitoSync {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -195,30 +163,6 @@ class CognitoSync {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -248,14 +192,6 @@ class CognitoSync {
   Future<DescribeIdentityPoolUsageResponse> describeIdentityPoolUsage({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -290,22 +226,6 @@ class CognitoSync {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -333,14 +253,6 @@ class CognitoSync {
   Future<GetBulkPublishDetailsResponse> getBulkPublishDetails({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -368,14 +280,6 @@ class CognitoSync {
   Future<GetCognitoEventsResponse> getCognitoEvents({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -404,14 +308,6 @@ class CognitoSync {
   Future<GetIdentityPoolConfigurationResponse> getIdentityPoolConfiguration({
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -456,22 +352,6 @@ class CognitoSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -569,30 +449,6 @@ class CognitoSync {
     String? nextToken,
     String? syncSessionToken,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (lastSyncCount != null) 'lastSyncCount': [lastSyncCount.toString()],
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -641,24 +497,6 @@ class CognitoSync {
     required Platform platform,
     required String token,
   }) async {
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(platform, 'platform');
-    ArgumentError.checkNotNull(token, 'token');
     final $payload = <String, dynamic>{
       'Platform': platform.toValue(),
       'Token': token,
@@ -696,15 +534,6 @@ class CognitoSync {
     required Map<String, String> events,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(events, 'events');
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Events': events,
     };
@@ -744,14 +573,6 @@ class CognitoSync {
     CognitoStreams? cognitoStreams,
     PushSync? pushSync,
   }) async {
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (cognitoStreams != null) 'CognitoStreams': cognitoStreams,
       if (pushSync != null) 'PushSync': pushSync,
@@ -798,38 +619,6 @@ class CognitoSync {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    _s.validateStringLength(
-      'deviceId',
-      deviceId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -871,38 +660,6 @@ class CognitoSync {
     required String identityId,
     required String identityPoolId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    _s.validateStringLength(
-      'deviceId',
-      deviceId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -978,37 +735,6 @@ class CognitoSync {
     String? deviceId,
     List<RecordPatch>? recordPatches,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityId, 'identityId');
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityPoolId, 'identityPoolId');
-    _s.validateStringLength(
-      'identityPoolId',
-      identityPoolId,
-      1,
-      55,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(syncSessionToken, 'syncSessionToken');
-    _s.validateStringLength(
-      'deviceId',
-      deviceId,
-      1,
-      256,
-    );
     final headers = <String, String>{
       if (clientContext != null)
         'x-amz-Client-Context': clientContext.toString(),

--- a/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
+++ b/generated/aws_comprehend_api/lib/comprehend-2017-11-27.dart
@@ -70,7 +70,6 @@ class Comprehend {
   Future<BatchDetectDominantLanguageResponse> batchDetectDominantLanguage({
     required List<String> textList,
   }) async {
-    ArgumentError.checkNotNull(textList, 'textList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.BatchDetectDominantLanguage'
@@ -112,8 +111,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required List<String> textList,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(textList, 'textList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.BatchDetectEntities'
@@ -154,8 +151,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required List<String> textList,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(textList, 'textList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.BatchDetectKeyPhrases'
@@ -198,8 +193,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required List<String> textList,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(textList, 'textList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.BatchDetectSentiment'
@@ -243,8 +236,6 @@ class Comprehend {
     required SyntaxLanguageCode languageCode,
     required List<String> textList,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(textList, 'textList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.BatchDetectSyntax'
@@ -282,22 +273,6 @@ class Comprehend {
     required String endpointArn,
     required String text,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    _s.validateStringLength(
-      'endpointArn',
-      endpointArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ClassifyDocument'
@@ -405,37 +380,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        documentClassifierName, 'documentClassifierName');
-    _s.validateStringLength(
-      'documentClassifierName',
-      documentClassifierName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.CreateDocumentClassifier'
@@ -507,35 +451,12 @@ class Comprehend {
     String? clientRequestToken,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(desiredInferenceUnits, 'desiredInferenceUnits');
     _s.validateNumRange(
       'desiredInferenceUnits',
       desiredInferenceUnits,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelArn, 'modelArn');
-    _s.validateStringLength(
-      'modelArn',
-      modelArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -636,36 +557,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(recognizerName, 'recognizerName');
-    _s.validateStringLength(
-      'recognizerName',
-      recognizerName,
-      0,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.CreateEntityRecognizer'
@@ -715,14 +606,6 @@ class Comprehend {
   Future<void> deleteDocumentClassifier({
     required String documentClassifierArn,
   }) async {
-    ArgumentError.checkNotNull(documentClassifierArn, 'documentClassifierArn');
-    _s.validateStringLength(
-      'documentClassifierArn',
-      documentClassifierArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DeleteDocumentClassifier'
@@ -753,14 +636,6 @@ class Comprehend {
   Future<void> deleteEndpoint({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    _s.validateStringLength(
-      'endpointArn',
-      endpointArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DeleteEndpoint'
@@ -800,14 +675,6 @@ class Comprehend {
   Future<void> deleteEntityRecognizer({
     required String entityRecognizerArn,
   }) async {
-    ArgumentError.checkNotNull(entityRecognizerArn, 'entityRecognizerArn');
-    _s.validateStringLength(
-      'entityRecognizerArn',
-      entityRecognizerArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DeleteEntityRecognizer'
@@ -839,14 +706,6 @@ class Comprehend {
       describeDocumentClassificationJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeDocumentClassificationJob'
@@ -879,14 +738,6 @@ class Comprehend {
   Future<DescribeDocumentClassifierResponse> describeDocumentClassifier({
     required String documentClassifierArn,
   }) async {
-    ArgumentError.checkNotNull(documentClassifierArn, 'documentClassifierArn');
-    _s.validateStringLength(
-      'documentClassifierArn',
-      documentClassifierArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeDocumentClassifier'
@@ -920,14 +771,6 @@ class Comprehend {
       describeDominantLanguageDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeDominantLanguageDetectionJob'
@@ -960,14 +803,6 @@ class Comprehend {
   Future<DescribeEndpointResponse> describeEndpoint({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    _s.validateStringLength(
-      'endpointArn',
-      endpointArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeEndpoint'
@@ -1000,14 +835,6 @@ class Comprehend {
   Future<DescribeEntitiesDetectionJobResponse> describeEntitiesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeEntitiesDetectionJob'
@@ -1039,14 +866,6 @@ class Comprehend {
   Future<DescribeEntityRecognizerResponse> describeEntityRecognizer({
     required String entityRecognizerArn,
   }) async {
-    ArgumentError.checkNotNull(entityRecognizerArn, 'entityRecognizerArn');
-    _s.validateStringLength(
-      'entityRecognizerArn',
-      entityRecognizerArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeEntityRecognizer'
@@ -1077,14 +896,6 @@ class Comprehend {
   Future<DescribeEventsDetectionJobResponse> describeEventsDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeEventsDetectionJob'
@@ -1118,14 +929,6 @@ class Comprehend {
       describeKeyPhrasesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeKeyPhrasesDetectionJob'
@@ -1159,14 +962,6 @@ class Comprehend {
       describePiiEntitiesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribePiiEntitiesDetectionJob'
@@ -1199,14 +994,6 @@ class Comprehend {
   Future<DescribeSentimentDetectionJobResponse> describeSentimentDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeSentimentDetectionJob'
@@ -1238,14 +1025,6 @@ class Comprehend {
   Future<DescribeTopicsDetectionJobResponse> describeTopicsDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DescribeTopicsDetectionJob'
@@ -1279,14 +1058,6 @@ class Comprehend {
   Future<DetectDominantLanguageResponse> detectDominantLanguage({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectDominantLanguage'
@@ -1341,20 +1112,6 @@ class Comprehend {
     String? endpointArn,
     LanguageCode? languageCode,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'endpointArn',
-      endpointArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectEntities'
@@ -1394,15 +1151,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required String text,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectKeyPhrases'
@@ -1440,15 +1188,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required String text,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectPiiEntities'
@@ -1489,15 +1228,6 @@ class Comprehend {
     required LanguageCode languageCode,
     required String text,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectSentiment'
@@ -1538,15 +1268,6 @@ class Comprehend {
     required SyntaxLanguageCode languageCode,
     required String text,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.DetectSyntax'
@@ -1596,12 +1317,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListDocumentClassificationJobs'
@@ -1649,12 +1364,6 @@ class Comprehend {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1706,12 +1415,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListDominantLanguageDetectionJobs'
@@ -1760,12 +1463,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListEndpoints'
@@ -1813,12 +1510,6 @@ class Comprehend {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1875,12 +1566,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListEntityRecognizers'
@@ -1928,12 +1613,6 @@ class Comprehend {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1983,12 +1662,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListKeyPhrasesDetectionJobs'
@@ -2036,12 +1709,6 @@ class Comprehend {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2091,12 +1758,6 @@ class Comprehend {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListSentimentDetectionJobs'
@@ -2129,14 +1790,6 @@ class Comprehend {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.ListTagsForResource'
@@ -2182,12 +1835,6 @@ class Comprehend {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2273,42 +1920,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(documentClassifierArn, 'documentClassifierArn');
-    _s.validateStringLength(
-      'documentClassifierArn',
-      documentClassifierArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartDocumentClassificationJob'
@@ -2394,34 +2005,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartDominantLanguageDetectionJob'
@@ -2526,41 +2109,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'entityRecognizerArn',
-      entityRecognizerArn,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartEntitiesDetectionJob'
@@ -2627,30 +2175,6 @@ class Comprehend {
     String? clientRequestToken,
     String? jobName,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    ArgumentError.checkNotNull(targetEventTypes, 'targetEventTypes');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartEventsDetectionJob'
@@ -2740,35 +2264,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartKeyPhrasesDetectionJob'
@@ -2845,30 +2340,6 @@ class Comprehend {
     String? jobName,
     RedactionConfig? redactionConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(mode, 'mode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartPiiEntitiesDetectionJob'
@@ -2959,35 +2430,6 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StartSentimentDetectionJob'
@@ -3080,39 +2522,11 @@ class Comprehend {
     String? volumeKmsKeyId,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'numberOfTopics',
       numberOfTopics,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'volumeKmsKeyId',
-      volumeKmsKeyId,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3165,14 +2579,6 @@ class Comprehend {
       stopDominantLanguageDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopDominantLanguageDetectionJob'
@@ -3215,14 +2621,6 @@ class Comprehend {
   Future<StopEntitiesDetectionJobResponse> stopEntitiesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopEntitiesDetectionJob'
@@ -3252,14 +2650,6 @@ class Comprehend {
   Future<StopEventsDetectionJobResponse> stopEventsDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopEventsDetectionJob'
@@ -3302,14 +2692,6 @@ class Comprehend {
   Future<StopKeyPhrasesDetectionJobResponse> stopKeyPhrasesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopKeyPhrasesDetectionJob'
@@ -3339,14 +2721,6 @@ class Comprehend {
   Future<StopPiiEntitiesDetectionJobResponse> stopPiiEntitiesDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopPiiEntitiesDetectionJob'
@@ -3389,14 +2763,6 @@ class Comprehend {
   Future<StopSentimentDetectionJobResponse> stopSentimentDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopSentimentDetectionJob'
@@ -3435,14 +2801,6 @@ class Comprehend {
   Future<void> stopTrainingDocumentClassifier({
     required String documentClassifierArn,
   }) async {
-    ArgumentError.checkNotNull(documentClassifierArn, 'documentClassifierArn');
-    _s.validateStringLength(
-      'documentClassifierArn',
-      documentClassifierArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopTrainingDocumentClassifier'
@@ -3479,14 +2837,6 @@ class Comprehend {
   Future<void> stopTrainingEntityRecognizer({
     required String entityRecognizerArn,
   }) async {
-    ArgumentError.checkNotNull(entityRecognizerArn, 'entityRecognizerArn');
-    _s.validateStringLength(
-      'entityRecognizerArn',
-      entityRecognizerArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.StopTrainingEntityRecognizer'
@@ -3526,15 +2876,6 @@ class Comprehend {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.TagResource'
@@ -3573,15 +2914,6 @@ class Comprehend {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Comprehend_20171127.UntagResource'
@@ -3620,20 +2952,11 @@ class Comprehend {
     required int desiredInferenceUnits,
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(desiredInferenceUnits, 'desiredInferenceUnits');
     _s.validateNumRange(
       'desiredInferenceUnits',
       desiredInferenceUnits,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    _s.validateStringLength(
-      'endpointArn',
-      endpointArn,
-      0,
-      256,
       isRequired: true,
     );
     final headers = <String, String>{

--- a/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
+++ b/generated/aws_comprehendmedical_api/lib/comprehendmedical-2018-10-30.dart
@@ -65,14 +65,6 @@ class ComprehendMedical {
       describeEntitiesDetectionV2Job({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -107,14 +99,6 @@ class ComprehendMedical {
   Future<DescribeICD10CMInferenceJobResponse> describeICD10CMInferenceJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DescribeICD10CMInferenceJob'
@@ -148,14 +132,6 @@ class ComprehendMedical {
   Future<DescribePHIDetectionJobResponse> describePHIDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DescribePHIDetectionJob'
@@ -188,14 +164,6 @@ class ComprehendMedical {
   Future<DescribeRxNormInferenceJobResponse> describeRxNormInferenceJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DescribeRxNormInferenceJob'
@@ -235,14 +203,6 @@ class ComprehendMedical {
   Future<DetectEntitiesResponse> detectEntities({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      20000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DetectEntities'
@@ -289,14 +249,6 @@ class ComprehendMedical {
   Future<DetectEntitiesV2Response> detectEntitiesV2({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      20000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DetectEntitiesV2'
@@ -333,14 +285,6 @@ class ComprehendMedical {
   Future<DetectPHIResponse> detectPHI({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      20000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.DetectPHI'
@@ -378,14 +322,6 @@ class ComprehendMedical {
   Future<InferICD10CMResponse> inferICD10CM({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      10000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.InferICD10CM'
@@ -422,14 +358,6 @@ class ComprehendMedical {
   Future<InferRxNormResponse> inferRxNorm({
     required String text,
   }) async {
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      10000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.InferRxNorm'
@@ -475,12 +403,6 @@ class ComprehendMedical {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -529,12 +451,6 @@ class ComprehendMedical {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -585,12 +501,6 @@ class ComprehendMedical {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.ListPHIDetectionJobs'
@@ -638,12 +548,6 @@ class ComprehendMedical {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -710,35 +614,6 @@ class ComprehendMedical {
     String? jobName,
     String? kMSKey,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StartEntitiesDetectionV2Job'
@@ -809,35 +684,6 @@ class ComprehendMedical {
     String? jobName,
     String? kMSKey,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StartICD10CMInferenceJob'
@@ -908,35 +754,6 @@ class ComprehendMedical {
     String? jobName,
     String? kMSKey,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StartPHIDetectionJob'
@@ -1007,35 +824,6 @@ class ComprehendMedical {
     String? jobName,
     String? kMSKey,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StartRxNormInferenceJob'
@@ -1072,14 +860,6 @@ class ComprehendMedical {
   Future<StopEntitiesDetectionV2JobResponse> stopEntitiesDetectionV2Job({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StopEntitiesDetectionV2Job'
@@ -1109,14 +889,6 @@ class ComprehendMedical {
   Future<StopICD10CMInferenceJobResponse> stopICD10CMInferenceJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StopICD10CMInferenceJob'
@@ -1146,14 +918,6 @@ class ComprehendMedical {
   Future<StopPHIDetectionJobResponse> stopPHIDetectionJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StopPHIDetectionJob'
@@ -1183,14 +947,6 @@ class ComprehendMedical {
   Future<StopRxNormInferenceJobResponse> stopRxNormInferenceJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ComprehendMedical_20181030.StopRxNormInferenceJob'

--- a/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
+++ b/generated/aws_compute_optimizer_api/lib/compute-optimizer-2019-11-01.dart
@@ -220,7 +220,6 @@ class ComputeOptimizer {
     List<Filter>? filters,
     bool? includeMemberAccounts,
   }) async {
-    ArgumentError.checkNotNull(s3DestinationConfig, 's3DestinationConfig');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -335,7 +334,6 @@ class ComputeOptimizer {
     List<Filter>? filters,
     bool? includeMemberAccounts,
   }) async {
-    ArgumentError.checkNotNull(s3DestinationConfig, 's3DestinationConfig');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'ComputeOptimizerService.ExportEC2InstanceRecommendations'
@@ -629,11 +627,6 @@ class ComputeOptimizer {
     required DateTime startTime,
     required MetricStatistic stat,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    ArgumentError.checkNotNull(period, 'period');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(stat, 'stat');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target':
@@ -854,7 +847,6 @@ class ComputeOptimizer {
     required Status status,
     bool? includeMemberAccounts,
   }) async {
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'ComputeOptimizerService.UpdateEnrollmentStatus'

--- a/generated/aws_configservice_api/lib/config-2014-11-12.dart
+++ b/generated/aws_configservice_api/lib/config-2014-11-12.dart
@@ -84,16 +84,6 @@ class ConfigService {
     required String configurationAggregatorName,
     required List<AggregateResourceIdentifier> resourceIdentifiers,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceIdentifiers, 'resourceIdentifiers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.BatchGetAggregateResourceConfig'
@@ -138,7 +128,6 @@ class ConfigService {
   Future<BatchGetResourceConfigResponse> batchGetResourceConfig({
     required List<ResourceKey> resourceKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceKeys, 'resourceKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.BatchGetResourceConfig'
@@ -171,15 +160,6 @@ class ConfigService {
     required String authorizedAccountId,
     required String authorizedAwsRegion,
   }) async {
-    ArgumentError.checkNotNull(authorizedAccountId, 'authorizedAccountId');
-    ArgumentError.checkNotNull(authorizedAwsRegion, 'authorizedAwsRegion');
-    _s.validateStringLength(
-      'authorizedAwsRegion',
-      authorizedAwsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteAggregationAuthorization'
@@ -216,14 +196,6 @@ class ConfigService {
   Future<void> deleteConfigRule({
     required String configRuleName,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteConfigRule'
@@ -250,15 +222,6 @@ class ConfigService {
   Future<void> deleteConfigurationAggregator({
     required String configurationAggregatorName,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteConfigurationAggregator'
@@ -296,15 +259,6 @@ class ConfigService {
   Future<void> deleteConfigurationRecorder({
     required String configurationRecorderName,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationRecorderName, 'configurationRecorderName');
-    _s.validateStringLength(
-      'configurationRecorderName',
-      configurationRecorderName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteConfigurationRecorder'
@@ -337,14 +291,6 @@ class ConfigService {
   Future<void> deleteConformancePack({
     required String conformancePackName,
   }) async {
-    ArgumentError.checkNotNull(conformancePackName, 'conformancePackName');
-    _s.validateStringLength(
-      'conformancePackName',
-      conformancePackName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteConformancePack'
@@ -375,14 +321,6 @@ class ConfigService {
   Future<void> deleteDeliveryChannel({
     required String deliveryChannelName,
   }) async {
-    ArgumentError.checkNotNull(deliveryChannelName, 'deliveryChannelName');
-    _s.validateStringLength(
-      'deliveryChannelName',
-      deliveryChannelName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteDeliveryChannel'
@@ -413,14 +351,6 @@ class ConfigService {
   Future<void> deleteEvaluationResults({
     required String configRuleName,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteEvaluationResults'
@@ -457,15 +387,6 @@ class ConfigService {
   Future<void> deleteOrganizationConfigRule({
     required String organizationConfigRuleName,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConfigRuleName, 'organizationConfigRuleName');
-    _s.validateStringLength(
-      'organizationConfigRuleName',
-      organizationConfigRuleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteOrganizationConfigRule'
@@ -504,15 +425,6 @@ class ConfigService {
   Future<void> deleteOrganizationConformancePack({
     required String organizationConformancePackName,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConformancePackName, 'organizationConformancePackName');
-    _s.validateStringLength(
-      'organizationConformancePackName',
-      organizationConformancePackName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteOrganizationConformancePack'
@@ -543,15 +455,6 @@ class ConfigService {
     required String requesterAccountId,
     required String requesterAwsRegion,
   }) async {
-    ArgumentError.checkNotNull(requesterAccountId, 'requesterAccountId');
-    ArgumentError.checkNotNull(requesterAwsRegion, 'requesterAwsRegion');
-    _s.validateStringLength(
-      'requesterAwsRegion',
-      requesterAwsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeletePendingAggregationRequest'
@@ -585,14 +488,6 @@ class ConfigService {
     required String configRuleName,
     String? resourceType,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteRemediationConfiguration'
@@ -631,15 +526,6 @@ class ConfigService {
     required String configRuleName,
     required List<RemediationExceptionResourceKey> resourceKeys,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceKeys, 'resourceKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteRemediationExceptions'
@@ -676,22 +562,6 @@ class ConfigService {
     required String resourceId,
     required String resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      768,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      196,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteResourceConfig'
@@ -719,15 +589,6 @@ class ConfigService {
   Future<void> deleteRetentionConfiguration({
     required String retentionConfigurationName,
   }) async {
-    ArgumentError.checkNotNull(
-        retentionConfigurationName, 'retentionConfigurationName');
-    _s.validateStringLength(
-      'retentionConfigurationName',
-      retentionConfigurationName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteRetentionConfiguration'
@@ -754,14 +615,6 @@ class ConfigService {
   Future<void> deleteStoredQuery({
     required String queryName,
   }) async {
-    ArgumentError.checkNotNull(queryName, 'queryName');
-    _s.validateStringLength(
-      'queryName',
-      queryName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeleteStoredQuery'
@@ -805,14 +658,6 @@ class ConfigService {
   Future<DeliverConfigSnapshotResponse> deliverConfigSnapshot({
     required String deliveryChannelName,
   }) async {
-    ArgumentError.checkNotNull(deliveryChannelName, 'deliveryChannelName');
-    _s.validateStringLength(
-      'deliveryChannelName',
-      deliveryChannelName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DeliverConfigSnapshot'
@@ -863,15 +708,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1095,18 +931,6 @@ class ConfigService {
       0,
       100,
     );
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      768,
-    );
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DescribeComplianceByResource'
@@ -1267,15 +1091,6 @@ class ConfigService {
     String? nextToken,
     List<AggregatedSourceStatusType>? updateStatus,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1462,14 +1277,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(conformancePackName, 'conformancePackName');
-    _s.validateStringLength(
-      'conformancePackName',
-      conformancePackName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1969,7 +1776,6 @@ class ConfigService {
       describeRemediationConfigurations({
     required List<String> configRuleNames,
   }) async {
-    ArgumentError.checkNotNull(configRuleNames, 'configRuleNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.DescribeRemediationConfigurations'
@@ -2030,14 +1836,6 @@ class ConfigService {
     String? nextToken,
     List<RemediationExceptionResourceKey>? resourceKeys,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2094,14 +1892,6 @@ class ConfigService {
     String? nextToken,
     List<ResourceKey>? resourceKeys,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2232,32 +2022,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(awsRegion, 'awsRegion');
-    _s.validateStringLength(
-      'awsRegion',
-      awsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2328,15 +2092,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2407,15 +2162,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2462,16 +2208,6 @@ class ConfigService {
     required String configurationAggregatorName,
     required AggregateResourceIdentifier resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.GetAggregateResourceConfig'
@@ -2524,14 +2260,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2588,22 +2316,6 @@ class ConfigService {
     List<ComplianceType>? complianceTypes,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      768,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.GetComplianceDetailsByResource'
@@ -2710,14 +2422,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(conformancePackName, 'conformancePackName');
-    _s.validateStringLength(
-      'conformancePackName',
-      conformancePackName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2768,7 +2472,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(conformancePackNames, 'conformancePackNames');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2934,15 +2637,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConfigRuleName, 'organizationConfigRuleName');
-    _s.validateStringLength(
-      'organizationConfigRuleName',
-      organizationConfigRuleName,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -3003,15 +2697,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConformancePackName, 'organizationConformancePackName');
-    _s.validateStringLength(
-      'organizationConformancePackName',
-      organizationConformancePackName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -3104,15 +2789,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      768,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     _s.validateNumRange(
       'limit',
       limit,
@@ -3155,14 +2831,6 @@ class ConfigService {
   Future<GetStoredQueryResponse> getStoredQuery({
     required String queryName,
   }) async {
-    ArgumentError.checkNotNull(queryName, 'queryName');
-    _s.validateStringLength(
-      'queryName',
-      queryName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.GetStoredQuery'
@@ -3223,16 +2891,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     _s.validateNumRange(
       'limit',
       limit,
@@ -3316,7 +2974,6 @@ class ConfigService {
     List<String>? resourceIds,
     String? resourceName,
   }) async {
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     _s.validateNumRange(
       'limit',
       limit,
@@ -3414,14 +3071,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1000,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -3466,15 +3115,6 @@ class ConfigService {
     required String authorizedAwsRegion,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(authorizedAccountId, 'authorizedAccountId');
-    ArgumentError.checkNotNull(authorizedAwsRegion, 'authorizedAwsRegion');
-    _s.validateStringLength(
-      'authorizedAwsRegion',
-      authorizedAwsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutAggregationAuthorization'
@@ -3554,7 +3194,6 @@ class ConfigService {
     required ConfigRule configRule,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(configRule, 'configRule');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutConfigRule'
@@ -3609,15 +3248,6 @@ class ConfigService {
     OrganizationAggregationSource? organizationAggregationSource,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutConfigurationAggregator'
@@ -3667,7 +3297,6 @@ class ConfigService {
   Future<void> putConfigurationRecorder({
     required ConfigurationRecorder configurationRecorder,
   }) async {
-    ArgumentError.checkNotNull(configurationRecorder, 'configurationRecorder');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutConfigurationRecorder'
@@ -3742,38 +3371,6 @@ class ConfigService {
     String? templateBody,
     String? templateS3Uri,
   }) async {
-    ArgumentError.checkNotNull(conformancePackName, 'conformancePackName');
-    _s.validateStringLength(
-      'conformancePackName',
-      conformancePackName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deliveryS3Bucket',
-      deliveryS3Bucket,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'deliveryS3KeyPrefix',
-      deliveryS3KeyPrefix,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      51200,
-    );
-    _s.validateStringLength(
-      'templateS3Uri',
-      templateS3Uri,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutConformancePack'
@@ -3829,7 +3426,6 @@ class ConfigService {
   Future<void> putDeliveryChannel({
     required DeliveryChannel deliveryChannel,
   }) async {
-    ArgumentError.checkNotNull(deliveryChannel, 'deliveryChannel');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutDeliveryChannel'
@@ -3878,7 +3474,6 @@ class ConfigService {
     List<Evaluation>? evaluations,
     bool? testMode,
   }) async {
-    ArgumentError.checkNotNull(resultToken, 'resultToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutEvaluations'
@@ -3906,15 +3501,6 @@ class ConfigService {
     required String configRuleName,
     required ExternalEvaluation externalEvaluation,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(externalEvaluation, 'externalEvaluation');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutExternalEvaluation'
@@ -4001,15 +3587,6 @@ class ConfigService {
     OrganizationCustomRuleMetadata? organizationCustomRuleMetadata,
     OrganizationManagedRuleMetadata? organizationManagedRuleMetadata,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConfigRuleName, 'organizationConfigRuleName');
-    _s.validateStringLength(
-      'organizationConfigRuleName',
-      organizationConfigRuleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutOrganizationConfigRule'
@@ -4121,39 +3698,6 @@ class ConfigService {
     String? templateBody,
     String? templateS3Uri,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationConformancePackName, 'organizationConformancePackName');
-    _s.validateStringLength(
-      'organizationConformancePackName',
-      organizationConformancePackName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deliveryS3Bucket',
-      deliveryS3Bucket,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'deliveryS3KeyPrefix',
-      deliveryS3KeyPrefix,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      51200,
-    );
-    _s.validateStringLength(
-      'templateS3Uri',
-      templateS3Uri,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutOrganizationConformancePack'
@@ -4204,8 +3748,6 @@ class ConfigService {
   Future<PutRemediationConfigurationsResponse> putRemediationConfigurations({
     required List<RemediationConfiguration> remediationConfigurations,
   }) async {
-    ArgumentError.checkNotNull(
-        remediationConfigurations, 'remediationConfigurations');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutRemediationConfigurations'
@@ -4257,21 +3799,6 @@ class ConfigService {
     DateTime? expirationTime,
     String? message,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceKeys, 'resourceKeys');
-    _s.validateStringLength(
-      'message',
-      message,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutRemediationExceptions'
@@ -4352,31 +3879,6 @@ class ConfigService {
     String? resourceName,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(configuration, 'configuration');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      768,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      196,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaVersionId, 'schemaVersionId');
-    _s.validateStringLength(
-      'schemaVersionId',
-      schemaVersionId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutResourceConfig'
@@ -4420,7 +3922,6 @@ class ConfigService {
   Future<PutRetentionConfigurationResponse> putRetentionConfiguration({
     required int retentionPeriodInDays,
   }) async {
-    ArgumentError.checkNotNull(retentionPeriodInDays, 'retentionPeriodInDays');
     _s.validateNumRange(
       'retentionPeriodInDays',
       retentionPeriodInDays,
@@ -4464,7 +3965,6 @@ class ConfigService {
     required StoredQuery storedQuery,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(storedQuery, 'storedQuery');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.PutStoredQuery'
@@ -4521,23 +4021,6 @@ class ConfigService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationAggregatorName, 'configurationAggregatorName');
-    _s.validateStringLength(
-      'configurationAggregatorName',
-      configurationAggregatorName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(expression, 'expression');
-    _s.validateStringLength(
-      'expression',
-      expression,
-      1,
-      4096,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -4598,14 +4081,6 @@ class ConfigService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(expression, 'expression');
-    _s.validateStringLength(
-      'expression',
-      expression,
-      1,
-      4096,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -4714,15 +4189,6 @@ class ConfigService {
   Future<void> startConfigurationRecorder({
     required String configurationRecorderName,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationRecorderName, 'configurationRecorderName');
-    _s.validateStringLength(
-      'configurationRecorderName',
-      configurationRecorderName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.StartConfigurationRecorder'
@@ -4762,15 +4228,6 @@ class ConfigService {
     required String configRuleName,
     required List<ResourceKey> resourceKeys,
   }) async {
-    ArgumentError.checkNotNull(configRuleName, 'configRuleName');
-    _s.validateStringLength(
-      'configRuleName',
-      configRuleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceKeys, 'resourceKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.StartRemediationExecution'
@@ -4801,15 +4258,6 @@ class ConfigService {
   Future<void> stopConfigurationRecorder({
     required String configurationRecorderName,
   }) async {
-    ArgumentError.checkNotNull(
-        configurationRecorderName, 'configurationRecorderName');
-    _s.validateStringLength(
-      'configurationRecorderName',
-      configurationRecorderName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.StopConfigurationRecorder'
@@ -4847,15 +4295,6 @@ class ConfigService {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.TagResource'
@@ -4890,15 +4329,6 @@ class ConfigService {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StarlingDoveService.UntagResource'

--- a/generated/aws_connect_api/lib/connect-2017-08-08.dart
+++ b/generated/aws_connect_api/lib/connect-2017-08-08.dart
@@ -92,22 +92,6 @@ class Connect {
     required String instanceId,
     required String origin,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(origin, 'origin');
-    _s.validateStringLength(
-      'origin',
-      origin,
-      0,
-      267,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Origin': origin,
     };
@@ -154,16 +138,6 @@ class Connect {
     required InstanceStorageResourceType resourceType,
     required InstanceStorageConfig storageConfig,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(storageConfig, 'storageConfig');
     final $payload = <String, dynamic>{
       'ResourceType': resourceType.toValue(),
       'StorageConfig': storageConfig,
@@ -201,22 +175,6 @@ class Connect {
     required String functionArn,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(functionArn, 'functionArn');
-    _s.validateStringLength(
-      'functionArn',
-      functionArn,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FunctionArn': functionArn,
     };
@@ -252,15 +210,6 @@ class Connect {
     required String instanceId,
     required LexBot lexBot,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lexBot, 'lexBot');
     final $payload = <String, dynamic>{
       'LexBot': lexBot,
     };
@@ -293,16 +242,6 @@ class Connect {
     required List<RoutingProfileQueueConfig> queueConfigs,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queueConfigs, 'queueConfigs');
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final $payload = <String, dynamic>{
       'QueueConfigs': queueConfigs,
     };
@@ -337,22 +276,6 @@ class Connect {
     required String instanceId,
     required String key,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1024,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Key': key,
     };
@@ -408,24 +331,6 @@ class Connect {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'Content': content,
       'Name': name,
@@ -481,28 +386,6 @@ class Connect {
     String? directoryId,
     String? instanceAlias,
   }) async {
-    ArgumentError.checkNotNull(
-        identityManagementType, 'identityManagementType');
-    ArgumentError.checkNotNull(inboundCallsEnabled, 'inboundCallsEnabled');
-    ArgumentError.checkNotNull(outboundCallsEnabled, 'outboundCallsEnabled');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      12,
-      12,
-    );
-    _s.validateStringLength(
-      'instanceAlias',
-      instanceAlias,
-      1,
-      62,
-    );
     final $payload = <String, dynamic>{
       'IdentityManagementType': identityManagementType.toValue(),
       'InboundCallsEnabled': inboundCallsEnabled,
@@ -556,33 +439,6 @@ class Connect {
     required String sourceApplicationUrl,
     required SourceType sourceType,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(integrationArn, 'integrationArn');
-    ArgumentError.checkNotNull(integrationType, 'integrationType');
-    ArgumentError.checkNotNull(sourceApplicationName, 'sourceApplicationName');
-    _s.validateStringLength(
-      'sourceApplicationName',
-      sourceApplicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceApplicationUrl, 'sourceApplicationUrl');
-    _s.validateStringLength(
-      'sourceApplicationUrl',
-      sourceApplicationUrl,
-      1,
-      2000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceType, 'sourceType');
     final $payload = <String, dynamic>{
       'IntegrationArn': integrationArn,
       'IntegrationType': integrationType.toValue(),
@@ -634,29 +490,6 @@ class Connect {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      127,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quickConnectConfig, 'quickConnectConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      250,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'QuickConnectConfig': quickConnectConfig,
@@ -713,33 +546,6 @@ class Connect {
     List<RoutingProfileQueueConfig>? queueConfigs,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        defaultOutboundQueueId, 'defaultOutboundQueueId');
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      250,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mediaConcurrencies, 'mediaConcurrencies');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      127,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DefaultOutboundQueueId': defaultOutboundQueueId,
       'Description': description,
@@ -782,24 +588,6 @@ class Connect {
     required String integrationAssociationId,
     required UseCaseType useCaseType,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        integrationAssociationId, 'integrationAssociationId');
-    _s.validateStringLength(
-      'integrationAssociationId',
-      integrationAssociationId,
-      1,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(useCaseType, 'useCaseType');
     final $payload = <String, dynamic>{
       'UseCaseType': useCaseType.toValue(),
     };
@@ -883,25 +671,6 @@ class Connect {
     String? password,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(phoneConfig, 'phoneConfig');
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
-    ArgumentError.checkNotNull(securityProfileIds, 'securityProfileIds');
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'PhoneConfig': phoneConfig,
       'RoutingProfileId': routingProfileId,
@@ -947,15 +716,6 @@ class Connect {
     required String name,
     String? parentGroupId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'Name': name,
       if (parentGroupId != null) 'ParentGroupId': parentGroupId,
@@ -983,14 +743,6 @@ class Connect {
   Future<void> deleteInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1019,23 +771,6 @@ class Connect {
     required String instanceId,
     required String integrationAssociationId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        integrationAssociationId, 'integrationAssociationId');
-    _s.validateStringLength(
-      'integrationAssociationId',
-      integrationAssociationId,
-      1,
-      200,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1065,15 +800,6 @@ class Connect {
     required String instanceId,
     required String quickConnectId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quickConnectId, 'quickConnectId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1106,31 +832,6 @@ class Connect {
     required String integrationAssociationId,
     required String useCaseId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        integrationAssociationId, 'integrationAssociationId');
-    _s.validateStringLength(
-      'integrationAssociationId',
-      integrationAssociationId,
-      1,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(useCaseId, 'useCaseId');
-    _s.validateStringLength(
-      'useCaseId',
-      useCaseId,
-      1,
-      200,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1163,15 +864,6 @@ class Connect {
     required String instanceId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1200,15 +892,6 @@ class Connect {
     required String hierarchyGroupId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(hierarchyGroupId, 'hierarchyGroupId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1240,22 +923,6 @@ class Connect {
     required String contactFlowId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1287,14 +954,6 @@ class Connect {
   Future<DescribeInstanceResponse> describeInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1324,15 +983,6 @@ class Connect {
     required InstanceAttributeType attributeType,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(attributeType, 'attributeType');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1369,23 +1019,6 @@ class Connect {
     required String instanceId,
     required InstanceStorageResourceType resourceType,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    _s.validateStringLength(
-      'associationId',
-      associationId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final $query = <String, List<String>>{
       'resourceType': [resourceType.toValue()],
     };
@@ -1420,15 +1053,6 @@ class Connect {
     required String instanceId,
     required String quickConnectId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quickConnectId, 'quickConnectId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1456,15 +1080,6 @@ class Connect {
     required String instanceId,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1494,15 +1109,6 @@ class Connect {
     required String instanceId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1530,15 +1136,6 @@ class Connect {
     required String hierarchyGroupId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(hierarchyGroupId, 'hierarchyGroupId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1564,14 +1161,6 @@ class Connect {
       describeUserHierarchyStructure({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1602,22 +1191,6 @@ class Connect {
     required String instanceId,
     required String origin,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(origin, 'origin');
-    _s.validateStringLength(
-      'origin',
-      origin,
-      0,
-      267,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'origin': [origin],
     };
@@ -1657,23 +1230,6 @@ class Connect {
     required String instanceId,
     required InstanceStorageResourceType resourceType,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    _s.validateStringLength(
-      'associationId',
-      associationId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final $query = <String, List<String>>{
       'resourceType': [resourceType.toValue()],
     };
@@ -1708,22 +1264,6 @@ class Connect {
     required String functionArn,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(functionArn, 'functionArn');
-    _s.validateStringLength(
-      'functionArn',
-      functionArn,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'functionArn': [functionArn],
     };
@@ -1762,30 +1302,6 @@ class Connect {
     required String instanceId,
     required String lexRegion,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      0,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lexRegion, 'lexRegion');
-    _s.validateStringLength(
-      'lexRegion',
-      lexRegion,
-      0,
-      60,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'botName': [botName],
       'lexRegion': [lexRegion],
@@ -1820,16 +1336,6 @@ class Connect {
     required List<RoutingProfileQueueReference> queueReferences,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queueReferences, 'queueReferences');
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final $payload = <String, dynamic>{
       'QueueReferences': queueReferences,
     };
@@ -1863,22 +1369,6 @@ class Connect {
     required String associationId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    _s.validateStringLength(
-      'associationId',
-      associationId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1903,22 +1393,6 @@ class Connect {
     required String initialContactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2064,16 +1538,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(currentMetrics, 'currentMetrics');
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2111,14 +1575,6 @@ class Connect {
   Future<GetFederationTokenResponse> getFederationToken({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2305,18 +1761,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(historicalMetrics, 'historicalMetrics');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2368,14 +1812,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2432,14 +1868,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2490,14 +1918,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2544,14 +1964,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2602,15 +2014,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2699,14 +2102,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2754,14 +2149,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2809,14 +2196,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2873,14 +2252,6 @@ class Connect {
     List<PhoneNumberCountryCode>? phoneNumberCountryCodes,
     List<PhoneNumberType>? phoneNumberTypes,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2929,14 +2300,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2988,14 +2351,6 @@ class Connect {
     String? nextToken,
     List<QueueType>? queueTypes,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3050,14 +2405,6 @@ class Connect {
     String? nextToken,
     List<QuickConnectType>? quickConnectTypes,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3106,15 +2453,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3165,14 +2503,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3220,14 +2550,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3275,14 +2597,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3322,7 +2636,6 @@ class Connect {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3360,23 +2673,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        integrationAssociationId, 'integrationAssociationId');
-    _s.validateStringLength(
-      'integrationAssociationId',
-      integrationAssociationId,
-      1,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3425,14 +2721,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3477,14 +2765,6 @@ class Connect {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3528,30 +2808,6 @@ class Connect {
     required String initialContactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ContactId': contactId,
       'InitialContactId': initialContactId,
@@ -3639,29 +2895,6 @@ class Connect {
     String? clientToken,
     ChatMessage? initialMessage,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(participantDetails, 'participantDetails');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       'ContactFlowId': contactFlowId,
       'InstanceId': instanceId,
@@ -3717,32 +2950,6 @@ class Connect {
     required String instanceId,
     required VoiceRecordingConfiguration voiceRecordingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        voiceRecordingConfiguration, 'voiceRecordingConfiguration');
     final $payload = <String, dynamic>{
       'ContactId': contactId,
       'InitialContactId': initialContactId,
@@ -3835,30 +3042,6 @@ class Connect {
     String? queueId,
     String? sourcePhoneNumber,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        destinationPhoneNumber, 'destinationPhoneNumber');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       'ContactFlowId': contactFlowId,
       'DestinationPhoneNumber': destinationPhoneNumber,
@@ -3936,48 +3119,6 @@ class Connect {
     String? previousContactId,
     Map<String, Reference>? references,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      4096,
-    );
-    _s.validateStringLength(
-      'previousContactId',
-      previousContactId,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'ContactFlowId': contactFlowId,
       'InstanceId': instanceId,
@@ -4014,22 +3155,6 @@ class Connect {
     required String contactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ContactId': contactId,
       'InstanceId': instanceId,
@@ -4070,30 +3195,6 @@ class Connect {
     required String initialContactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ContactId': contactId,
       'InitialContactId': initialContactId,
@@ -4135,30 +3236,6 @@ class Connect {
     required String initialContactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ContactId': contactId,
       'InitialContactId': initialContactId,
@@ -4198,8 +3275,6 @@ class Connect {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -4228,8 +3303,6 @@ class Connect {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -4289,23 +3362,6 @@ class Connect {
     required String initialContactId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(initialContactId, 'initialContactId');
-    _s.validateStringLength(
-      'initialContactId',
-      initialContactId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Attributes': attributes,
       'InitialContactId': initialContactId,
@@ -4349,23 +3405,6 @@ class Connect {
     required String content,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Content': content,
     };
@@ -4408,28 +3447,6 @@ class Connect {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(contactFlowId, 'contactFlowId');
-    _s.validateStringLength(
-      'contactFlowId',
-      contactFlowId,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -4467,23 +3484,6 @@ class Connect {
     required String instanceId,
     required String value,
   }) async {
-    ArgumentError.checkNotNull(attributeType, 'attributeType');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(value, 'value');
-    _s.validateStringLength(
-      'value',
-      value,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Value': value,
     };
@@ -4523,24 +3523,6 @@ class Connect {
     required InstanceStorageResourceType resourceType,
     required InstanceStorageConfig storageConfig,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    _s.validateStringLength(
-      'associationId',
-      associationId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(storageConfig, 'storageConfig');
     final $query = <String, List<String>>{
       'resourceType': [resourceType.toValue()],
     };
@@ -4581,16 +3563,6 @@ class Connect {
     required QuickConnectConfig quickConnectConfig,
     required String quickConnectId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quickConnectConfig, 'quickConnectConfig');
-    ArgumentError.checkNotNull(quickConnectId, 'quickConnectId');
     final $payload = <String, dynamic>{
       'QuickConnectConfig': quickConnectConfig,
     };
@@ -4633,27 +3605,6 @@ class Connect {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quickConnectId, 'quickConnectId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      250,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      127,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -4689,16 +3640,6 @@ class Connect {
     required List<MediaConcurrency> mediaConcurrencies,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mediaConcurrencies, 'mediaConcurrencies');
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final $payload = <String, dynamic>{
       'MediaConcurrencies': mediaConcurrencies,
     };
@@ -4732,17 +3673,6 @@ class Connect {
     required String instanceId,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(
-        defaultOutboundQueueId, 'defaultOutboundQueueId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final $payload = <String, dynamic>{
       'DefaultOutboundQueueId': defaultOutboundQueueId,
     };
@@ -4784,27 +3714,6 @@ class Connect {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      250,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      127,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -4842,16 +3751,6 @@ class Connect {
     required List<RoutingProfileQueueConfig> queueConfigs,
     required String routingProfileId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queueConfigs, 'queueConfigs');
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
     final $payload = <String, dynamic>{
       'QueueConfigs': queueConfigs,
     };
@@ -4885,15 +3784,6 @@ class Connect {
     required String userId,
     String? hierarchyGroupId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       if (hierarchyGroupId != null) 'HierarchyGroupId': hierarchyGroupId,
     };
@@ -4928,16 +3818,6 @@ class Connect {
     required String instanceId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(hierarchyGroupId, 'hierarchyGroupId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'Name': name,
     };
@@ -4969,15 +3849,6 @@ class Connect {
     required HierarchyStructureUpdate hierarchyStructure,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(hierarchyStructure, 'hierarchyStructure');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'HierarchyStructure': hierarchyStructure,
     };
@@ -5023,16 +3894,6 @@ class Connect {
     required String instanceId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(identityInfo, 'identityInfo');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       'IdentityInfo': identityInfo,
     };
@@ -5066,16 +3927,6 @@ class Connect {
     required UserPhoneConfig phoneConfig,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(phoneConfig, 'phoneConfig');
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       'PhoneConfig': phoneConfig,
     };
@@ -5109,16 +3960,6 @@ class Connect {
     required String routingProfileId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingProfileId, 'routingProfileId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       'RoutingProfileId': routingProfileId,
     };
@@ -5152,16 +3993,6 @@ class Connect {
     required List<String> securityProfileIds,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(securityProfileIds, 'securityProfileIds');
-    ArgumentError.checkNotNull(userId, 'userId');
     final $payload = <String, dynamic>{
       'SecurityProfileIds': securityProfileIds,
     };

--- a/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
+++ b/generated/aws_connectparticipant_api/lib/connectparticipant-2018-09-07.dart
@@ -79,21 +79,6 @@ class ConnectParticipant {
     required String connectionToken,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(attachmentIds, 'attachmentIds');
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      500,
-    );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
     };
@@ -152,15 +137,6 @@ class ConnectParticipant {
     required String participantToken,
     required List<ConnectionType> type,
   }) async {
-    ArgumentError.checkNotNull(participantToken, 'participantToken');
-    _s.validateStringLength(
-      'participantToken',
-      participantToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'X-Amz-Bearer': participantToken.toString(),
     };
@@ -199,20 +175,6 @@ class ConnectParticipant {
     required String connectionToken,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
     };
@@ -245,22 +207,6 @@ class ConnectParticipant {
     required String attachmentId,
     required String connectionToken,
   }) async {
-    ArgumentError.checkNotNull(attachmentId, 'attachmentId');
-    _s.validateStringLength(
-      'attachmentId',
-      attachmentId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
     };
@@ -322,31 +268,11 @@ class ConnectParticipant {
     SortKey? sortOrder,
     StartPosition? startPosition,
   }) async {
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'contactId',
-      contactId,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
@@ -409,34 +335,6 @@ class ConnectParticipant {
     String? clientToken,
     String? content,
   }) async {
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
     };
@@ -486,36 +384,6 @@ class ConnectParticipant {
     required String contentType,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      500,
-    );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),
     };
@@ -567,43 +435,12 @@ class ConnectParticipant {
     required String contentType,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(attachmentName, 'attachmentName');
-    _s.validateStringLength(
-      'attachmentName',
-      attachmentName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(attachmentSizeInBytes, 'attachmentSizeInBytes');
     _s.validateNumRange(
       'attachmentSizeInBytes',
       attachmentSizeInBytes,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(connectionToken, 'connectionToken');
-    _s.validateStringLength(
-      'connectionToken',
-      connectionToken,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      500,
     );
     final headers = <String, String>{
       'X-Amz-Bearer': connectionToken.toString(),

--- a/generated/aws_cur_api/lib/cur-2017-01-06.dart
+++ b/generated/aws_cur_api/lib/cur-2017-01-06.dart
@@ -76,12 +76,6 @@ class CostandUsageReportService {
   Future<DeleteReportDefinitionResponse> deleteReportDefinition({
     String? reportName,
   }) async {
-    _s.validateStringLength(
-      'reportName',
-      reportName,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrigamiServiceGatewayService.DeleteReportDefinition'
@@ -113,12 +107,6 @@ class CostandUsageReportService {
       5,
       5,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -147,15 +135,6 @@ class CostandUsageReportService {
     required ReportDefinition reportDefinition,
     required String reportName,
   }) async {
-    ArgumentError.checkNotNull(reportDefinition, 'reportDefinition');
-    ArgumentError.checkNotNull(reportName, 'reportName');
-    _s.validateStringLength(
-      'reportName',
-      reportName,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrigamiServiceGatewayService.ModifyReportDefinition'
@@ -186,7 +165,6 @@ class CostandUsageReportService {
   Future<void> putReportDefinition({
     required ReportDefinition reportDefinition,
   }) async {
-    ArgumentError.checkNotNull(reportDefinition, 'reportDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrigamiServiceGatewayService.PutReportDefinition'

--- a/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
+++ b/generated/aws_dataexchange_api/lib/dataexchange-2017-07-25.dart
@@ -82,7 +82,6 @@ class DataExchange {
   Future<void> cancelJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -122,9 +121,6 @@ class DataExchange {
     required String name,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(assetType, 'assetType');
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'AssetType': assetType.toValue(),
       'Description': description,
@@ -157,8 +153,6 @@ class DataExchange {
     required RequestDetails details,
     required Type type,
   }) async {
-    ArgumentError.checkNotNull(details, 'details');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'Details': details,
       'Type': type.toValue(),
@@ -197,13 +191,6 @@ class DataExchange {
     String? comment,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      16384,
-    );
     final $payload = <String, dynamic>{
       if (comment != null) 'Comment': comment,
       if (tags != null) 'Tags': tags,
@@ -239,9 +226,6 @@ class DataExchange {
     required String dataSetId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(assetId, 'assetId');
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -265,7 +249,6 @@ class DataExchange {
   Future<void> deleteDataSet({
     required String dataSetId,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -292,8 +275,6 @@ class DataExchange {
     required String dataSetId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -323,9 +304,6 @@ class DataExchange {
     required String dataSetId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(assetId, 'assetId');
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -348,7 +326,6 @@ class DataExchange {
   Future<GetDataSetResponse> getDataSet({
     required String dataSetId,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -370,7 +347,6 @@ class DataExchange {
   Future<GetJobResponse> getJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -396,8 +372,6 @@ class DataExchange {
     required String dataSetId,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -430,7 +404,6 @@ class DataExchange {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -569,8 +542,6 @@ class DataExchange {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -599,7 +570,6 @@ class DataExchange {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -623,7 +593,6 @@ class DataExchange {
   Future<void> startJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final response = await _protocol.send(
       payload: null,
       method: 'PATCH',
@@ -643,8 +612,6 @@ class DataExchange {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -667,8 +634,6 @@ class DataExchange {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -709,10 +674,6 @@ class DataExchange {
     required String name,
     required String revisionId,
   }) async {
-    ArgumentError.checkNotNull(assetId, 'assetId');
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
     final $payload = <String, dynamic>{
       'Name': name,
     };
@@ -747,7 +708,6 @@ class DataExchange {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -789,14 +749,6 @@ class DataExchange {
     String? comment,
     bool? finalized,
   }) async {
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      16384,
-    );
     final $payload = <String, dynamic>{
       if (comment != null) 'Comment': comment,
       if (finalized != null) 'Finalized': finalized,

--- a/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
+++ b/generated/aws_datapipeline_api/lib/datapipeline-2012-10-29.dart
@@ -97,14 +97,6 @@ class DataPipeline {
     List<ParameterValue>? parameterValues,
     DateTime? startTimestamp,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.ActivatePipeline'
@@ -140,15 +132,6 @@ class DataPipeline {
     required String pipelineId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.AddTags'
@@ -207,28 +190,6 @@ class DataPipeline {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uniqueId, 'uniqueId');
-    _s.validateStringLength(
-      'uniqueId',
-      uniqueId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.CreatePipeline'
@@ -274,14 +235,6 @@ class DataPipeline {
     required String pipelineId,
     bool? cancelActive,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.DeactivatePipeline'
@@ -318,14 +271,6 @@ class DataPipeline {
   Future<void> deletePipeline({
     required String pipelineId,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.DeletePipeline'
@@ -374,21 +319,6 @@ class DataPipeline {
     bool? evaluateExpressions,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(objectIds, 'objectIds');
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.DescribeObjects'
@@ -434,7 +364,6 @@ class DataPipeline {
   Future<DescribePipelinesOutput> describePipelines({
     required List<String> pipelineIds,
   }) async {
-    ArgumentError.checkNotNull(pipelineIds, 'pipelineIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.DescribePipelines'
@@ -476,30 +405,6 @@ class DataPipeline {
     required String objectId,
     required String pipelineId,
   }) async {
-    ArgumentError.checkNotNull(expression, 'expression');
-    _s.validateStringLength(
-      'expression',
-      expression,
-      0,
-      20971520,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(objectId, 'objectId');
-    _s.validateStringLength(
-      'objectId',
-      objectId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.EvaluateExpression'
@@ -541,20 +446,6 @@ class DataPipeline {
     required String pipelineId,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'version',
-      version,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.GetPipelineDefinition'
@@ -588,12 +479,6 @@ class DataPipeline {
   Future<ListPipelinesOutput> listPipelines({
     String? marker,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.ListPipelines'
@@ -659,20 +544,6 @@ class DataPipeline {
     String? hostname,
     InstanceIdentity? instanceIdentity,
   }) async {
-    ArgumentError.checkNotNull(workerGroup, 'workerGroup');
-    _s.validateStringLength(
-      'workerGroup',
-      workerGroup,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'hostname',
-      hostname,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.PollForTask'
@@ -732,15 +603,6 @@ class DataPipeline {
     List<ParameterObject>? parameterObjects,
     List<ParameterValue>? parameterValues,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pipelineObjects, 'pipelineObjects');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.PutPipelineDefinition'
@@ -800,28 +662,6 @@ class DataPipeline {
     String? marker,
     Query? query,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sphere, 'sphere');
-    _s.validateStringLength(
-      'sphere',
-      sphere,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.QueryObjects'
@@ -860,15 +700,6 @@ class DataPipeline {
     required String pipelineId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.RemoveTags'
@@ -916,14 +747,6 @@ class DataPipeline {
     required String taskId,
     List<Field>? fields,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.ReportTaskProgress'
@@ -973,26 +796,6 @@ class DataPipeline {
     String? hostname,
     String? workerGroup,
   }) async {
-    ArgumentError.checkNotNull(taskrunnerId, 'taskrunnerId');
-    _s.validateStringLength(
-      'taskrunnerId',
-      taskrunnerId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'hostname',
-      hostname,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'workerGroup',
-      workerGroup,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.ReportTaskRunnerHeartbeat'
@@ -1042,23 +845,6 @@ class DataPipeline {
     required String pipelineId,
     required String status,
   }) async {
-    ArgumentError.checkNotNull(objectIds, 'objectIds');
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    _s.validateStringLength(
-      'status',
-      status,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.SetStatus'
@@ -1123,27 +909,6 @@ class DataPipeline {
     String? errorMessage,
     String? errorStackTrace,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskStatus, 'taskStatus');
-    _s.validateStringLength(
-      'errorId',
-      errorId,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'errorStackTrace',
-      errorStackTrace,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.SetTaskStatus'
@@ -1190,15 +955,6 @@ class DataPipeline {
     List<ParameterObject>? parameterObjects,
     List<ParameterValue>? parameterValues,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'pipelineId',
-      pipelineId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pipelineObjects, 'pipelineObjects');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DataPipeline.ValidatePipelineDefinition'

--- a/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
+++ b/generated/aws_datasync_api/lib/datasync-2018-11-09.dart
@@ -69,14 +69,6 @@ class DataSync {
   Future<void> cancelTaskExecution({
     required String taskExecutionArn,
   }) async {
-    ArgumentError.checkNotNull(taskExecutionArn, 'taskExecutionArn');
-    _s.validateStringLength(
-      'taskExecutionArn',
-      taskExecutionArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CancelTaskExecution'
@@ -175,20 +167,6 @@ class DataSync {
     List<TagListEntry>? tags,
     String? vpcEndpointId,
   }) async {
-    ArgumentError.checkNotNull(activationKey, 'activationKey');
-    _s.validateStringLength(
-      'activationKey',
-      activationKey,
-      0,
-      29,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'agentName',
-      agentName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateAgent'
@@ -268,21 +246,6 @@ class DataSync {
     String? subdirectory,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(ec2Config, 'ec2Config');
-    ArgumentError.checkNotNull(efsFilesystemArn, 'efsFilesystemArn');
-    _s.validateStringLength(
-      'efsFilesystemArn',
-      efsFilesystemArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateLocationEfs'
@@ -346,43 +309,6 @@ class DataSync {
     String? subdirectory,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(fsxFilesystemArn, 'fsxFilesystemArn');
-    _s.validateStringLength(
-      'fsxFilesystemArn',
-      fsxFilesystemArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      0,
-      104,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(securityGroupArns, 'securityGroupArns');
-    ArgumentError.checkNotNull(user, 'user');
-    _s.validateStringLength(
-      'user',
-      user,
-      0,
-      104,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'domain',
-      domain,
-      0,
-      253,
-    );
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateLocationFsxWindows'
@@ -476,23 +402,6 @@ class DataSync {
     NfsMountOptions? mountOptions,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(onPremConfig, 'onPremConfig');
-    ArgumentError.checkNotNull(serverHostname, 'serverHostname');
-    _s.validateStringLength(
-      'serverHostname',
-      serverHostname,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subdirectory, 'subdirectory');
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateLocationNfs'
@@ -578,46 +487,11 @@ class DataSync {
     String? subdirectory,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(agentArns, 'agentArns');
-    ArgumentError.checkNotNull(bucketName, 'bucketName');
-    _s.validateStringLength(
-      'bucketName',
-      bucketName,
-      3,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverHostname, 'serverHostname');
-    _s.validateStringLength(
-      'serverHostname',
-      serverHostname,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accessKey',
-      accessKey,
-      8,
-      200,
-    );
-    _s.validateStringLength(
-      'secretKey',
-      secretKey,
-      8,
-      200,
-    );
     _s.validateNumRange(
       'serverPort',
       serverPort,
       1,
       65536,
-    );
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -692,21 +566,6 @@ class DataSync {
     String? subdirectory,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(s3BucketArn, 's3BucketArn');
-    _s.validateStringLength(
-      's3BucketArn',
-      s3BucketArn,
-      0,
-      156,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3Config, 's3Config');
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateLocationS3'
@@ -797,45 +656,6 @@ class DataSync {
     SmbMountOptions? mountOptions,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(agentArns, 'agentArns');
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      0,
-      104,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverHostname, 'serverHostname');
-    _s.validateStringLength(
-      'serverHostname',
-      serverHostname,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subdirectory, 'subdirectory');
-    _s.validateStringLength(
-      'subdirectory',
-      subdirectory,
-      0,
-      4096,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(user, 'user');
-    _s.validateStringLength(
-      'user',
-      user,
-      0,
-      104,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'domain',
-      domain,
-      0,
-      253,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateLocationSmb'
@@ -933,35 +753,6 @@ class DataSync {
     TaskSchedule? schedule,
     List<TagListEntry>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationLocationArn, 'destinationLocationArn');
-    _s.validateStringLength(
-      'destinationLocationArn',
-      destinationLocationArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceLocationArn, 'sourceLocationArn');
-    _s.validateStringLength(
-      'sourceLocationArn',
-      sourceLocationArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cloudWatchLogGroupArn',
-      cloudWatchLogGroupArn,
-      0,
-      562,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.CreateTask'
@@ -1003,14 +794,6 @@ class DataSync {
   Future<void> deleteAgent({
     required String agentArn,
   }) async {
-    ArgumentError.checkNotNull(agentArn, 'agentArn');
-    _s.validateStringLength(
-      'agentArn',
-      agentArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DeleteAgent'
@@ -1037,14 +820,6 @@ class DataSync {
   Future<void> deleteLocation({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DeleteLocation'
@@ -1071,14 +846,6 @@ class DataSync {
   Future<void> deleteTask({
     required String taskArn,
   }) async {
-    ArgumentError.checkNotNull(taskArn, 'taskArn');
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DeleteTask'
@@ -1108,14 +875,6 @@ class DataSync {
   Future<DescribeAgentResponse> describeAgent({
     required String agentArn,
   }) async {
-    ArgumentError.checkNotNull(agentArn, 'agentArn');
-    _s.validateStringLength(
-      'agentArn',
-      agentArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeAgent'
@@ -1145,14 +904,6 @@ class DataSync {
   Future<DescribeLocationEfsResponse> describeLocationEfs({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationEfs'
@@ -1183,14 +934,6 @@ class DataSync {
   Future<DescribeLocationFsxWindowsResponse> describeLocationFsxWindows({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationFsxWindows'
@@ -1219,14 +962,6 @@ class DataSync {
   Future<DescribeLocationNfsResponse> describeLocationNfs({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationNfs'
@@ -1258,14 +993,6 @@ class DataSync {
   Future<DescribeLocationObjectStorageResponse> describeLocationObjectStorage({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationObjectStorage'
@@ -1295,14 +1022,6 @@ class DataSync {
   Future<DescribeLocationS3Response> describeLocationS3({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationS3'
@@ -1332,14 +1051,6 @@ class DataSync {
   Future<DescribeLocationSmbResponse> describeLocationSmb({
     required String locationArn,
   }) async {
-    ArgumentError.checkNotNull(locationArn, 'locationArn');
-    _s.validateStringLength(
-      'locationArn',
-      locationArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeLocationSmb'
@@ -1368,14 +1079,6 @@ class DataSync {
   Future<DescribeTaskResponse> describeTask({
     required String taskArn,
   }) async {
-    ArgumentError.checkNotNull(taskArn, 'taskArn');
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeTask'
@@ -1404,14 +1107,6 @@ class DataSync {
   Future<DescribeTaskExecutionResponse> describeTaskExecution({
     required String taskExecutionArn,
   }) async {
-    ArgumentError.checkNotNull(taskExecutionArn, 'taskExecutionArn');
-    _s.validateStringLength(
-      'taskExecutionArn',
-      taskExecutionArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.DescribeTaskExecution'
@@ -1461,12 +1156,6 @@ class DataSync {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1520,12 +1209,6 @@ class DataSync {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.ListLocations'
@@ -1565,25 +1248,11 @@ class DataSync {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1629,18 +1298,6 @@ class DataSync {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
-    );
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      0,
-      128,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1691,12 +1348,6 @@ class DataSync {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      65535,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.ListTasks'
@@ -1745,14 +1396,6 @@ class DataSync {
     List<FilterRule>? includes,
     Options? overrideOptions,
   }) async {
-    ArgumentError.checkNotNull(taskArn, 'taskArn');
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.StartTaskExecution'
@@ -1787,15 +1430,6 @@ class DataSync {
     required String resourceArn,
     required List<TagListEntry> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.TagResource'
@@ -1827,15 +1461,6 @@ class DataSync {
     required List<String> keys,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(keys, 'keys');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.UntagResource'
@@ -1867,20 +1492,6 @@ class DataSync {
     required String agentArn,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(agentArn, 'agentArn');
-    _s.validateStringLength(
-      'agentArn',
-      agentArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.UpdateAgent'
@@ -1935,26 +1546,6 @@ class DataSync {
     Options? options,
     TaskSchedule? schedule,
   }) async {
-    ArgumentError.checkNotNull(taskArn, 'taskArn');
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cloudWatchLogGroupArn',
-      cloudWatchLogGroupArn,
-      0,
-      562,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.UpdateTask'
@@ -2000,15 +1591,6 @@ class DataSync {
     required Options options,
     required String taskExecutionArn,
   }) async {
-    ArgumentError.checkNotNull(options, 'options');
-    ArgumentError.checkNotNull(taskExecutionArn, 'taskExecutionArn');
-    _s.validateStringLength(
-      'taskExecutionArn',
-      taskExecutionArn,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'FmrsService.UpdateTaskExecution'

--- a/generated/aws_dax_api/lib/dax-2017-04-19.dart
+++ b/generated/aws_dax_api/lib/dax-2017-04-19.dart
@@ -199,10 +199,6 @@ class DAX {
     String? subnetGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(nodeType, 'nodeType');
-    ArgumentError.checkNotNull(replicationFactor, 'replicationFactor');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.CreateCluster'
@@ -256,7 +252,6 @@ class DAX {
     required String parameterGroupName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.CreateParameterGroup'
@@ -297,8 +292,6 @@ class DAX {
     required List<String> subnetIds,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(subnetGroupName, 'subnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.CreateSubnetGroup'
@@ -350,8 +343,6 @@ class DAX {
     List<String>? availabilityZones,
     List<String>? nodeIdsToRemove,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(newReplicationFactor, 'newReplicationFactor');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.DecreaseReplicationFactor'
@@ -389,7 +380,6 @@ class DAX {
   Future<DeleteClusterResponse> deleteCluster({
     required String clusterName,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.DeleteCluster'
@@ -422,7 +412,6 @@ class DAX {
   Future<DeleteParameterGroupResponse> deleteParameterGroup({
     required String parameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.DeleteParameterGroup'
@@ -456,7 +445,6 @@ class DAX {
   Future<DeleteSubnetGroupResponse> deleteSubnetGroup({
     required String subnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(subnetGroupName, 'subnetGroupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.DeleteSubnetGroup'
@@ -737,7 +725,6 @@ class DAX {
     String? nextToken,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.DescribeParameters'
@@ -833,8 +820,6 @@ class DAX {
     required int newReplicationFactor,
     List<String>? availabilityZones,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(newReplicationFactor, 'newReplicationFactor');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.IncreaseReplicationFactor'
@@ -876,7 +861,6 @@ class DAX {
     required String resourceName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.ListTags'
@@ -919,8 +903,6 @@ class DAX {
     required String clusterName,
     required String nodeId,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodeId, 'nodeId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.RebootNode'
@@ -960,8 +942,6 @@ class DAX {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.TagResource'
@@ -1002,8 +982,6 @@ class DAX {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.UntagResource'
@@ -1069,7 +1047,6 @@ class DAX {
     String? preferredMaintenanceWindow,
     List<String>? securityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.UpdateCluster'
@@ -1118,8 +1095,6 @@ class DAX {
     required String parameterGroupName,
     required List<ParameterNameValue> parameterNameValues,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    ArgumentError.checkNotNull(parameterNameValues, 'parameterNameValues');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.UpdateParameterGroup'
@@ -1160,7 +1135,6 @@ class DAX {
     String? description,
     List<String>? subnetIds,
   }) async {
-    ArgumentError.checkNotNull(subnetGroupName, 'subnetGroupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDAXV3.UpdateSubnetGroup'

--- a/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
+++ b/generated/aws_deploy_api/lib/codedeploy-2014-10-06.dart
@@ -72,8 +72,6 @@ class CodeDeploy {
     required List<String> instanceNames,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.AddTagsToOnPremisesInstances'
@@ -114,15 +112,6 @@ class CodeDeploy {
     required String applicationName,
     required List<RevisionLocation> revisions,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revisions, 'revisions');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetApplicationRevisions'
@@ -156,7 +145,6 @@ class CodeDeploy {
   Future<BatchGetApplicationsOutput> batchGetApplications({
     required List<String> applicationNames,
   }) async {
-    ArgumentError.checkNotNull(applicationNames, 'applicationNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetApplications'
@@ -195,15 +183,6 @@ class CodeDeploy {
     required String applicationName,
     required List<String> deploymentGroupNames,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deploymentGroupNames, 'deploymentGroupNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetDeploymentGroups'
@@ -251,8 +230,6 @@ class CodeDeploy {
     required String deploymentId,
     required List<String> instanceIds,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetDeploymentInstances'
@@ -373,7 +350,6 @@ class CodeDeploy {
   Future<BatchGetDeploymentsOutput> batchGetDeployments({
     required List<String> deploymentIds,
   }) async {
-    ArgumentError.checkNotNull(deploymentIds, 'deploymentIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetDeployments'
@@ -405,7 +381,6 @@ class CodeDeploy {
   Future<BatchGetOnPremisesInstancesOutput> batchGetOnPremisesInstances({
     required List<String> instanceNames,
   }) async {
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.BatchGetOnPremisesInstances'
@@ -497,14 +472,6 @@ class CodeDeploy {
     ComputePlatform? computePlatform,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.CreateApplication'
@@ -651,26 +618,6 @@ class CodeDeploy {
     TargetInstances? targetInstances,
     bool? updateOutdatedInstancesOnly,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'deploymentGroupName',
-      deploymentGroupName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.CreateDeployment'
@@ -754,14 +701,6 @@ class CodeDeploy {
     MinimumHealthyHosts? minimumHealthyHosts,
     TrafficRoutingConfig? trafficRoutingConfig,
   }) async {
-    ArgumentError.checkNotNull(deploymentConfigName, 'deploymentConfigName');
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.CreateDeploymentConfig'
@@ -929,29 +868,6 @@ class CodeDeploy {
     List<Tag>? tags,
     List<TriggerConfig>? triggerConfigurations,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deploymentGroupName, 'deploymentGroupName');
-    _s.validateStringLength(
-      'deploymentGroupName',
-      deploymentGroupName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceRoleArn, 'serviceRoleArn');
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.CreateDeploymentGroup'
@@ -1004,14 +920,6 @@ class CodeDeploy {
   Future<void> deleteApplication({
     required String applicationName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.DeleteApplication'
@@ -1045,14 +953,6 @@ class CodeDeploy {
   Future<void> deleteDeploymentConfig({
     required String deploymentConfigName,
   }) async {
-    ArgumentError.checkNotNull(deploymentConfigName, 'deploymentConfigName');
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.DeleteDeploymentConfig'
@@ -1087,22 +987,6 @@ class CodeDeploy {
     required String applicationName,
     required String deploymentGroupName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deploymentGroupName, 'deploymentGroupName');
-    _s.validateStringLength(
-      'deploymentGroupName',
-      deploymentGroupName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.DeleteDeploymentGroup'
@@ -1187,7 +1071,6 @@ class CodeDeploy {
   Future<void> deregisterOnPremisesInstance({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.DeregisterOnPremisesInstance'
@@ -1216,14 +1099,6 @@ class CodeDeploy {
   Future<GetApplicationOutput> getApplication({
     required String applicationName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetApplication'
@@ -1261,15 +1136,6 @@ class CodeDeploy {
     required String applicationName,
     required RevisionLocation revision,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revision, 'revision');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetApplicationRevision'
@@ -1307,7 +1173,6 @@ class CodeDeploy {
   Future<GetDeploymentOutput> getDeployment({
     required String deploymentId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetDeployment'
@@ -1339,14 +1204,6 @@ class CodeDeploy {
   Future<GetDeploymentConfigOutput> getDeploymentConfig({
     required String deploymentConfigName,
   }) async {
-    ArgumentError.checkNotNull(deploymentConfigName, 'deploymentConfigName');
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetDeploymentConfig'
@@ -1385,22 +1242,6 @@ class CodeDeploy {
     required String applicationName,
     required String deploymentGroupName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deploymentGroupName, 'deploymentGroupName');
-    _s.validateStringLength(
-      'deploymentGroupName',
-      deploymentGroupName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetDeploymentGroup'
@@ -1440,8 +1281,6 @@ class CodeDeploy {
     required String deploymentId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetDeploymentInstance'
@@ -1511,7 +1350,6 @@ class CodeDeploy {
   Future<GetOnPremisesInstanceOutput> getOnPremisesInstance({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.GetOnPremisesInstance'
@@ -1622,14 +1460,6 @@ class CodeDeploy {
     ApplicationRevisionSortBy? sortBy,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.ListApplicationRevisions'
@@ -1730,14 +1560,6 @@ class CodeDeploy {
     required String applicationName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.ListDeploymentGroups'
@@ -1822,7 +1644,6 @@ class CodeDeploy {
     List<InstanceType>? instanceTypeFilter,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.ListDeploymentInstances'
@@ -1986,18 +1807,6 @@ class CodeDeploy {
     List<DeploymentStatus>? includeOnlyStatuses,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'deploymentGroupName',
-      deploymentGroupName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.ListDeployments'
@@ -2133,14 +1942,6 @@ class CodeDeploy {
     required String resourceArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.ListTagsForResource'
@@ -2246,15 +2047,6 @@ class CodeDeploy {
     required RevisionLocation revision,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revision, 'revision');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.RegisterApplicationRevision'
@@ -2303,7 +2095,6 @@ class CodeDeploy {
     String? iamSessionArn,
     String? iamUserArn,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.RegisterOnPremisesInstance'
@@ -2341,8 +2132,6 @@ class CodeDeploy {
     required List<String> instanceNames,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.RemoveTagsFromOnPremisesInstances'
@@ -2413,7 +2202,6 @@ class CodeDeploy {
     required String deploymentId,
     bool? autoRollbackEnabled,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.StopDeployment'
@@ -2458,15 +2246,6 @@ class CodeDeploy {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.TagResource'
@@ -2510,15 +2289,6 @@ class CodeDeploy {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.UntagResource'
@@ -2552,18 +2322,6 @@ class CodeDeploy {
     String? applicationName,
     String? newApplicationName,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'newApplicationName',
-      newApplicationName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.UpdateApplication'
@@ -2708,35 +2466,6 @@ class CodeDeploy {
     String? serviceRoleArn,
     List<TriggerConfig>? triggerConfigurations,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentDeploymentGroupName, 'currentDeploymentGroupName');
-    _s.validateStringLength(
-      'currentDeploymentGroupName',
-      currentDeploymentGroupName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deploymentConfigName',
-      deploymentConfigName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'newDeploymentGroupName',
-      newDeploymentGroupName,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'CodeDeploy_20141006.UpdateDeploymentGroup'

--- a/generated/aws_detective_api/lib/detective-2018-10-26.dart
+++ b/generated/aws_detective_api/lib/detective-2018-10-26.dart
@@ -120,7 +120,6 @@ class Detective {
   Future<void> acceptInvitation({
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'GraphArn': graphArn,
     };
@@ -215,14 +214,6 @@ class Detective {
     required String graphArn,
     String? message,
   }) async {
-    ArgumentError.checkNotNull(accounts, 'accounts');
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
-    _s.validateStringLength(
-      'message',
-      message,
-      1,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'Accounts': accounts,
       'GraphArn': graphArn,
@@ -253,7 +244,6 @@ class Detective {
   Future<void> deleteGraph({
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'GraphArn': graphArn,
     };
@@ -286,8 +276,6 @@ class Detective {
     required List<String> accountIds,
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
       'GraphArn': graphArn,
@@ -318,7 +306,6 @@ class Detective {
   Future<void> disassociateMembership({
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'GraphArn': graphArn,
     };
@@ -350,8 +337,6 @@ class Detective {
     required List<String> accountIds,
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
       'GraphArn': graphArn,
@@ -392,12 +377,6 @@ class Detective {
       maxResults,
       1,
       200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $payload = <String, dynamic>{
       if (maxResults != null) 'MaxResults': maxResults,
@@ -444,12 +423,6 @@ class Detective {
       1,
       200,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (maxResults != null) 'MaxResults': maxResults,
       if (nextToken != null) 'NextToken': nextToken,
@@ -488,18 +461,11 @@ class Detective {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $payload = <String, dynamic>{
       'GraphArn': graphArn,
@@ -532,7 +498,6 @@ class Detective {
   Future<void> rejectInvitation({
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'GraphArn': graphArn,
     };
@@ -578,15 +543,6 @@ class Detective {
     required String accountId,
     required String graphArn,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(graphArn, 'graphArn');
     final $payload = <String, dynamic>{
       'AccountId': accountId,
       'GraphArn': graphArn,

--- a/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
+++ b/generated/aws_devicefarm_api/lib/devicefarm-2015-06-23.dart
@@ -102,29 +102,6 @@ class DeviceFarm {
     String? description,
     int? maxDevices,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rules, 'rules');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateDevicePool'
@@ -182,20 +159,6 @@ class DeviceFarm {
     bool? packageCleanup,
     bool? rebootAfterUse,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateInstanceProfile'
@@ -283,28 +246,6 @@ class DeviceFarm {
     int? uplinkJitterMs,
     int? uplinkLossPercent,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
     _s.validateNumRange(
       'downlinkLossPercent',
       downlinkLossPercent,
@@ -368,14 +309,6 @@ class DeviceFarm {
     required String name,
     int? defaultJobTimeoutMinutes,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateProject'
@@ -500,52 +433,6 @@ class DeviceFarm {
     bool? skipAppResign,
     String? sshPublicKey,
   }) async {
-    ArgumentError.checkNotNull(deviceArn, 'deviceArn');
-    _s.validateStringLength(
-      'deviceArn',
-      deviceArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'remoteRecordAppArn',
-      remoteRecordAppArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'sshPublicKey',
-      sshPublicKey,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateRemoteAccessSession'
@@ -593,20 +480,6 @@ class DeviceFarm {
     required String name,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateTestGridProject'
@@ -643,20 +516,11 @@ class DeviceFarm {
     required int expiresInSeconds,
     required String projectArn,
   }) async {
-    ArgumentError.checkNotNull(expiresInSeconds, 'expiresInSeconds');
     _s.validateNumRange(
       'expiresInSeconds',
       expiresInSeconds,
       60,
       86400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -810,29 +674,6 @@ class DeviceFarm {
     required UploadType type,
     String? contentType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateUpload'
@@ -882,36 +723,6 @@ class DeviceFarm {
     required String vpceServiceName,
     String? vpceConfigurationDescription,
   }) async {
-    ArgumentError.checkNotNull(serviceDnsName, 'serviceDnsName');
-    _s.validateStringLength(
-      'serviceDnsName',
-      serviceDnsName,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpceConfigurationName, 'vpceConfigurationName');
-    _s.validateStringLength(
-      'vpceConfigurationName',
-      vpceConfigurationName,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpceServiceName, 'vpceServiceName');
-    _s.validateStringLength(
-      'vpceServiceName',
-      vpceServiceName,
-      0,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vpceConfigurationDescription',
-      vpceConfigurationDescription,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.CreateVPCEConfiguration'
@@ -948,14 +759,6 @@ class DeviceFarm {
   Future<void> deleteDevicePool({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteDevicePool'
@@ -986,14 +789,6 @@ class DeviceFarm {
   Future<void> deleteInstanceProfile({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteInstanceProfile'
@@ -1022,14 +817,6 @@ class DeviceFarm {
   Future<void> deleteNetworkProfile({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteNetworkProfile'
@@ -1061,14 +848,6 @@ class DeviceFarm {
   Future<void> deleteProject({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteProject'
@@ -1098,14 +877,6 @@ class DeviceFarm {
   Future<void> deleteRemoteAccessSession({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteRemoteAccessSession'
@@ -1136,14 +907,6 @@ class DeviceFarm {
   Future<void> deleteRun({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteRun'
@@ -1178,14 +941,6 @@ class DeviceFarm {
   Future<void> deleteTestGridProject({
     required String projectArn,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteTestGridProject'
@@ -1215,14 +970,6 @@ class DeviceFarm {
   Future<void> deleteUpload({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteUpload'
@@ -1253,14 +1000,6 @@ class DeviceFarm {
   Future<void> deleteVPCEConfiguration({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.DeleteVPCEConfiguration'
@@ -1312,14 +1051,6 @@ class DeviceFarm {
   Future<GetDeviceResult> getDevice({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetDevice'
@@ -1352,14 +1083,6 @@ class DeviceFarm {
   Future<GetDeviceInstanceResult> getDeviceInstance({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetDeviceInstance'
@@ -1390,14 +1113,6 @@ class DeviceFarm {
   Future<GetDevicePoolResult> getDevicePool({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetDevicePool'
@@ -1504,20 +1219,6 @@ class DeviceFarm {
     ScheduleRunTest? test,
     TestType? testType,
   }) async {
-    ArgumentError.checkNotNull(devicePoolArn, 'devicePoolArn');
-    _s.validateStringLength(
-      'devicePoolArn',
-      devicePoolArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'appArn',
-      appArn,
-      32,
-      1011,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetDevicePoolCompatibility'
@@ -1552,14 +1253,6 @@ class DeviceFarm {
   Future<GetInstanceProfileResult> getInstanceProfile({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetInstanceProfile'
@@ -1590,14 +1283,6 @@ class DeviceFarm {
   Future<GetJobResult> getJob({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetJob'
@@ -1628,14 +1313,6 @@ class DeviceFarm {
   Future<GetNetworkProfileResult> getNetworkProfile({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetNetworkProfile'
@@ -1674,12 +1351,6 @@ class DeviceFarm {
   Future<GetOfferingStatusResult> getOfferingStatus({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetOfferingStatus'
@@ -1710,14 +1381,6 @@ class DeviceFarm {
   Future<GetProjectResult> getProject({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetProject'
@@ -1749,14 +1412,6 @@ class DeviceFarm {
   Future<GetRemoteAccessSessionResult> getRemoteAccessSession({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetRemoteAccessSession'
@@ -1787,14 +1442,6 @@ class DeviceFarm {
   Future<GetRunResult> getRun({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetRun'
@@ -1825,14 +1472,6 @@ class DeviceFarm {
   Future<GetSuiteResult> getSuite({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetSuite'
@@ -1863,14 +1502,6 @@ class DeviceFarm {
   Future<GetTestResult> getTest({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetTest'
@@ -1901,14 +1532,6 @@ class DeviceFarm {
   Future<GetTestGridProjectResult> getTestGridProject({
     required String projectArn,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetTestGridProject'
@@ -1961,24 +1584,6 @@ class DeviceFarm {
     String? sessionArn,
     String? sessionId,
   }) async {
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'sessionArn',
-      sessionArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'sessionId',
-      sessionId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetTestGridSession'
@@ -2011,14 +1616,6 @@ class DeviceFarm {
   Future<GetUploadResult> getUpload({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetUpload'
@@ -2050,14 +1647,6 @@ class DeviceFarm {
   Future<GetVPCEConfigurationResult> getVPCEConfiguration({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.GetVPCEConfiguration'
@@ -2095,23 +1684,6 @@ class DeviceFarm {
     required String appArn,
     required String remoteAccessSessionArn,
   }) async {
-    ArgumentError.checkNotNull(appArn, 'appArn');
-    _s.validateStringLength(
-      'appArn',
-      appArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        remoteAccessSessionArn, 'remoteAccessSessionArn');
-    _s.validateStringLength(
-      'remoteAccessSessionArn',
-      remoteAccessSessionArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.InstallToRemoteAccessSession'
@@ -2166,21 +1738,6 @@ class DeviceFarm {
     required ArtifactCategory type,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListArtifacts'
@@ -2220,12 +1777,6 @@ class DeviceFarm {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListDeviceInstances'
@@ -2278,20 +1829,6 @@ class DeviceFarm {
     String? nextToken,
     DevicePoolType? type,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListDevicePools'
@@ -2425,18 +1962,6 @@ class DeviceFarm {
     List<DeviceFilter>? filters,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListDevices'
@@ -2475,12 +2000,6 @@ class DeviceFarm {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListInstanceProfiles'
@@ -2517,20 +2036,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListJobs'
@@ -2573,20 +2078,6 @@ class DeviceFarm {
     String? nextToken,
     NetworkProfileType? type,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListNetworkProfiles'
@@ -2626,12 +2117,6 @@ class DeviceFarm {
   Future<ListOfferingPromotionsResult> listOfferingPromotions({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListOfferingPromotions'
@@ -2669,12 +2154,6 @@ class DeviceFarm {
   Future<ListOfferingTransactionsResult> listOfferingTransactions({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListOfferingTransactions'
@@ -2712,12 +2191,6 @@ class DeviceFarm {
   Future<ListOfferingsResult> listOfferings({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListOfferings'
@@ -2755,18 +2228,6 @@ class DeviceFarm {
     String? arn,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListProjects'
@@ -2804,20 +2265,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListRemoteAccessSessions'
@@ -2855,20 +2302,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListRuns'
@@ -2905,20 +2338,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListSamples'
@@ -2955,20 +2374,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListSuites'
@@ -3005,14 +2410,6 @@ class DeviceFarm {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListTagsForResource'
@@ -3050,12 +2447,6 @@ class DeviceFarm {
       maxResult,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3095,25 +2486,11 @@ class DeviceFarm {
     int? maxResult,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(sessionArn, 'sessionArn');
-    _s.validateStringLength(
-      'sessionArn',
-      sessionArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResult',
       maxResult,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3158,25 +2535,11 @@ class DeviceFarm {
     String? nextToken,
     TestGridSessionArtifactCategory? type,
   }) async {
-    ArgumentError.checkNotNull(sessionArn, 'sessionArn');
-    _s.validateStringLength(
-      'sessionArn',
-      sessionArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResult',
       maxResult,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3238,25 +2601,11 @@ class DeviceFarm {
     String? nextToken,
     TestGridSessionStatus? status,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResult',
       maxResult,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3304,20 +2653,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListTests'
@@ -3360,20 +2695,6 @@ class DeviceFarm {
     required String arn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListUniqueProblems'
@@ -3516,20 +2837,6 @@ class DeviceFarm {
     String? nextToken,
     UploadType? type,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListUploads'
@@ -3567,12 +2874,6 @@ class DeviceFarm {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ListVPCEConfigurations'
@@ -3618,18 +2919,6 @@ class DeviceFarm {
     String? offeringPromotionId,
     int? quantity,
   }) async {
-    _s.validateStringLength(
-      'offeringId',
-      offeringId,
-      32,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'offeringPromotionId',
-      offeringPromotionId,
-      4,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.PurchaseOffering'
@@ -3672,12 +2961,6 @@ class DeviceFarm {
     String? offeringId,
     int? quantity,
   }) async {
-    _s.validateStringLength(
-      'offeringId',
-      offeringId,
-      32,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.RenewOffering'
@@ -3744,33 +3027,6 @@ class DeviceFarm {
     ExecutionConfiguration? executionConfiguration,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(test, 'test');
-    _s.validateStringLength(
-      'appArn',
-      appArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'devicePoolArn',
-      devicePoolArn,
-      32,
-      1011,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.ScheduleRun'
@@ -3815,14 +3071,6 @@ class DeviceFarm {
   Future<StopJobResult> stopJob({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.StopJob'
@@ -3853,14 +3101,6 @@ class DeviceFarm {
   Future<StopRemoteAccessSessionResult> stopRemoteAccessSession({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.StopRemoteAccessSession'
@@ -3896,14 +3136,6 @@ class DeviceFarm {
   Future<StopRunResult> stopRun({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.StopRun'
@@ -3949,15 +3181,6 @@ class DeviceFarm {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.TagResource'
@@ -3996,15 +3219,6 @@ class DeviceFarm {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      32,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UntagResource'
@@ -4043,20 +3257,6 @@ class DeviceFarm {
     List<String>? labels,
     String? profileArn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'profileArn',
-      profileArn,
-      32,
-      1011,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateDeviceInstance'
@@ -4131,26 +3331,6 @@ class DeviceFarm {
     String? name,
     List<Rule>? rules,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateDevicePool'
@@ -4212,26 +3392,6 @@ class DeviceFarm {
     bool? packageCleanup,
     bool? rebootAfterUse,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateInstanceProfile'
@@ -4322,31 +3482,11 @@ class DeviceFarm {
     int? uplinkJitterMs,
     int? uplinkLossPercent,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      16384,
-    );
     _s.validateNumRange(
       'downlinkLossPercent',
       downlinkLossPercent,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
     );
     _s.validateNumRange(
       'uplinkLossPercent',
@@ -4408,20 +3548,6 @@ class DeviceFarm {
     int? defaultJobTimeoutMinutes,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateProject'
@@ -4462,26 +3588,6 @@ class DeviceFarm {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateTestGridProject'
@@ -4529,26 +3635,6 @@ class DeviceFarm {
     bool? editContent,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateUpload'
@@ -4604,38 +3690,6 @@ class DeviceFarm {
     String? vpceConfigurationName,
     String? vpceServiceName,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      32,
-      1011,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'serviceDnsName',
-      serviceDnsName,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'vpceConfigurationDescription',
-      vpceConfigurationDescription,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'vpceConfigurationName',
-      vpceConfigurationName,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'vpceServiceName',
-      vpceServiceName,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DeviceFarm_20150623.UpdateVPCEConfiguration'

--- a/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
+++ b/generated/aws_directconnect_api/lib/directconnect-2012-10-25.dart
@@ -85,11 +85,6 @@ class DirectConnect {
     required String proposalId,
     List<RouteFilterPrefix>? overrideAllowedPrefixesToDirectConnectGateway,
   }) async {
-    ArgumentError.checkNotNull(
-        associatedGatewayOwnerAccount, 'associatedGatewayOwnerAccount');
-    ArgumentError.checkNotNull(
-        directConnectGatewayId, 'directConnectGatewayId');
-    ArgumentError.checkNotNull(proposalId, 'proposalId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -155,11 +150,6 @@ class DirectConnect {
     required String ownerAccount,
     required int vlan,
   }) async {
-    ArgumentError.checkNotNull(bandwidth, 'bandwidth');
-    ArgumentError.checkNotNull(connectionName, 'connectionName');
-    ArgumentError.checkNotNull(interconnectId, 'interconnectId');
-    ArgumentError.checkNotNull(ownerAccount, 'ownerAccount');
-    ArgumentError.checkNotNull(vlan, 'vlan');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AllocateConnectionOnInterconnect'
@@ -228,11 +218,6 @@ class DirectConnect {
     required int vlan,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(bandwidth, 'bandwidth');
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(connectionName, 'connectionName');
-    ArgumentError.checkNotNull(ownerAccount, 'ownerAccount');
-    ArgumentError.checkNotNull(vlan, 'vlan');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AllocateHostedConnection'
@@ -284,10 +269,6 @@ class DirectConnect {
         newPrivateVirtualInterfaceAllocation,
     required String ownerAccount,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(newPrivateVirtualInterfaceAllocation,
-        'newPrivateVirtualInterfaceAllocation');
-    ArgumentError.checkNotNull(ownerAccount, 'ownerAccount');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AllocatePrivateVirtualInterface'
@@ -344,10 +325,6 @@ class DirectConnect {
         newPublicVirtualInterfaceAllocation,
     required String ownerAccount,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(newPublicVirtualInterfaceAllocation,
-        'newPublicVirtualInterfaceAllocation');
-    ArgumentError.checkNotNull(ownerAccount, 'ownerAccount');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AllocatePublicVirtualInterface'
@@ -402,10 +379,6 @@ class DirectConnect {
         newTransitVirtualInterfaceAllocation,
     required String ownerAccount,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(newTransitVirtualInterfaceAllocation,
-        'newTransitVirtualInterfaceAllocation');
-    ArgumentError.checkNotNull(ownerAccount, 'ownerAccount');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AllocateTransitVirtualInterface'
@@ -458,8 +431,6 @@ class DirectConnect {
     required String connectionId,
     required String lagId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(lagId, 'lagId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AssociateConnectionWithLag'
@@ -500,8 +471,6 @@ class DirectConnect {
     required String connectionId,
     required String parentConnectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(parentConnectionId, 'parentConnectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AssociateHostedConnection'
@@ -548,8 +517,6 @@ class DirectConnect {
     required String connectionId,
     required String virtualInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.AssociateVirtualInterface'
@@ -584,7 +551,6 @@ class DirectConnect {
   Future<ConfirmConnectionResponse> confirmConnection({
     required String connectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.ConfirmConnection'
@@ -627,7 +593,6 @@ class DirectConnect {
     String? directConnectGatewayId,
     String? virtualGatewayId,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.ConfirmPrivateVirtualInterface'
@@ -663,7 +628,6 @@ class DirectConnect {
   Future<ConfirmPublicVirtualInterfaceResponse> confirmPublicVirtualInterface({
     required String virtualInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.ConfirmPublicVirtualInterface'
@@ -702,9 +666,6 @@ class DirectConnect {
     required String directConnectGatewayId,
     required String virtualInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(
-        directConnectGatewayId, 'directConnectGatewayId');
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.ConfirmTransitVirtualInterface'
@@ -818,9 +779,6 @@ class DirectConnect {
     String? providerName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(bandwidth, 'bandwidth');
-    ArgumentError.checkNotNull(connectionName, 'connectionName');
-    ArgumentError.checkNotNull(location, 'location');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateConnection'
@@ -868,8 +826,6 @@ class DirectConnect {
     required String directConnectGatewayName,
     int? amazonSideAsn,
   }) async {
-    ArgumentError.checkNotNull(
-        directConnectGatewayName, 'directConnectGatewayName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateDirectConnectGateway'
@@ -921,8 +877,6 @@ class DirectConnect {
     String? gatewayId,
     String? virtualGatewayId,
   }) async {
-    ArgumentError.checkNotNull(
-        directConnectGatewayId, 'directConnectGatewayId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateDirectConnectGatewayAssociation'
@@ -979,11 +933,6 @@ class DirectConnect {
     List<RouteFilterPrefix>? addAllowedPrefixesToDirectConnectGateway,
     List<RouteFilterPrefix>? removeAllowedPrefixesToDirectConnectGateway,
   }) async {
-    ArgumentError.checkNotNull(
-        directConnectGatewayId, 'directConnectGatewayId');
-    ArgumentError.checkNotNull(
-        directConnectGatewayOwnerAccount, 'directConnectGatewayOwnerAccount');
-    ArgumentError.checkNotNull(gatewayId, 'gatewayId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1068,9 +1017,6 @@ class DirectConnect {
     String? providerName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(bandwidth, 'bandwidth');
-    ArgumentError.checkNotNull(interconnectName, 'interconnectName');
-    ArgumentError.checkNotNull(location, 'location');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateInterconnect'
@@ -1161,10 +1107,6 @@ class DirectConnect {
     String? providerName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(connectionsBandwidth, 'connectionsBandwidth');
-    ArgumentError.checkNotNull(lagName, 'lagName');
-    ArgumentError.checkNotNull(location, 'location');
-    ArgumentError.checkNotNull(numberOfConnections, 'numberOfConnections');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateLag'
@@ -1221,9 +1163,6 @@ class DirectConnect {
     required String connectionId,
     required NewPrivateVirtualInterface newPrivateVirtualInterface,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(
-        newPrivateVirtualInterface, 'newPrivateVirtualInterface');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreatePrivateVirtualInterface'
@@ -1266,9 +1205,6 @@ class DirectConnect {
     required String connectionId,
     required NewPublicVirtualInterface newPublicVirtualInterface,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(
-        newPublicVirtualInterface, 'newPublicVirtualInterface');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreatePublicVirtualInterface'
@@ -1321,9 +1257,6 @@ class DirectConnect {
     required String connectionId,
     required NewTransitVirtualInterface newTransitVirtualInterface,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(
-        newTransitVirtualInterface, 'newTransitVirtualInterface');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.CreateTransitVirtualInterface'
@@ -1406,7 +1339,6 @@ class DirectConnect {
   Future<Connection> deleteConnection({
     required String connectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DeleteConnection'
@@ -1438,8 +1370,6 @@ class DirectConnect {
   Future<DeleteDirectConnectGatewayResult> deleteDirectConnectGateway({
     required String directConnectGatewayId,
   }) async {
-    ArgumentError.checkNotNull(
-        directConnectGatewayId, 'directConnectGatewayId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DeleteDirectConnectGateway'
@@ -1518,7 +1448,6 @@ class DirectConnect {
       deleteDirectConnectGatewayAssociationProposal({
     required String proposalId,
   }) async {
-    ArgumentError.checkNotNull(proposalId, 'proposalId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1552,7 +1481,6 @@ class DirectConnect {
   Future<DeleteInterconnectResponse> deleteInterconnect({
     required String interconnectId,
   }) async {
-    ArgumentError.checkNotNull(interconnectId, 'interconnectId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DeleteInterconnect'
@@ -1582,7 +1510,6 @@ class DirectConnect {
   Future<Lag> deleteLag({
     required String lagId,
   }) async {
-    ArgumentError.checkNotNull(lagId, 'lagId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DeleteLag'
@@ -1611,7 +1538,6 @@ class DirectConnect {
   Future<DeleteVirtualInterfaceResponse> deleteVirtualInterface({
     required String virtualInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DeleteVirtualInterface'
@@ -1663,7 +1589,6 @@ class DirectConnect {
     LoaContentType? loaContentType,
     String? providerName,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeConnectionLoa'
@@ -1729,7 +1654,6 @@ class DirectConnect {
   Future<Connections> describeConnectionsOnInterconnect({
     required String interconnectId,
   }) async {
-    ArgumentError.checkNotNull(interconnectId, 'interconnectId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeConnectionsOnInterconnect'
@@ -1994,7 +1918,6 @@ class DirectConnect {
   Future<Connections> describeHostedConnections({
     required String connectionId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeHostedConnections'
@@ -2044,7 +1967,6 @@ class DirectConnect {
     LoaContentType? loaContentType,
     String? providerName,
   }) async {
-    ArgumentError.checkNotNull(interconnectId, 'interconnectId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeInterconnectLoa'
@@ -2151,7 +2073,6 @@ class DirectConnect {
     LoaContentType? loaContentType,
     String? providerName,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeLoa'
@@ -2205,7 +2126,6 @@ class DirectConnect {
   Future<DescribeTagsResponse> describeTags({
     required List<String> resourceArns,
   }) async {
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DescribeTags'
@@ -2314,8 +2234,6 @@ class DirectConnect {
     required String connectionId,
     required String lagId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(lagId, 'lagId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.DisassociateConnectionFromLag'
@@ -2431,7 +2349,6 @@ class DirectConnect {
     List<String>? bgpPeers,
     int? testDurationInMinutes,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.StartBgpFailoverTest'
@@ -2463,7 +2380,6 @@ class DirectConnect {
   Future<StopBgpFailoverTestResponse> stopBgpFailoverTest({
     required String virtualInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.StopBgpFailoverTest'
@@ -2503,8 +2419,6 @@ class DirectConnect {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.TagResource'
@@ -2536,8 +2450,6 @@ class DirectConnect {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.UntagResource'
@@ -2640,7 +2552,6 @@ class DirectConnect {
     String? lagName,
     int? minimumLinks,
   }) async {
-    ArgumentError.checkNotNull(lagId, 'lagId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.UpdateLag'
@@ -2685,7 +2596,6 @@ class DirectConnect {
     required String virtualInterfaceId,
     int? mtu,
   }) async {
-    ArgumentError.checkNotNull(virtualInterfaceId, 'virtualInterfaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OvertureService.UpdateVirtualInterfaceAttributes'

--- a/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
+++ b/generated/aws_discovery_api/lib/discovery-2015-11-01.dart
@@ -71,9 +71,6 @@ class ApplicationDiscoveryService {
     required String applicationConfigurationId,
     required List<String> configurationIds,
   }) async {
-    ArgumentError.checkNotNull(
-        applicationConfigurationId, 'applicationConfigurationId');
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -114,7 +111,6 @@ class ApplicationDiscoveryService {
   Future<BatchDeleteImportDataResponse> batchDeleteImportData({
     required List<String> importTaskIds,
   }) async {
-    ArgumentError.checkNotNull(importTaskIds, 'importTaskIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.BatchDeleteImportData'
@@ -150,7 +146,6 @@ class ApplicationDiscoveryService {
     required String name,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.CreateApplication'
@@ -194,8 +189,6 @@ class ApplicationDiscoveryService {
     required List<String> configurationIds,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.CreateTags'
@@ -227,7 +220,6 @@ class ApplicationDiscoveryService {
   Future<void> deleteApplications({
     required List<String> configurationIds,
   }) async {
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.DeleteApplications'
@@ -267,7 +259,6 @@ class ApplicationDiscoveryService {
     required List<String> configurationIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.DeleteTags'
@@ -384,7 +375,6 @@ class ApplicationDiscoveryService {
   Future<DescribeConfigurationsResponse> describeConfigurations({
     required List<String> configurationIds,
   }) async {
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.DescribeConfigurations'
@@ -701,9 +691,6 @@ class ApplicationDiscoveryService {
     required String applicationConfigurationId,
     required List<String> configurationIds,
   }) async {
-    ArgumentError.checkNotNull(
-        applicationConfigurationId, 'applicationConfigurationId');
-    ArgumentError.checkNotNull(configurationIds, 'configurationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -830,7 +817,6 @@ class ApplicationDiscoveryService {
     String? nextToken,
     List<OrderByElement>? orderBy,
   }) async {
-    ArgumentError.checkNotNull(configurationType, 'configurationType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.ListConfigurations'
@@ -889,7 +875,6 @@ class ApplicationDiscoveryService {
     String? nextToken,
     bool? portInformationNeeded,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.ListServerNeighbors'
@@ -960,7 +945,6 @@ class ApplicationDiscoveryService {
   Future<StartDataCollectionByAgentIdsResponse> startDataCollectionByAgentIds({
     required List<String> agentIds,
   }) async {
-    ArgumentError.checkNotNull(agentIds, 'agentIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1122,28 +1106,6 @@ class ApplicationDiscoveryService {
     required String name,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(importUrl, 'importUrl');
-    _s.validateStringLength(
-      'importUrl',
-      importUrl,
-      1,
-      4000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.StartImportTask'
@@ -1181,7 +1143,6 @@ class ApplicationDiscoveryService {
   Future<StopContinuousExportResponse> stopContinuousExport({
     required String exportId,
   }) async {
-    ArgumentError.checkNotNull(exportId, 'exportId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.StopContinuousExport'
@@ -1213,7 +1174,6 @@ class ApplicationDiscoveryService {
   Future<StopDataCollectionByAgentIdsResponse> stopDataCollectionByAgentIds({
     required List<String> agentIds,
   }) async {
-    ArgumentError.checkNotNull(agentIds, 'agentIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1254,7 +1214,6 @@ class ApplicationDiscoveryService {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSPoseidonService_V2015_11_01.UpdateApplication'

--- a/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
+++ b/generated/aws_dlm_api/lib/dlm-2018-01-12.dart
@@ -80,24 +80,6 @@ class DLM {
     required SettablePolicyStateValues state,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(executionRoleArn, 'executionRoleArn');
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyDetails, 'policyDetails');
-    ArgumentError.checkNotNull(state, 'state');
     final $payload = <String, dynamic>{
       'Description': description,
       'ExecutionRoleArn': executionRoleArn,
@@ -126,14 +108,6 @@ class DLM {
   Future<void> deleteLifecyclePolicy({
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -209,14 +183,6 @@ class DLM {
   Future<GetLifecyclePolicyResponse> getLifecyclePolicy({
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -237,14 +203,6 @@ class DLM {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -269,15 +227,6 @@ class DLM {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -304,15 +253,6 @@ class DLM {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -355,26 +295,6 @@ class DLM {
     PolicyDetails? policyDetails,
     SettablePolicyStateValues? state,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      0,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (executionRoleArn != null) 'ExecutionRoleArn': executionRoleArn,

--- a/generated/aws_dms_api/lib/dms-2016-01-01.dart
+++ b/generated/aws_dms_api/lib/dms-2016-01-01.dart
@@ -76,8 +76,6 @@ class DatabaseMigrationService {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.AddTagsToResource'
@@ -131,10 +129,6 @@ class DatabaseMigrationService {
     required String optInType,
     required String replicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(applyAction, 'applyAction');
-    ArgumentError.checkNotNull(optInType, 'optInType');
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ApplyPendingMaintenanceAction'
@@ -172,8 +166,6 @@ class DatabaseMigrationService {
       cancelReplicationTaskAssessmentRun({
     required String replicationTaskAssessmentRunArn,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationTaskAssessmentRunArn, 'replicationTaskAssessmentRunArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CancelReplicationTaskAssessmentRun'
@@ -453,9 +445,6 @@ class DatabaseMigrationService {
     List<Tag>? tags,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(endpointIdentifier, 'endpointIdentifier');
-    ArgumentError.checkNotNull(endpointType, 'endpointType');
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CreateEndpoint'
@@ -595,8 +584,6 @@ class DatabaseMigrationService {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CreateEventSubscription'
@@ -778,10 +765,6 @@ class DatabaseMigrationService {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationInstanceClass, 'replicationInstanceClass');
-    ArgumentError.checkNotNull(
-        replicationInstanceIdentifier, 'replicationInstanceIdentifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CreateReplicationInstance'
@@ -853,11 +836,6 @@ class DatabaseMigrationService {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationSubnetGroupDescription, 'replicationSubnetGroupDescription');
-    ArgumentError.checkNotNull(
-        replicationSubnetGroupIdentifier, 'replicationSubnetGroupIdentifier');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CreateReplicationSubnetGroup'
@@ -1011,14 +989,6 @@ class DatabaseMigrationService {
     List<Tag>? tags,
     String? taskData,
   }) async {
-    ArgumentError.checkNotNull(migrationType, 'migrationType');
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
-    ArgumentError.checkNotNull(
-        replicationTaskIdentifier, 'replicationTaskIdentifier');
-    ArgumentError.checkNotNull(sourceEndpointArn, 'sourceEndpointArn');
-    ArgumentError.checkNotNull(tableMappings, 'tableMappings');
-    ArgumentError.checkNotNull(targetEndpointArn, 'targetEndpointArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.CreateReplicationTask'
@@ -1062,7 +1032,6 @@ class DatabaseMigrationService {
   Future<DeleteCertificateResponse> deleteCertificate({
     required String certificateArn,
   }) async {
-    ArgumentError.checkNotNull(certificateArn, 'certificateArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteCertificate'
@@ -1097,9 +1066,6 @@ class DatabaseMigrationService {
     required String endpointArn,
     required String replicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteConnection'
@@ -1134,7 +1100,6 @@ class DatabaseMigrationService {
   Future<DeleteEndpointResponse> deleteEndpoint({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteEndpoint'
@@ -1163,7 +1128,6 @@ class DatabaseMigrationService {
   Future<DeleteEventSubscriptionResponse> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteEventSubscription'
@@ -1196,8 +1160,6 @@ class DatabaseMigrationService {
   Future<DeleteReplicationInstanceResponse> deleteReplicationInstance({
     required String replicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteReplicationInstance'
@@ -1226,8 +1188,6 @@ class DatabaseMigrationService {
   Future<void> deleteReplicationSubnetGroup({
     required String replicationSubnetGroupIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationSubnetGroupIdentifier, 'replicationSubnetGroupIdentifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteReplicationSubnetGroup'
@@ -1254,7 +1214,6 @@ class DatabaseMigrationService {
   Future<DeleteReplicationTaskResponse> deleteReplicationTask({
     required String replicationTaskArn,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteReplicationTask'
@@ -1290,8 +1249,6 @@ class DatabaseMigrationService {
       deleteReplicationTaskAssessmentRun({
     required String replicationTaskAssessmentRunArn,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationTaskAssessmentRunArn, 'replicationTaskAssessmentRunArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DeleteReplicationTaskAssessmentRun'
@@ -1906,7 +1863,6 @@ class DatabaseMigrationService {
   Future<DescribeRefreshSchemasStatusResponse> describeRefreshSchemasStatus({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DescribeRefreshSchemasStatus'
@@ -1953,8 +1909,6 @@ class DatabaseMigrationService {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DescribeReplicationInstanceTaskLogs'
@@ -2328,7 +2282,6 @@ class DatabaseMigrationService {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DescribeSchemas'
@@ -2390,7 +2343,6 @@ class DatabaseMigrationService {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.DescribeTableStatistics'
@@ -2438,7 +2390,6 @@ class DatabaseMigrationService {
     Uint8List? certificateWallet,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(certificateIdentifier, 'certificateIdentifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ImportCertificate'
@@ -2475,7 +2426,6 @@ class DatabaseMigrationService {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ListTagsForResource'
@@ -2730,7 +2680,6 @@ class DatabaseMigrationService {
     SybaseSettings? sybaseSettings,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ModifyEndpoint'
@@ -2826,7 +2775,6 @@ class DatabaseMigrationService {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ModifyEventSubscription'
@@ -2964,8 +2912,6 @@ class DatabaseMigrationService {
     String? replicationInstanceIdentifier,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ModifyReplicationInstance'
@@ -3022,9 +2968,6 @@ class DatabaseMigrationService {
     required List<String> subnetIds,
     String? replicationSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationSubnetGroupIdentifier, 'replicationSubnetGroupIdentifier');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ModifyReplicationSubnetGroup'
@@ -3152,7 +3095,6 @@ class DatabaseMigrationService {
     String? tableMappings,
     String? taskData,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ModifyReplicationTask'
@@ -3200,9 +3142,6 @@ class DatabaseMigrationService {
     required String replicationTaskArn,
     required String targetReplicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
-    ArgumentError.checkNotNull(
-        targetReplicationInstanceArn, 'targetReplicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.MoveReplicationTask'
@@ -3239,8 +3178,6 @@ class DatabaseMigrationService {
     required String replicationInstanceArn,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.RebootReplicationInstance'
@@ -3279,9 +3216,6 @@ class DatabaseMigrationService {
     required String endpointArn,
     required String replicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.RefreshSchemas'
@@ -3326,8 +3260,6 @@ class DatabaseMigrationService {
     required List<TableToReload> tablesToReload,
     ReloadOptionValue? reloadOption,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
-    ArgumentError.checkNotNull(tablesToReload, 'tablesToReload');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.ReloadTables'
@@ -3366,8 +3298,6 @@ class DatabaseMigrationService {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.RemoveTagsFromResource'
@@ -3447,9 +3377,6 @@ class DatabaseMigrationService {
     DateTime? cdcStartTime,
     String? cdcStopPosition,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
-    ArgumentError.checkNotNull(
-        startReplicationTaskType, 'startReplicationTaskType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.StartReplicationTask'
@@ -3485,7 +3412,6 @@ class DatabaseMigrationService {
       startReplicationTaskAssessment({
     required String replicationTaskArn,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.StartReplicationTaskAssessment'
@@ -3608,10 +3534,6 @@ class DatabaseMigrationService {
     String? resultKmsKeyArn,
     String? resultLocationFolder,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunName, 'assessmentRunName');
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
-    ArgumentError.checkNotNull(resultLocationBucket, 'resultLocationBucket');
-    ArgumentError.checkNotNull(serviceAccessRoleArn, 'serviceAccessRoleArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.StartReplicationTaskAssessmentRun'
@@ -3651,7 +3573,6 @@ class DatabaseMigrationService {
   Future<StopReplicationTaskResponse> stopReplicationTask({
     required String replicationTaskArn,
   }) async {
-    ArgumentError.checkNotNull(replicationTaskArn, 'replicationTaskArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.StopReplicationTask'
@@ -3687,9 +3608,6 @@ class DatabaseMigrationService {
     required String endpointArn,
     required String replicationInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
-    ArgumentError.checkNotNull(
-        replicationInstanceArn, 'replicationInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonDMSv20160101.TestConnection'

--- a/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
+++ b/generated/aws_docdb_api/lib/docdb-2014-10-31.dart
@@ -73,8 +73,6 @@ class DocDB {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -130,9 +128,6 @@ class DocDB {
     required String optInType,
     required String resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(applyAction, 'applyAction');
-    ArgumentError.checkNotNull(optInType, 'optInType');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final $request = <String, dynamic>{};
     $request['ApplyAction'] = applyAction;
     $request['OptInType'] = optInType;
@@ -211,12 +206,6 @@ class DocDB {
     required String targetDBClusterParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(sourceDBClusterParameterGroupIdentifier,
-        'sourceDBClusterParameterGroupIdentifier');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupDescription,
-        'targetDBClusterParameterGroupDescription');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupIdentifier,
-        'targetDBClusterParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterParameterGroupIdentifier'] =
         sourceDBClusterParameterGroupIdentifier;
@@ -376,10 +365,6 @@ class DocDB {
     String? preSignedUrl,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBClusterSnapshotIdentifier, 'sourceDBClusterSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBClusterSnapshotIdentifier, 'targetDBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterSnapshotIdentifier'] =
         sourceDBClusterSnapshotIdentifier;
@@ -612,10 +597,6 @@ class DocDB {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -707,11 +688,6 @@ class DocDB {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
@@ -778,9 +754,6 @@ class DocDB {
     required String dBClusterSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -897,10 +870,6 @@ class DocDB {
     int? promotionTier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['DBInstanceClass'] = dBInstanceClass;
@@ -958,10 +927,6 @@ class DocDB {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -1041,7 +1006,6 @@ class DocDB {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     finalDBSnapshotIdentifier
@@ -1086,8 +1050,6 @@ class DocDB {
   Future<void> deleteDBClusterParameterGroup({
     required String dBClusterParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     await _protocol.send(
@@ -1120,8 +1082,6 @@ class DocDB {
   Future<DeleteDBClusterSnapshotResult> deleteDBClusterSnapshot({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -1160,7 +1120,6 @@ class DocDB {
   Future<DeleteDBInstanceResult> deleteDBInstance({
     required String dBInstanceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     final $result = await _protocol.send(
@@ -1201,7 +1160,6 @@ class DocDB {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -1396,8 +1354,6 @@ class DocDB {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1437,8 +1393,6 @@ class DocDB {
       describeDBClusterSnapshotAttributes({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -1914,8 +1868,6 @@ class DocDB {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -2130,7 +2082,6 @@ class DocDB {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -2289,7 +2240,6 @@ class DocDB {
     required String resourceName,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -2477,7 +2427,6 @@ class DocDB {
     String? preferredMaintenanceWindow,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -2543,9 +2492,6 @@ class DocDB {
     required String dBClusterParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['Parameters'] = parameters;
@@ -2621,9 +2567,6 @@ class DocDB {
     List<String>? valuesToAdd,
     List<String>? valuesToRemove,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -2767,7 +2710,6 @@ class DocDB {
     String? preferredMaintenanceWindow,
     int? promotionTier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -2823,8 +2765,6 @@ class DocDB {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -2877,7 +2817,6 @@ class DocDB {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -2911,8 +2850,6 @@ class DocDB {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -2960,8 +2897,6 @@ class DocDB {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -3125,9 +3060,6 @@ class DocDB {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -3317,9 +3249,6 @@ class DocDB {
     bool? useLatestRestorableTime,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBClusterIdentifier, 'sourceDBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['SourceDBClusterIdentifier'] = sourceDBClusterIdentifier;
@@ -3364,7 +3293,6 @@ class DocDB {
   Future<StartDBClusterResult> startDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -3397,7 +3325,6 @@ class DocDB {
   Future<StopDBClusterResult> stopDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(

--- a/generated/aws_ds_api/lib/ds-2015-04-16.dart
+++ b/generated/aws_ds_api/lib/ds-2015-04-16.dart
@@ -78,7 +78,6 @@ class DirectoryService {
   Future<AcceptSharedDirectoryResult> acceptSharedDirectory({
     required String sharedDirectoryId,
   }) async {
-    ArgumentError.checkNotNull(sharedDirectoryId, 'sharedDirectoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.AcceptSharedDirectory'
@@ -202,8 +201,6 @@ class DirectoryService {
     required List<IpRoute> ipRoutes,
     bool? updateSecurityGroupForDirectoryControllers,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(ipRoutes, 'ipRoutes');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.AddIpRoutes'
@@ -250,16 +247,6 @@ class DirectoryService {
     required String regionName,
     required DirectoryVpcSettings vPCSettings,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(regionName, 'regionName');
-    _s.validateStringLength(
-      'regionName',
-      regionName,
-      8,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vPCSettings, 'vPCSettings');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.AddRegion'
@@ -297,8 +284,6 @@ class DirectoryService {
     required String resourceId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.AddTagsToResource'
@@ -335,8 +320,6 @@ class DirectoryService {
     required String directoryId,
     required String schemaExtensionId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(schemaExtensionId, 'schemaExtensionId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CancelSchemaExtension'
@@ -400,23 +383,6 @@ class DirectoryService {
     String? shortName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(connectSettings, 'connectSettings');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(size, 'size');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.ConnectDirectory'
@@ -468,15 +434,6 @@ class DirectoryService {
     required String alias,
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(alias, 'alias');
-    _s.validateStringLength(
-      'alias',
-      alias,
-      1,
-      62,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateAlias'
@@ -531,29 +488,6 @@ class DirectoryService {
     List<Attribute>? computerAttributes,
     String? organizationalUnitDistinguishedName,
   }) async {
-    ArgumentError.checkNotNull(computerName, 'computerName');
-    _s.validateStringLength(
-      'computerName',
-      computerName,
-      1,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      8,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'organizationalUnitDistinguishedName',
-      organizationalUnitDistinguishedName,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateComputer'
@@ -608,9 +542,6 @@ class DirectoryService {
     required List<String> dnsIpAddrs,
     required String remoteDomainName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(dnsIpAddrs, 'dnsIpAddrs');
-    ArgumentError.checkNotNull(remoteDomainName, 'remoteDomainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateConditionalForwarder'
@@ -714,15 +645,6 @@ class DirectoryService {
     List<Tag>? tags,
     DirectoryVpcSettings? vpcSettings,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(password, 'password');
-    ArgumentError.checkNotNull(size, 'size');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateDirectory'
@@ -769,15 +691,6 @@ class DirectoryService {
     required String directoryId,
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateLogSubscription'
@@ -855,15 +768,6 @@ class DirectoryService {
     String? shortName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(password, 'password');
-    ArgumentError.checkNotNull(vpcSettings, 'vpcSettings');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateMicrosoftAD'
@@ -909,13 +813,6 @@ class DirectoryService {
     required String directoryId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateSnapshot'
@@ -986,17 +883,6 @@ class DirectoryService {
     SelectiveAuth? selectiveAuth,
     TrustType? trustType,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(remoteDomainName, 'remoteDomainName');
-    ArgumentError.checkNotNull(trustDirection, 'trustDirection');
-    ArgumentError.checkNotNull(trustPassword, 'trustPassword');
-    _s.validateStringLength(
-      'trustPassword',
-      trustPassword,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.CreateTrust'
@@ -1042,8 +928,6 @@ class DirectoryService {
     required String directoryId,
     required String remoteDomainName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(remoteDomainName, 'remoteDomainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeleteConditionalForwarder'
@@ -1080,7 +964,6 @@ class DirectoryService {
   Future<DeleteDirectoryResult> deleteDirectory({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeleteDirectory'
@@ -1111,7 +994,6 @@ class DirectoryService {
   Future<void> deleteLogSubscription({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeleteLogSubscription'
@@ -1140,7 +1022,6 @@ class DirectoryService {
   Future<DeleteSnapshotResult> deleteSnapshot({
     required String snapshotId,
   }) async {
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeleteSnapshot'
@@ -1177,7 +1058,6 @@ class DirectoryService {
     required String trustId,
     bool? deleteAssociatedConditionalForwarder,
   }) async {
-    ArgumentError.checkNotNull(trustId, 'trustId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeleteTrust'
@@ -1220,8 +1100,6 @@ class DirectoryService {
     required String certificateId,
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeregisterCertificate'
@@ -1257,15 +1135,6 @@ class DirectoryService {
     required String directoryId,
     required String topicName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(topicName, 'topicName');
-    _s.validateStringLength(
-      'topicName',
-      topicName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DeregisterEventTopic'
@@ -1302,8 +1171,6 @@ class DirectoryService {
     required String certificateId,
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DescribeCertificate'
@@ -1347,7 +1214,6 @@ class DirectoryService {
     required String directoryId,
     List<String>? remoteDomainNames,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DescribeConditionalForwarders'
@@ -1464,7 +1330,6 @@ class DirectoryService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -1565,7 +1430,6 @@ class DirectoryService {
     String? nextToken,
     LDAPSType? type,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -1618,13 +1482,6 @@ class DirectoryService {
     String? nextToken,
     String? regionName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'regionName',
-      regionName,
-      8,
-      32,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DescribeRegions'
@@ -1673,7 +1530,6 @@ class DirectoryService {
     String? nextToken,
     List<String>? sharedDirectoryIds,
   }) async {
-    ArgumentError.checkNotNull(ownerDirectoryId, 'ownerDirectoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -1851,8 +1707,6 @@ class DirectoryService {
     required String directoryId,
     required ClientAuthenticationType type,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DisableClientAuthentication'
@@ -1890,8 +1744,6 @@ class DirectoryService {
     required String directoryId,
     required LDAPSType type,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DisableLDAPS'
@@ -1922,7 +1774,6 @@ class DirectoryService {
   Future<void> disableRadius({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DisableRadius'
@@ -1970,19 +1821,6 @@ class DirectoryService {
     String? password,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.DisableSso'
@@ -2024,8 +1862,6 @@ class DirectoryService {
     required String directoryId,
     required ClientAuthenticationType type,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.EnableClientAuthentication'
@@ -2065,8 +1901,6 @@ class DirectoryService {
     required String directoryId,
     required LDAPSType type,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.EnableLDAPS'
@@ -2104,8 +1938,6 @@ class DirectoryService {
     required String directoryId,
     required RadiusSettings radiusSettings,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(radiusSettings, 'radiusSettings');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.EnableRadius'
@@ -2156,19 +1988,6 @@ class DirectoryService {
     String? password,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.EnableSso'
@@ -2219,7 +2038,6 @@ class DirectoryService {
   Future<GetSnapshotLimitsResult> getSnapshotLimits({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.GetSnapshotLimits'
@@ -2265,7 +2083,6 @@ class DirectoryService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2316,7 +2133,6 @@ class DirectoryService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2415,7 +2231,6 @@ class DirectoryService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2463,7 +2278,6 @@ class DirectoryService {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
     _s.validateNumRange(
       'limit',
       limit,
@@ -2523,15 +2337,6 @@ class DirectoryService {
     ClientCertAuthSettings? clientCertAuthSettings,
     CertificateType? type,
   }) async {
-    ArgumentError.checkNotNull(certificateData, 'certificateData');
-    _s.validateStringLength(
-      'certificateData',
-      certificateData,
-      1,
-      8192,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RegisterCertificate'
@@ -2576,15 +2381,6 @@ class DirectoryService {
     required String directoryId,
     required String topicName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(topicName, 'topicName');
-    _s.validateStringLength(
-      'topicName',
-      topicName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RegisterEventTopic'
@@ -2617,7 +2413,6 @@ class DirectoryService {
   Future<RejectSharedDirectoryResult> rejectSharedDirectory({
     required String sharedDirectoryId,
   }) async {
-    ArgumentError.checkNotNull(sharedDirectoryId, 'sharedDirectoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RejectSharedDirectory'
@@ -2654,8 +2449,6 @@ class DirectoryService {
     required List<String> cidrIps,
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(cidrIps, 'cidrIps');
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RemoveIpRoutes'
@@ -2690,7 +2483,6 @@ class DirectoryService {
   Future<void> removeRegion({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RemoveRegion'
@@ -2723,8 +2515,6 @@ class DirectoryService {
     required String resourceId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RemoveTagsFromResource'
@@ -2787,23 +2577,6 @@ class DirectoryService {
     required String newPassword,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(newPassword, 'newPassword');
-    _s.validateStringLength(
-      'newPassword',
-      newPassword,
-      1,
-      127,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.ResetUserPassword'
@@ -2843,7 +2616,6 @@ class DirectoryService {
   Future<void> restoreFromSnapshot({
     required String snapshotId,
   }) async {
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.RestoreFromSnapshot'
@@ -2917,15 +2689,6 @@ class DirectoryService {
     required ShareTarget shareTarget,
     String? shareNotes,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(shareMethod, 'shareMethod');
-    ArgumentError.checkNotNull(shareTarget, 'shareTarget');
-    _s.validateStringLength(
-      'shareNotes',
-      shareNotes,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.ShareDirectory'
@@ -2978,25 +2741,6 @@ class DirectoryService {
     required String directoryId,
     required String ldifContent,
   }) async {
-    ArgumentError.checkNotNull(createSnapshotBeforeSchemaExtension,
-        'createSnapshotBeforeSchemaExtension');
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(ldifContent, 'ldifContent');
-    _s.validateStringLength(
-      'ldifContent',
-      ldifContent,
-      1,
-      500000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.StartSchemaExtension'
@@ -3039,8 +2783,6 @@ class DirectoryService {
     required String directoryId,
     required UnshareTarget unshareTarget,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(unshareTarget, 'unshareTarget');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.UnshareDirectory'
@@ -3086,9 +2828,6 @@ class DirectoryService {
     required List<String> dnsIpAddrs,
     required String remoteDomainName,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(dnsIpAddrs, 'dnsIpAddrs');
-    ArgumentError.checkNotNull(remoteDomainName, 'remoteDomainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.UpdateConditionalForwarder'
@@ -3132,7 +2871,6 @@ class DirectoryService {
     required int desiredNumber,
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(desiredNumber, 'desiredNumber');
     _s.validateNumRange(
       'desiredNumber',
       desiredNumber,
@@ -3140,7 +2878,6 @@ class DirectoryService {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3178,8 +2915,6 @@ class DirectoryService {
     required String directoryId,
     required RadiusSettings radiusSettings,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    ArgumentError.checkNotNull(radiusSettings, 'radiusSettings');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.UpdateRadius'
@@ -3214,7 +2949,6 @@ class DirectoryService {
     required String trustId,
     SelectiveAuth? selectiveAuth,
   }) async {
-    ArgumentError.checkNotNull(trustId, 'trustId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.UpdateTrust'
@@ -3251,7 +2985,6 @@ class DirectoryService {
   Future<VerifyTrustResult> verifyTrust({
     required String trustId,
   }) async {
-    ArgumentError.checkNotNull(trustId, 'trustId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'DirectoryService_20150416.VerifyTrust'

--- a/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2011-12-05.dart
@@ -75,7 +75,6 @@ class DynamoDB {
   Future<BatchGetItemOutput> batchGetItem({
     required Map<String, KeysAndAttributes> requestItems,
   }) async {
-    ArgumentError.checkNotNull(requestItems, 'requestItems');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.BatchGetItem'
@@ -112,7 +111,6 @@ class DynamoDB {
   Future<BatchWriteItemOutput> batchWriteItem({
     required Map<String, List<WriteRequest>> requestItems,
   }) async {
-    ArgumentError.checkNotNull(requestItems, 'requestItems');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.BatchWriteItem'
@@ -156,16 +154,6 @@ class DynamoDB {
     required ProvisionedThroughput provisionedThroughput,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(keySchema, 'keySchema');
-    ArgumentError.checkNotNull(provisionedThroughput, 'provisionedThroughput');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.CreateTable'
@@ -209,15 +197,6 @@ class DynamoDB {
     Map<String, ExpectedAttributeValue>? expected,
     ReturnValue? returnValues,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.DeleteItem'
@@ -259,14 +238,6 @@ class DynamoDB {
   Future<DeleteTableOutput> deleteTable({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.DeleteTable'
@@ -301,14 +272,6 @@ class DynamoDB {
   Future<DescribeTableOutput> describeTable({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.DescribeTable'
@@ -350,15 +313,6 @@ class DynamoDB {
     List<String>? attributesToGet,
     bool? consistentRead,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.GetItem'
@@ -394,12 +348,6 @@ class DynamoDB {
     String? exclusiveStartTableName,
     int? limit,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartTableName',
-      exclusiveStartTableName,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -452,15 +400,6 @@ class DynamoDB {
     Map<String, ExpectedAttributeValue>? expected,
     ReturnValue? returnValues,
   }) async {
-    ArgumentError.checkNotNull(item, 'item');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.PutItem'
@@ -547,15 +486,6 @@ class DynamoDB {
     Condition? rangeKeyCondition,
     bool? scanIndexForward,
   }) async {
-    ArgumentError.checkNotNull(hashKeyValue, 'hashKeyValue');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -638,14 +568,6 @@ class DynamoDB {
     int? limit,
     Map<String, Condition>? scanFilter,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -700,16 +622,6 @@ class DynamoDB {
     Map<String, ExpectedAttributeValue>? expected,
     ReturnValue? returnValues,
   }) async {
-    ArgumentError.checkNotNull(attributeUpdates, 'attributeUpdates');
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.UpdateItem'
@@ -750,15 +662,6 @@ class DynamoDB {
     required ProvisionedThroughput provisionedThroughput,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(provisionedThroughput, 'provisionedThroughput');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20111205.UpdateTable'

--- a/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodb_api/lib/dynamodb-2012-08-10.dart
@@ -62,7 +62,6 @@ class DynamoDB {
   Future<BatchExecuteStatementOutput> batchExecuteStatement({
     required List<BatchStatementRequest> statements,
   }) async {
-    ArgumentError.checkNotNull(statements, 'statements');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.BatchExecuteStatement'
@@ -247,7 +246,6 @@ class DynamoDB {
     required Map<String, KeysAndAttributes> requestItems,
     ReturnConsumedCapacity? returnConsumedCapacity,
   }) async {
-    ArgumentError.checkNotNull(requestItems, 'requestItems');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.BatchGetItem'
@@ -419,7 +417,6 @@ class DynamoDB {
     ReturnConsumedCapacity? returnConsumedCapacity,
     ReturnItemCollectionMetrics? returnItemCollectionMetrics,
   }) async {
-    ArgumentError.checkNotNull(requestItems, 'requestItems');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.BatchWriteItem'
@@ -499,22 +496,6 @@ class DynamoDB {
     required String backupName,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(backupName, 'backupName');
-    _s.validateStringLength(
-      'backupName',
-      backupName,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.CreateBackup'
@@ -609,15 +590,6 @@ class DynamoDB {
     required String globalTableName,
     required List<Replica> replicationGroup,
   }) async {
-    ArgumentError.checkNotNull(globalTableName, 'globalTableName');
-    _s.validateStringLength(
-      'globalTableName',
-      globalTableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(replicationGroup, 'replicationGroup');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.CreateGlobalTable'
@@ -911,16 +883,6 @@ class DynamoDB {
     StreamSpecification? streamSpecification,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(attributeDefinitions, 'attributeDefinitions');
-    ArgumentError.checkNotNull(keySchema, 'keySchema');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.CreateTable'
@@ -967,14 +929,6 @@ class DynamoDB {
   Future<DeleteBackupOutput> deleteBackup({
     required String backupArn,
   }) async {
-    ArgumentError.checkNotNull(backupArn, 'backupArn');
-    _s.validateStringLength(
-      'backupArn',
-      backupArn,
-      37,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DeleteBackup'
@@ -1180,15 +1134,6 @@ class DynamoDB {
     ReturnItemCollectionMetrics? returnItemCollectionMetrics,
     ReturnValue? returnValues,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DeleteItem'
@@ -1255,14 +1200,6 @@ class DynamoDB {
   Future<DeleteTableOutput> deleteTable({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DeleteTable'
@@ -1294,14 +1231,6 @@ class DynamoDB {
   Future<DescribeBackupOutput> describeBackup({
     required String backupArn,
   }) async {
-    ArgumentError.checkNotNull(backupArn, 'backupArn');
-    _s.validateStringLength(
-      'backupArn',
-      backupArn,
-      37,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeBackup'
@@ -1346,14 +1275,6 @@ class DynamoDB {
   Future<DescribeContinuousBackupsOutput> describeContinuousBackups({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeContinuousBackups'
@@ -1387,20 +1308,6 @@ class DynamoDB {
     required String tableName,
     String? indexName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      3,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeContributorInsights'
@@ -1448,14 +1355,6 @@ class DynamoDB {
   Future<DescribeExportOutput> describeExport({
     required String exportArn,
   }) async {
-    ArgumentError.checkNotNull(exportArn, 'exportArn');
-    _s.validateStringLength(
-      'exportArn',
-      exportArn,
-      37,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeExport'
@@ -1493,14 +1392,6 @@ class DynamoDB {
   Future<DescribeGlobalTableOutput> describeGlobalTable({
     required String globalTableName,
   }) async {
-    ArgumentError.checkNotNull(globalTableName, 'globalTableName');
-    _s.validateStringLength(
-      'globalTableName',
-      globalTableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeGlobalTable'
@@ -1534,14 +1425,6 @@ class DynamoDB {
   Future<DescribeGlobalTableSettingsOutput> describeGlobalTableSettings({
     required String globalTableName,
   }) async {
-    ArgumentError.checkNotNull(globalTableName, 'globalTableName');
-    _s.validateStringLength(
-      'globalTableName',
-      globalTableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeGlobalTableSettings'
@@ -1571,14 +1454,6 @@ class DynamoDB {
       describeKinesisStreamingDestination({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeKinesisStreamingDestination'
@@ -1710,14 +1585,6 @@ class DynamoDB {
   Future<DescribeTableOutput> describeTable({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeTable'
@@ -1753,14 +1620,6 @@ class DynamoDB {
       describeTableReplicaAutoScaling({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeTableReplicaAutoScaling'
@@ -1790,14 +1649,6 @@ class DynamoDB {
   Future<DescribeTimeToLiveOutput> describeTimeToLive({
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DescribeTimeToLive'
@@ -1833,22 +1684,6 @@ class DynamoDB {
     required String streamArn,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(streamArn, 'streamArn');
-    _s.validateStringLength(
-      'streamArn',
-      streamArn,
-      37,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.DisableKinesisStreamingDestination'
@@ -1887,22 +1722,6 @@ class DynamoDB {
     required String streamArn,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(streamArn, 'streamArn');
-    _s.validateStringLength(
-      'streamArn',
-      streamArn,
-      37,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.EnableKinesisStreamingDestination'
@@ -1954,20 +1773,6 @@ class DynamoDB {
     String? nextToken,
     List<AttributeValue>? parameters,
   }) async {
-    ArgumentError.checkNotNull(statement, 'statement');
-    _s.validateStringLength(
-      'statement',
-      statement,
-      1,
-      8192,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      32768,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.ExecuteStatement'
@@ -2010,13 +1815,6 @@ class DynamoDB {
     required List<ParameterizedStatement> transactStatements,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(transactStatements, 'transactStatements');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.ExecuteTransaction'
@@ -2112,14 +1910,6 @@ class DynamoDB {
     S3SseAlgorithm? s3SseAlgorithm,
     String? s3SseKmsKeyId,
   }) async {
-    ArgumentError.checkNotNull(s3Bucket, 's3Bucket');
-    ArgumentError.checkNotNull(tableArn, 'tableArn');
-    _s.validateStringLength(
-      's3SseKmsKeyId',
-      s3SseKmsKeyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.ExportTableToPointInTime'
@@ -2259,15 +2049,6 @@ class DynamoDB {
     String? projectionExpression,
     ReturnConsumedCapacity? returnConsumedCapacity,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.GetItem'
@@ -2354,23 +2135,11 @@ class DynamoDB {
     DateTime? timeRangeLowerBound,
     DateTime? timeRangeUpperBound,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartBackupArn',
-      exclusiveStartBackupArn,
-      37,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -2422,12 +2191,6 @@ class DynamoDB {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -2524,12 +2287,6 @@ class DynamoDB {
     int? limit,
     String? regionName,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartGlobalTableName',
-      exclusiveStartGlobalTableName,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2575,12 +2332,6 @@ class DynamoDB {
     String? exclusiveStartTableName,
     int? limit,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartTableName',
-      exclusiveStartTableName,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -2629,14 +2380,6 @@ class DynamoDB {
     required String resourceArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1283,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.ListTagsOfResource'
@@ -2927,15 +2670,6 @@ class DynamoDB {
     ReturnItemCollectionMetrics? returnItemCollectionMetrics,
     ReturnValue? returnValues,
   }) async {
-    ArgumentError.checkNotNull(item, 'item');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.PutItem'
@@ -3395,20 +3129,6 @@ class DynamoDB {
     bool? scanIndexForward,
     Select? select,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -3525,22 +3245,6 @@ class DynamoDB {
     ProvisionedThroughput? provisionedThroughputOverride,
     SSESpecification? sSESpecificationOverride,
   }) async {
-    ArgumentError.checkNotNull(backupArn, 'backupArn');
-    _s.validateStringLength(
-      'backupArn',
-      backupArn,
-      37,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetTableName, 'targetTableName');
-    _s.validateStringLength(
-      'targetTableName',
-      targetTableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.RestoreTableFromBackup'
@@ -3682,20 +3386,6 @@ class DynamoDB {
     String? sourceTableName,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(targetTableName, 'targetTableName');
-    _s.validateStringLength(
-      'targetTableName',
-      targetTableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceTableName',
-      sourceTableName,
-      3,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.RestoreTableToPointInTime'
@@ -4063,20 +3753,6 @@ class DynamoDB {
     Select? select,
     int? totalSegments,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -4157,15 +3833,6 @@ class DynamoDB {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1283,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.TagResource'
@@ -4230,7 +3897,6 @@ class DynamoDB {
     required List<TransactGetItem> transactItems,
     ReturnConsumedCapacity? returnConsumedCapacity,
   }) async {
-    ArgumentError.checkNotNull(transactItems, 'transactItems');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.TransactGetItems'
@@ -4374,13 +4040,6 @@ class DynamoDB {
     ReturnConsumedCapacity? returnConsumedCapacity,
     ReturnItemCollectionMetrics? returnItemCollectionMetrics,
   }) async {
-    ArgumentError.checkNotNull(transactItems, 'transactItems');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.TransactWriteItems'
@@ -4428,15 +4087,6 @@ class DynamoDB {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1283,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UntagResource'
@@ -4484,16 +4134,6 @@ class DynamoDB {
     required PointInTimeRecoverySpecification pointInTimeRecoverySpecification,
     required String tableName,
   }) async {
-    ArgumentError.checkNotNull(
-        pointInTimeRecoverySpecification, 'pointInTimeRecoverySpecification');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateContinuousBackups'
@@ -4531,22 +4171,6 @@ class DynamoDB {
     required String tableName,
     String? indexName,
   }) async {
-    ArgumentError.checkNotNull(
-        contributorInsightsAction, 'contributorInsightsAction');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      3,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateContributorInsights'
@@ -4609,15 +4233,6 @@ class DynamoDB {
     required String globalTableName,
     required List<ReplicaUpdate> replicaUpdates,
   }) async {
-    ArgumentError.checkNotNull(globalTableName, 'globalTableName');
-    _s.validateStringLength(
-      'globalTableName',
-      globalTableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(replicaUpdates, 'replicaUpdates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateGlobalTable'
@@ -4696,14 +4311,6 @@ class DynamoDB {
     int? globalTableProvisionedWriteCapacityUnits,
     List<ReplicaSettingsUpdate>? replicaSettingsUpdate,
   }) async {
-    ArgumentError.checkNotNull(globalTableName, 'globalTableName');
-    _s.validateStringLength(
-      'globalTableName',
-      globalTableName,
-      3,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'globalTableProvisionedWriteCapacityUnits',
       globalTableProvisionedWriteCapacityUnits,
@@ -5048,15 +4655,6 @@ class DynamoDB {
     ReturnValue? returnValues,
     String? updateExpression,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateItem'
@@ -5215,14 +4813,6 @@ class DynamoDB {
     SSESpecification? sSESpecification,
     StreamSpecification? streamSpecification,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateTable'
@@ -5280,14 +4870,6 @@ class DynamoDB {
     AutoScalingSettingsUpdate? provisionedWriteCapacityAutoScalingUpdate,
     List<ReplicaAutoScalingUpdate>? replicaUpdates,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateTableReplicaAutoScaling'
@@ -5358,16 +4940,6 @@ class DynamoDB {
     required String tableName,
     required TimeToLiveSpecification timeToLiveSpecification,
   }) async {
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        timeToLiveSpecification, 'timeToLiveSpecification');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDB_20120810.UpdateTimeToLive'

--- a/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
+++ b/generated/aws_dynamodbstreams_api/lib/streams-dynamodb-2012-08-10.dart
@@ -86,20 +86,6 @@ class DynamoDBStreams {
     String? exclusiveStartShardId,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(streamArn, 'streamArn');
-    _s.validateStringLength(
-      'streamArn',
-      streamArn,
-      37,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'exclusiveStartShardId',
-      exclusiveStartShardId,
-      28,
-      65,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -159,14 +145,6 @@ class DynamoDBStreams {
     required String shardIterator,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(shardIterator, 'shardIterator');
-    _s.validateStringLength(
-      'shardIterator',
-      shardIterator,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -246,29 +224,6 @@ class DynamoDBStreams {
     required String streamArn,
     String? sequenceNumber,
   }) async {
-    ArgumentError.checkNotNull(shardId, 'shardId');
-    _s.validateStringLength(
-      'shardId',
-      shardId,
-      28,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(shardIteratorType, 'shardIteratorType');
-    ArgumentError.checkNotNull(streamArn, 'streamArn');
-    _s.validateStringLength(
-      'streamArn',
-      streamArn,
-      37,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sequenceNumber',
-      sequenceNumber,
-      21,
-      40,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'DynamoDBStreams_20120810.GetShardIterator'
@@ -317,23 +272,11 @@ class DynamoDBStreams {
     int? limit,
     String? tableName,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartStreamArn',
-      exclusiveStartStreamArn,
-      37,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      3,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',

--- a/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
+++ b/generated/aws_ebs_api/lib/ebs-2019-11-02.dart
@@ -115,27 +115,12 @@ class EBS {
     ChecksumAggregationMethod? checksumAggregationMethod,
     ChecksumAlgorithm? checksumAlgorithm,
   }) async {
-    ArgumentError.checkNotNull(changedBlocksCount, 'changedBlocksCount');
     _s.validateNumRange(
       'changedBlocksCount',
       changedBlocksCount,
       0,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
-    _s.validateStringLength(
-      'snapshotId',
-      snapshotId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'checksum',
-      checksum,
-      0,
-      64,
     );
     final headers = <String, String>{
       'x-amz-ChangedBlocksCount': changedBlocksCount.toString(),
@@ -186,28 +171,11 @@ class EBS {
     required String blockToken,
     required String snapshotId,
   }) async {
-    ArgumentError.checkNotNull(blockIndex, 'blockIndex');
     _s.validateNumRange(
       'blockIndex',
       blockIndex,
       0,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(blockToken, 'blockToken');
-    _s.validateStringLength(
-      'blockToken',
-      blockToken,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
-    _s.validateStringLength(
-      'snapshotId',
-      snapshotId,
-      1,
-      64,
       isRequired: true,
     );
     final $query = <String, List<String>>{
@@ -275,31 +243,11 @@ class EBS {
     String? nextToken,
     int? startingBlockIndex,
   }) async {
-    ArgumentError.checkNotNull(secondSnapshotId, 'secondSnapshotId');
-    _s.validateStringLength(
-      'secondSnapshotId',
-      secondSnapshotId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'firstSnapshotId',
-      firstSnapshotId,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       100,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
     );
     _s.validateNumRange(
       'startingBlockIndex',
@@ -354,25 +302,11 @@ class EBS {
     String? nextToken,
     int? startingBlockIndex,
   }) async {
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
-    _s.validateStringLength(
-      'snapshotId',
-      snapshotId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       100,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      256,
     );
     _s.validateNumRange(
       'startingBlockIndex',
@@ -460,31 +394,11 @@ class EBS {
     required String snapshotId,
     int? progress,
   }) async {
-    ArgumentError.checkNotNull(blockData, 'blockData');
-    ArgumentError.checkNotNull(blockIndex, 'blockIndex');
     _s.validateNumRange(
       'blockIndex',
       blockIndex,
       0,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(checksum, 'checksum');
-    _s.validateStringLength(
-      'checksum',
-      checksum,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(checksumAlgorithm, 'checksumAlgorithm');
-    ArgumentError.checkNotNull(dataLength, 'dataLength');
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
-    _s.validateStringLength(
-      'snapshotId',
-      snapshotId,
-      1,
-      64,
       isRequired: true,
     );
     _s.validateNumRange(
@@ -628,37 +542,12 @@ class EBS {
     List<Tag>? tags,
     int? timeout,
   }) async {
-    ArgumentError.checkNotNull(volumeSize, 'volumeSize');
     _s.validateNumRange(
       'volumeSize',
       volumeSize,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'kmsKeyArn',
-      kmsKeyArn,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'parentSnapshotId',
-      parentSnapshotId,
-      1,
-      64,
     );
     _s.validateNumRange(
       'timeout',

--- a/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
+++ b/generated/aws_ec2_api/lib/ec2-2016-11-15.dart
@@ -55,7 +55,6 @@ class EC2 {
     bool? dryRun,
     List<TargetConfigurationRequest>? targetConfigurations,
   }) async {
-    ArgumentError.checkNotNull(reservedInstanceIds, 'reservedInstanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -107,8 +106,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -134,8 +131,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -160,8 +155,6 @@ class EC2 {
     required List<String> vpcEndpointIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    ArgumentError.checkNotNull(vpcEndpointIds, 'vpcEndpointIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -224,7 +217,6 @@ class EC2 {
     required String cidr,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -388,8 +380,6 @@ class EC2 {
     String? instanceType,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(quantity, 'quantity');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -421,9 +411,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(securityGroupIds, 'securityGroupIds');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -458,7 +445,6 @@ class EC2 {
     int? ipv6AddressCount,
     List<String>? ipv6Addresses,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -515,7 +501,6 @@ class EC2 {
     List<String>? privateIpAddresses,
     int? secondaryPrivateIpAddressCount,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -647,8 +632,6 @@ class EC2 {
     String? clientToken,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -685,8 +668,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(dhcpOptionsId, 'dhcpOptionsId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -733,18 +714,6 @@ class EC2 {
     bool? dryRun,
     String? roleArn,
   }) async {
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      1,
-      1283,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1283,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -761,8 +730,6 @@ class EC2 {
     required IamInstanceProfileSpecification iamInstanceProfile,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(iamInstanceProfile, 'iamInstanceProfile');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -799,7 +766,6 @@ class EC2 {
     String? gatewayId,
     String? subnetId,
   }) async {
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -818,8 +784,6 @@ class EC2 {
     required String ipv6CidrBlock,
     required String subnetId,
   }) async {
-    ArgumentError.checkNotNull(ipv6CidrBlock, 'ipv6CidrBlock');
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -881,10 +845,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -941,7 +901,6 @@ class EC2 {
     String? ipv6CidrBlockNetworkBorderGroup,
     String? ipv6Pool,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -982,9 +941,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(groups, 'groups');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1012,8 +968,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(internetGatewayId, 'internetGatewayId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1047,9 +1001,6 @@ class EC2 {
     bool? dryRun,
     int? networkCardIndex,
   }) async {
-    ArgumentError.checkNotNull(deviceIndex, 'deviceIndex');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1112,9 +1063,6 @@ class EC2 {
     required String volumeId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(device, 'device');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1143,8 +1091,6 @@ class EC2 {
     required String vpnGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
-    ArgumentError.checkNotNull(vpnGatewayId, 'vpnGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1196,8 +1142,6 @@ class EC2 {
     String? description,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(targetNetworkCidr, 'targetNetworkCidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1266,7 +1210,6 @@ class EC2 {
     String? sourceSecurityGroupOwnerId,
     int? toPort,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1415,8 +1358,6 @@ class EC2 {
     required Storage storage,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(storage, 'storage');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1437,7 +1378,6 @@ class EC2 {
     required String bundleId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1465,7 +1405,6 @@ class EC2 {
     required String capacityReservationId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(capacityReservationId, 'capacityReservationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1497,7 +1436,6 @@ class EC2 {
     bool? dryRun,
     String? reasonMessage,
   }) async {
-    ArgumentError.checkNotNull(conversionTaskId, 'conversionTaskId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1513,7 +1451,6 @@ class EC2 {
   Future<void> cancelExportTask({
     required String exportTaskId,
   }) async {
-    ArgumentError.checkNotNull(exportTaskId, 'exportTaskId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1554,8 +1491,6 @@ class EC2 {
   Future<CancelReservedInstancesListingResult> cancelReservedInstancesListing({
     required String reservedInstancesListingId,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedInstancesListingId, 'reservedInstancesListingId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1588,8 +1523,6 @@ class EC2 {
     required bool terminateInstances,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(spotFleetRequestIds, 'spotFleetRequestIds');
-    ArgumentError.checkNotNull(terminateInstances, 'terminateInstances');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1613,8 +1546,6 @@ class EC2 {
     required List<String> spotInstanceRequestIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        spotInstanceRequestIds, 'spotInstanceRequestIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1641,8 +1572,6 @@ class EC2 {
     required String productCode,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(productCode, 'productCode');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1681,8 +1610,6 @@ class EC2 {
     bool? dryRun,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(sourceFpgaImageId, 'sourceFpgaImageId');
-    ArgumentError.checkNotNull(sourceRegion, 'sourceRegion');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1778,9 +1705,6 @@ class EC2 {
     bool? encrypted,
     String? kmsKeyId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(sourceImageId, 'sourceImageId');
-    ArgumentError.checkNotNull(sourceRegion, 'sourceRegion');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -1905,8 +1829,6 @@ class EC2 {
     String? presignedUrl,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(sourceRegion, 'sourceRegion');
-    ArgumentError.checkNotNull(sourceSnapshotId, 'sourceSnapshotId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2068,9 +1990,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     CapacityReservationTenancy? tenancy,
   }) async {
-    ArgumentError.checkNotNull(instanceCount, 'instanceCount');
-    ArgumentError.checkNotNull(instancePlatform, 'instancePlatform');
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2104,7 +2023,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2234,10 +2152,6 @@ class EC2 {
     String? vpcId,
     int? vpnPort,
   }) async {
-    ArgumentError.checkNotNull(authenticationOptions, 'authenticationOptions');
-    ArgumentError.checkNotNull(clientCidrBlock, 'clientCidrBlock');
-    ArgumentError.checkNotNull(connectionLogOptions, 'connectionLogOptions');
-    ArgumentError.checkNotNull(serverCertificateArn, 'serverCertificateArn');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2301,9 +2215,6 @@ class EC2 {
     String? description,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(targetVpcSubnetId, 'targetVpcSubnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2386,8 +2297,6 @@ class EC2 {
     String? publicIp,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(bgpAsn, 'bgpAsn');
-    ArgumentError.checkNotNull(type, 'type');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2412,7 +2321,6 @@ class EC2 {
     required String availabilityZone,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2518,7 +2426,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(dhcpConfigurations, 'dhcpConfigurations');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2553,7 +2460,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2667,9 +2573,6 @@ class EC2 {
     DateTime? validFrom,
     DateTime? validUntil,
   }) async {
-    ArgumentError.checkNotNull(launchTemplateConfigs, 'launchTemplateConfigs');
-    ArgumentError.checkNotNull(
-        targetCapacitySpecification, 'targetCapacitySpecification');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2812,9 +2715,6 @@ class EC2 {
     int? maxAggregationInterval,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(resourceIds, 'resourceIds');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(trafficType, 'trafficType');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2867,7 +2767,6 @@ class EC2 {
     String? name,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(inputStorageLocation, 'inputStorageLocation');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2948,8 +2847,6 @@ class EC2 {
     bool? noReboot,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(name, 'name');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -2984,9 +2881,6 @@ class EC2 {
     String? description,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(exportToS3Task, 'exportToS3Task');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(targetEnvironment, 'targetEnvironment');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3051,7 +2945,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(keyName, 'keyName');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3098,21 +2991,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(launchTemplateData, 'launchTemplateData');
-    ArgumentError.checkNotNull(launchTemplateName, 'launchTemplateName');
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      0,
-      255,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3174,19 +3052,6 @@ class EC2 {
     String? sourceVersion,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(launchTemplateData, 'launchTemplateData');
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      0,
-      255,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3215,11 +3080,6 @@ class EC2 {
     required String localGatewayVirtualInterfaceGroupId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(
-        localGatewayRouteTableId, 'localGatewayRouteTableId');
-    ArgumentError.checkNotNull(localGatewayVirtualInterfaceGroupId,
-        'localGatewayVirtualInterfaceGroupId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3248,9 +3108,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(
-        localGatewayRouteTableId, 'localGatewayRouteTableId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3305,9 +3162,6 @@ class EC2 {
     List<AddPrefixListEntry>? entries,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(addressFamily, 'addressFamily');
-    ArgumentError.checkNotNull(maxEntries, 'maxEntries');
-    ArgumentError.checkNotNull(prefixListName, 'prefixListName');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3353,8 +3207,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(allocationId, 'allocationId');
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3383,7 +3235,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3469,11 +3320,6 @@ class EC2 {
     String? ipv6CidrBlock,
     PortRange? portRange,
   }) async {
-    ArgumentError.checkNotNull(egress, 'egress');
-    ArgumentError.checkNotNull(networkAclId, 'networkAclId');
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    ArgumentError.checkNotNull(ruleAction, 'ruleAction');
-    ArgumentError.checkNotNull(ruleNumber, 'ruleNumber');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3530,26 +3376,11 @@ class EC2 {
     String? sourceIp,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'destinationIp',
-      destinationIp,
-      0,
-      15,
-    );
     _s.validateNumRange(
       'destinationPort',
       destinationPort,
       1,
       65535,
-    );
-    _s.validateStringLength(
-      'sourceIp',
-      sourceIp,
-      0,
-      15,
     );
 // TODO: implement ec2
     throw UnimplementedError();
@@ -3636,7 +3467,6 @@ class EC2 {
     int? secondaryPrivateIpAddressCount,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3673,8 +3503,6 @@ class EC2 {
     String? awsService,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(permission, 'permission');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3781,10 +3609,6 @@ class EC2 {
     required List<PriceScheduleSpecification> priceSchedules,
     required String reservedInstancesId,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    ArgumentError.checkNotNull(instanceCount, 'instanceCount');
-    ArgumentError.checkNotNull(priceSchedules, 'priceSchedules');
-    ArgumentError.checkNotNull(reservedInstancesId, 'reservedInstancesId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3892,7 +3716,6 @@ class EC2 {
     String? vpcEndpointId,
     String? vpcPeeringConnectionId,
   }) async {
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3921,7 +3744,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -3997,8 +3819,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     String? vpcId,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(groupName, 'groupName');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4061,7 +3881,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4096,7 +3915,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(instanceSpecification, 'instanceSpecification');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4128,7 +3946,6 @@ class EC2 {
     bool? dryRun,
     String? prefix,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4212,8 +4029,6 @@ class EC2 {
     String? outpostArn,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(cidrBlock, 'cidrBlock');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4255,8 +4070,6 @@ class EC2 {
     required List<Tag> tags,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(resources, 'resources');
-    ArgumentError.checkNotNull(tags, 'tags');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4370,12 +4183,6 @@ class EC2 {
     int? protocol,
     TrafficMirrorPortRangeRequest? sourcePortRange,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(ruleAction, 'ruleAction');
-    ArgumentError.checkNotNull(ruleNumber, 'ruleNumber');
-    ArgumentError.checkNotNull(sourceCidrBlock, 'sourceCidrBlock');
-    ArgumentError.checkNotNull(trafficDirection, 'trafficDirection');
-    ArgumentError.checkNotNull(trafficMirrorFilterId, 'trafficMirrorFilterId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4459,10 +4266,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     int? virtualNetworkId,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(sessionNumber, 'sessionNumber');
-    ArgumentError.checkNotNull(trafficMirrorFilterId, 'trafficMirrorFilterId');
-    ArgumentError.checkNotNull(trafficMirrorTargetId, 'trafficMirrorTargetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4596,9 +4399,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(options, 'options');
-    ArgumentError.checkNotNull(transportTransitGatewayAttachmentId,
-        'transportTransitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4655,10 +4455,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     String? transitGatewayAddress,
   }) async {
-    ArgumentError.checkNotNull(insideCidrBlocks, 'insideCidrBlocks');
-    ArgumentError.checkNotNull(peerAddress, 'peerAddress');
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4692,7 +4488,6 @@ class EC2 {
     CreateTransitGatewayMulticastDomainRequestOptions? options,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4736,10 +4531,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(peerAccountId, 'peerAccountId');
-    ArgumentError.checkNotNull(peerRegion, 'peerRegion');
-    ArgumentError.checkNotNull(peerTransitGatewayId, 'peerTransitGatewayId');
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4773,9 +4564,6 @@ class EC2 {
     bool? dryRun,
     String? transitGatewayAttachmentId,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4808,9 +4596,6 @@ class EC2 {
     bool? dryRun,
     String? transitGatewayAttachmentId,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4834,7 +4619,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -4881,9 +4665,6 @@ class EC2 {
     CreateTransitGatewayVpcAttachmentRequestOptions? options,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5085,7 +4866,6 @@ class EC2 {
     int? throughput,
     VolumeType? volumeType,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5176,7 +4956,6 @@ class EC2 {
     String? ipv6Pool,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(cidrBlock, 'cidrBlock');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5282,8 +5061,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     VpcEndpointType? vpcEndpointType,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5333,9 +5110,6 @@ class EC2 {
     String? serviceId,
     String? vpcEndpointId,
   }) async {
-    ArgumentError.checkNotNull(connectionEvents, 'connectionEvents');
-    ArgumentError.checkNotNull(
-        connectionNotificationArn, 'connectionNotificationArn');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5532,8 +5306,6 @@ class EC2 {
     String? transitGatewayId,
     String? vpnGatewayId,
   }) async {
-    ArgumentError.checkNotNull(customerGatewayId, 'customerGatewayId');
-    ArgumentError.checkNotNull(type, 'type');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5556,8 +5328,6 @@ class EC2 {
     required String destinationCidrBlock,
     required String vpnConnectionId,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5600,7 +5370,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(type, 'type');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5626,7 +5395,6 @@ class EC2 {
     required String carrierGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(carrierGatewayId, 'carrierGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5647,7 +5415,6 @@ class EC2 {
     required String clientVpnEndpointId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5679,8 +5446,6 @@ class EC2 {
     bool? dryRun,
     String? targetVpcSubnetId,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5701,7 +5466,6 @@ class EC2 {
     required String customerGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(customerGatewayId, 'customerGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5724,7 +5488,6 @@ class EC2 {
     required String dhcpOptionsId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(dhcpOptionsId, 'dhcpOptionsId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5745,8 +5508,6 @@ class EC2 {
     required String egressOnlyInternetGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        egressOnlyInternetGatewayId, 'egressOnlyInternetGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5809,8 +5570,6 @@ class EC2 {
     required bool terminateInstances,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(fleetIds, 'fleetIds');
-    ArgumentError.checkNotNull(terminateInstances, 'terminateInstances');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5832,7 +5591,6 @@ class EC2 {
     required List<String> flowLogIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(flowLogIds, 'flowLogIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5852,7 +5610,6 @@ class EC2 {
     required String fpgaImageId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(fpgaImageId, 'fpgaImageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5873,7 +5630,6 @@ class EC2 {
     required String internetGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(internetGatewayId, 'internetGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5924,12 +5680,6 @@ class EC2 {
     String? launchTemplateId,
     String? launchTemplateName,
   }) async {
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5963,13 +5713,6 @@ class EC2 {
     String? launchTemplateId,
     String? launchTemplateName,
   }) async {
-    ArgumentError.checkNotNull(versions, 'versions');
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -5994,9 +5737,6 @@ class EC2 {
     required String localGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(
-        localGatewayRouteTableId, 'localGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6018,8 +5758,6 @@ class EC2 {
     required String localGatewayRouteTableVpcAssociationId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(localGatewayRouteTableVpcAssociationId,
-        'localGatewayRouteTableVpcAssociationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6040,7 +5778,6 @@ class EC2 {
     required String prefixListId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6063,7 +5800,6 @@ class EC2 {
     required String natGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(natGatewayId, 'natGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6084,7 +5820,6 @@ class EC2 {
     required String networkAclId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(networkAclId, 'networkAclId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6113,9 +5848,6 @@ class EC2 {
     required int ruleNumber,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(egress, 'egress');
-    ArgumentError.checkNotNull(networkAclId, 'networkAclId');
-    ArgumentError.checkNotNull(ruleNumber, 'ruleNumber');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6135,8 +5867,6 @@ class EC2 {
     required String networkInsightsAnalysisId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        networkInsightsAnalysisId, 'networkInsightsAnalysisId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6156,7 +5886,6 @@ class EC2 {
     required String networkInsightsPathId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(networkInsightsPathId, 'networkInsightsPathId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6177,7 +5906,6 @@ class EC2 {
     required String networkInterfaceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6206,8 +5934,6 @@ class EC2 {
     bool? dryRun,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(
-        networkInterfacePermissionId, 'networkInterfacePermissionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6231,7 +5957,6 @@ class EC2 {
     required String groupName,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6251,7 +5976,6 @@ class EC2 {
     required List<String> reservedInstancesIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(reservedInstancesIds, 'reservedInstancesIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6285,7 +6009,6 @@ class EC2 {
     String? destinationPrefixListId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6307,7 +6030,6 @@ class EC2 {
     required String routeTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6373,7 +6095,6 @@ class EC2 {
     required String snapshotId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6409,7 +6130,6 @@ class EC2 {
     required String subnetId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6449,7 +6169,6 @@ class EC2 {
     bool? dryRun,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(resources, 'resources');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6472,7 +6191,6 @@ class EC2 {
     required String trafficMirrorFilterId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(trafficMirrorFilterId, 'trafficMirrorFilterId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6492,8 +6210,6 @@ class EC2 {
     required String trafficMirrorFilterRuleId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        trafficMirrorFilterRuleId, 'trafficMirrorFilterRuleId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6513,8 +6229,6 @@ class EC2 {
     required String trafficMirrorSessionId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        trafficMirrorSessionId, 'trafficMirrorSessionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6537,7 +6251,6 @@ class EC2 {
     required String trafficMirrorTargetId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(trafficMirrorTargetId, 'trafficMirrorTargetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6557,7 +6270,6 @@ class EC2 {
     required String transitGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6578,8 +6290,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6600,8 +6310,6 @@ class EC2 {
     required String transitGatewayConnectPeerId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayConnectPeerId, 'transitGatewayConnectPeerId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6622,8 +6330,6 @@ class EC2 {
     required String transitGatewayMulticastDomainId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayMulticastDomainId, 'transitGatewayMulticastDomainId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6644,8 +6350,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6671,9 +6375,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6699,9 +6400,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6723,8 +6421,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6745,8 +6441,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6775,7 +6469,6 @@ class EC2 {
     required String volumeId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6800,7 +6493,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6821,8 +6513,6 @@ class EC2 {
     required List<String> connectionNotificationIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        connectionNotificationIds, 'connectionNotificationIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6846,7 +6536,6 @@ class EC2 {
     required List<String> serviceIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(serviceIds, 'serviceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6871,7 +6560,6 @@ class EC2 {
     required List<String> vpcEndpointIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcEndpointIds, 'vpcEndpointIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6896,8 +6584,6 @@ class EC2 {
     required String vpcPeeringConnectionId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        vpcPeeringConnectionId, 'vpcPeeringConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6930,7 +6616,6 @@ class EC2 {
     required String vpnConnectionId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6949,8 +6634,6 @@ class EC2 {
     required String destinationCidrBlock,
     required String vpnConnectionId,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -6973,7 +6656,6 @@ class EC2 {
     required String vpnGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpnGatewayId, 'vpnGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -7000,7 +6682,6 @@ class EC2 {
     required String cidr,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -7029,7 +6710,6 @@ class EC2 {
     required String imageId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -7482,7 +7162,6 @@ class EC2 {
     bool? dryRun,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7831,7 +7510,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7883,7 +7561,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7986,7 +7663,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -8046,7 +7722,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -8544,8 +8219,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(startTime, 'startTime');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -8585,7 +8258,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -8747,8 +8419,6 @@ class EC2 {
     required String fpgaImageId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(fpgaImageId, 'fpgaImageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -9186,7 +8856,6 @@ class EC2 {
     required String principalArn,
     String? resource,
   }) async {
-    ArgumentError.checkNotNull(principalArn, 'principalArn');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -9217,8 +8886,6 @@ class EC2 {
     required String imageId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(imageId, 'imageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -9497,8 +9164,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -10732,12 +10397,6 @@ class EC2 {
     String? nextToken,
     List<String>? versions,
   }) async {
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -11586,7 +11245,6 @@ class EC2 {
     NetworkInterfaceAttribute? attribute,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -12753,9 +12411,6 @@ class EC2 {
     int? minSlotDurationInHours,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        firstSlotStartTimeRange, 'firstSlotStartTimeRange');
-    ArgumentError.checkNotNull(recurrence, 'recurrence');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -12841,7 +12496,6 @@ class EC2 {
     required List<String> groupId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -13040,8 +12694,6 @@ class EC2 {
     required String snapshotId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -13262,7 +12914,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(spotFleetRequestId, 'spotFleetRequestId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -13313,8 +12964,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(spotFleetRequestId, 'spotFleetRequestId');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -13696,18 +13345,11 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       5,
       255,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
 // TODO: implement ec2
     throw UnimplementedError();
@@ -14656,8 +14298,6 @@ class EC2 {
     required String volumeId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -15043,8 +14683,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -15122,12 +14760,6 @@ class EC2 {
       maxResults,
       5,
       255,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
 // TODO: implement ec2
     throw UnimplementedError();
@@ -15351,7 +14983,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -15878,8 +15509,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -15905,8 +15534,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(internetGatewayId, 'internetGatewayId');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -15949,7 +15576,6 @@ class EC2 {
     bool? dryRun,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(attachmentId, 'attachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16003,7 +15629,6 @@ class EC2 {
     bool? force,
     String? instanceId,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16035,8 +15660,6 @@ class EC2 {
     required String vpnGatewayId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
-    ArgumentError.checkNotNull(vpnGatewayId, 'vpnGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16087,8 +15710,6 @@ class EC2 {
     required List<String> sourceSnapshotIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(availabilityZones, 'availabilityZones');
-    ArgumentError.checkNotNull(sourceSnapshotIds, 'sourceSnapshotIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16114,10 +15735,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16142,8 +15759,6 @@ class EC2 {
     required String routeTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(gatewayId, 'gatewayId');
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16164,7 +15779,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16258,8 +15872,6 @@ class EC2 {
     required String clientVpnEndpointId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16290,18 +15902,6 @@ class EC2 {
     bool? dryRun,
     String? roleArn,
   }) async {
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      1,
-      1283,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1283,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16316,7 +15916,6 @@ class EC2 {
   Future<DisassociateIamInstanceProfileResult> disassociateIamInstanceProfile({
     required String associationId,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16343,7 +15942,6 @@ class EC2 {
     required String associationId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16358,7 +15956,6 @@ class EC2 {
   Future<DisassociateSubnetCidrBlockResult> disassociateSubnetCidrBlock({
     required String associationId,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16412,10 +16009,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16433,7 +16026,6 @@ class EC2 {
   Future<DisassociateVpcCidrBlockResult> disassociateVpcCidrBlock({
     required String associationId,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16503,8 +16095,6 @@ class EC2 {
     required List<String> sourceSnapshotIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(availabilityZones, 'availabilityZones');
-    ArgumentError.checkNotNull(sourceSnapshotIds, 'sourceSnapshotIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16530,10 +16120,6 @@ class EC2 {
     required String transitGatewayRouteTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16561,8 +16147,6 @@ class EC2 {
     required String routeTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(gatewayId, 'gatewayId');
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16583,7 +16167,6 @@ class EC2 {
     required String volumeId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16611,7 +16194,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16653,7 +16235,6 @@ class EC2 {
     required String clientVpnEndpointId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16677,7 +16258,6 @@ class EC2 {
     required String clientVpnEndpointId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16730,9 +16310,6 @@ class EC2 {
     String? roleName,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(diskImageFormat, 'diskImageFormat');
-    ArgumentError.checkNotNull(imageId, 'imageId');
-    ArgumentError.checkNotNull(s3ExportLocation, 's3ExportLocation');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16808,9 +16385,6 @@ class EC2 {
     bool? dryRun,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(s3Bucket, 's3Bucket');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16837,12 +16411,6 @@ class EC2 {
     String? certificateArn,
     bool? dryRun,
   }) async {
-    _s.validateStringLength(
-      'certificateArn',
-      certificateArn,
-      1,
-      1283,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -16873,7 +16441,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(poolId, 'poolId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -16917,7 +16484,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(capacityReservationId, 'capacityReservationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -16978,7 +16544,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(poolId, 'poolId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17028,7 +16593,6 @@ class EC2 {
     bool? dryRun,
     bool? latest,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17056,7 +16620,6 @@ class EC2 {
     bool? dryRun,
     bool? wakeUp,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17082,7 +16645,6 @@ class EC2 {
     required UnlimitedSupportedInstanceFamily instanceFamily,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceFamily, 'instanceFamily');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17157,7 +16719,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(capacityReservationId, 'capacityReservationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17185,8 +16746,6 @@ class EC2 {
     required List<String> hostIdSet,
     required String offeringId,
   }) async {
-    ArgumentError.checkNotNull(hostIdSet, 'hostIdSet');
-    ArgumentError.checkNotNull(offeringId, 'offeringId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17214,7 +16773,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17246,7 +16804,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17287,7 +16844,6 @@ class EC2 {
     String? nextToken,
     int? targetVersion,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17336,7 +16892,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17366,7 +16921,6 @@ class EC2 {
     bool? dryRun,
     List<TargetConfigurationRequest>? targetConfigurations,
   }) async {
-    ArgumentError.checkNotNull(reservedInstanceIds, 'reservedInstanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17409,8 +16963,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17547,8 +17099,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17604,8 +17154,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17661,8 +17209,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -17702,9 +17248,6 @@ class EC2 {
     required String clientVpnEndpointId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateRevocationList, 'certificateRevocationList');
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17881,7 +17424,6 @@ class EC2 {
     bool? dryRun,
     ImportInstanceLaunchSpecification? launchSpecification,
   }) async {
-    ArgumentError.checkNotNull(platform, 'platform');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -17918,8 +17460,6 @@ class EC2 {
     bool? dryRun,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(keyName, 'keyName');
-    ArgumentError.checkNotNull(publicKeyMaterial, 'publicKeyMaterial');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18052,9 +17592,6 @@ class EC2 {
     String? description,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(image, 'image');
-    ArgumentError.checkNotNull(volume, 'volume');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18089,8 +17626,6 @@ class EC2 {
     required ModifyAvailabilityZoneOptInStatus optInStatus,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    ArgumentError.checkNotNull(optInStatus, 'optInStatus');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18153,7 +17688,6 @@ class EC2 {
     EndDateType? endDateType,
     int? instanceCount,
   }) async {
-    ArgumentError.checkNotNull(capacityReservationId, 'capacityReservationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18246,7 +17780,6 @@ class EC2 {
     String? vpcId,
     int? vpnPort,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18291,8 +17824,6 @@ class EC2 {
     required UnlimitedSupportedInstanceFamily instanceFamily,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(cpuCredits, 'cpuCredits');
-    ArgumentError.checkNotNull(instanceFamily, 'instanceFamily');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18354,7 +17885,6 @@ class EC2 {
     required String kmsKeyId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(kmsKeyId, 'kmsKeyId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18421,7 +17951,6 @@ class EC2 {
     List<FleetLaunchTemplateConfigRequest>? launchTemplateConfigs,
     TargetCapacitySpecificationRequest? targetCapacitySpecification,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18477,7 +18006,6 @@ class EC2 {
     List<String>? userGroups,
     List<String>? userIds,
   }) async {
-    ArgumentError.checkNotNull(fpgaImageId, 'fpgaImageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18532,7 +18060,6 @@ class EC2 {
     String? instanceFamily,
     String? instanceType,
   }) async {
-    ArgumentError.checkNotNull(hostIds, 'hostIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18595,8 +18122,6 @@ class EC2 {
     required String resource,
     required bool useLongIds,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(useLongIds, 'useLongIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18664,9 +18189,6 @@ class EC2 {
     required String resource,
     required bool useLongIds,
   }) async {
-    ArgumentError.checkNotNull(principalArn, 'principalArn');
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(useLongIds, 'useLongIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18736,7 +18258,6 @@ class EC2 {
     List<String>? userIds,
     String? value,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18877,7 +18398,6 @@ class EC2 {
     BlobAttributeValue? userData,
     String? value,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18905,9 +18425,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        capacityReservationSpecification, 'capacityReservationSpecification');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18943,8 +18460,6 @@ class EC2 {
     String? clientToken,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        instanceCreditSpecifications, 'instanceCreditSpecifications');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -18972,9 +18487,6 @@ class EC2 {
     required DateTime notBefore,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceEventId, 'instanceEventId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(notBefore, 'notBefore');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19037,7 +18549,6 @@ class EC2 {
     int? httpPutResponseHopLimit,
     HttpTokensState? httpTokens,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19112,7 +18623,6 @@ class EC2 {
     int? partitionNumber,
     HostTenancy? tenancy,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19153,12 +18663,6 @@ class EC2 {
     String? launchTemplateId,
     String? launchTemplateName,
   }) async {
-    _s.validateStringLength(
-      'launchTemplateName',
-      launchTemplateName,
-      3,
-      128,
-    );
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19201,7 +18705,6 @@ class EC2 {
     String? prefixListName,
     List<RemovePrefixListEntry>? removeEntries,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19249,7 +18752,6 @@ class EC2 {
     List<String>? groups,
     AttributeBooleanValue? sourceDestCheck,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19279,8 +18781,6 @@ class EC2 {
     required List<ReservedInstancesConfiguration> targetConfigurations,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(reservedInstancesIds, 'reservedInstancesIds');
-    ArgumentError.checkNotNull(targetConfigurations, 'targetConfigurations');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19334,7 +18834,6 @@ class EC2 {
     OperationType? operationType,
     List<String>? userIds,
   }) async {
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19400,7 +18899,6 @@ class EC2 {
     int? onDemandTargetCapacity,
     int? targetCapacity,
   }) async {
-    ArgumentError.checkNotNull(spotFleetRequestId, 'spotFleetRequestId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19445,7 +18943,6 @@ class EC2 {
     AttributeBooleanValue? mapCustomerOwnedIpOnLaunch,
     AttributeBooleanValue? mapPublicIpOnLaunch,
   }) async {
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19487,7 +18984,6 @@ class EC2 {
     bool? dryRun,
     List<TrafficMirrorNetworkService>? removeNetworkServices,
   }) async {
-    ArgumentError.checkNotNull(trafficMirrorFilterId, 'trafficMirrorFilterId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19557,8 +19053,6 @@ class EC2 {
     TrafficMirrorPortRangeRequest? sourcePortRange,
     TrafficDirection? trafficDirection,
   }) async {
-    ArgumentError.checkNotNull(
-        trafficMirrorFilterRuleId, 'trafficMirrorFilterRuleId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19618,8 +19112,6 @@ class EC2 {
     String? trafficMirrorTargetId,
     int? virtualNetworkId,
   }) async {
-    ArgumentError.checkNotNull(
-        trafficMirrorSessionId, 'trafficMirrorSessionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19649,7 +19141,6 @@ class EC2 {
     bool? dryRun,
     ModifyTransitGatewayOptions? options,
   }) async {
-    ArgumentError.checkNotNull(transitGatewayId, 'transitGatewayId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19683,9 +19174,6 @@ class EC2 {
     bool? dryRun,
     String? transitGatewayAttachmentId,
   }) async {
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19722,8 +19210,6 @@ class EC2 {
     ModifyTransitGatewayVpcAttachmentRequestOptions? options,
     List<String>? removeSubnetIds,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19857,7 +19343,6 @@ class EC2 {
     int? throughput,
     VolumeType? volumeType,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19891,7 +19376,6 @@ class EC2 {
     AttributeBooleanValue? autoEnableIO,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19923,7 +19407,6 @@ class EC2 {
     AttributeBooleanValue? enableDnsHostnames,
     AttributeBooleanValue? enableDnsSupport,
   }) async {
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -19994,7 +19477,6 @@ class EC2 {
     List<String>? removeSubnetIds,
     bool? resetPolicy,
   }) async {
-    ArgumentError.checkNotNull(vpcEndpointId, 'vpcEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20026,8 +19508,6 @@ class EC2 {
     String? connectionNotificationArn,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        connectionNotificationId, 'connectionNotificationId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20092,7 +19572,6 @@ class EC2 {
     List<String>? removeNetworkLoadBalancerArns,
     bool? removePrivateDnsName,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20133,7 +19612,6 @@ class EC2 {
     bool? dryRun,
     List<String>? removeAllowedPrincipals,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20190,8 +19668,6 @@ class EC2 {
     bool? dryRun,
     PeeringConnectionOptionsRequest? requesterPeeringConnectionOptions,
   }) async {
-    ArgumentError.checkNotNull(
-        vpcPeeringConnectionId, 'vpcPeeringConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20227,8 +19703,6 @@ class EC2 {
     required String vpcId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceTenancy, 'instanceTenancy');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20309,7 +19783,6 @@ class EC2 {
     String? transitGatewayId,
     String? vpnGatewayId,
   }) async {
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20360,7 +19833,6 @@ class EC2 {
     String? remoteIpv4NetworkCidr,
     String? remoteIpv6NetworkCidr,
   }) async {
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20384,9 +19856,6 @@ class EC2 {
     required String vpnTunnelOutsideIpAddress,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
-    ArgumentError.checkNotNull(
-        vpnTunnelOutsideIpAddress, 'vpnTunnelOutsideIpAddress');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20420,10 +19889,6 @@ class EC2 {
     required String vpnTunnelOutsideIpAddress,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(tunnelOptions, 'tunnelOptions');
-    ArgumentError.checkNotNull(vpnConnectionId, 'vpnConnectionId');
-    ArgumentError.checkNotNull(
-        vpnTunnelOutsideIpAddress, 'vpnTunnelOutsideIpAddress');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20449,7 +19914,6 @@ class EC2 {
     required List<String> instanceIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20476,7 +19940,6 @@ class EC2 {
     required String publicIp,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(publicIp, 'publicIp');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20538,7 +20001,6 @@ class EC2 {
     List<TagSpecification>? poolTagSpecifications,
     bool? publiclyAdvertisable,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20585,8 +20047,6 @@ class EC2 {
     String? limitPrice,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(hostIdSet, 'hostIdSet');
-    ArgumentError.checkNotNull(offeringId, 'offeringId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20639,9 +20099,6 @@ class EC2 {
     ReservedInstanceLimitPrice? limitPrice,
     DateTime? purchaseTime,
   }) async {
-    ArgumentError.checkNotNull(instanceCount, 'instanceCount');
-    ArgumentError.checkNotNull(
-        reservedInstancesOfferingId, 'reservedInstancesOfferingId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20678,7 +20135,6 @@ class EC2 {
     String? clientToken,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(purchaseRequests, 'purchaseRequests');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20709,7 +20165,6 @@ class EC2 {
     required List<String> instanceIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -20851,7 +20306,6 @@ class EC2 {
     String? sriovNetSupport,
     String? virtualizationType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21004,8 +20458,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21031,8 +20483,6 @@ class EC2 {
     required String transitGatewayAttachmentId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        transitGatewayAttachmentId, 'transitGatewayAttachmentId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21057,8 +20507,6 @@ class EC2 {
     required List<String> vpcEndpointIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    ArgumentError.checkNotNull(vpcEndpointIds, 'vpcEndpointIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21083,8 +20531,6 @@ class EC2 {
     required String vpcPeeringConnectionId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        vpcPeeringConnectionId, 'vpcPeeringConnectionId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21167,7 +20613,6 @@ class EC2 {
   Future<ReleaseHostsResult> releaseHosts({
     required List<String> hostIds,
   }) async {
-    ArgumentError.checkNotNull(hostIds, 'hostIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21190,8 +20635,6 @@ class EC2 {
     required String associationId,
     required IamInstanceProfileSpecification iamInstanceProfile,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    ArgumentError.checkNotNull(iamInstanceProfile, 'iamInstanceProfile');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21222,8 +20665,6 @@ class EC2 {
     required String networkAclId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    ArgumentError.checkNotNull(networkAclId, 'networkAclId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21289,11 +20730,6 @@ class EC2 {
     String? ipv6CidrBlock,
     PortRange? portRange,
   }) async {
-    ArgumentError.checkNotNull(egress, 'egress');
-    ArgumentError.checkNotNull(networkAclId, 'networkAclId');
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    ArgumentError.checkNotNull(ruleAction, 'ruleAction');
-    ArgumentError.checkNotNull(ruleNumber, 'ruleNumber');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21380,7 +20816,6 @@ class EC2 {
     String? vpcEndpointId,
     String? vpcPeeringConnectionId,
   }) async {
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21413,8 +20848,6 @@ class EC2 {
     required String routeTableId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    ArgumentError.checkNotNull(routeTableId, 'routeTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21447,9 +20880,6 @@ class EC2 {
     bool? dryRun,
     String? transitGatewayAttachmentId,
   }) async {
-    ArgumentError.checkNotNull(destinationCidrBlock, 'destinationCidrBlock');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21533,9 +20963,6 @@ class EC2 {
     DateTime? endTime,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(instances, 'instances');
-    ArgumentError.checkNotNull(reasonCodes, 'reasonCodes');
-    ArgumentError.checkNotNull(status, 'status');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21584,8 +21011,6 @@ class EC2 {
     required SpotFleetRequestConfigData spotFleetRequestConfig,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        spotFleetRequestConfig, 'spotFleetRequestConfig');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21774,7 +21199,6 @@ class EC2 {
     ResetFpgaImageAttributeName? attribute,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(fpgaImageId, 'fpgaImageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21802,8 +21226,6 @@ class EC2 {
     required String imageId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(imageId, 'imageId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21843,8 +21265,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21870,7 +21290,6 @@ class EC2 {
     bool? dryRun,
     String? sourceDestCheck,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21899,8 +21318,6 @@ class EC2 {
     required String snapshotId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(attribute, 'attribute');
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21923,7 +21340,6 @@ class EC2 {
     required String publicIp,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(publicIp, 'publicIp');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21953,9 +21369,6 @@ class EC2 {
     required int previousVersion,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    ArgumentError.checkNotNull(prefixListId, 'prefixListId');
-    ArgumentError.checkNotNull(previousVersion, 'previousVersion');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -21989,8 +21402,6 @@ class EC2 {
     bool? dryRun,
     bool? revokeAllGroups,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
-    ArgumentError.checkNotNull(targetNetworkCidr, 'targetNetworkCidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22062,7 +21473,6 @@ class EC2 {
     String? sourceSecurityGroupOwnerId,
     int? toPort,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22558,8 +21968,6 @@ class EC2 {
     List<TagSpecification>? tagSpecifications,
     String? userData,
   }) async {
-    ArgumentError.checkNotNull(maxCount, 'maxCount');
-    ArgumentError.checkNotNull(minCount, 'minCount');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22608,8 +22016,6 @@ class EC2 {
     bool? dryRun,
     int? instanceCount,
   }) async {
-    ArgumentError.checkNotNull(launchSpecification, 'launchSpecification');
-    ArgumentError.checkNotNull(scheduledInstanceId, 'scheduledInstanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22643,9 +22049,6 @@ class EC2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(
-        localGatewayRouteTableId, 'localGatewayRouteTableId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22803,9 +22206,6 @@ class EC2 {
     bool? dryRun,
     int? maxResults,
   }) async {
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(
-        transitGatewayRouteTableId, 'transitGatewayRouteTableId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -22850,7 +22250,6 @@ class EC2 {
     required String instanceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22897,7 +22296,6 @@ class EC2 {
     String? additionalInfo,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22934,7 +22332,6 @@ class EC2 {
     List<String>? filterInArns,
     List<TagSpecification>? tagSpecifications,
   }) async {
-    ArgumentError.checkNotNull(networkInsightsPathId, 'networkInsightsPathId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -22965,7 +22362,6 @@ class EC2 {
     required String serviceId,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23056,7 +22452,6 @@ class EC2 {
     bool? force,
     bool? hibernate,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23088,7 +22483,6 @@ class EC2 {
     bool? dryRun,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(clientVpnEndpointId, 'clientVpnEndpointId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23139,7 +22533,6 @@ class EC2 {
     required List<String> instanceIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23155,8 +22548,6 @@ class EC2 {
     required List<String> ipv6Addresses,
     required String networkInterfaceId,
   }) async {
-    ArgumentError.checkNotNull(ipv6Addresses, 'ipv6Addresses');
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23175,8 +22566,6 @@ class EC2 {
     required String networkInterfaceId,
     required List<String> privateIpAddresses,
   }) async {
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(privateIpAddresses, 'privateIpAddresses');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23200,7 +22589,6 @@ class EC2 {
     required List<String> instanceIds,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23238,7 +22626,6 @@ class EC2 {
     String? groupId,
     String? groupName,
   }) async {
-    ArgumentError.checkNotNull(ipPermissions, 'ipPermissions');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23277,7 +22664,6 @@ class EC2 {
     String? groupId,
     String? groupName,
   }) async {
-    ArgumentError.checkNotNull(ipPermissions, 'ipPermissions');
 // TODO: implement ec2
     throw UnimplementedError();
   }
@@ -23303,7 +22689,6 @@ class EC2 {
     required String cidr,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
 // TODO: implement ec2
     throw UnimplementedError();
   }

--- a/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
+++ b/generated/aws_ec2_instance_connect_api/lib/ec2-instance-connect-2018-04-02.dart
@@ -78,38 +78,6 @@ class EC2InstanceConnect {
     required String instanceOSUser,
     required String sSHPublicKey,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    _s.validateStringLength(
-      'availabilityZone',
-      availabilityZone,
-      6,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      10,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceOSUser, 'instanceOSUser');
-    _s.validateStringLength(
-      'instanceOSUser',
-      instanceOSUser,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sSHPublicKey, 'sSHPublicKey');
-    _s.validateStringLength(
-      'sSHPublicKey',
-      sSHPublicKey,
-      256,
-      4096,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEC2InstanceConnectService.SendSSHPublicKey'

--- a/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
+++ b/generated/aws_ecr_api/lib/ecr-2015-09-21.dart
@@ -85,15 +85,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(layerDigests, 'layerDigests');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -146,15 +137,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageIds, 'imageIds');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.BatchDeleteImage'
@@ -211,15 +193,6 @@ class ECR {
     List<String>? acceptedMediaTypes,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageIds, 'imageIds');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.BatchGetImage'
@@ -284,16 +257,6 @@ class ECR {
     required String uploadId,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(layerDigests, 'layerDigests');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.CompleteLayerUpload'
@@ -362,14 +325,6 @@ class ECR {
     ImageTagMutability? imageTagMutability,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.CreateRepository'
@@ -413,14 +368,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -488,14 +435,6 @@ class ECR {
     bool? force,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.DeleteRepository'
@@ -535,14 +474,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -606,15 +537,6 @@ class ECR {
     String? nextToken,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -701,14 +623,6 @@ class ECR {
     String? nextToken,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -913,15 +827,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(layerDigest, 'layerDigest');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -961,14 +866,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicy'
@@ -1042,14 +939,6 @@ class ECR {
     String? nextToken,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1119,14 +1008,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.GetRepositoryPolicy'
@@ -1174,14 +1055,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.InitiateLayerUpload'
@@ -1256,14 +1129,6 @@ class ECR {
     String? nextToken,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1305,7 +1170,6 @@ class ECR {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.ListTagsForResource'
@@ -1377,28 +1241,6 @@ class ECR {
     String? imageTag,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageManifest, 'imageManifest');
-    _s.validateStringLength(
-      'imageManifest',
-      imageManifest,
-      1,
-      4194304,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'imageTag',
-      imageTag,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.PutImage'
@@ -1447,16 +1289,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(
-        imageScanningConfiguration, 'imageScanningConfiguration');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1507,15 +1339,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageTagMutability, 'imageTagMutability');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1561,22 +1384,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(lifecyclePolicyText, 'lifecyclePolicyText');
-    _s.validateStringLength(
-      'lifecyclePolicyText',
-      lifecyclePolicyText,
-      100,
-      30720,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.PutLifecyclePolicy'
@@ -1618,14 +1425,6 @@ class ECR {
   Future<PutRegistryPolicyResponse> putRegistryPolicy({
     required String policyText,
   }) async {
-    ArgumentError.checkNotNull(policyText, 'policyText');
-    _s.validateStringLength(
-      'policyText',
-      policyText,
-      0,
-      10240,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.PutRegistryPolicy'
@@ -1669,8 +1468,6 @@ class ECR {
   Future<PutReplicationConfigurationResponse> putReplicationConfiguration({
     required ReplicationConfiguration replicationConfiguration,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationConfiguration, 'replicationConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1726,22 +1523,6 @@ class ECR {
     bool? force,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(policyText, 'policyText');
-    _s.validateStringLength(
-      'policyText',
-      policyText,
-      0,
-      10240,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.SetRepositoryPolicy'
@@ -1788,15 +1569,6 @@ class ECR {
     required String repositoryName,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.StartImageScan'
@@ -1843,20 +1615,6 @@ class ECR {
     String? lifecyclePolicyText,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'lifecyclePolicyText',
-      lifecyclePolicyText,
-      100,
-      30720,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1901,8 +1659,6 @@ class ECR {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.TagResource'
@@ -1938,8 +1694,6 @@ class ECR {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.UntagResource'
@@ -2007,8 +1761,6 @@ class ECR {
     required String uploadId,
     String? registryId,
   }) async {
-    ArgumentError.checkNotNull(layerPartBlob, 'layerPartBlob');
-    ArgumentError.checkNotNull(partFirstByte, 'partFirstByte');
     _s.validateNumRange(
       'partFirstByte',
       partFirstByte,
@@ -2016,7 +1768,6 @@ class ECR {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(partLastByte, 'partLastByte');
     _s.validateNumRange(
       'partLastByte',
       partLastByte,
@@ -2024,15 +1775,6 @@ class ECR {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(repositoryName, 'repositoryName');
-    _s.validateStringLength(
-      'repositoryName',
-      repositoryName,
-      2,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerRegistry_V20150921.UploadLayerPart'

--- a/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
+++ b/generated/aws_ecs_api/lib/ecs-2014-11-13.dart
@@ -123,9 +123,6 @@ class ECS {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        autoScalingGroupProvider, 'autoScalingGroupProvider');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -760,7 +757,6 @@ class ECS {
     List<Tag>? tags,
     String? taskDefinition,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.CreateService'
@@ -957,9 +953,6 @@ class ECS {
     List<ServiceRegistry>? serviceRegistries,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(service, 'service');
-    ArgumentError.checkNotNull(taskDefinition, 'taskDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.CreateTaskSet'
@@ -1019,7 +1012,6 @@ class ECS {
     required SettingName name,
     String? principalArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DeleteAccountSetting'
@@ -1059,7 +1051,6 @@ class ECS {
     required List<Attribute> attributes,
     String? cluster,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DeleteAttributes'
@@ -1107,7 +1098,6 @@ class ECS {
   Future<DeleteCapacityProviderResponse> deleteCapacityProvider({
     required String capacityProvider,
   }) async {
-    ArgumentError.checkNotNull(capacityProvider, 'capacityProvider');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1153,7 +1143,6 @@ class ECS {
   Future<DeleteClusterResponse> deleteCluster({
     required String cluster,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DeleteCluster'
@@ -1219,7 +1208,6 @@ class ECS {
     String? cluster,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(service, 'service');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DeleteService'
@@ -1278,9 +1266,6 @@ class ECS {
     required String taskSet,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(service, 'service');
-    ArgumentError.checkNotNull(taskSet, 'taskSet');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DeleteTaskSet'
@@ -1358,7 +1343,6 @@ class ECS {
     String? cluster,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(containerInstance, 'containerInstance');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1411,7 +1395,6 @@ class ECS {
   Future<DeregisterTaskDefinitionResponse> deregisterTaskDefinition({
     required String taskDefinition,
   }) async {
-    ArgumentError.checkNotNull(taskDefinition, 'taskDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1605,7 +1588,6 @@ class ECS {
     String? cluster,
     List<ContainerInstanceField>? include,
   }) async {
-    ArgumentError.checkNotNull(containerInstances, 'containerInstances');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1655,7 +1637,6 @@ class ECS {
     String? cluster,
     List<ServiceField>? include,
   }) async {
-    ArgumentError.checkNotNull(services, 'services');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DescribeServices'
@@ -1704,7 +1685,6 @@ class ECS {
     required String taskDefinition,
     List<TaskDefinitionField>? include,
   }) async {
-    ArgumentError.checkNotNull(taskDefinition, 'taskDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1763,8 +1743,6 @@ class ECS {
     List<TaskSetField>? include,
     List<String>? taskSets,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(service, 'service');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DescribeTaskSets'
@@ -1813,7 +1791,6 @@ class ECS {
     String? cluster,
     List<TaskField>? include,
   }) async {
-    ArgumentError.checkNotNull(tasks, 'tasks');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.DescribeTasks'
@@ -2012,7 +1989,6 @@ class ECS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(targetType, 'targetType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.ListAttributes'
@@ -2255,7 +2231,6 @@ class ECS {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.ListTagsForResource'
@@ -2625,8 +2600,6 @@ class ECS {
     required String value,
     String? principalArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(value, 'value');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.PutAccountSetting'
@@ -2674,8 +2647,6 @@ class ECS {
     required SettingName name,
     required String value,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(value, 'value');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2721,7 +2692,6 @@ class ECS {
     required List<Attribute> attributes,
     String? cluster,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.PutAttributes'
@@ -2811,10 +2781,6 @@ class ECS {
     required String cluster,
     required List<CapacityProviderStrategyItem> defaultCapacityProviderStrategy,
   }) async {
-    ArgumentError.checkNotNull(capacityProviders, 'capacityProviders');
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(
-        defaultCapacityProviderStrategy, 'defaultCapacityProviderStrategy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3291,8 +3257,6 @@ class ECS {
     String? taskRoleArn,
     List<Volume>? volumes,
   }) async {
-    ArgumentError.checkNotNull(containerDefinitions, 'containerDefinitions');
-    ArgumentError.checkNotNull(family, 'family');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3567,7 +3531,6 @@ class ECS {
     String? startedBy,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(taskDefinition, 'taskDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.RunTask'
@@ -3737,8 +3700,6 @@ class ECS {
     String? startedBy,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(containerInstances, 'containerInstances');
-    ArgumentError.checkNotNull(taskDefinition, 'taskDefinition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.StartTask'
@@ -3811,7 +3772,6 @@ class ECS {
     String? cluster,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(task, 'task');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.StopTask'
@@ -3853,7 +3813,6 @@ class ECS {
     required List<AttachmentStateChange> attachments,
     String? cluster,
   }) async {
-    ArgumentError.checkNotNull(attachments, 'attachments');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4078,8 +4037,6 @@ class ECS {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.TagResource'
@@ -4116,8 +4073,6 @@ class ECS {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.UntagResource'
@@ -4151,9 +4106,6 @@ class ECS {
     required AutoScalingGroupProviderUpdate autoScalingGroupProvider,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(
-        autoScalingGroupProvider, 'autoScalingGroupProvider');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4193,8 +4145,6 @@ class ECS {
     required String cluster,
     required List<ClusterSetting> settings,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(settings, 'settings');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.UpdateClusterSettings'
@@ -4248,7 +4198,6 @@ class ECS {
     required String containerInstance,
     String? cluster,
   }) async {
-    ArgumentError.checkNotNull(containerInstance, 'containerInstance');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.UpdateContainerAgent'
@@ -4356,8 +4305,6 @@ class ECS {
     required ContainerInstanceStatus status,
     String? cluster,
   }) async {
-    ArgumentError.checkNotNull(containerInstances, 'containerInstances');
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4639,7 +4586,6 @@ class ECS {
     String? platformVersion,
     String? taskDefinition,
   }) async {
-    ArgumentError.checkNotNull(service, 'service');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.UpdateService'
@@ -4710,9 +4656,6 @@ class ECS {
     required String primaryTaskSet,
     required String service,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(primaryTaskSet, 'primaryTaskSet');
-    ArgumentError.checkNotNull(service, 'service');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4768,10 +4711,6 @@ class ECS {
     required String service,
     required String taskSet,
   }) async {
-    ArgumentError.checkNotNull(cluster, 'cluster');
-    ArgumentError.checkNotNull(scale, 'scale');
-    ArgumentError.checkNotNull(service, 'service');
-    ArgumentError.checkNotNull(taskSet, 'taskSet');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonEC2ContainerServiceV20141113.UpdateTaskSet'

--- a/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
+++ b/generated/aws_efs_api/lib/elasticfilesystem-2015-02-01.dart
@@ -104,20 +104,6 @@ class EFS {
     RootDirectory? rootDirectory,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'FileSystemId': fileSystemId,
       'ClientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -285,18 +271,6 @@ class EFS {
     List<Tag>? tags,
     ThroughputMode? throughputMode,
   }) async {
-    _s.validateStringLength(
-      'creationToken',
-      creationToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
     _s.validateNumRange(
       'provisionedThroughputInMibps',
       provisionedThroughputInMibps,
@@ -491,28 +465,6 @@ class EFS {
     String? ipAddress,
     List<String>? securityGroups,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetId, 'subnetId');
-    _s.validateStringLength(
-      'subnetId',
-      subnetId,
-      15,
-      47,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'ipAddress',
-      ipAddress,
-      7,
-      15,
-    );
     final $payload = <String, dynamic>{
       'FileSystemId': fileSystemId,
       'SubnetId': subnetId,
@@ -554,15 +506,6 @@ class EFS {
     required String fileSystemId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -592,7 +535,6 @@ class EFS {
   Future<void> deleteAccessPoint({
     required String accessPointId,
   }) async {
-    ArgumentError.checkNotNull(accessPointId, 'accessPointId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -630,14 +572,6 @@ class EFS {
   Future<void> deleteFileSystem({
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -667,14 +601,6 @@ class EFS {
   Future<void> deleteFileSystemPolicy({
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -728,14 +654,6 @@ class EFS {
   Future<void> deleteMountTarget({
     required String mountTargetId,
   }) async {
-    ArgumentError.checkNotNull(mountTargetId, 'mountTargetId');
-    _s.validateStringLength(
-      'mountTargetId',
-      mountTargetId,
-      13,
-      45,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -769,15 +687,6 @@ class EFS {
     required String fileSystemId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'TagKeys': tagKeys,
     };
@@ -828,12 +737,6 @@ class EFS {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -870,14 +773,6 @@ class EFS {
   Future<BackupPolicyDescription> describeBackupPolicy({
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -904,14 +799,6 @@ class EFS {
   Future<FileSystemPolicyDescription> describeFileSystemPolicy({
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -978,24 +865,6 @@ class EFS {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'creationToken',
-      creationToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -1038,14 +907,6 @@ class EFS {
   Future<LifecycleConfigurationDescription> describeLifecycleConfiguration({
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1085,14 +946,6 @@ class EFS {
       describeMountTargetSecurityGroups({
     required String mountTargetId,
   }) async {
-    ArgumentError.checkNotNull(mountTargetId, 'mountTargetId');
-    _s.validateStringLength(
-      'mountTargetId',
-      mountTargetId,
-      13,
-      45,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1155,29 +1008,11 @@ class EFS {
     int? maxItems,
     String? mountTargetId,
   }) async {
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'mountTargetId',
-      mountTargetId,
-      13,
-      45,
     );
     final $query = <String, List<String>>{
       if (accessPointId != null) 'AccessPointId': [accessPointId],
@@ -1227,20 +1062,6 @@ class EFS {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -1289,7 +1110,6 @@ class EFS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1350,14 +1170,6 @@ class EFS {
     required String mountTargetId,
     List<String>? securityGroups,
   }) async {
-    ArgumentError.checkNotNull(mountTargetId, 'mountTargetId');
-    _s.validateStringLength(
-      'mountTargetId',
-      mountTargetId,
-      13,
-      45,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (securityGroups != null) 'SecurityGroups': securityGroups,
     };
@@ -1388,15 +1200,6 @@ class EFS {
     required BackupPolicy backupPolicy,
     required String fileSystemId,
   }) async {
-    ArgumentError.checkNotNull(backupPolicy, 'backupPolicy');
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'BackupPolicy': backupPolicy,
     };
@@ -1454,15 +1257,6 @@ class EFS {
     required String policy,
     bool? bypassPolicyLockoutSafetyCheck,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
     final $payload = <String, dynamic>{
       'Policy': policy,
       if (bypassPolicyLockoutSafetyCheck != null)
@@ -1534,15 +1328,6 @@ class EFS {
     required String fileSystemId,
     required List<LifecyclePolicy> lifecyclePolicies,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecyclePolicies, 'lifecyclePolicies');
     final $payload = <String, dynamic>{
       'LifecyclePolicies': lifecyclePolicies,
     };
@@ -1576,8 +1361,6 @@ class EFS {
     required String resourceId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1611,8 +1394,6 @@ class EFS {
     required String resourceId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1658,14 +1439,6 @@ class EFS {
     double? provisionedThroughputInMibps,
     ThroughputMode? throughputMode,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      0,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'provisionedThroughputInMibps',
       provisionedThroughputInMibps,

--- a/generated/aws_eks_api/lib/eks-2017-11-01.dart
+++ b/generated/aws_eks_api/lib/eks-2017-11-01.dart
@@ -128,21 +128,6 @@ class EKS {
     String? serviceAccountRoleArn,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(addonName, 'addonName');
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'serviceAccountRoleArn',
-      serviceAccountRoleArn,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'addonName': addonName,
       if (addonVersion != null) 'addonVersion': addonVersion,
@@ -286,16 +271,6 @@ class EKS {
     Map<String, String>? tags,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourcesVpcConfig, 'resourcesVpcConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $payload = <String, dynamic>{
       'name': name,
       'resourcesVpcConfig': resourcesVpcConfig,
@@ -408,9 +383,6 @@ class EKS {
     List<String>? subnets,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(fargateProfileName, 'fargateProfileName');
-    ArgumentError.checkNotNull(podExecutionRoleArn, 'podExecutionRoleArn');
     final $payload = <String, dynamic>{
       'fargateProfileName': fargateProfileName,
       'podExecutionRoleArn': podExecutionRoleArn,
@@ -608,10 +580,6 @@ class EKS {
     Map<String, String>? tags,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodeRole, 'nodeRole');
-    ArgumentError.checkNotNull(nodegroupName, 'nodegroupName');
-    ArgumentError.checkNotNull(subnets, 'subnets');
     final $payload = <String, dynamic>{
       'nodeRole': nodeRole,
       'nodegroupName': nodegroupName,
@@ -662,15 +630,6 @@ class EKS {
     required String addonName,
     required String clusterName,
   }) async {
-    ArgumentError.checkNotNull(addonName, 'addonName');
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -706,7 +665,6 @@ class EKS {
   Future<DeleteClusterResponse> deleteCluster({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -743,8 +701,6 @@ class EKS {
     required String clusterName,
     required String fargateProfileName,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(fargateProfileName, 'fargateProfileName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -774,8 +730,6 @@ class EKS {
     required String clusterName,
     required String nodegroupName,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodegroupName, 'nodegroupName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -806,15 +760,6 @@ class EKS {
     required String addonName,
     required String clusterName,
   }) async {
-    ArgumentError.checkNotNull(addonName, 'addonName');
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -904,7 +849,6 @@ class EKS {
   Future<DescribeClusterResponse> describeCluster({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -930,8 +874,6 @@ class EKS {
     required String clusterName,
     required String fargateProfileName,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(fargateProfileName, 'fargateProfileName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -959,8 +901,6 @@ class EKS {
     required String clusterName,
     required String nodegroupName,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodegroupName, 'nodegroupName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1003,8 +943,6 @@ class EKS {
     String? addonName,
     String? nodegroupName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(updateId, 'updateId');
     final $query = <String, List<String>>{
       if (addonName != null) 'addonName': [addonName],
       if (nodegroupName != null) 'nodegroupName': [nodegroupName],
@@ -1058,14 +996,6 @@ class EKS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1173,7 +1103,6 @@ class EKS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1232,7 +1161,6 @@ class EKS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1265,7 +1193,6 @@ class EKS {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1316,7 +1243,6 @@ class EKS {
     String? nextToken,
     String? nodegroupName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1362,8 +1288,6 @@ class EKS {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1391,8 +1315,6 @@ class EKS {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1460,21 +1382,6 @@ class EKS {
     ResolveConflicts? resolveConflicts,
     String? serviceAccountRoleArn,
   }) async {
-    ArgumentError.checkNotNull(addonName, 'addonName');
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'serviceAccountRoleArn',
-      serviceAccountRoleArn,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       if (addonVersion != null) 'addonVersion': addonVersion,
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -1561,7 +1468,6 @@ class EKS {
     Logging? logging,
     VpcConfigRequest? resourcesVpcConfig,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
       if (logging != null) 'logging': logging,
@@ -1612,8 +1518,6 @@ class EKS {
     required String version,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(version, 'version');
     final $payload = <String, dynamic>{
       'version': version,
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -1664,8 +1568,6 @@ class EKS {
     UpdateLabelsPayload? labels,
     NodegroupScalingConfig? scalingConfig,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodegroupName, 'nodegroupName');
     final $payload = <String, dynamic>{
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
       if (labels != null) 'labels': labels,
@@ -1772,8 +1674,6 @@ class EKS {
     String? releaseVersion,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    ArgumentError.checkNotNull(nodegroupName, 'nodegroupName');
     final $payload = <String, dynamic>{
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
       if (force != null) 'force': force,

--- a/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
+++ b/generated/aws_elastic_inference_api/lib/elastic-inference-2017-07-25.dart
@@ -69,7 +69,6 @@ class ElasticInference {
     required LocationType locationType,
     List<String>? acceleratorTypes,
   }) async {
-    ArgumentError.checkNotNull(locationType, 'locationType');
     final $payload = <String, dynamic>{
       'locationType': locationType.toValue(),
       if (acceleratorTypes != null) 'acceleratorTypes': acceleratorTypes,
@@ -135,12 +134,6 @@ class ElasticInference {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (acceleratorIds != null) 'acceleratorIds': acceleratorIds,
       if (filters != null) 'filters': filters,
@@ -167,14 +160,6 @@ class ElasticInference {
   Future<ListTagsForResourceResult> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -199,15 +184,6 @@ class ElasticInference {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -234,15 +210,6 @@ class ElasticInference {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
+++ b/generated/aws_elasticache_api/lib/elasticache-2015-02-02.dart
@@ -91,8 +91,6 @@ class ElastiCache {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -141,11 +139,6 @@ class ElastiCache {
     required String eC2SecurityGroupName,
     required String eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheSecurityGroupName, 'cacheSecurityGroupName');
-    ArgumentError.checkNotNull(eC2SecurityGroupName, 'eC2SecurityGroupName');
-    ArgumentError.checkNotNull(
-        eC2SecurityGroupOwnerId, 'eC2SecurityGroupOwnerId');
     final $request = <String, dynamic>{};
     $request['CacheSecurityGroupName'] = cacheSecurityGroupName;
     $request['EC2SecurityGroupName'] = eC2SecurityGroupName;
@@ -185,7 +178,6 @@ class ElastiCache {
     List<String>? cacheClusterIds,
     List<String>? replicationGroupIds,
   }) async {
-    ArgumentError.checkNotNull(serviceUpdateName, 'serviceUpdateName');
     final $request = <String, dynamic>{};
     $request['ServiceUpdateName'] = serviceUpdateName;
     cacheClusterIds?.also((arg) => $request['CacheClusterIds'] = arg);
@@ -225,7 +217,6 @@ class ElastiCache {
     List<String>? cacheClusterIds,
     List<String>? replicationGroupIds,
   }) async {
-    ArgumentError.checkNotNull(serviceUpdateName, 'serviceUpdateName');
     final $request = <String, dynamic>{};
     $request['ServiceUpdateName'] = serviceUpdateName;
     cacheClusterIds?.also((arg) => $request['CacheClusterIds'] = arg);
@@ -261,7 +252,6 @@ class ElastiCache {
     required String replicationGroupId,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ReplicationGroupId'] = replicationGroupId;
     force?.also((arg) => $request['Force'] = arg);
@@ -408,8 +398,6 @@ class ElastiCache {
     String? kmsKeyId,
     String? targetBucket,
   }) async {
-    ArgumentError.checkNotNull(sourceSnapshotName, 'sourceSnapshotName');
-    ArgumentError.checkNotNull(targetSnapshotName, 'targetSnapshotName');
     final $request = <String, dynamic>{};
     $request['SourceSnapshotName'] = sourceSnapshotName;
     $request['TargetSnapshotName'] = targetSnapshotName;
@@ -865,7 +853,6 @@ class ElastiCache {
     String? snapshotWindow,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(cacheClusterId, 'cacheClusterId');
     final $request = <String, dynamic>{};
     $request['CacheClusterId'] = cacheClusterId;
     aZMode?.also((arg) => $request['AZMode'] = arg.toValue());
@@ -962,11 +949,6 @@ class ElastiCache {
     required String cacheParameterGroupName,
     required String description,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupFamily, 'cacheParameterGroupFamily');
-    ArgumentError.checkNotNull(
-        cacheParameterGroupName, 'cacheParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupFamily'] = cacheParameterGroupFamily;
     $request['CacheParameterGroupName'] = cacheParameterGroupName;
@@ -1014,9 +996,6 @@ class ElastiCache {
     required String cacheSecurityGroupName,
     required String description,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheSecurityGroupName, 'cacheSecurityGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['CacheSecurityGroupName'] = cacheSecurityGroupName;
     $request['Description'] = description;
@@ -1064,10 +1043,6 @@ class ElastiCache {
     required String cacheSubnetGroupName,
     required List<String> subnetIds,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheSubnetGroupDescription, 'cacheSubnetGroupDescription');
-    ArgumentError.checkNotNull(cacheSubnetGroupName, 'cacheSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['CacheSubnetGroupDescription'] = cacheSubnetGroupDescription;
     $request['CacheSubnetGroupName'] = cacheSubnetGroupName;
@@ -1137,10 +1112,6 @@ class ElastiCache {
     required String primaryReplicationGroupId,
     String? globalReplicationGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(
-        globalReplicationGroupIdSuffix, 'globalReplicationGroupIdSuffix');
-    ArgumentError.checkNotNull(
-        primaryReplicationGroupId, 'primaryReplicationGroupId');
     final $request = <String, dynamic>{};
     $request['GlobalReplicationGroupIdSuffix'] = globalReplicationGroupIdSuffix;
     $request['PrimaryReplicationGroupId'] = primaryReplicationGroupId;
@@ -1708,9 +1679,6 @@ class ElastiCache {
     bool? transitEncryptionEnabled,
     List<String>? userGroupIds,
   }) async {
-    ArgumentError.checkNotNull(
-        replicationGroupDescription, 'replicationGroupDescription');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ReplicationGroupDescription'] = replicationGroupDescription;
     $request['ReplicationGroupId'] = replicationGroupId;
@@ -1804,7 +1772,6 @@ class ElastiCache {
     String? kmsKeyId,
     String? replicationGroupId,
   }) async {
-    ArgumentError.checkNotNull(snapshotName, 'snapshotName');
     final $request = <String, dynamic>{};
     $request['SnapshotName'] = snapshotName;
     cacheClusterId?.also((arg) => $request['CacheClusterId'] = arg);
@@ -1861,24 +1828,6 @@ class ElastiCache {
     bool? noPasswordRequired,
     List<String>? passwords,
   }) async {
-    ArgumentError.checkNotNull(accessString, 'accessString');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccessString'] = accessString;
     $request['Engine'] = engine;
@@ -1925,8 +1874,6 @@ class ElastiCache {
     required String userGroupId,
     List<String>? userIds,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(userGroupId, 'userGroupId');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     $request['UserGroupId'] = userGroupId;
@@ -1984,10 +1931,6 @@ class ElastiCache {
     List<String>? globalNodeGroupsToRemove,
     List<String>? globalNodeGroupsToRetain,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
-    ArgumentError.checkNotNull(nodeGroupCount, 'nodeGroupCount');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
@@ -2081,8 +2024,6 @@ class ElastiCache {
     List<ConfigureShard>? replicaConfiguration,
     List<String>? replicasToRemove,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['ReplicationGroupId'] = replicationGroupId;
@@ -2149,7 +2090,6 @@ class ElastiCache {
     required String cacheClusterId,
     String? finalSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(cacheClusterId, 'cacheClusterId');
     final $request = <String, dynamic>{};
     $request['CacheClusterId'] = cacheClusterId;
     finalSnapshotIdentifier
@@ -2185,8 +2125,6 @@ class ElastiCache {
   Future<void> deleteCacheParameterGroup({
     required String cacheParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupName, 'cacheParameterGroupName');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupName'] = cacheParameterGroupName;
     await _protocol.send(
@@ -2220,8 +2158,6 @@ class ElastiCache {
   Future<void> deleteCacheSecurityGroup({
     required String cacheSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheSecurityGroupName, 'cacheSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['CacheSecurityGroupName'] = cacheSecurityGroupName;
     await _protocol.send(
@@ -2253,7 +2189,6 @@ class ElastiCache {
   Future<void> deleteCacheSubnetGroup({
     required String cacheSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(cacheSubnetGroupName, 'cacheSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['CacheSubnetGroupName'] = cacheSubnetGroupName;
     await _protocol.send(
@@ -2303,10 +2238,6 @@ class ElastiCache {
     required String globalReplicationGroupId,
     required bool retainPrimaryReplicationGroup,
   }) async {
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
-    ArgumentError.checkNotNull(
-        retainPrimaryReplicationGroup, 'retainPrimaryReplicationGroup');
     final $request = <String, dynamic>{};
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
     $request['RetainPrimaryReplicationGroup'] = retainPrimaryReplicationGroup;
@@ -2363,7 +2294,6 @@ class ElastiCache {
     String? finalSnapshotIdentifier,
     bool? retainPrimaryCluster,
   }) async {
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ReplicationGroupId'] = replicationGroupId;
     finalSnapshotIdentifier
@@ -2400,7 +2330,6 @@ class ElastiCache {
   Future<DeleteSnapshotResult> deleteSnapshot({
     required String snapshotName,
   }) async {
-    ArgumentError.checkNotNull(snapshotName, 'snapshotName');
     final $request = <String, dynamic>{};
     $request['SnapshotName'] = snapshotName;
     final $result = await _protocol.send(
@@ -2433,14 +2362,6 @@ class ElastiCache {
   Future<User> deleteUser({
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserId'] = userId;
     final $result = await _protocol.send(
@@ -2472,7 +2393,6 @@ class ElastiCache {
   Future<UserGroup> deleteUserGroup({
     required String userGroupId,
   }) async {
-    ArgumentError.checkNotNull(userGroupId, 'userGroupId');
     final $request = <String, dynamic>{};
     $request['UserGroupId'] = userGroupId;
     final $result = await _protocol.send(
@@ -2742,8 +2662,6 @@ class ElastiCache {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupName, 'cacheParameterGroupName');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupName'] = cacheParameterGroupName;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -2893,8 +2811,6 @@ class ElastiCache {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupFamily, 'cacheParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupFamily'] = cacheParameterGroupFamily;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -3790,12 +3706,6 @@ class ElastiCache {
     int? maxRecords,
     String? userId,
   }) async {
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      1152921504606846976,
-    );
     final $request = <String, dynamic>{};
     engine?.also((arg) => $request['Engine'] = arg);
     filters?.also((arg) => $request['Filters'] = arg);
@@ -3842,11 +3752,6 @@ class ElastiCache {
     required String replicationGroupId,
     required String replicationGroupRegion,
   }) async {
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
-    ArgumentError.checkNotNull(
-        replicationGroupRegion, 'replicationGroupRegion');
     final $request = <String, dynamic>{};
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
     $request['ReplicationGroupId'] = replicationGroupId;
@@ -3887,11 +3792,6 @@ class ElastiCache {
     required String primaryRegion,
     required String primaryReplicationGroupId,
   }) async {
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
-    ArgumentError.checkNotNull(primaryRegion, 'primaryRegion');
-    ArgumentError.checkNotNull(
-        primaryReplicationGroupId, 'primaryReplicationGroupId');
     final $request = <String, dynamic>{};
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
     $request['PrimaryRegion'] = primaryRegion;
@@ -3936,10 +3836,6 @@ class ElastiCache {
     required int nodeGroupCount,
     List<RegionalConfiguration>? regionalConfigurations,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
-    ArgumentError.checkNotNull(nodeGroupCount, 'nodeGroupCount');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
@@ -4005,8 +3901,6 @@ class ElastiCache {
     int? newReplicaCount,
     List<ConfigureShard>? replicaConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['ReplicationGroupId'] = replicationGroupId;
@@ -4108,7 +4002,6 @@ class ElastiCache {
   Future<TagListMessage> listTagsForResource({
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     final $result = await _protocol.send(
@@ -4491,7 +4384,6 @@ class ElastiCache {
     int? snapshotRetentionLimit,
     String? snapshotWindow,
   }) async {
-    ArgumentError.checkNotNull(cacheClusterId, 'cacheClusterId');
     final $request = <String, dynamic>{};
     $request['CacheClusterId'] = cacheClusterId;
     aZMode?.also((arg) => $request['AZMode'] = arg.toValue());
@@ -4554,9 +4446,6 @@ class ElastiCache {
     required String cacheParameterGroupName,
     required List<ParameterNameValue> parameterNameValues,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupName, 'cacheParameterGroupName');
-    ArgumentError.checkNotNull(parameterNameValues, 'parameterNameValues');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupName'] = cacheParameterGroupName;
     $request['ParameterNameValues'] = parameterNameValues;
@@ -4601,7 +4490,6 @@ class ElastiCache {
     String? cacheSubnetGroupDescription,
     List<String>? subnetIds,
   }) async {
-    ArgumentError.checkNotNull(cacheSubnetGroupName, 'cacheSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['CacheSubnetGroupName'] = cacheSubnetGroupName;
     cacheSubnetGroupDescription
@@ -4657,9 +4545,6 @@ class ElastiCache {
     String? engineVersion,
     String? globalReplicationGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
@@ -4941,7 +4826,6 @@ class ElastiCache {
     List<String>? userGroupIdsToAdd,
     List<String>? userGroupIdsToRemove,
   }) async {
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ReplicationGroupId'] = replicationGroupId;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -5058,9 +4942,6 @@ class ElastiCache {
     List<String>? nodeGroupsToRetain,
     List<ReshardingConfiguration>? reshardingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(nodeGroupCount, 'nodeGroupCount');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['NodeGroupCount'] = nodeGroupCount;
@@ -5111,14 +4992,6 @@ class ElastiCache {
     bool? noPasswordRequired,
     List<String>? passwords,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserId'] = userId;
     accessString?.also((arg) => $request['AccessString'] = arg);
@@ -5162,7 +5035,6 @@ class ElastiCache {
     List<String>? userIdsToAdd,
     List<String>? userIdsToRemove,
   }) async {
-    ArgumentError.checkNotNull(userGroupId, 'userGroupId');
     final $request = <String, dynamic>{};
     $request['UserGroupId'] = userGroupId;
     userIdsToAdd?.also((arg) => $request['UserIdsToAdd'] = arg);
@@ -5213,8 +5085,6 @@ class ElastiCache {
     int? cacheNodeCount,
     String? reservedCacheNodeId,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedCacheNodesOfferingId, 'reservedCacheNodesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedCacheNodesOfferingId'] = reservedCacheNodesOfferingId;
     cacheNodeCount?.also((arg) => $request['CacheNodeCount'] = arg);
@@ -5250,9 +5120,6 @@ class ElastiCache {
     required bool applyImmediately,
     required String globalReplicationGroupId,
   }) async {
-    ArgumentError.checkNotNull(applyImmediately, 'applyImmediately');
-    ArgumentError.checkNotNull(
-        globalReplicationGroupId, 'globalReplicationGroupId');
     final $request = <String, dynamic>{};
     $request['ApplyImmediately'] = applyImmediately;
     $request['GlobalReplicationGroupId'] = globalReplicationGroupId;
@@ -5304,8 +5171,6 @@ class ElastiCache {
     required String cacheClusterId,
     required List<String> cacheNodeIdsToReboot,
   }) async {
-    ArgumentError.checkNotNull(cacheClusterId, 'cacheClusterId');
-    ArgumentError.checkNotNull(cacheNodeIdsToReboot, 'cacheNodeIdsToReboot');
     final $request = <String, dynamic>{};
     $request['CacheClusterId'] = cacheClusterId;
     $request['CacheNodeIdsToReboot'] = cacheNodeIdsToReboot;
@@ -5348,8 +5213,6 @@ class ElastiCache {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -5401,8 +5264,6 @@ class ElastiCache {
     List<ParameterNameValue>? parameterNameValues,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheParameterGroupName, 'cacheParameterGroupName');
     final $request = <String, dynamic>{};
     $request['CacheParameterGroupName'] = cacheParameterGroupName;
     parameterNameValues?.also((arg) => $request['ParameterNameValues'] = arg);
@@ -5447,11 +5308,6 @@ class ElastiCache {
     required String eC2SecurityGroupName,
     required String eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(
-        cacheSecurityGroupName, 'cacheSecurityGroupName');
-    ArgumentError.checkNotNull(eC2SecurityGroupName, 'eC2SecurityGroupName');
-    ArgumentError.checkNotNull(
-        eC2SecurityGroupOwnerId, 'eC2SecurityGroupOwnerId');
     final $request = <String, dynamic>{};
     $request['CacheSecurityGroupName'] = cacheSecurityGroupName;
     $request['EC2SecurityGroupName'] = eC2SecurityGroupName;
@@ -5487,9 +5343,6 @@ class ElastiCache {
     required List<CustomerNodeEndpoint> customerNodeEndpointList,
     required String replicationGroupId,
   }) async {
-    ArgumentError.checkNotNull(
-        customerNodeEndpointList, 'customerNodeEndpointList');
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['CustomerNodeEndpointList'] = customerNodeEndpointList;
     $request['ReplicationGroupId'] = replicationGroupId;
@@ -5597,15 +5450,6 @@ class ElastiCache {
     required String nodeGroupId,
     required String replicationGroupId,
   }) async {
-    ArgumentError.checkNotNull(nodeGroupId, 'nodeGroupId');
-    _s.validateStringLength(
-      'nodeGroupId',
-      nodeGroupId,
-      1,
-      4,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(replicationGroupId, 'replicationGroupId');
     final $request = <String, dynamic>{};
     $request['NodeGroupId'] = nodeGroupId;
     $request['ReplicationGroupId'] = replicationGroupId;

--- a/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
+++ b/generated/aws_elasticbeanstalk_api/lib/elasticbeanstalk-2010-12-01.dart
@@ -70,12 +70,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -112,7 +106,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    ArgumentError.checkNotNull(actionId, 'actionId');
     final $request = <String, dynamic>{};
     $request['ActionId'] = actionId;
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
@@ -150,22 +143,6 @@ class ElasticBeanstalk {
     required String environmentName,
     required String operationsRole,
   }) async {
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(operationsRole, 'operationsRole');
-    _s.validateStringLength(
-      'operationsRole',
-      operationsRole,
-      1,
-      256,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['EnvironmentName'] = environmentName;
     $request['OperationsRole'] = operationsRole;
@@ -188,14 +165,6 @@ class ElasticBeanstalk {
   Future<CheckDNSAvailabilityResultMessage> checkDNSAvailability({
     required String cNAMEPrefix,
   }) async {
-    ArgumentError.checkNotNull(cNAMEPrefix, 'cNAMEPrefix');
-    _s.validateStringLength(
-      'cNAMEPrefix',
-      cNAMEPrefix,
-      4,
-      63,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['CNAMEPrefix'] = cNAMEPrefix;
     final $result = await _protocol.send(
@@ -245,18 +214,6 @@ class ElasticBeanstalk {
     String? groupName,
     List<String>? versionLabels,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      19,
-    );
     final $request = <String, dynamic>{};
     applicationName?.also((arg) => $request['ApplicationName'] = arg);
     groupName?.also((arg) => $request['GroupName'] = arg);
@@ -301,20 +258,6 @@ class ElasticBeanstalk {
     ApplicationResourceLifecycleConfig? resourceLifecycleConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     description?.also((arg) => $request['Description'] = arg);
@@ -431,28 +374,6 @@ class ElasticBeanstalk {
     S3Location? sourceBundle,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionLabel, 'versionLabel');
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['VersionLabel'] = versionLabel;
@@ -590,28 +511,6 @@ class ElasticBeanstalk {
     SourceConfiguration? sourceConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['TemplateName'] = templateName;
@@ -755,56 +654,6 @@ class ElasticBeanstalk {
     EnvironmentTier? tier,
     String? versionLabel,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cNAMEPrefix',
-      cNAMEPrefix,
-      4,
-      63,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'operationsRole',
-      operationsRole,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     cNAMEPrefix?.also((arg) => $request['CNAMEPrefix'] = arg);
@@ -869,16 +718,6 @@ class ElasticBeanstalk {
     List<ConfigurationOptionSetting>? optionSettings,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        platformDefinitionBundle, 'platformDefinitionBundle');
-    ArgumentError.checkNotNull(platformName, 'platformName');
-    ArgumentError.checkNotNull(platformVersion, 'platformVersion');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     $request['PlatformDefinitionBundle'] = platformDefinitionBundle;
     $request['PlatformName'] = platformName;
@@ -944,14 +783,6 @@ class ElasticBeanstalk {
     required String applicationName,
     bool? terminateEnvByForce,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     terminateEnvByForce?.also((arg) => $request['TerminateEnvByForce'] = arg);
@@ -993,22 +824,6 @@ class ElasticBeanstalk {
     required String versionLabel,
     bool? deleteSourceBundle,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionLabel, 'versionLabel');
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['VersionLabel'] = versionLabel;
@@ -1044,22 +859,6 @@ class ElasticBeanstalk {
     required String applicationName,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['TemplateName'] = templateName;
@@ -1094,22 +893,6 @@ class ElasticBeanstalk {
     required String applicationName,
     required String environmentName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['EnvironmentName'] = environmentName;
@@ -1202,12 +985,6 @@ class ElasticBeanstalk {
     String? nextToken,
     List<String>? versionLabels,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
@@ -1295,24 +1072,6 @@ class ElasticBeanstalk {
     String? solutionStackName,
     String? templateName,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     applicationName?.also((arg) => $request['ApplicationName'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -1379,26 +1138,6 @@ class ElasticBeanstalk {
     String? environmentName,
     String? templateName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -1443,12 +1182,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     attributeNames?.also((arg) =>
         $request['AttributeNames'] = arg.map((e) => e.toValue()).toList());
@@ -1490,12 +1223,6 @@ class ElasticBeanstalk {
     int? maxItems,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -1578,12 +1305,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -1654,23 +1375,11 @@ class ElasticBeanstalk {
     String? nextToken,
     String? versionLabel,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
     );
     final $request = <String, dynamic>{};
     applicationName?.also((arg) => $request['ApplicationName'] = arg);
@@ -1765,35 +1474,11 @@ class ElasticBeanstalk {
     String? templateName,
     String? versionLabel,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
     );
     final $request = <String, dynamic>{};
     applicationName?.also((arg) => $request['ApplicationName'] = arg);
@@ -1849,18 +1534,6 @@ class ElasticBeanstalk {
     String? environmentName,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     attributeNames?.also((arg) =>
         $request['AttributeNames'] = arg.map((e) => e.toValue()).toList());
@@ -1929,14 +1602,6 @@ class ElasticBeanstalk {
   Future<void> disassociateEnvironmentOperationsRole({
     required String environmentName,
   }) async {
-    ArgumentError.checkNotNull(environmentName, 'environmentName');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['EnvironmentName'] = environmentName;
     await _protocol.send(
@@ -2153,7 +1818,6 @@ class ElasticBeanstalk {
   Future<ResourceTagsDescriptionMessage> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     final $result = await _protocol.send(
@@ -2193,12 +1857,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -2263,13 +1921,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    ArgumentError.checkNotNull(infoType, 'infoType');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     $request['InfoType'] = infoType.toValue();
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
@@ -2306,12 +1957,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -2365,13 +2010,6 @@ class ElasticBeanstalk {
     String? environmentId,
     String? environmentName,
   }) async {
-    ArgumentError.checkNotNull(infoType, 'infoType');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     $request['InfoType'] = infoType.toValue();
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
@@ -2431,18 +2069,6 @@ class ElasticBeanstalk {
     String? sourceEnvironmentId,
     String? sourceEnvironmentName,
   }) async {
-    _s.validateStringLength(
-      'destinationEnvironmentName',
-      destinationEnvironmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'sourceEnvironmentName',
-      sourceEnvironmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     destinationEnvironmentId
         ?.also((arg) => $request['DestinationEnvironmentId'] = arg);
@@ -2512,12 +2138,6 @@ class ElasticBeanstalk {
     bool? forceTerminate,
     bool? terminateResources,
   }) async {
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
     final $request = <String, dynamic>{};
     environmentId?.also((arg) => $request['EnvironmentId'] = arg);
     environmentName?.also((arg) => $request['EnvironmentName'] = arg);
@@ -2558,20 +2178,6 @@ class ElasticBeanstalk {
     required String applicationName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     description?.also((arg) => $request['Description'] = arg);
@@ -2603,16 +2209,6 @@ class ElasticBeanstalk {
     required String applicationName,
     required ApplicationResourceLifecycleConfig resourceLifecycleConfig,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        resourceLifecycleConfig, 'resourceLifecycleConfig');
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['ResourceLifecycleConfig'] = resourceLifecycleConfig;
@@ -2657,28 +2253,6 @@ class ElasticBeanstalk {
     required String versionLabel,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionLabel, 'versionLabel');
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['VersionLabel'] = versionLabel;
@@ -2749,28 +2323,6 @@ class ElasticBeanstalk {
     List<ConfigurationOptionSetting>? optionSettings,
     List<OptionSpecification>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['TemplateName'] = templateName;
@@ -2888,42 +2440,6 @@ class ElasticBeanstalk {
     EnvironmentTier? tier,
     String? versionLabel,
   }) async {
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      19,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'versionLabel',
-      versionLabel,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     applicationName?.also((arg) => $request['ApplicationName'] = arg);
     description?.also((arg) => $request['Description'] = arg);
@@ -3003,7 +2519,6 @@ class ElasticBeanstalk {
     List<Tag>? tagsToAdd,
     List<String>? tagsToRemove,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     tagsToAdd?.also((arg) => $request['TagsToAdd'] = arg);
@@ -3052,27 +2567,6 @@ class ElasticBeanstalk {
     String? environmentName,
     String? templateName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(optionSettings, 'optionSettings');
-    _s.validateStringLength(
-      'environmentName',
-      environmentName,
-      4,
-      40,
-    );
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      100,
-    );
     final $request = <String, dynamic>{};
     $request['ApplicationName'] = applicationName;
     $request['OptionSettings'] = optionSettings;

--- a/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
+++ b/generated/aws_elastictranscoder_api/lib/elastictranscoder-2012-09-25.dart
@@ -71,7 +71,6 @@ class ElasticTranscoder {
   Future<void> cancelJob({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -150,13 +149,6 @@ class ElasticTranscoder {
     List<CreateJobPlaylist>? playlists,
     Map<String, String>? userMetadata,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
-    _s.validateStringLength(
-      'outputKeyPrefix',
-      outputKeyPrefix,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'PipelineId': pipelineId,
       if (input != null) 'Input': input,
@@ -468,22 +460,6 @@ class ElasticTranscoder {
     String? outputBucket,
     PipelineOutputConfig? thumbnailConfig,
   }) async {
-    ArgumentError.checkNotNull(inputBucket, 'inputBucket');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'awsKmsKeyArn',
-      awsKmsKeyArn,
-      0,
-      255,
-    );
     final $payload = <String, dynamic>{
       'InputBucket': inputBucket,
       'Name': name,
@@ -559,21 +535,6 @@ class ElasticTranscoder {
     Thumbnails? thumbnails,
     VideoParameters? video,
   }) async {
-    ArgumentError.checkNotNull(container, 'container');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      40,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      255,
-    );
     final $payload = <String, dynamic>{
       'Container': container,
       'Name': name,
@@ -609,7 +570,6 @@ class ElasticTranscoder {
   Future<void> deletePipeline({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -637,7 +597,6 @@ class ElasticTranscoder {
   Future<void> deletePreset({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -676,7 +635,6 @@ class ElasticTranscoder {
     String? ascending,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (ascending != null) 'Ascending': [ascending],
       if (pageToken != null) 'PageToken': [pageToken],
@@ -722,7 +680,6 @@ class ElasticTranscoder {
     String? ascending,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(status, 'status');
     final $query = <String, List<String>>{
       if (ascending != null) 'Ascending': [ascending],
       if (pageToken != null) 'PageToken': [pageToken],
@@ -820,7 +777,6 @@ class ElasticTranscoder {
   Future<ReadJobResponse> readJob({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -843,7 +799,6 @@ class ElasticTranscoder {
   Future<ReadPipelineResponse> readPipeline({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -867,7 +822,6 @@ class ElasticTranscoder {
   Future<ReadPresetResponse> readPreset({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -914,10 +868,6 @@ class ElasticTranscoder {
     required String role,
     required List<String> topics,
   }) async {
-    ArgumentError.checkNotNull(inputBucket, 'inputBucket');
-    ArgumentError.checkNotNull(outputBucket, 'outputBucket');
-    ArgumentError.checkNotNull(role, 'role');
-    ArgumentError.checkNotNull(topics, 'topics');
     final $payload = <String, dynamic>{
       'InputBucket': inputBucket,
       'OutputBucket': outputBucket,
@@ -1195,19 +1145,6 @@ class ElasticTranscoder {
     String? role,
     PipelineOutputConfig? thumbnailConfig,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'awsKmsKeyArn',
-      awsKmsKeyArn,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       if (awsKmsKeyArn != null) 'AwsKmsKeyArn': awsKmsKeyArn,
       if (contentConfig != null) 'ContentConfig': contentConfig,
@@ -1277,8 +1214,6 @@ class ElasticTranscoder {
     required String id,
     required Notifications notifications,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(notifications, 'notifications');
     final $payload = <String, dynamic>{
       'Notifications': notifications,
     };
@@ -1326,8 +1261,6 @@ class ElasticTranscoder {
     required String id,
     required String status,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(status, 'status');
     final $payload = <String, dynamic>{
       'Status': status,
     };

--- a/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
+++ b/generated/aws_elb_api/lib/elasticloadbalancing-2012-06-01.dart
@@ -83,8 +83,6 @@ class ElasticLoadBalancing {
     required List<String> loadBalancerNames,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerNames, 'loadBalancerNames');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['LoadBalancerNames'] = loadBalancerNames;
     $request['Tags'] = tags;
@@ -125,8 +123,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required List<String> securityGroups,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(securityGroups, 'securityGroups');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['SecurityGroups'] = securityGroups;
@@ -168,8 +164,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required List<String> subnets,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(subnets, 'subnets');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['Subnets'] = subnets;
@@ -206,8 +200,6 @@ class ElasticLoadBalancing {
     required HealthCheck healthCheck,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(healthCheck, 'healthCheck');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['HealthCheck'] = healthCheck;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -263,9 +255,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(cookieName, 'cookieName');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(policyName, 'policyName');
     final $request = <String, dynamic>{};
     $request['CookieName'] = cookieName;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -327,8 +316,6 @@ class ElasticLoadBalancing {
     required String policyName,
     int? cookieExpirationPeriod,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(policyName, 'policyName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['PolicyName'] = policyName;
@@ -437,8 +424,6 @@ class ElasticLoadBalancing {
     List<String>? subnets,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(listeners, 'listeners');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['Listeners'] = listeners;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -486,8 +471,6 @@ class ElasticLoadBalancing {
     required List<Listener> listeners,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(listeners, 'listeners');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['Listeners'] = listeners;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -536,9 +519,6 @@ class ElasticLoadBalancing {
     required String policyTypeName,
     List<PolicyAttribute>? policyAttributes,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    ArgumentError.checkNotNull(policyTypeName, 'policyTypeName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['PolicyName'] = policyName;
@@ -573,7 +553,6 @@ class ElasticLoadBalancing {
   Future<void> deleteLoadBalancer({
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     await _protocol.send(
@@ -602,8 +581,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required List<int> loadBalancerPorts,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(loadBalancerPorts, 'loadBalancerPorts');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['LoadBalancerPorts'] = loadBalancerPorts;
@@ -635,8 +612,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(policyName, 'policyName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['PolicyName'] = policyName;
@@ -677,8 +652,6 @@ class ElasticLoadBalancing {
     required List<Instance> instances,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(instances, 'instances');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['Instances'] = instances;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -756,7 +729,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     List<Instance>? instances,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     instances?.also((arg) => $request['Instances'] = arg);
@@ -784,7 +756,6 @@ class ElasticLoadBalancing {
   Future<DescribeLoadBalancerAttributesOutput> describeLoadBalancerAttributes({
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     final $result = await _protocol.send(
@@ -932,7 +903,6 @@ class ElasticLoadBalancing {
   Future<DescribeTagsOutput> describeTags({
     required List<String> loadBalancerNames,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerNames, 'loadBalancerNames');
     final $request = <String, dynamic>{};
     $request['LoadBalancerNames'] = loadBalancerNames;
     final $result = await _protocol.send(
@@ -969,8 +939,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required List<String> subnets,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(subnets, 'subnets');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['Subnets'] = subnets;
@@ -1019,8 +987,6 @@ class ElasticLoadBalancing {
     required List<String> availabilityZones,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(availabilityZones, 'availabilityZones');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['AvailabilityZones'] = availabilityZones;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -1062,8 +1028,6 @@ class ElasticLoadBalancing {
     required List<String> availabilityZones,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(availabilityZones, 'availabilityZones');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['AvailabilityZones'] = availabilityZones;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -1129,9 +1093,6 @@ class ElasticLoadBalancing {
     required LoadBalancerAttributes loadBalancerAttributes,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(
-        loadBalancerAttributes, 'loadBalancerAttributes');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['LoadBalancerAttributes'] = loadBalancerAttributes;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -1189,8 +1150,6 @@ class ElasticLoadBalancing {
     required List<Instance> instances,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(instances, 'instances');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final $request = <String, dynamic>{};
     $request['Instances'] = instances;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -1222,8 +1181,6 @@ class ElasticLoadBalancing {
     required List<String> loadBalancerNames,
     required List<TagKeyOnly> tags,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerNames, 'loadBalancerNames');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['LoadBalancerNames'] = loadBalancerNames;
     $request['Tags'] = tags;
@@ -1268,9 +1225,6 @@ class ElasticLoadBalancing {
     required int loadBalancerPort,
     required String sSLCertificateId,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(loadBalancerPort, 'loadBalancerPort');
-    ArgumentError.checkNotNull(sSLCertificateId, 'sSLCertificateId');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['LoadBalancerPort'] = loadBalancerPort;
@@ -1328,9 +1282,6 @@ class ElasticLoadBalancing {
     required String loadBalancerName,
     required List<String> policyNames,
   }) async {
-    ArgumentError.checkNotNull(instancePort, 'instancePort');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(policyNames, 'policyNames');
     final $request = <String, dynamic>{};
     $request['InstancePort'] = instancePort;
     $request['LoadBalancerName'] = loadBalancerName;
@@ -1382,9 +1333,6 @@ class ElasticLoadBalancing {
     required int loadBalancerPort,
     required List<String> policyNames,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(loadBalancerPort, 'loadBalancerPort');
-    ArgumentError.checkNotNull(policyNames, 'policyNames');
     final $request = <String, dynamic>{};
     $request['LoadBalancerName'] = loadBalancerName;
     $request['LoadBalancerPort'] = loadBalancerPort;

--- a/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
+++ b/generated/aws_elbv2_api/lib/elasticloadbalancingv2-2015-12-01.dart
@@ -88,8 +88,6 @@ class ElasticLoadBalancingv2 {
     required List<Certificate> certificates,
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(certificates, 'certificates');
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
     final $request = <String, dynamic>{};
     $request['Certificates'] = certificates;
     $request['ListenerArn'] = listenerArn;
@@ -128,8 +126,6 @@ class ElasticLoadBalancingv2 {
     required List<String> resourceArns,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceArns'] = resourceArns;
     $request['Tags'] = tags;
@@ -261,8 +257,6 @@ class ElasticLoadBalancingv2 {
     String? sslPolicy,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(defaultActions, 'defaultActions');
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     _s.validateNumRange(
       'port',
       port,
@@ -429,13 +423,6 @@ class ElasticLoadBalancingv2 {
     List<Tag>? tags,
     LoadBalancerTypeEnum? type,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'customerOwnedIpv4Pool',
-      customerOwnedIpv4Pool,
-      0,
-      256,
-    );
     final $request = <String, dynamic>{};
     $request['Name'] = name;
     customerOwnedIpv4Pool
@@ -510,10 +497,6 @@ class ElasticLoadBalancingv2 {
     required int priority,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(conditions, 'conditions');
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    ArgumentError.checkNotNull(priority, 'priority');
     _s.validateNumRange(
       'priority',
       priority,
@@ -710,18 +693,11 @@ class ElasticLoadBalancingv2 {
     int? unhealthyThresholdCount,
     String? vpcId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'healthCheckIntervalSeconds',
       healthCheckIntervalSeconds,
       5,
       300,
-    );
-    _s.validateStringLength(
-      'healthCheckPath',
-      healthCheckPath,
-      1,
-      1024,
     );
     _s.validateNumRange(
       'healthCheckTimeoutSeconds',
@@ -795,7 +771,6 @@ class ElasticLoadBalancingv2 {
   Future<void> deleteListener({
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
     final $request = <String, dynamic>{};
     $request['ListenerArn'] = listenerArn;
     await _protocol.send(
@@ -833,7 +808,6 @@ class ElasticLoadBalancingv2 {
   Future<void> deleteLoadBalancer({
     required String loadBalancerArn,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     final $request = <String, dynamic>{};
     $request['LoadBalancerArn'] = loadBalancerArn;
     await _protocol.send(
@@ -861,7 +835,6 @@ class ElasticLoadBalancingv2 {
   Future<void> deleteRule({
     required String ruleArn,
   }) async {
-    ArgumentError.checkNotNull(ruleArn, 'ruleArn');
     final $request = <String, dynamic>{};
     $request['RuleArn'] = ruleArn;
     await _protocol.send(
@@ -892,7 +865,6 @@ class ElasticLoadBalancingv2 {
   Future<void> deleteTargetGroup({
     required String targetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
     final $request = <String, dynamic>{};
     $request['TargetGroupArn'] = targetGroupArn;
     await _protocol.send(
@@ -926,8 +898,6 @@ class ElasticLoadBalancingv2 {
     required String targetGroupArn,
     required List<TargetDescription> targets,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
-    ArgumentError.checkNotNull(targets, 'targets');
     final $request = <String, dynamic>{};
     $request['TargetGroupArn'] = targetGroupArn;
     $request['Targets'] = targets;
@@ -1029,7 +999,6 @@ class ElasticLoadBalancingv2 {
     String? marker,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -1136,7 +1105,6 @@ class ElasticLoadBalancingv2 {
   Future<DescribeLoadBalancerAttributesOutput> describeLoadBalancerAttributes({
     required String loadBalancerArn,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     final $request = <String, dynamic>{};
     $request['LoadBalancerArn'] = loadBalancerArn;
     final $result = await _protocol.send(
@@ -1315,7 +1283,6 @@ class ElasticLoadBalancingv2 {
   Future<DescribeTagsOutput> describeTags({
     required List<String> resourceArns,
   }) async {
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
     final $request = <String, dynamic>{};
     $request['ResourceArns'] = resourceArns;
     final $result = await _protocol.send(
@@ -1361,7 +1328,6 @@ class ElasticLoadBalancingv2 {
   Future<DescribeTargetGroupAttributesOutput> describeTargetGroupAttributes({
     required String targetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
     final $request = <String, dynamic>{};
     $request['TargetGroupArn'] = targetGroupArn;
     final $result = await _protocol.send(
@@ -1450,7 +1416,6 @@ class ElasticLoadBalancingv2 {
     required String targetGroupArn,
     List<TargetDescription>? targets,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
     final $request = <String, dynamic>{};
     $request['TargetGroupArn'] = targetGroupArn;
     targets?.also((arg) => $request['Targets'] = arg);
@@ -1564,7 +1529,6 @@ class ElasticLoadBalancingv2 {
     ProtocolEnum? protocol,
     String? sslPolicy,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
     _s.validateNumRange(
       'port',
       port,
@@ -1612,8 +1576,6 @@ class ElasticLoadBalancingv2 {
     required List<LoadBalancerAttribute> attributes,
     required String loadBalancerArn,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['LoadBalancerArn'] = loadBalancerArn;
@@ -1663,7 +1625,6 @@ class ElasticLoadBalancingv2 {
     List<Action>? actions,
     List<RuleCondition>? conditions,
   }) async {
-    ArgumentError.checkNotNull(ruleArn, 'ruleArn');
     final $request = <String, dynamic>{};
     $request['RuleArn'] = ruleArn;
     actions?.also((arg) => $request['Actions'] = arg);
@@ -1753,18 +1714,11 @@ class ElasticLoadBalancingv2 {
     Matcher? matcher,
     int? unhealthyThresholdCount,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
     _s.validateNumRange(
       'healthCheckIntervalSeconds',
       healthCheckIntervalSeconds,
       5,
       300,
-    );
-    _s.validateStringLength(
-      'healthCheckPath',
-      healthCheckPath,
-      1,
-      1024,
     );
     _s.validateNumRange(
       'healthCheckTimeoutSeconds',
@@ -1828,8 +1782,6 @@ class ElasticLoadBalancingv2 {
     required List<TargetGroupAttribute> attributes,
     required String targetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['TargetGroupArn'] = targetGroupArn;
@@ -1877,8 +1829,6 @@ class ElasticLoadBalancingv2 {
     required String targetGroupArn,
     required List<TargetDescription> targets,
   }) async {
-    ArgumentError.checkNotNull(targetGroupArn, 'targetGroupArn');
-    ArgumentError.checkNotNull(targets, 'targets');
     final $request = <String, dynamic>{};
     $request['TargetGroupArn'] = targetGroupArn;
     $request['Targets'] = targets;
@@ -1912,8 +1862,6 @@ class ElasticLoadBalancingv2 {
     required List<Certificate> certificates,
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(certificates, 'certificates');
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
     final $request = <String, dynamic>{};
     $request['Certificates'] = certificates;
     $request['ListenerArn'] = listenerArn;
@@ -1950,8 +1898,6 @@ class ElasticLoadBalancingv2 {
     required List<String> resourceArns,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceArns'] = resourceArns;
     $request['TagKeys'] = tagKeys;
@@ -1987,8 +1933,6 @@ class ElasticLoadBalancingv2 {
     required IpAddressType ipAddressType,
     required String loadBalancerArn,
   }) async {
-    ArgumentError.checkNotNull(ipAddressType, 'ipAddressType');
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     final $request = <String, dynamic>{};
     $request['IpAddressType'] = ipAddressType.toValue();
     $request['LoadBalancerArn'] = loadBalancerArn;
@@ -2021,7 +1965,6 @@ class ElasticLoadBalancingv2 {
   Future<SetRulePrioritiesOutput> setRulePriorities({
     required List<RulePriorityPair> rulePriorities,
   }) async {
-    ArgumentError.checkNotNull(rulePriorities, 'rulePriorities');
     final $request = <String, dynamic>{};
     $request['RulePriorities'] = rulePriorities;
     final $result = await _protocol.send(
@@ -2058,8 +2001,6 @@ class ElasticLoadBalancingv2 {
     required String loadBalancerArn,
     required List<String> securityGroups,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
-    ArgumentError.checkNotNull(securityGroups, 'securityGroups');
     final $request = <String, dynamic>{};
     $request['LoadBalancerArn'] = loadBalancerArn;
     $request['SecurityGroups'] = securityGroups;
@@ -2144,7 +2085,6 @@ class ElasticLoadBalancingv2 {
     List<SubnetMapping>? subnetMappings,
     List<String>? subnets,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerArn, 'loadBalancerArn');
     final $request = <String, dynamic>{};
     $request['LoadBalancerArn'] = loadBalancerArn;
     ipAddressType?.also((arg) => $request['IpAddressType'] = arg.toValue());

--- a/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
+++ b/generated/aws_emr_api/lib/elasticmapreduce-2009-03-31.dart
@@ -69,15 +69,6 @@ class EMR {
     required String clusterId,
     required InstanceFleetConfig instanceFleet,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceFleet, 'instanceFleet');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.AddInstanceFleet'
@@ -110,15 +101,6 @@ class EMR {
     required List<InstanceGroupConfig> instanceGroups,
     required String jobFlowId,
   }) async {
-    ArgumentError.checkNotNull(instanceGroups, 'instanceGroups');
-    ArgumentError.checkNotNull(jobFlowId, 'jobFlowId');
-    _s.validateStringLength(
-      'jobFlowId',
-      jobFlowId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.AddInstanceGroups'
@@ -178,15 +160,6 @@ class EMR {
     required String jobFlowId,
     required List<StepConfig> steps,
   }) async {
-    ArgumentError.checkNotNull(jobFlowId, 'jobFlowId');
-    _s.validateStringLength(
-      'jobFlowId',
-      jobFlowId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(steps, 'steps');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.AddJobFlowSteps'
@@ -228,8 +201,6 @@ class EMR {
     required String resourceId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.AddTags'
@@ -273,15 +244,6 @@ class EMR {
     required List<String> stepIds,
     StepCancellationOption? stepCancellationOption,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stepIds, 'stepIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.CancelSteps'
@@ -322,15 +284,6 @@ class EMR {
     required String name,
     required String securityConfiguration,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      10280,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(securityConfiguration, 'securityConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.CreateSecurityConfiguration'
@@ -423,69 +376,6 @@ class EMR {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(authMode, 'authMode');
-    ArgumentError.checkNotNull(engineSecurityGroupId, 'engineSecurityGroupId');
-    _s.validateStringLength(
-      'engineSecurityGroupId',
-      engineSecurityGroupId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceRole, 'serviceRole');
-    _s.validateStringLength(
-      'serviceRole',
-      serviceRole,
-      0,
-      10280,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    ArgumentError.checkNotNull(userRole, 'userRole');
-    _s.validateStringLength(
-      'userRole',
-      userRole,
-      0,
-      10280,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
-    _s.validateStringLength(
-      'vpcId',
-      vpcId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        workspaceSecurityGroupId, 'workspaceSecurityGroupId');
-    _s.validateStringLength(
-      'workspaceSecurityGroupId',
-      workspaceSecurityGroupId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultS3Location',
-      defaultS3Location,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.CreateStudio'
@@ -559,35 +449,6 @@ class EMR {
     String? identityId,
     String? identityName,
   }) async {
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    ArgumentError.checkNotNull(sessionPolicyArn, 'sessionPolicyArn');
-    _s.validateStringLength(
-      'sessionPolicyArn',
-      sessionPolicyArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'identityName',
-      identityName,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.CreateStudioSessionMapping'
@@ -618,14 +479,6 @@ class EMR {
   Future<void> deleteSecurityConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      10280,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DeleteSecurityConfiguration'
@@ -656,14 +509,6 @@ class EMR {
   Future<void> deleteStudio({
     required String studioId,
   }) async {
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DeleteStudio'
@@ -719,27 +564,6 @@ class EMR {
     String? identityId,
     String? identityName,
   }) async {
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'identityName',
-      identityName,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DeleteStudioSessionMapping'
@@ -770,7 +594,6 @@ class EMR {
   Future<DescribeClusterOutput> describeCluster({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DescribeCluster'
@@ -870,14 +693,6 @@ class EMR {
   Future<DescribeNotebookExecutionOutput> describeNotebookExecution({
     required String notebookExecutionId,
   }) async {
-    ArgumentError.checkNotNull(notebookExecutionId, 'notebookExecutionId');
-    _s.validateStringLength(
-      'notebookExecutionId',
-      notebookExecutionId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DescribeNotebookExecution'
@@ -907,14 +722,6 @@ class EMR {
   Future<DescribeSecurityConfigurationOutput> describeSecurityConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      10280,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DescribeSecurityConfiguration'
@@ -947,8 +754,6 @@ class EMR {
     required String clusterId,
     required String stepId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(stepId, 'stepId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DescribeStep'
@@ -983,14 +788,6 @@ class EMR {
   Future<DescribeStudioOutput> describeStudio({
     required String studioId,
   }) async {
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.DescribeStudio'
@@ -1042,7 +839,6 @@ class EMR {
   Future<GetManagedScalingPolicyOutput> getManagedScalingPolicy({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.GetManagedScalingPolicy'
@@ -1099,27 +895,6 @@ class EMR {
     String? identityId,
     String? identityName,
   }) async {
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'identityName',
-      identityName,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.GetStudioSessionMapping'
@@ -1156,7 +931,6 @@ class EMR {
     required String clusterId,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListBootstrapActions'
@@ -1244,7 +1018,6 @@ class EMR {
     required String clusterId,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListInstanceFleets'
@@ -1278,7 +1051,6 @@ class EMR {
     required String clusterId,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListInstanceGroups'
@@ -1336,7 +1108,6 @@ class EMR {
     List<InstanceState>? instanceStates,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListInstances'
@@ -1442,12 +1213,6 @@ class EMR {
     NotebookExecutionStatus? status,
     DateTime? to,
   }) async {
-    _s.validateStringLength(
-      'editorId',
-      editorId,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListNotebookExecutions'
@@ -1528,7 +1293,6 @@ class EMR {
     List<String>? stepIds,
     List<StepState>? stepStates,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListSteps'
@@ -1576,12 +1340,6 @@ class EMR {
     String? marker,
     String? studioId,
   }) async {
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ListStudioSessionMappings'
@@ -1652,7 +1410,6 @@ class EMR {
     required String clusterId,
     int? stepConcurrencyLevel,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ModifyCluster'
@@ -1693,8 +1450,6 @@ class EMR {
     required String clusterId,
     required InstanceFleetModifyConfig instanceFleet,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(instanceFleet, 'instanceFleet');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.ModifyInstanceFleet'
@@ -1765,9 +1520,6 @@ class EMR {
     required String clusterId,
     required String instanceGroupId,
   }) async {
-    ArgumentError.checkNotNull(autoScalingPolicy, 'autoScalingPolicy');
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(instanceGroupId, 'instanceGroupId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.PutAutoScalingPolicy'
@@ -1819,8 +1571,6 @@ class EMR {
   Future<void> putBlockPublicAccessConfiguration({
     required BlockPublicAccessConfiguration blockPublicAccessConfiguration,
   }) async {
-    ArgumentError.checkNotNull(
-        blockPublicAccessConfiguration, 'blockPublicAccessConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.PutBlockPublicAccessConfiguration'
@@ -1853,8 +1603,6 @@ class EMR {
     required String clusterId,
     required ManagedScalingPolicy managedScalingPolicy,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(managedScalingPolicy, 'managedScalingPolicy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.PutManagedScalingPolicy'
@@ -1886,8 +1634,6 @@ class EMR {
     required String clusterId,
     required String instanceGroupId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    ArgumentError.checkNotNull(instanceGroupId, 'instanceGroupId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.RemoveAutoScalingPolicy'
@@ -1913,7 +1659,6 @@ class EMR {
   Future<void> removeManagedScalingPolicy({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.RemoveManagedScalingPolicy'
@@ -1952,8 +1697,6 @@ class EMR {
     required String resourceId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.RemoveTags'
@@ -2242,75 +1985,6 @@ class EMR {
     List<Tag>? tags,
     bool? visibleToAllUsers,
   }) async {
-    ArgumentError.checkNotNull(instances, 'instances');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'additionalInfo',
-      additionalInfo,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'amiVersion',
-      amiVersion,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'autoScalingRole',
-      autoScalingRole,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'customAmiId',
-      customAmiId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'jobFlowRole',
-      jobFlowRole,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'logEncryptionKmsKeyId',
-      logEncryptionKmsKeyId,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'logUri',
-      logUri,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'releaseLabel',
-      releaseLabel,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'securityConfiguration',
-      securityConfiguration,
-      0,
-      10280,
-    );
-    _s.validateStringLength(
-      'serviceRole',
-      serviceRole,
-      0,
-      10280,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.RunJobFlow'
@@ -2402,8 +2076,6 @@ class EMR {
     required List<String> jobFlowIds,
     required bool terminationProtected,
   }) async {
-    ArgumentError.checkNotNull(jobFlowIds, 'jobFlowIds');
-    ArgumentError.checkNotNull(terminationProtected, 'terminationProtected');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.SetTerminationProtection'
@@ -2446,8 +2118,6 @@ class EMR {
     required List<String> jobFlowIds,
     required bool visibleToAllUsers,
   }) async {
-    ArgumentError.checkNotNull(jobFlowIds, 'jobFlowIds');
-    ArgumentError.checkNotNull(visibleToAllUsers, 'visibleToAllUsers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.SetVisibleToAllUsers'
@@ -2517,49 +2187,6 @@ class EMR {
     String? notebookParams,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(editorId, 'editorId');
-    _s.validateStringLength(
-      'editorId',
-      editorId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(executionEngine, 'executionEngine');
-    ArgumentError.checkNotNull(relativePath, 'relativePath');
-    _s.validateStringLength(
-      'relativePath',
-      relativePath,
-      0,
-      10280,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceRole, 'serviceRole');
-    _s.validateStringLength(
-      'serviceRole',
-      serviceRole,
-      0,
-      10280,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'notebookExecutionName',
-      notebookExecutionName,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'notebookInstanceSecurityGroupId',
-      notebookInstanceSecurityGroupId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'notebookParams',
-      notebookParams,
-      0,
-      10280,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.StartNotebookExecution'
@@ -2597,14 +2224,6 @@ class EMR {
   Future<void> stopNotebookExecution({
     required String notebookExecutionId,
   }) async {
-    ArgumentError.checkNotNull(notebookExecutionId, 'notebookExecutionId');
-    _s.validateStringLength(
-      'notebookExecutionId',
-      notebookExecutionId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.StopNotebookExecution'
@@ -2640,7 +2259,6 @@ class EMR {
   Future<void> terminateJobFlows({
     required List<String> jobFlowIds,
   }) async {
-    ArgumentError.checkNotNull(jobFlowIds, 'jobFlowIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.TerminateJobFlows'
@@ -2700,35 +2318,6 @@ class EMR {
     String? identityId,
     String? identityName,
   }) async {
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    ArgumentError.checkNotNull(sessionPolicyArn, 'sessionPolicyArn');
-    _s.validateStringLength(
-      'sessionPolicyArn',
-      sessionPolicyArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(studioId, 'studioId');
-    _s.validateStringLength(
-      'studioId',
-      studioId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'identityId',
-      identityId,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'identityName',
-      identityName,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ElasticMapReduce.UpdateStudioSessionMapping'

--- a/generated/aws_es_api/lib/es-2015-01-01.dart
+++ b/generated/aws_es_api/lib/es-2015-01-01.dart
@@ -61,8 +61,6 @@ class ElasticsearchService {
       acceptInboundCrossClusterSearchConnection({
     required String crossClusterSearchConnectionId,
   }) async {
-    ArgumentError.checkNotNull(
-        crossClusterSearchConnectionId, 'crossClusterSearchConnectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -95,8 +93,6 @@ class ElasticsearchService {
     required String arn,
     required List<Tag> tagList,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tagList, 'tagList');
     final $payload = <String, dynamic>{
       'ARN': arn,
       'TagList': tagList,
@@ -128,15 +124,6 @@ class ElasticsearchService {
     required String domainName,
     required String packageID,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(packageID, 'packageID');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -164,14 +151,6 @@ class ElasticsearchService {
       cancelElasticsearchServiceSoftwareUpdate({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
     };
@@ -277,14 +256,6 @@ class ElasticsearchService {
     SnapshotOptions? snapshotOptions,
     VPCOptions? vPCOptions,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       if (accessPolicies != null) 'AccessPolicies': accessPolicies,
@@ -343,16 +314,6 @@ class ElasticsearchService {
     required DomainInformation destinationDomainInfo,
     required DomainInformation sourceDomainInfo,
   }) async {
-    ArgumentError.checkNotNull(connectionAlias, 'connectionAlias');
-    _s.validateStringLength(
-      'connectionAlias',
-      connectionAlias,
-      0,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(destinationDomainInfo, 'destinationDomainInfo');
-    ArgumentError.checkNotNull(sourceDomainInfo, 'sourceDomainInfo');
     final $payload = <String, dynamic>{
       'ConnectionAlias': connectionAlias,
       'DestinationDomainInfo': destinationDomainInfo,
@@ -396,22 +357,6 @@ class ElasticsearchService {
     required PackageType packageType,
     String? packageDescription,
   }) async {
-    ArgumentError.checkNotNull(packageName, 'packageName');
-    _s.validateStringLength(
-      'packageName',
-      packageName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(packageSource, 'packageSource');
-    ArgumentError.checkNotNull(packageType, 'packageType');
-    _s.validateStringLength(
-      'packageDescription',
-      packageDescription,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'PackageName': packageName,
       'PackageSource': packageSource,
@@ -440,14 +385,6 @@ class ElasticsearchService {
   Future<DeleteElasticsearchDomainResponse> deleteElasticsearchDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -489,8 +426,6 @@ class ElasticsearchService {
       deleteInboundCrossClusterSearchConnection({
     required String crossClusterSearchConnectionId,
   }) async {
-    ArgumentError.checkNotNull(
-        crossClusterSearchConnectionId, 'crossClusterSearchConnectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -513,8 +448,6 @@ class ElasticsearchService {
       deleteOutboundCrossClusterSearchConnection({
     required String crossClusterSearchConnectionId,
   }) async {
-    ArgumentError.checkNotNull(
-        crossClusterSearchConnectionId, 'crossClusterSearchConnectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -541,7 +474,6 @@ class ElasticsearchService {
   Future<DeletePackageResponse> deletePackage({
     required String packageID,
   }) async {
-    ArgumentError.checkNotNull(packageID, 'packageID');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -564,14 +496,6 @@ class ElasticsearchService {
   Future<DescribeElasticsearchDomainResponse> describeElasticsearchDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -596,14 +520,6 @@ class ElasticsearchService {
       describeElasticsearchDomainConfig({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -626,7 +542,6 @@ class ElasticsearchService {
   Future<DescribeElasticsearchDomainsResponse> describeElasticsearchDomains({
     required List<String> domainNames,
   }) async {
-    ArgumentError.checkNotNull(domainNames, 'domainNames');
     final $payload = <String, dynamic>{
       'DomainNames': domainNames,
     };
@@ -668,14 +583,6 @@ class ElasticsearchService {
     required ESPartitionInstanceType instanceType,
     String? domainName,
   }) async {
-    ArgumentError.checkNotNull(elasticsearchVersion, 'elasticsearchVersion');
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     final $query = <String, List<String>>{
       if (domainName != null) 'domainName': [domainName],
     };
@@ -952,15 +859,6 @@ class ElasticsearchService {
     required String domainName,
     required String packageID,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(packageID, 'packageID');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -984,12 +882,6 @@ class ElasticsearchService {
       getCompatibleElasticsearchVersions({
     String? domainName,
   }) async {
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     final $query = <String, List<String>>{
       if (domainName != null) 'domainName': [domainName],
     };
@@ -1026,7 +918,6 @@ class ElasticsearchService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(packageID, 'packageID');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1061,14 +952,6 @@ class ElasticsearchService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1101,14 +984,6 @@ class ElasticsearchService {
   Future<GetUpgradeStatusResponse> getUpgradeStatus({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1156,7 +1031,6 @@ class ElasticsearchService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(packageID, 'packageID');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1209,13 +1083,6 @@ class ElasticsearchService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(elasticsearchVersion, 'elasticsearchVersion');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1294,14 +1161,6 @@ class ElasticsearchService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1336,7 +1195,6 @@ class ElasticsearchService {
   Future<ListTagsResponse> listTags({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $query = <String, List<String>>{
       'arn': [arn],
     };
@@ -1373,16 +1231,6 @@ class ElasticsearchService {
     required String reservedElasticsearchInstanceOfferingId,
     int? instanceCount,
   }) async {
-    ArgumentError.checkNotNull(reservationName, 'reservationName');
-    _s.validateStringLength(
-      'reservationName',
-      reservationName,
-      5,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reservedElasticsearchInstanceOfferingId,
-        'reservedElasticsearchInstanceOfferingId');
     _s.validateNumRange(
       'instanceCount',
       instanceCount,
@@ -1417,8 +1265,6 @@ class ElasticsearchService {
       rejectInboundCrossClusterSearchConnection({
     required String crossClusterSearchConnectionId,
   }) async {
-    ArgumentError.checkNotNull(
-        crossClusterSearchConnectionId, 'crossClusterSearchConnectionId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -1446,8 +1292,6 @@ class ElasticsearchService {
     required String arn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ARN': arn,
       'TagKeys': tagKeys,
@@ -1474,14 +1318,6 @@ class ElasticsearchService {
       startElasticsearchServiceSoftwareUpdate({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
     };
@@ -1565,14 +1401,6 @@ class ElasticsearchService {
     SnapshotOptions? snapshotOptions,
     VPCOptions? vPCOptions,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (accessPolicies != null) 'AccessPolicies': accessPolicies,
       if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
@@ -1624,20 +1452,6 @@ class ElasticsearchService {
     String? commitMessage,
     String? packageDescription,
   }) async {
-    ArgumentError.checkNotNull(packageID, 'packageID');
-    ArgumentError.checkNotNull(packageSource, 'packageSource');
-    _s.validateStringLength(
-      'commitMessage',
-      commitMessage,
-      0,
-      160,
-    );
-    _s.validateStringLength(
-      'packageDescription',
-      packageDescription,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'PackageID': packageID,
       'PackageSource': packageSource,
@@ -1674,15 +1488,6 @@ class ElasticsearchService {
     required String targetVersion,
     bool? performCheckOnly,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetVersion, 'targetVersion');
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'TargetVersion': targetVersion,

--- a/generated/aws_es_api/lib/opensearch-2021-01-01.dart
+++ b/generated/aws_es_api/lib/opensearch-2021-01-01.dart
@@ -61,13 +61,6 @@ class OpenSearchService {
     required String connectionId,
   }) async {
     ArgumentError.checkNotNull(connectionId, 'connectionId');
-    _s.validateStringLength(
-      'connectionId',
-      connectionId,
-      10,
-      256,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -99,13 +92,6 @@ class OpenSearchService {
     required List<Tag> tagList,
   }) async {
     ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      2048,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(tagList, 'tagList');
     final $payload = <String, dynamic>{
       'ARN': arn,
@@ -139,13 +125,6 @@ class OpenSearchService {
     required String packageID,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(packageID, 'packageID');
     final response = await _protocol.send(
       payload: null,
@@ -174,13 +153,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
     };
@@ -298,25 +270,6 @@ class OpenSearchService {
     VPCOptions? vPCOptions,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accessPolicies',
-      accessPolicies,
-      0,
-      102400,
-    );
-    _s.validateStringLength(
-      'engineVersion',
-      engineVersion,
-      14,
-      18,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       if (accessPolicies != null) 'AccessPolicies': accessPolicies,
@@ -375,13 +328,6 @@ class OpenSearchService {
     required DomainInformationContainer remoteDomainInfo,
   }) async {
     ArgumentError.checkNotNull(connectionAlias, 'connectionAlias');
-    _s.validateStringLength(
-      'connectionAlias',
-      connectionAlias,
-      2,
-      100,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(localDomainInfo, 'localDomainInfo');
     ArgumentError.checkNotNull(remoteDomainInfo, 'remoteDomainInfo');
     final $payload = <String, dynamic>{
@@ -426,21 +372,8 @@ class OpenSearchService {
     String? packageDescription,
   }) async {
     ArgumentError.checkNotNull(packageName, 'packageName');
-    _s.validateStringLength(
-      'packageName',
-      packageName,
-      3,
-      28,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(packageSource, 'packageSource');
     ArgumentError.checkNotNull(packageType, 'packageType');
-    _s.validateStringLength(
-      'packageDescription',
-      packageDescription,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'PackageName': packageName,
       'PackageSource': packageSource,
@@ -470,13 +403,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -499,13 +425,6 @@ class OpenSearchService {
     required String connectionId,
   }) async {
     ArgumentError.checkNotNull(connectionId, 'connectionId');
-    _s.validateStringLength(
-      'connectionId',
-      connectionId,
-      10,
-      256,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -528,13 +447,6 @@ class OpenSearchService {
     required String connectionId,
   }) async {
     ArgumentError.checkNotNull(connectionId, 'connectionId');
-    _s.validateStringLength(
-      'connectionId',
-      connectionId,
-      10,
-      256,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -584,13 +496,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -625,13 +530,6 @@ class OpenSearchService {
     String? nextToken,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -668,19 +566,6 @@ class OpenSearchService {
     String? changeId,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'changeId',
-      changeId,
-      36,
-      36,
-    );
     final $query = <String, List<String>>{
       if (changeId != null) 'changeid': [changeId],
     };
@@ -710,13 +595,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -829,20 +707,7 @@ class OpenSearchService {
     String? domainName,
   }) async {
     ArgumentError.checkNotNull(engineVersion, 'engineVersion');
-    _s.validateStringLength(
-      'engineVersion',
-      engineVersion,
-      14,
-      18,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     final $query = <String, List<String>>{
       if (domainName != null) 'domainName': [domainName],
     };
@@ -980,12 +845,6 @@ class OpenSearchService {
       0,
       100,
     );
-    _s.validateStringLength(
-      'reservedInstanceOfferingId',
-      reservedInstanceOfferingId,
-      36,
-      36,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1031,12 +890,6 @@ class OpenSearchService {
       0,
       100,
     );
-    _s.validateStringLength(
-      'reservedInstanceId',
-      reservedInstanceId,
-      36,
-      36,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -1072,13 +925,6 @@ class OpenSearchService {
     required String packageID,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(packageID, 'packageID');
     final response = await _protocol.send(
       payload: null,
@@ -1103,12 +949,6 @@ class OpenSearchService {
   Future<GetCompatibleVersionsResponse> getCompatibleVersions({
     String? domainName,
   }) async {
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     final $query = <String, List<String>>{
       if (domainName != null) 'domainName': [domainName],
     };
@@ -1181,13 +1021,6 @@ class OpenSearchService {
     String? nextToken,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1221,13 +1054,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1318,19 +1144,6 @@ class OpenSearchService {
     String? nextToken,
   }) async {
     ArgumentError.checkNotNull(engineVersion, 'engineVersion');
-    _s.validateStringLength(
-      'engineVersion',
-      engineVersion,
-      14,
-      18,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1376,13 +1189,6 @@ class OpenSearchService {
     String? nextToken,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1418,13 +1224,6 @@ class OpenSearchService {
     required String arn,
   }) async {
     ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'arn': [arn],
     };
@@ -1496,22 +1295,8 @@ class OpenSearchService {
     int? instanceCount,
   }) async {
     ArgumentError.checkNotNull(reservationName, 'reservationName');
-    _s.validateStringLength(
-      'reservationName',
-      reservationName,
-      5,
-      64,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(
         reservedInstanceOfferingId, 'reservedInstanceOfferingId');
-    _s.validateStringLength(
-      'reservedInstanceOfferingId',
-      reservedInstanceOfferingId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'instanceCount',
       instanceCount,
@@ -1544,13 +1329,6 @@ class OpenSearchService {
     required String connectionId,
   }) async {
     ArgumentError.checkNotNull(connectionId, 'connectionId');
-    _s.validateStringLength(
-      'connectionId',
-      connectionId,
-      10,
-      256,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -1578,13 +1356,6 @@ class OpenSearchService {
     required List<String> tagKeys,
   }) async {
     ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      2048,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ARN': arn,
@@ -1613,13 +1384,6 @@ class OpenSearchService {
     required String domainName,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
     };
@@ -1722,19 +1486,6 @@ class OpenSearchService {
     VPCOptions? vPCOptions,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accessPolicies',
-      accessPolicies,
-      0,
-      102400,
-    );
     final $payload = <String, dynamic>{
       if (accessPolicies != null) 'AccessPolicies': accessPolicies,
       if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
@@ -1793,18 +1544,6 @@ class OpenSearchService {
   }) async {
     ArgumentError.checkNotNull(packageID, 'packageID');
     ArgumentError.checkNotNull(packageSource, 'packageSource');
-    _s.validateStringLength(
-      'commitMessage',
-      commitMessage,
-      0,
-      160,
-    );
-    _s.validateStringLength(
-      'packageDescription',
-      packageDescription,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'PackageID': packageID,
       'PackageSource': packageSource,
@@ -1843,21 +1582,7 @@ class OpenSearchService {
     bool? performCheckOnly,
   }) async {
     ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      3,
-      28,
-      isRequired: true,
-    );
     ArgumentError.checkNotNull(targetVersion, 'targetVersion');
-    _s.validateStringLength(
-      'targetVersion',
-      targetVersion,
-      14,
-      18,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'TargetVersion': targetVersion,
@@ -1922,6 +1647,13 @@ class AcceptInboundConnectionResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connection = this.connection;
+    return {
+      if (connection != null) 'Connection': connection,
+    };
+  }
 }
 
 /// The configured access rules for the domain's document and search endpoints,
@@ -1946,6 +1678,15 @@ class AccessPoliciesStatus {
       options: json['Options'] as String,
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
   }
 }
 
@@ -1982,6 +1723,15 @@ class AdditionalLimit {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final limitName = this.limitName;
+    final limitValues = this.limitValues;
+    return {
+      if (limitName != null) 'LimitName': limitName,
+      if (limitValues != null) 'LimitValues': limitValues,
+    };
+  }
 }
 
 /// Status of the advanced options for the specified domain. Currently, the
@@ -2016,6 +1766,15 @@ class AdvancedOptionsStatus {
           .map((k, e) => MapEntry(k, e as String)),
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
   }
 }
 
@@ -2058,6 +1817,25 @@ class AdvancedSecurityOptions {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final anonymousAuthDisableDate = this.anonymousAuthDisableDate;
+    final anonymousAuthEnabled = this.anonymousAuthEnabled;
+    final enabled = this.enabled;
+    final internalUserDatabaseEnabled = this.internalUserDatabaseEnabled;
+    final sAMLOptions = this.sAMLOptions;
+    return {
+      if (anonymousAuthDisableDate != null)
+        'AnonymousAuthDisableDate':
+            unixTimestampToJson(anonymousAuthDisableDate),
+      if (anonymousAuthEnabled != null)
+        'AnonymousAuthEnabled': anonymousAuthEnabled,
+      if (enabled != null) 'Enabled': enabled,
+      if (internalUserDatabaseEnabled != null)
+        'InternalUserDatabaseEnabled': internalUserDatabaseEnabled,
+      if (sAMLOptions != null) 'SAMLOptions': sAMLOptions,
+    };
+  }
 }
 
 /// The advanced security configuration: whether advanced security is enabled,
@@ -2088,6 +1866,7 @@ class AdvancedSecurityOptionsInput {
     this.masterUserOptions,
     this.sAMLOptions,
   });
+
   Map<String, dynamic> toJson() {
     final anonymousAuthEnabled = this.anonymousAuthEnabled;
     final enabled = this.enabled;
@@ -2125,6 +1904,15 @@ class AdvancedSecurityOptionsStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 /// Container for the response returned by <code> <a>AssociatePackage</a>
@@ -2143,6 +1931,14 @@ class AssociatePackageResponse {
               json['DomainPackageDetails'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainPackageDetails = this.domainPackageDetails;
+    return {
+      if (domainPackageDetails != null)
+        'DomainPackageDetails': domainPackageDetails,
+    };
   }
 }
 
@@ -2170,6 +1966,15 @@ class AutoTune {
       autoTuneType: (json['AutoTuneType'] as String?)?.toAutoTuneType(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final autoTuneDetails = this.autoTuneDetails;
+    final autoTuneType = this.autoTuneType;
+    return {
+      if (autoTuneDetails != null) 'AutoTuneDetails': autoTuneDetails,
+      if (autoTuneType != null) 'AutoTuneType': autoTuneType.toValue(),
+    };
+  }
 }
 
 /// The Auto-Tune desired state. Valid values are ENABLED and DISABLED.
@@ -2178,7 +1983,7 @@ enum AutoTuneDesiredState {
   disabled,
 }
 
-extension AutoTuneDesiredStateValue on AutoTuneDesiredState {
+extension AutoTuneDesiredStateValueExtension on AutoTuneDesiredState {
   String toValue() {
     switch (this) {
       case AutoTuneDesiredState.enabled:
@@ -2218,6 +2023,14 @@ class AutoTuneDetails {
               json['ScheduledAutoTuneDetails'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final scheduledAutoTuneDetails = this.scheduledAutoTuneDetails;
+    return {
+      if (scheduledAutoTuneDetails != null)
+        'ScheduledAutoTuneDetails': scheduledAutoTuneDetails,
+    };
   }
 }
 
@@ -2335,6 +2148,7 @@ class AutoTuneOptionsInput {
     this.desiredState,
     this.maintenanceSchedules,
   });
+
   Map<String, dynamic> toJson() {
     final desiredState = this.desiredState;
     final maintenanceSchedules = this.maintenanceSchedules;
@@ -2365,6 +2179,15 @@ class AutoTuneOptionsOutput {
       state: (json['State'] as String?)?.toAutoTuneState(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final errorMessage = this.errorMessage;
+    final state = this.state;
+    return {
+      if (errorMessage != null) 'ErrorMessage': errorMessage,
+      if (state != null) 'State': state.toValue(),
+    };
+  }
 }
 
 /// The Auto-Tune status for the domain.
@@ -2389,6 +2212,15 @@ class AutoTuneOptionsStatus {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      if (options != null) 'Options': options,
+      if (status != null) 'Status': status,
+    };
+  }
 }
 
 /// The Auto-Tune state for the domain. For valid states see <a
@@ -2406,7 +2238,7 @@ enum AutoTuneState {
   error,
 }
 
-extension AutoTuneStateValue on AutoTuneState {
+extension AutoTuneStateValueExtension on AutoTuneState {
   String toValue() {
     switch (this) {
       case AutoTuneState.enabled:
@@ -2496,6 +2328,23 @@ class AutoTuneStatus {
       updateVersion: json['UpdateVersion'] as int?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final creationDate = this.creationDate;
+    final state = this.state;
+    final updateDate = this.updateDate;
+    final errorMessage = this.errorMessage;
+    final pendingDeletion = this.pendingDeletion;
+    final updateVersion = this.updateVersion;
+    return {
+      'CreationDate': unixTimestampToJson(creationDate),
+      'State': state.toValue(),
+      'UpdateDate': unixTimestampToJson(updateDate),
+      if (errorMessage != null) 'ErrorMessage': errorMessage,
+      if (pendingDeletion != null) 'PendingDeletion': pendingDeletion,
+      if (updateVersion != null) 'UpdateVersion': updateVersion,
+    };
+  }
 }
 
 /// Specifies the Auto-Tune type. Valid value is SCHEDULED_ACTION.
@@ -2503,7 +2352,7 @@ enum AutoTuneType {
   scheduledAction,
 }
 
-extension AutoTuneTypeValue on AutoTuneType {
+extension AutoTuneTypeValueExtension on AutoTuneType {
   String toValue() {
     switch (this) {
       case AutoTuneType.scheduledAction:
@@ -2540,6 +2389,14 @@ class CancelServiceSoftwareUpdateResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final serviceSoftwareOptions = this.serviceSoftwareOptions;
+    return {
+      if (serviceSoftwareOptions != null)
+        'ServiceSoftwareOptions': serviceSoftwareOptions,
+    };
+  }
 }
 
 /// Specifies change details of the domain configuration change.
@@ -2561,6 +2418,15 @@ class ChangeProgressDetails {
       changeId: json['ChangeId'] as String?,
       message: json['Message'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final changeId = this.changeId;
+    final message = this.message;
+    return {
+      if (changeId != null) 'ChangeId': changeId,
+      if (message != null) 'Message': message,
+    };
   }
 }
 
@@ -2591,6 +2457,19 @@ class ChangeProgressStage {
       name: json['Name'] as String?,
       status: json['Status'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final description = this.description;
+    final lastUpdated = this.lastUpdated;
+    final name = this.name;
+    final status = this.status;
+    return {
+      if (description != null) 'Description': description,
+      if (lastUpdated != null) 'LastUpdated': unixTimestampToJson(lastUpdated),
+      if (name != null) 'Name': name,
+      if (status != null) 'Status': status,
+    };
   }
 }
 
@@ -2651,6 +2530,28 @@ class ChangeProgressStatusDetails {
       status: (json['Status'] as String?)?.toOverallChangeStatus(),
       totalNumberOfStages: json['TotalNumberOfStages'] as int?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final changeId = this.changeId;
+    final changeProgressStages = this.changeProgressStages;
+    final completedProperties = this.completedProperties;
+    final pendingProperties = this.pendingProperties;
+    final startTime = this.startTime;
+    final status = this.status;
+    final totalNumberOfStages = this.totalNumberOfStages;
+    return {
+      if (changeId != null) 'ChangeId': changeId,
+      if (changeProgressStages != null)
+        'ChangeProgressStages': changeProgressStages,
+      if (completedProperties != null)
+        'CompletedProperties': completedProperties,
+      if (pendingProperties != null) 'PendingProperties': pendingProperties,
+      if (startTime != null) 'StartTime': unixTimestampToJson(startTime),
+      if (status != null) 'Status': status.toValue(),
+      if (totalNumberOfStages != null)
+        'TotalNumberOfStages': totalNumberOfStages,
+    };
   }
 }
 
@@ -2789,6 +2690,15 @@ class ClusterConfigStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 /// Options to specify the Cognito user and identity pools for OpenSearch
@@ -2857,6 +2767,15 @@ class CognitoOptionsStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 /// Specifies the configuration for cold storage options such as enabled
@@ -2901,6 +2820,15 @@ class CompatibleVersionsMap {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final sourceVersion = this.sourceVersion;
+    final targetVersions = this.targetVersions;
+    return {
+      if (sourceVersion != null) 'SourceVersion': sourceVersion,
+      if (targetVersions != null) 'TargetVersions': targetVersions,
+    };
+  }
 }
 
 /// The result of a <code>CreateDomain</code> operation. Contains the status of
@@ -2918,6 +2846,13 @@ class CreateDomainResponse {
           ? DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainStatus = this.domainStatus;
+    return {
+      if (domainStatus != null) 'DomainStatus': domainStatus,
+    };
   }
 }
 
@@ -2968,6 +2903,21 @@ class CreateOutboundConnectionResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connectionAlias = this.connectionAlias;
+    final connectionId = this.connectionId;
+    final connectionStatus = this.connectionStatus;
+    final localDomainInfo = this.localDomainInfo;
+    final remoteDomainInfo = this.remoteDomainInfo;
+    return {
+      if (connectionAlias != null) 'ConnectionAlias': connectionAlias,
+      if (connectionId != null) 'ConnectionId': connectionId,
+      if (connectionStatus != null) 'ConnectionStatus': connectionStatus,
+      if (localDomainInfo != null) 'LocalDomainInfo': localDomainInfo,
+      if (remoteDomainInfo != null) 'RemoteDomainInfo': remoteDomainInfo,
+    };
+  }
 }
 
 /// Container for the response returned by the <code> <a>CreatePackage</a>
@@ -2987,6 +2937,13 @@ class CreatePackageResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final packageDetails = this.packageDetails;
+    return {
+      if (packageDetails != null) 'PackageDetails': packageDetails,
+    };
+  }
 }
 
 /// The result of a <code>DeleteDomain</code> request. Contains the status of
@@ -3005,6 +2962,13 @@ class DeleteDomainResponse {
           ? DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainStatus = this.domainStatus;
+    return {
+      if (domainStatus != null) 'DomainStatus': domainStatus,
+    };
   }
 }
 
@@ -3026,6 +2990,13 @@ class DeleteInboundConnectionResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connection = this.connection;
+    return {
+      if (connection != null) 'Connection': connection,
+    };
+  }
 }
 
 /// The result of a <code> <a>DeleteOutboundConnection</a> </code> operation.
@@ -3046,6 +3017,13 @@ class DeleteOutboundConnectionResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connection = this.connection;
+    return {
+      if (connection != null) 'Connection': connection,
+    };
+  }
 }
 
 /// Container for the response parameters to the <code> <a>DeletePackage</a>
@@ -3065,6 +3043,13 @@ class DeletePackageResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final packageDetails = this.packageDetails;
+    return {
+      if (packageDetails != null) 'PackageDetails': packageDetails,
+    };
+  }
 }
 
 enum DeploymentStatus {
@@ -3075,7 +3060,7 @@ enum DeploymentStatus {
   eligible,
 }
 
-extension DeploymentStatusValue on DeploymentStatus {
+extension DeploymentStatusValueExtension on DeploymentStatus {
   String toValue() {
     switch (this) {
       case DeploymentStatus.pendingUpdate:
@@ -3138,6 +3123,15 @@ class DescribeDomainAutoTunesResponse {
       nextToken: json['NextToken'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final autoTunes = this.autoTunes;
+    final nextToken = this.nextToken;
+    return {
+      if (autoTunes != null) 'AutoTunes': autoTunes,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+  }
 }
 
 /// The result of a <code>DescribeDomainChangeProgress</code> request. Contains
@@ -3159,6 +3153,14 @@ class DescribeDomainChangeProgressResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final changeProgressStatus = this.changeProgressStatus;
+    return {
+      if (changeProgressStatus != null)
+        'ChangeProgressStatus': changeProgressStatus,
+    };
+  }
 }
 
 /// The result of a <code>DescribeDomainConfig</code> request. Contains the
@@ -3177,6 +3179,13 @@ class DescribeDomainConfigResponse {
           DomainConfig.fromJson(json['DomainConfig'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final domainConfig = this.domainConfig;
+    return {
+      'DomainConfig': domainConfig,
+    };
+  }
 }
 
 /// The result of a <code>DescribeDomain</code> request. Contains the status of
@@ -3193,6 +3202,13 @@ class DescribeDomainResponse {
       domainStatus:
           DomainStatus.fromJson(json['DomainStatus'] as Map<String, dynamic>),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainStatus = this.domainStatus;
+    return {
+      'DomainStatus': domainStatus,
+    };
   }
 }
 
@@ -3213,6 +3229,13 @@ class DescribeDomainsResponse {
           .map((e) => DomainStatus.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainStatusList = this.domainStatusList;
+    return {
+      'DomainStatusList': domainStatusList,
+    };
   }
 }
 
@@ -3242,6 +3265,15 @@ class DescribeInboundConnectionsResponse {
       nextToken: json['NextToken'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connections = this.connections;
+    final nextToken = this.nextToken;
+    return {
+      if (connections != null) 'Connections': connections,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+  }
 }
 
 /// Container for the parameters received from the <code>
@@ -3258,6 +3290,13 @@ class DescribeInstanceTypeLimitsResponse {
       limitsByRole: (json['LimitsByRole'] as Map<String, dynamic>?)?.map(
           (k, e) => MapEntry(k, Limits.fromJson(e as Map<String, dynamic>))),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final limitsByRole = this.limitsByRole;
+    return {
+      if (limitsByRole != null) 'LimitsByRole': limitsByRole,
+    };
   }
 }
 
@@ -3287,6 +3326,15 @@ class DescribeOutboundConnectionsResponse {
       nextToken: json['NextToken'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connections = this.connections;
+    final nextToken = this.nextToken;
+    return {
+      if (connections != null) 'Connections': connections,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+  }
 }
 
 /// A filter to apply to the <code>DescribePackage</code> response.
@@ -3301,6 +3349,7 @@ class DescribePackagesFilter {
     this.name,
     this.value,
   });
+
   Map<String, dynamic> toJson() {
     final name = this.name;
     final value = this.value;
@@ -3317,7 +3366,8 @@ enum DescribePackagesFilterName {
   packageStatus,
 }
 
-extension DescribePackagesFilterNameValue on DescribePackagesFilterName {
+extension DescribePackagesFilterNameValueExtension
+    on DescribePackagesFilterName {
   String toValue() {
     switch (this) {
       case DescribePackagesFilterName.packageID:
@@ -3365,6 +3415,15 @@ class DescribePackagesResponse {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final packageDetailsList = this.packageDetailsList;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (packageDetailsList != null) 'PackageDetailsList': packageDetailsList,
+    };
+  }
 }
 
 /// Container for results from <code>DescribeReservedInstanceOfferings</code>
@@ -3390,6 +3449,16 @@ class DescribeReservedInstanceOfferingsResponse {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final reservedInstanceOfferings = this.reservedInstanceOfferings;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (reservedInstanceOfferings != null)
+        'ReservedInstanceOfferings': reservedInstanceOfferings,
+    };
+  }
 }
 
 /// Container for results from <code>DescribeReservedInstances</code>
@@ -3414,6 +3483,15 @@ class DescribeReservedInstancesResponse {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final reservedInstances = this.reservedInstances;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (reservedInstances != null) 'ReservedInstances': reservedInstances,
+    };
+  }
 }
 
 /// Container for the response returned by <code> <a>DissociatePackage</a>
@@ -3432,6 +3510,14 @@ class DissociatePackageResponse {
               json['DomainPackageDetails'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainPackageDetails = this.domainPackageDetails;
+    return {
+      if (domainPackageDetails != null)
+        'DomainPackageDetails': domainPackageDetails,
+    };
   }
 }
 
@@ -3574,6 +3660,47 @@ class DomainConfig {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final accessPolicies = this.accessPolicies;
+    final advancedOptions = this.advancedOptions;
+    final advancedSecurityOptions = this.advancedSecurityOptions;
+    final autoTuneOptions = this.autoTuneOptions;
+    final changeProgressDetails = this.changeProgressDetails;
+    final clusterConfig = this.clusterConfig;
+    final cognitoOptions = this.cognitoOptions;
+    final domainEndpointOptions = this.domainEndpointOptions;
+    final eBSOptions = this.eBSOptions;
+    final encryptionAtRestOptions = this.encryptionAtRestOptions;
+    final engineVersion = this.engineVersion;
+    final logPublishingOptions = this.logPublishingOptions;
+    final nodeToNodeEncryptionOptions = this.nodeToNodeEncryptionOptions;
+    final snapshotOptions = this.snapshotOptions;
+    final vPCOptions = this.vPCOptions;
+    return {
+      if (accessPolicies != null) 'AccessPolicies': accessPolicies,
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (advancedSecurityOptions != null)
+        'AdvancedSecurityOptions': advancedSecurityOptions,
+      if (autoTuneOptions != null) 'AutoTuneOptions': autoTuneOptions,
+      if (changeProgressDetails != null)
+        'ChangeProgressDetails': changeProgressDetails,
+      if (clusterConfig != null) 'ClusterConfig': clusterConfig,
+      if (cognitoOptions != null) 'CognitoOptions': cognitoOptions,
+      if (domainEndpointOptions != null)
+        'DomainEndpointOptions': domainEndpointOptions,
+      if (eBSOptions != null) 'EBSOptions': eBSOptions,
+      if (encryptionAtRestOptions != null)
+        'EncryptionAtRestOptions': encryptionAtRestOptions,
+      if (engineVersion != null) 'EngineVersion': engineVersion,
+      if (logPublishingOptions != null)
+        'LogPublishingOptions': logPublishingOptions,
+      if (nodeToNodeEncryptionOptions != null)
+        'NodeToNodeEncryptionOptions': nodeToNodeEncryptionOptions,
+      if (snapshotOptions != null) 'SnapshotOptions': snapshotOptions,
+      if (vPCOptions != null) 'VPCOptions': vPCOptions,
+    };
+  }
 }
 
 /// Options to configure the endpoint for the domain.
@@ -3658,6 +3785,15 @@ class DomainEndpointOptionsStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 class DomainInfo {
@@ -3676,6 +3812,15 @@ class DomainInfo {
       domainName: json['DomainName'] as String?,
       engineType: (json['EngineType'] as String?)?.toEngineType(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainName = this.domainName;
+    final engineType = this.engineType;
+    return {
+      if (domainName != null) 'DomainName': domainName,
+      if (engineType != null) 'EngineType': engineType.toValue(),
+    };
   }
 }
 
@@ -3759,6 +3904,30 @@ class DomainPackageDetails {
       referencePath: json['ReferencePath'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final domainName = this.domainName;
+    final domainPackageStatus = this.domainPackageStatus;
+    final errorDetails = this.errorDetails;
+    final lastUpdated = this.lastUpdated;
+    final packageID = this.packageID;
+    final packageName = this.packageName;
+    final packageType = this.packageType;
+    final packageVersion = this.packageVersion;
+    final referencePath = this.referencePath;
+    return {
+      if (domainName != null) 'DomainName': domainName,
+      if (domainPackageStatus != null)
+        'DomainPackageStatus': domainPackageStatus.toValue(),
+      if (errorDetails != null) 'ErrorDetails': errorDetails,
+      if (lastUpdated != null) 'LastUpdated': unixTimestampToJson(lastUpdated),
+      if (packageID != null) 'PackageID': packageID,
+      if (packageName != null) 'PackageName': packageName,
+      if (packageType != null) 'PackageType': packageType.toValue(),
+      if (packageVersion != null) 'PackageVersion': packageVersion,
+      if (referencePath != null) 'ReferencePath': referencePath,
+    };
+  }
 }
 
 enum DomainPackageStatus {
@@ -3769,7 +3938,7 @@ enum DomainPackageStatus {
   dissociationFailed,
 }
 
-extension DomainPackageStatusValue on DomainPackageStatus {
+extension DomainPackageStatusValueExtension on DomainPackageStatus {
   String toValue() {
     switch (this) {
       case DomainPackageStatus.associating:
@@ -3995,6 +4164,69 @@ class DomainStatus {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final arn = this.arn;
+    final clusterConfig = this.clusterConfig;
+    final domainId = this.domainId;
+    final domainName = this.domainName;
+    final accessPolicies = this.accessPolicies;
+    final advancedOptions = this.advancedOptions;
+    final advancedSecurityOptions = this.advancedSecurityOptions;
+    final autoTuneOptions = this.autoTuneOptions;
+    final changeProgressDetails = this.changeProgressDetails;
+    final cognitoOptions = this.cognitoOptions;
+    final created = this.created;
+    final deleted = this.deleted;
+    final domainEndpointOptions = this.domainEndpointOptions;
+    final eBSOptions = this.eBSOptions;
+    final encryptionAtRestOptions = this.encryptionAtRestOptions;
+    final endpoint = this.endpoint;
+    final endpoints = this.endpoints;
+    final engineVersion = this.engineVersion;
+    final logPublishingOptions = this.logPublishingOptions;
+    final nodeToNodeEncryptionOptions = this.nodeToNodeEncryptionOptions;
+    final processing = this.processing;
+    final serviceSoftwareOptions = this.serviceSoftwareOptions;
+    final snapshotOptions = this.snapshotOptions;
+    final upgradeProcessing = this.upgradeProcessing;
+    final vPCOptions = this.vPCOptions;
+    return {
+      'ARN': arn,
+      'ClusterConfig': clusterConfig,
+      'DomainId': domainId,
+      'DomainName': domainName,
+      if (accessPolicies != null) 'AccessPolicies': accessPolicies,
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (advancedSecurityOptions != null)
+        'AdvancedSecurityOptions': advancedSecurityOptions,
+      if (autoTuneOptions != null) 'AutoTuneOptions': autoTuneOptions,
+      if (changeProgressDetails != null)
+        'ChangeProgressDetails': changeProgressDetails,
+      if (cognitoOptions != null) 'CognitoOptions': cognitoOptions,
+      if (created != null) 'Created': created,
+      if (deleted != null) 'Deleted': deleted,
+      if (domainEndpointOptions != null)
+        'DomainEndpointOptions': domainEndpointOptions,
+      if (eBSOptions != null) 'EBSOptions': eBSOptions,
+      if (encryptionAtRestOptions != null)
+        'EncryptionAtRestOptions': encryptionAtRestOptions,
+      if (endpoint != null) 'Endpoint': endpoint,
+      if (endpoints != null) 'Endpoints': endpoints,
+      if (engineVersion != null) 'EngineVersion': engineVersion,
+      if (logPublishingOptions != null)
+        'LogPublishingOptions':
+            logPublishingOptions.map((k, e) => MapEntry(k.toValue(), e)),
+      if (nodeToNodeEncryptionOptions != null)
+        'NodeToNodeEncryptionOptions': nodeToNodeEncryptionOptions,
+      if (processing != null) 'Processing': processing,
+      if (serviceSoftwareOptions != null)
+        'ServiceSoftwareOptions': serviceSoftwareOptions,
+      if (snapshotOptions != null) 'SnapshotOptions': snapshotOptions,
+      if (upgradeProcessing != null) 'UpgradeProcessing': upgradeProcessing,
+      if (vPCOptions != null) 'VPCOptions': vPCOptions,
+    };
+  }
 }
 
 class DryRunResults {
@@ -4018,6 +4250,15 @@ class DryRunResults {
       deploymentType: json['DeploymentType'] as String?,
       message: json['Message'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final deploymentType = this.deploymentType;
+    final message = this.message;
+    return {
+      if (deploymentType != null) 'DeploymentType': deploymentType,
+      if (message != null) 'Message': message,
+    };
   }
 }
 
@@ -4065,8 +4306,11 @@ class EBSOptions {
   /// Whether EBS-based storage is enabled.
   final bool? eBSEnabled;
 
-  /// The IOPD for a Provisioned IOPS EBS volume (SSD).
+  /// The IOPS for Provisioned IOPS And GP3 EBS volume (SSD).
   final int? iops;
+
+  /// The Throughput for GP3 EBS volume (SSD).
+  final int? throughput;
 
   /// Integer to specify the size of an EBS volume.
   final int? volumeSize;
@@ -4077,6 +4321,7 @@ class EBSOptions {
   EBSOptions({
     this.eBSEnabled,
     this.iops,
+    this.throughput,
     this.volumeSize,
     this.volumeType,
   });
@@ -4084,6 +4329,7 @@ class EBSOptions {
     return EBSOptions(
       eBSEnabled: json['EBSEnabled'] as bool?,
       iops: json['Iops'] as int?,
+      throughput: json['Throughput'] as int?,
       volumeSize: json['VolumeSize'] as int?,
       volumeType: (json['VolumeType'] as String?)?.toVolumeType(),
     );
@@ -4092,11 +4338,13 @@ class EBSOptions {
   Map<String, dynamic> toJson() {
     final eBSEnabled = this.eBSEnabled;
     final iops = this.iops;
+    final throughput = this.throughput;
     final volumeSize = this.volumeSize;
     final volumeType = this.volumeType;
     return {
       if (eBSEnabled != null) 'EBSEnabled': eBSEnabled,
       if (iops != null) 'Iops': iops,
+      if (throughput != null) 'Throughput': throughput,
       if (volumeSize != null) 'VolumeSize': volumeSize,
       if (volumeType != null) 'VolumeType': volumeType.toValue(),
     };
@@ -4120,6 +4368,15 @@ class EBSOptionsStatus {
       options: EBSOptions.fromJson(json['Options'] as Map<String, dynamic>),
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
   }
 }
 
@@ -4171,6 +4428,15 @@ class EncryptionAtRestOptionsStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 enum EngineType {
@@ -4178,7 +4444,7 @@ enum EngineType {
   elasticsearch,
 }
 
-extension EngineTypeValue on EngineType {
+extension EngineTypeValueExtension on EngineType {
   String toValue() {
     switch (this) {
       case EngineType.openSearch:
@@ -4215,6 +4481,15 @@ class ErrorDetails {
       errorType: json['ErrorType'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final errorMessage = this.errorMessage;
+    final errorType = this.errorType;
+    return {
+      if (errorMessage != null) 'ErrorMessage': errorMessage,
+      if (errorType != null) 'ErrorType': errorType,
+    };
+  }
 }
 
 /// A filter used to limit results when describing inbound or outbound
@@ -4232,6 +4507,7 @@ class Filter {
     this.name,
     this.values,
   });
+
   Map<String, dynamic> toJson() {
     final name = this.name;
     final values = this.values;
@@ -4260,6 +4536,13 @@ class GetCompatibleVersionsResponse {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final compatibleVersions = this.compatibleVersions;
+    return {
+      if (compatibleVersions != null) 'CompatibleVersions': compatibleVersions,
+    };
+  }
 }
 
 /// Container for response returned by <code> <a>GetPackageVersionHistory</a>
@@ -4285,6 +4568,18 @@ class GetPackageVersionHistoryResponse {
           .map((e) => PackageVersionHistory.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final packageID = this.packageID;
+    final packageVersionHistoryList = this.packageVersionHistoryList;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (packageID != null) 'PackageID': packageID,
+      if (packageVersionHistoryList != null)
+        'PackageVersionHistoryList': packageVersionHistoryList,
+    };
   }
 }
 
@@ -4312,6 +4607,15 @@ class GetUpgradeHistoryResponse {
           .map((e) => UpgradeHistory.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final upgradeHistories = this.upgradeHistories;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (upgradeHistories != null) 'UpgradeHistories': upgradeHistories,
+    };
   }
 }
 
@@ -4351,6 +4655,17 @@ class GetUpgradeStatusResponse {
       upgradeName: json['UpgradeName'] as String?,
       upgradeStep: (json['UpgradeStep'] as String?)?.toUpgradeStep(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final stepStatus = this.stepStatus;
+    final upgradeName = this.upgradeName;
+    final upgradeStep = this.upgradeStep;
+    return {
+      if (stepStatus != null) 'StepStatus': stepStatus.toValue(),
+      if (upgradeName != null) 'UpgradeName': upgradeName,
+      if (upgradeStep != null) 'UpgradeStep': upgradeStep.toValue(),
+    };
   }
 }
 
@@ -4394,6 +4709,19 @@ class InboundConnection {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connectionId = this.connectionId;
+    final connectionStatus = this.connectionStatus;
+    final localDomainInfo = this.localDomainInfo;
+    final remoteDomainInfo = this.remoteDomainInfo;
+    return {
+      if (connectionId != null) 'ConnectionId': connectionId,
+      if (connectionStatus != null) 'ConnectionStatus': connectionStatus,
+      if (localDomainInfo != null) 'LocalDomainInfo': localDomainInfo,
+      if (remoteDomainInfo != null) 'RemoteDomainInfo': remoteDomainInfo,
+    };
+  }
 }
 
 /// The connection status of an inbound cross-cluster connection.
@@ -4428,6 +4756,15 @@ class InboundConnectionStatus {
           (json['StatusCode'] as String?)?.toInboundConnectionStatusCode(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final message = this.message;
+    final statusCode = this.statusCode;
+    return {
+      if (message != null) 'Message': message,
+      if (statusCode != null) 'StatusCode': statusCode.toValue(),
+    };
+  }
 }
 
 enum InboundConnectionStatusCode {
@@ -4441,7 +4778,8 @@ enum InboundConnectionStatusCode {
   deleted,
 }
 
-extension InboundConnectionStatusCodeValue on InboundConnectionStatusCode {
+extension InboundConnectionStatusCodeValueExtension
+    on InboundConnectionStatusCode {
   String toValue() {
     switch (this) {
       case InboundConnectionStatusCode.pendingAcceptance:
@@ -4504,6 +4842,17 @@ class InstanceCountLimits {
       minimumInstanceCount: json['MinimumInstanceCount'] as int?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final maximumInstanceCount = this.maximumInstanceCount;
+    final minimumInstanceCount = this.minimumInstanceCount;
+    return {
+      if (maximumInstanceCount != null)
+        'MaximumInstanceCount': maximumInstanceCount,
+      if (minimumInstanceCount != null)
+        'MinimumInstanceCount': minimumInstanceCount,
+    };
+  }
 }
 
 /// InstanceLimits represents the list of instance-related attributes that are
@@ -4521,6 +4870,14 @@ class InstanceLimits {
               json['InstanceCountLimits'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final instanceCountLimits = this.instanceCountLimits;
+    return {
+      if (instanceCountLimits != null)
+        'InstanceCountLimits': instanceCountLimits,
+    };
   }
 }
 
@@ -4556,6 +4913,26 @@ class InstanceTypeDetails {
           ?.toOpenSearchPartitionInstanceType(),
       warmEnabled: json['WarmEnabled'] as bool?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final advancedSecurityEnabled = this.advancedSecurityEnabled;
+    final appLogsEnabled = this.appLogsEnabled;
+    final cognitoEnabled = this.cognitoEnabled;
+    final encryptionEnabled = this.encryptionEnabled;
+    final instanceRole = this.instanceRole;
+    final instanceType = this.instanceType;
+    final warmEnabled = this.warmEnabled;
+    return {
+      if (advancedSecurityEnabled != null)
+        'AdvancedSecurityEnabled': advancedSecurityEnabled,
+      if (appLogsEnabled != null) 'AppLogsEnabled': appLogsEnabled,
+      if (cognitoEnabled != null) 'CognitoEnabled': cognitoEnabled,
+      if (encryptionEnabled != null) 'EncryptionEnabled': encryptionEnabled,
+      if (instanceRole != null) 'InstanceRole': instanceRole,
+      if (instanceType != null) 'InstanceType': instanceType.toValue(),
+      if (warmEnabled != null) 'WarmEnabled': warmEnabled,
+    };
   }
 }
 
@@ -4593,6 +4970,17 @@ class Limits {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final additionalLimits = this.additionalLimits;
+    final instanceLimits = this.instanceLimits;
+    final storageTypes = this.storageTypes;
+    return {
+      if (additionalLimits != null) 'AdditionalLimits': additionalLimits,
+      if (instanceLimits != null) 'InstanceLimits': instanceLimits,
+      if (storageTypes != null) 'StorageTypes': storageTypes,
+    };
+  }
 }
 
 /// The result of a <code>ListDomainNames</code> operation. Contains the names
@@ -4611,6 +4999,13 @@ class ListDomainNamesResponse {
           .map((e) => DomainInfo.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final domainNames = this.domainNames;
+    return {
+      if (domainNames != null) 'DomainNames': domainNames,
+    };
   }
 }
 
@@ -4634,6 +5029,16 @@ class ListDomainsForPackageResponse {
       nextToken: json['NextToken'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final domainPackageDetailsList = this.domainPackageDetailsList;
+    final nextToken = this.nextToken;
+    return {
+      if (domainPackageDetailsList != null)
+        'DomainPackageDetailsList': domainPackageDetailsList,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+  }
 }
 
 class ListInstanceTypeDetailsResponse {
@@ -4652,6 +5057,16 @@ class ListInstanceTypeDetailsResponse {
           .toList(),
       nextToken: json['NextToken'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final instanceTypeDetails = this.instanceTypeDetails;
+    final nextToken = this.nextToken;
+    return {
+      if (instanceTypeDetails != null)
+        'InstanceTypeDetails': instanceTypeDetails,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
   }
 }
 
@@ -4677,6 +5092,16 @@ class ListPackagesForDomainResponse {
       nextToken: json['NextToken'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final domainPackageDetailsList = this.domainPackageDetailsList;
+    final nextToken = this.nextToken;
+    return {
+      if (domainPackageDetailsList != null)
+        'DomainPackageDetailsList': domainPackageDetailsList,
+      if (nextToken != null) 'NextToken': nextToken,
+    };
+  }
 }
 
 /// The result of a <code>ListTags</code> operation. Contains tags for all
@@ -4695,6 +5120,13 @@ class ListTagsResponse {
           .map((e) => Tag.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final tagList = this.tagList;
+    return {
+      if (tagList != null) 'TagList': tagList,
+    };
   }
 }
 
@@ -4716,6 +5148,15 @@ class ListVersionsResponse {
           .map((e) => e as String)
           .toList(),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final nextToken = this.nextToken;
+    final versions = this.versions;
+    return {
+      if (nextToken != null) 'NextToken': nextToken,
+      if (versions != null) 'Versions': versions,
+    };
   }
 }
 
@@ -4779,6 +5220,16 @@ class LogPublishingOptionsStatus {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      if (options != null)
+        'Options': options.map((k, e) => MapEntry(k.toValue(), e)),
+      if (status != null) 'Status': status,
+    };
+  }
 }
 
 /// Type of log file. Can be one of the following:
@@ -4800,7 +5251,7 @@ enum LogType {
   auditLogs,
 }
 
-extension LogTypeValue on LogType {
+extension LogTypeValueExtension on LogType {
   String toValue() {
     switch (this) {
       case LogType.indexSlowLogs:
@@ -4849,6 +5300,7 @@ class MasterUserOptions {
     this.masterUserName,
     this.masterUserPassword,
   });
+
   Map<String, dynamic> toJson() {
     final masterUserARN = this.masterUserARN;
     final masterUserName = this.masterUserName;
@@ -4902,6 +5354,15 @@ class NodeToNodeEncryptionOptionsStatus {
           json['Options'] as Map<String, dynamic>),
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
   }
 }
 
@@ -5003,7 +5464,7 @@ enum OpenSearchPartitionInstanceType {
   t4gMediumSearch,
 }
 
-extension OpenSearchPartitionInstanceTypeValue
+extension OpenSearchPartitionInstanceTypeValueExtension
     on OpenSearchPartitionInstanceType {
   String toValue() {
     switch (this) {
@@ -5406,7 +5867,7 @@ enum OpenSearchWarmPartitionInstanceType {
   ultrawarm1XlargeSearch,
 }
 
-extension OpenSearchWarmPartitionInstanceTypeValue
+extension OpenSearchWarmPartitionInstanceTypeValueExtension
     on OpenSearchWarmPartitionInstanceType {
   String toValue() {
     switch (this) {
@@ -5447,7 +5908,7 @@ enum OptionState {
   active,
 }
 
-extension OptionStateValue on OptionState {
+extension OptionStateValueExtension on OptionState {
   String toValue() {
     switch (this) {
       case OptionState.requiresIndexDocuments:
@@ -5508,6 +5969,21 @@ class OptionStatus {
       updateVersion: json['UpdateVersion'] as int?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final creationDate = this.creationDate;
+    final state = this.state;
+    final updateDate = this.updateDate;
+    final pendingDeletion = this.pendingDeletion;
+    final updateVersion = this.updateVersion;
+    return {
+      'CreationDate': unixTimestampToJson(creationDate),
+      'State': state.toValue(),
+      'UpdateDate': unixTimestampToJson(updateDate),
+      if (pendingDeletion != null) 'PendingDeletion': pendingDeletion,
+      if (updateVersion != null) 'UpdateVersion': updateVersion,
+    };
+  }
 }
 
 /// Specifies details about an outbound connection.
@@ -5554,6 +6030,21 @@ class OutboundConnection {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final connectionAlias = this.connectionAlias;
+    final connectionId = this.connectionId;
+    final connectionStatus = this.connectionStatus;
+    final localDomainInfo = this.localDomainInfo;
+    final remoteDomainInfo = this.remoteDomainInfo;
+    return {
+      if (connectionAlias != null) 'ConnectionAlias': connectionAlias,
+      if (connectionId != null) 'ConnectionId': connectionId,
+      if (connectionStatus != null) 'ConnectionStatus': connectionStatus,
+      if (localDomainInfo != null) 'LocalDomainInfo': localDomainInfo,
+      if (remoteDomainInfo != null) 'RemoteDomainInfo': remoteDomainInfo,
+    };
+  }
 }
 
 /// The connection status of an outbound cross-cluster connection.
@@ -5592,6 +6083,15 @@ class OutboundConnectionStatus {
           (json['StatusCode'] as String?)?.toOutboundConnectionStatusCode(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final message = this.message;
+    final statusCode = this.statusCode;
+    return {
+      if (message != null) 'Message': message,
+      if (statusCode != null) 'StatusCode': statusCode.toValue(),
+    };
+  }
 }
 
 enum OutboundConnectionStatusCode {
@@ -5607,7 +6107,8 @@ enum OutboundConnectionStatusCode {
   deleted,
 }
 
-extension OutboundConnectionStatusCodeValue on OutboundConnectionStatusCode {
+extension OutboundConnectionStatusCodeValueExtension
+    on OutboundConnectionStatusCode {
   String toValue() {
     switch (this) {
       case OutboundConnectionStatusCode.validating:
@@ -5670,7 +6171,7 @@ enum OverallChangeStatus {
   failed,
 }
 
-extension OverallChangeStatusValue on OverallChangeStatus {
+extension OverallChangeStatusValueExtension on OverallChangeStatus {
   String toValue() {
     switch (this) {
       case OverallChangeStatus.pending:
@@ -5754,6 +6255,31 @@ class PackageDetails {
       packageType: (json['PackageType'] as String?)?.toPackageType(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final availablePackageVersion = this.availablePackageVersion;
+    final createdAt = this.createdAt;
+    final errorDetails = this.errorDetails;
+    final lastUpdatedAt = this.lastUpdatedAt;
+    final packageDescription = this.packageDescription;
+    final packageID = this.packageID;
+    final packageName = this.packageName;
+    final packageStatus = this.packageStatus;
+    final packageType = this.packageType;
+    return {
+      if (availablePackageVersion != null)
+        'AvailablePackageVersion': availablePackageVersion,
+      if (createdAt != null) 'CreatedAt': unixTimestampToJson(createdAt),
+      if (errorDetails != null) 'ErrorDetails': errorDetails,
+      if (lastUpdatedAt != null)
+        'LastUpdatedAt': unixTimestampToJson(lastUpdatedAt),
+      if (packageDescription != null) 'PackageDescription': packageDescription,
+      if (packageID != null) 'PackageID': packageID,
+      if (packageName != null) 'PackageName': packageName,
+      if (packageStatus != null) 'PackageStatus': packageStatus.toValue(),
+      if (packageType != null) 'PackageType': packageType.toValue(),
+    };
+  }
 }
 
 /// The Amazon S3 location for importing the package specified as
@@ -5769,6 +6295,7 @@ class PackageSource {
     this.s3BucketName,
     this.s3Key,
   });
+
   Map<String, dynamic> toJson() {
     final s3BucketName = this.s3BucketName;
     final s3Key = this.s3Key;
@@ -5790,7 +6317,7 @@ enum PackageStatus {
   deleteFailed,
 }
 
-extension PackageStatusValue on PackageStatus {
+extension PackageStatusValueExtension on PackageStatus {
   String toValue() {
     switch (this) {
       case PackageStatus.copying:
@@ -5841,7 +6368,7 @@ enum PackageType {
   txtDictionary,
 }
 
-extension PackageTypeValue on PackageType {
+extension PackageTypeValueExtension on PackageType {
   String toValue() {
     switch (this) {
       case PackageType.txtDictionary:
@@ -5883,6 +6410,17 @@ class PackageVersionHistory {
       packageVersion: json['PackageVersion'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final commitMessage = this.commitMessage;
+    final createdAt = this.createdAt;
+    final packageVersion = this.packageVersion;
+    return {
+      if (commitMessage != null) 'CommitMessage': commitMessage,
+      if (createdAt != null) 'CreatedAt': unixTimestampToJson(createdAt),
+      if (packageVersion != null) 'PackageVersion': packageVersion,
+    };
+  }
 }
 
 /// Represents the output of a <code>PurchaseReservedInstanceOffering</code>
@@ -5904,6 +6442,15 @@ class PurchaseReservedInstanceOfferingResponse {
       reservationName: json['ReservationName'] as String?,
       reservedInstanceId: json['ReservedInstanceId'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final reservationName = this.reservationName;
+    final reservedInstanceId = this.reservedInstanceId;
+    return {
+      if (reservationName != null) 'ReservationName': reservationName,
+      if (reservedInstanceId != null) 'ReservedInstanceId': reservedInstanceId,
+    };
   }
 }
 
@@ -5927,6 +6474,17 @@ class RecurringCharge {
       recurringChargeFrequency: json['RecurringChargeFrequency'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final recurringChargeAmount = this.recurringChargeAmount;
+    final recurringChargeFrequency = this.recurringChargeFrequency;
+    return {
+      if (recurringChargeAmount != null)
+        'RecurringChargeAmount': recurringChargeAmount,
+      if (recurringChargeFrequency != null)
+        'RecurringChargeFrequency': recurringChargeFrequency,
+    };
+  }
 }
 
 /// The result of a <code> <a>RejectInboundConnection</a> </code> operation.
@@ -5946,6 +6504,13 @@ class RejectInboundConnectionResponse {
               json['Connection'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final connection = this.connection;
+    return {
+      if (connection != null) 'Connection': connection,
+    };
   }
 }
 
@@ -6034,6 +6599,41 @@ class ReservedInstance {
       usagePrice: json['UsagePrice'] as double?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final billingSubscriptionId = this.billingSubscriptionId;
+    final currencyCode = this.currencyCode;
+    final duration = this.duration;
+    final fixedPrice = this.fixedPrice;
+    final instanceCount = this.instanceCount;
+    final instanceType = this.instanceType;
+    final paymentOption = this.paymentOption;
+    final recurringCharges = this.recurringCharges;
+    final reservationName = this.reservationName;
+    final reservedInstanceId = this.reservedInstanceId;
+    final reservedInstanceOfferingId = this.reservedInstanceOfferingId;
+    final startTime = this.startTime;
+    final state = this.state;
+    final usagePrice = this.usagePrice;
+    return {
+      if (billingSubscriptionId != null)
+        'BillingSubscriptionId': billingSubscriptionId,
+      if (currencyCode != null) 'CurrencyCode': currencyCode,
+      if (duration != null) 'Duration': duration,
+      if (fixedPrice != null) 'FixedPrice': fixedPrice,
+      if (instanceCount != null) 'InstanceCount': instanceCount,
+      if (instanceType != null) 'InstanceType': instanceType.toValue(),
+      if (paymentOption != null) 'PaymentOption': paymentOption.toValue(),
+      if (recurringCharges != null) 'RecurringCharges': recurringCharges,
+      if (reservationName != null) 'ReservationName': reservationName,
+      if (reservedInstanceId != null) 'ReservedInstanceId': reservedInstanceId,
+      if (reservedInstanceOfferingId != null)
+        'ReservedInstanceOfferingId': reservedInstanceOfferingId,
+      if (startTime != null) 'StartTime': unixTimestampToJson(startTime),
+      if (state != null) 'State': state,
+      if (usagePrice != null) 'UsagePrice': usagePrice,
+    };
+  }
 }
 
 /// Details of a reserved OpenSearch instance offering.
@@ -6093,6 +6693,28 @@ class ReservedInstanceOffering {
       usagePrice: json['UsagePrice'] as double?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final currencyCode = this.currencyCode;
+    final duration = this.duration;
+    final fixedPrice = this.fixedPrice;
+    final instanceType = this.instanceType;
+    final paymentOption = this.paymentOption;
+    final recurringCharges = this.recurringCharges;
+    final reservedInstanceOfferingId = this.reservedInstanceOfferingId;
+    final usagePrice = this.usagePrice;
+    return {
+      if (currencyCode != null) 'CurrencyCode': currencyCode,
+      if (duration != null) 'Duration': duration,
+      if (fixedPrice != null) 'FixedPrice': fixedPrice,
+      if (instanceType != null) 'InstanceType': instanceType.toValue(),
+      if (paymentOption != null) 'PaymentOption': paymentOption.toValue(),
+      if (recurringCharges != null) 'RecurringCharges': recurringCharges,
+      if (reservedInstanceOfferingId != null)
+        'ReservedInstanceOfferingId': reservedInstanceOfferingId,
+      if (usagePrice != null) 'UsagePrice': usagePrice,
+    };
+  }
 }
 
 enum ReservedInstancePaymentOption {
@@ -6101,7 +6723,8 @@ enum ReservedInstancePaymentOption {
   noUpfront,
 }
 
-extension ReservedInstancePaymentOptionValue on ReservedInstancePaymentOption {
+extension ReservedInstancePaymentOptionValueExtension
+    on ReservedInstancePaymentOption {
   String toValue() {
     switch (this) {
       case ReservedInstancePaymentOption.allUpfront:
@@ -6135,7 +6758,7 @@ enum RollbackOnDisable {
   defaultRollback,
 }
 
-extension RollbackOnDisableValue on RollbackOnDisable {
+extension RollbackOnDisableValueExtension on RollbackOnDisable {
   String toValue() {
     switch (this) {
       case RollbackOnDisable.noRollback:
@@ -6221,6 +6844,7 @@ class SAMLOptionsInput {
     this.sessionTimeoutMinutes,
     this.subjectKey,
   });
+
   Map<String, dynamic> toJson() {
     final enabled = this.enabled;
     final idp = this.idp;
@@ -6277,6 +6901,22 @@ class SAMLOptionsOutput {
       subjectKey: json['SubjectKey'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final enabled = this.enabled;
+    final idp = this.idp;
+    final rolesKey = this.rolesKey;
+    final sessionTimeoutMinutes = this.sessionTimeoutMinutes;
+    final subjectKey = this.subjectKey;
+    return {
+      if (enabled != null) 'Enabled': enabled,
+      if (idp != null) 'Idp': idp,
+      if (rolesKey != null) 'RolesKey': rolesKey,
+      if (sessionTimeoutMinutes != null)
+        'SessionTimeoutMinutes': sessionTimeoutMinutes,
+      if (subjectKey != null) 'SubjectKey': subjectKey,
+    };
+  }
 }
 
 /// The Auto-Tune action type. Valid values are JVM_HEAP_SIZE_TUNING, and
@@ -6286,7 +6926,8 @@ enum ScheduledAutoTuneActionType {
   jvmYoungGenTuning,
 }
 
-extension ScheduledAutoTuneActionTypeValue on ScheduledAutoTuneActionType {
+extension ScheduledAutoTuneActionTypeValueExtension
+    on ScheduledAutoTuneActionType {
   String toValue() {
     switch (this) {
       case ScheduledAutoTuneActionType.jvmHeapSizeTuning:
@@ -6343,6 +6984,19 @@ class ScheduledAutoTuneDetails {
           (json['Severity'] as String?)?.toScheduledAutoTuneSeverityType(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final action = this.action;
+    final actionType = this.actionType;
+    final date = this.date;
+    final severity = this.severity;
+    return {
+      if (action != null) 'Action': action,
+      if (actionType != null) 'ActionType': actionType.toValue(),
+      if (date != null) 'Date': unixTimestampToJson(date),
+      if (severity != null) 'Severity': severity.toValue(),
+    };
+  }
 }
 
 /// The Auto-Tune action severity. Valid values are LOW, MEDIUM, and HIGH.
@@ -6352,7 +7006,8 @@ enum ScheduledAutoTuneSeverityType {
   high,
 }
 
-extension ScheduledAutoTuneSeverityTypeValue on ScheduledAutoTuneSeverityType {
+extension ScheduledAutoTuneSeverityTypeValueExtension
+    on ScheduledAutoTuneSeverityType {
   String toValue() {
     switch (this) {
       case ScheduledAutoTuneSeverityType.low:
@@ -6436,6 +7091,28 @@ class ServiceSoftwareOptions {
       updateStatus: (json['UpdateStatus'] as String?)?.toDeploymentStatus(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final automatedUpdateDate = this.automatedUpdateDate;
+    final cancellable = this.cancellable;
+    final currentVersion = this.currentVersion;
+    final description = this.description;
+    final newVersion = this.newVersion;
+    final optionalDeployment = this.optionalDeployment;
+    final updateAvailable = this.updateAvailable;
+    final updateStatus = this.updateStatus;
+    return {
+      if (automatedUpdateDate != null)
+        'AutomatedUpdateDate': unixTimestampToJson(automatedUpdateDate),
+      if (cancellable != null) 'Cancellable': cancellable,
+      if (currentVersion != null) 'CurrentVersion': currentVersion,
+      if (description != null) 'Description': description,
+      if (newVersion != null) 'NewVersion': newVersion,
+      if (optionalDeployment != null) 'OptionalDeployment': optionalDeployment,
+      if (updateAvailable != null) 'UpdateAvailable': updateAvailable,
+      if (updateStatus != null) 'UpdateStatus': updateStatus.toValue(),
+    };
+  }
 }
 
 /// The time, in UTC format, when the service takes a daily automated snapshot
@@ -6482,6 +7159,15 @@ class SnapshotOptionsStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 /// The result of a <code>StartServiceSoftwareUpdate</code> operation. Contains
@@ -6501,6 +7187,14 @@ class StartServiceSoftwareUpdateResponse {
               json['ServiceSoftwareOptions'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final serviceSoftwareOptions = this.serviceSoftwareOptions;
+    return {
+      if (serviceSoftwareOptions != null)
+        'ServiceSoftwareOptions': serviceSoftwareOptions,
+    };
   }
 }
 
@@ -6528,6 +7222,17 @@ class StorageType {
       storageTypeName: json['StorageTypeName'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final storageSubTypeName = this.storageSubTypeName;
+    final storageTypeLimits = this.storageTypeLimits;
+    final storageTypeName = this.storageTypeName;
+    return {
+      if (storageSubTypeName != null) 'StorageSubTypeName': storageSubTypeName,
+      if (storageTypeLimits != null) 'StorageTypeLimits': storageTypeLimits,
+      if (storageTypeName != null) 'StorageTypeName': storageTypeName,
+    };
+  }
 }
 
 /// Limits that are applicable for the given storage type.
@@ -6542,7 +7247,11 @@ class StorageTypeLimit {
   /// <li>MaximumIops</li> Maximum amount of Iops that is applicable for given the
   /// storage type. Can be empty if not applicable.
   /// <li>MinimumIops</li> Minimum amount of Iops that is applicable for given the
-  /// storage type. Can be empty if not applicable. </ol>
+  /// storage type. Can be empty if not applicable.
+  /// <li>MaximumThroughput</li> Maximum amount of Throughput that is applicable
+  /// for given the storage type. Can be empty if not applicable.
+  /// <li>MinimumThroughput</li> Minimum amount of Throughput that is applicable
+  /// for given the storage type. Can be empty if not applicable. </ol>
   final String? limitName;
 
   /// Values for the <code> <a>StorageTypeLimit$LimitName</a> </code> .
@@ -6561,6 +7270,15 @@ class StorageTypeLimit {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final limitName = this.limitName;
+    final limitValues = this.limitValues;
+    return {
+      if (limitName != null) 'LimitName': limitName,
+      if (limitValues != null) 'LimitValues': limitValues,
+    };
+  }
 }
 
 enum TLSSecurityPolicy {
@@ -6568,7 +7286,7 @@ enum TLSSecurityPolicy {
   policyMinTls_1_2_2019_07,
 }
 
-extension TLSSecurityPolicyValue on TLSSecurityPolicy {
+extension TLSSecurityPolicyValueExtension on TLSSecurityPolicy {
   String toValue() {
     switch (this) {
       case TLSSecurityPolicy.policyMinTls_1_0_2019_07:
@@ -6632,7 +7350,7 @@ enum TimeUnit {
   hours,
 }
 
-extension TimeUnitValue on TimeUnit {
+extension TimeUnitValueExtension on TimeUnit {
   String toValue() {
     switch (this) {
       case TimeUnit.hours:
@@ -6674,6 +7392,15 @@ class UpdateDomainConfigResponse {
           : null,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final domainConfig = this.domainConfig;
+    final dryRunResults = this.dryRunResults;
+    return {
+      'DomainConfig': domainConfig,
+      if (dryRunResults != null) 'DryRunResults': dryRunResults,
+    };
+  }
 }
 
 /// Container for the response returned by the <code> <a>UpdatePackage</a>
@@ -6692,6 +7419,13 @@ class UpdatePackageResponse {
               json['PackageDetails'] as Map<String, dynamic>)
           : null,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final packageDetails = this.packageDetails;
+    return {
+      if (packageDetails != null) 'PackageDetails': packageDetails,
+    };
   }
 }
 
@@ -6731,6 +7465,24 @@ class UpgradeDomainResponse {
       targetVersion: json['TargetVersion'] as String?,
       upgradeId: json['UpgradeId'] as String?,
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    final advancedOptions = this.advancedOptions;
+    final changeProgressDetails = this.changeProgressDetails;
+    final domainName = this.domainName;
+    final performCheckOnly = this.performCheckOnly;
+    final targetVersion = this.targetVersion;
+    final upgradeId = this.upgradeId;
+    return {
+      if (advancedOptions != null) 'AdvancedOptions': advancedOptions,
+      if (changeProgressDetails != null)
+        'ChangeProgressDetails': changeProgressDetails,
+      if (domainName != null) 'DomainName': domainName,
+      if (performCheckOnly != null) 'PerformCheckOnly': performCheckOnly,
+      if (targetVersion != null) 'TargetVersion': targetVersion,
+      if (upgradeId != null) 'UpgradeId': upgradeId,
+    };
   }
 }
 
@@ -6775,6 +7527,20 @@ class UpgradeHistory {
       upgradeStatus: (json['UpgradeStatus'] as String?)?.toUpgradeStatus(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final startTimestamp = this.startTimestamp;
+    final stepsList = this.stepsList;
+    final upgradeName = this.upgradeName;
+    final upgradeStatus = this.upgradeStatus;
+    return {
+      if (startTimestamp != null)
+        'StartTimestamp': unixTimestampToJson(startTimestamp),
+      if (stepsList != null) 'StepsList': stepsList,
+      if (upgradeName != null) 'UpgradeName': upgradeName,
+      if (upgradeStatus != null) 'UpgradeStatus': upgradeStatus.toValue(),
+    };
+  }
 }
 
 enum UpgradeStatus {
@@ -6784,7 +7550,7 @@ enum UpgradeStatus {
   failed,
 }
 
-extension UpgradeStatusValue on UpgradeStatus {
+extension UpgradeStatusValueExtension on UpgradeStatus {
   String toValue() {
     switch (this) {
       case UpgradeStatus.inProgress:
@@ -6821,7 +7587,7 @@ enum UpgradeStep {
   upgrade,
 }
 
-extension UpgradeStepValue on UpgradeStep {
+extension UpgradeStepValueExtension on UpgradeStep {
   String toValue() {
     switch (this) {
       case UpgradeStep.preUpgradeCheck:
@@ -6895,6 +7661,20 @@ class UpgradeStepItem {
           (json['UpgradeStepStatus'] as String?)?.toUpgradeStatus(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final issues = this.issues;
+    final progressPercent = this.progressPercent;
+    final upgradeStep = this.upgradeStep;
+    final upgradeStepStatus = this.upgradeStepStatus;
+    return {
+      if (issues != null) 'Issues': issues,
+      if (progressPercent != null) 'ProgressPercent': progressPercent,
+      if (upgradeStep != null) 'UpgradeStep': upgradeStep.toValue(),
+      if (upgradeStepStatus != null)
+        'UpgradeStepStatus': upgradeStepStatus.toValue(),
+    };
+  }
 }
 
 /// Options to specify the subnets and security groups for the VPC endpoint. For
@@ -6940,6 +7720,19 @@ class VPCDerivedInfo {
       vPCId: json['VPCId'] as String?,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final availabilityZones = this.availabilityZones;
+    final securityGroupIds = this.securityGroupIds;
+    final subnetIds = this.subnetIds;
+    final vPCId = this.vPCId;
+    return {
+      if (availabilityZones != null) 'AvailabilityZones': availabilityZones,
+      if (securityGroupIds != null) 'SecurityGroupIds': securityGroupIds,
+      if (subnetIds != null) 'SubnetIds': subnetIds,
+      if (vPCId != null) 'VPCId': vPCId,
+    };
+  }
 }
 
 /// Status of the VPC options for the specified domain.
@@ -6960,6 +7753,15 @@ class VPCDerivedInfoStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
 /// Options to specify the subnets and security groups for the VPC endpoint. For
@@ -6978,6 +7780,7 @@ class VPCOptions {
     this.securityGroupIds,
     this.subnetIds,
   });
+
   Map<String, dynamic> toJson() {
     final securityGroupIds = this.securityGroupIds;
     final subnetIds = this.subnetIds;
@@ -7008,18 +7811,28 @@ class VersionStatus {
       status: OptionStatus.fromJson(json['Status'] as Map<String, dynamic>),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    final options = this.options;
+    final status = this.status;
+    return {
+      'Options': options,
+      'Status': status,
+    };
+  }
 }
 
-/// The type of EBS volume, standard, gp2, or io1. See <a
+/// The type of EBS volume, standard, gp2, gp3 or io1. See <a
 /// href="http://docs.aws.amazon.com/opensearch-service/latest/developerguide/opensearch-createupdatedomains.html#opensearch-createdomain-configure-ebs"
 /// target="_blank">Configuring EBS-based Storage</a> for more information.
 enum VolumeType {
   standard,
   gp2,
   io1,
+  gp3,
 }
 
-extension VolumeTypeValue on VolumeType {
+extension VolumeTypeValueExtension on VolumeType {
   String toValue() {
     switch (this) {
       case VolumeType.standard:
@@ -7028,6 +7841,8 @@ extension VolumeTypeValue on VolumeType {
         return 'gp2';
       case VolumeType.io1:
         return 'io1';
+      case VolumeType.gp3:
+        return 'gp3';
     }
   }
 }
@@ -7041,6 +7856,8 @@ extension VolumeTypeFromString on String {
         return VolumeType.gp2;
       case 'io1':
         return VolumeType.io1;
+      case 'gp3':
+        return VolumeType.gp3;
     }
     throw Exception('$this is not known in enum VolumeType');
   }

--- a/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
+++ b/generated/aws_events_api/lib/eventbridge-2015-10-07.dart
@@ -85,14 +85,6 @@ class EventBridge {
   Future<void> activateEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ActivateEventSource'
@@ -121,14 +113,6 @@ class EventBridge {
   Future<CancelReplayResponse> cancelReplay({
     required String replayName,
   }) async {
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CancelReplay'
@@ -183,28 +167,6 @@ class EventBridge {
     String? eventPattern,
     int? retentionDays,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventSourceArn, 'eventSourceArn');
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'retentionDays',
       retentionDays,
@@ -267,20 +229,6 @@ class EventBridge {
     String? eventSourceName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventSourceName',
-      eventSourceName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CreateEventBus'
@@ -351,22 +299,6 @@ class EventBridge {
     required String account,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(account, 'account');
-    _s.validateStringLength(
-      'account',
-      account,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CreatePartnerEventSource'
@@ -407,14 +339,6 @@ class EventBridge {
   Future<void> deactivateEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeactivateEventSource'
@@ -442,14 +366,6 @@ class EventBridge {
   Future<void> deleteArchive({
     required String archiveName,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteArchive'
@@ -478,14 +394,6 @@ class EventBridge {
   Future<void> deleteEventBus({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteEventBus'
@@ -523,22 +431,6 @@ class EventBridge {
     required String account,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(account, 'account');
-    _s.validateStringLength(
-      'account',
-      account,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeletePartnerEventSource'
@@ -594,20 +486,6 @@ class EventBridge {
     String? eventBusName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteRule'
@@ -637,14 +515,6 @@ class EventBridge {
   Future<DescribeArchiveResponse> describeArchive({
     required String archiveName,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeArchive'
@@ -682,12 +552,6 @@ class EventBridge {
   Future<DescribeEventBusResponse> describeEventBus({
     String? name,
   }) async {
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeEventBus'
@@ -718,14 +582,6 @@ class EventBridge {
   Future<DescribeEventSourceResponse> describeEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeEventSource'
@@ -758,14 +614,6 @@ class EventBridge {
   Future<DescribePartnerEventSourceResponse> describePartnerEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribePartnerEventSource'
@@ -804,14 +652,6 @@ class EventBridge {
   Future<DescribeReplayResponse> describeReplay({
     required String replayName,
   }) async {
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeReplay'
@@ -848,20 +688,6 @@ class EventBridge {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeRule'
@@ -902,20 +728,6 @@ class EventBridge {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DisableRule'
@@ -955,20 +767,6 @@ class EventBridge {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.EnableRule'
@@ -1015,29 +813,11 @@ class EventBridge {
     String? nextToken,
     ArchiveState? state,
   }) async {
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      48,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1088,18 +868,6 @@ class EventBridge {
       1,
       100,
     );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListEventBuses'
@@ -1149,18 +917,6 @@ class EventBridge {
       1,
       100,
     );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListEventSources'
@@ -1206,25 +962,11 @@ class EventBridge {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(eventSourceName, 'eventSourceName');
-    _s.validateStringLength(
-      'eventSourceName',
-      eventSourceName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1270,25 +1012,11 @@ class EventBridge {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(namePrefix, 'namePrefix');
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1337,29 +1065,11 @@ class EventBridge {
     String? nextToken,
     ReplayState? state,
   }) async {
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1407,31 +1117,11 @@ class EventBridge {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(targetArn, 'targetArn');
-    _s.validateStringLength(
-      'targetArn',
-      targetArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1481,29 +1171,11 @@ class EventBridge {
     String? namePrefix,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1537,14 +1209,6 @@ class EventBridge {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListTagsForResource'
@@ -1586,31 +1250,11 @@ class EventBridge {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1645,7 +1289,6 @@ class EventBridge {
   Future<PutEventsResponse> putEvents({
     required List<PutEventsRequestEntry> entries,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutEvents'
@@ -1675,7 +1318,6 @@ class EventBridge {
   Future<PutPartnerEventsResponse> putPartnerEvents({
     required List<PutPartnerEventsRequestEntry> entries,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutPartnerEvents'
@@ -1779,30 +1421,6 @@ class EventBridge {
     String? principal,
     String? statementId,
   }) async {
-    _s.validateStringLength(
-      'action',
-      action,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'principal',
-      principal,
-      1,
-      12,
-    );
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutPermission'
@@ -1928,38 +1546,6 @@ class EventBridge {
     RuleState? state,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'scheduleExpression',
-      scheduleExpression,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutRule'
@@ -2157,21 +1743,6 @@ class EventBridge {
     required List<Target> targets,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutTargets'
@@ -2218,18 +1789,6 @@ class EventBridge {
     bool? removeAllPermissions,
     String? statementId,
   }) async {
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.RemovePermission'
@@ -2289,21 +1848,6 @@ class EventBridge {
     String? eventBusName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.RemoveTargets'
@@ -2372,31 +1916,6 @@ class EventBridge {
     required String replayName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(eventEndTime, 'eventEndTime');
-    ArgumentError.checkNotNull(eventSourceArn, 'eventSourceArn');
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventStartTime, 'eventStartTime');
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.StartReplay'
@@ -2451,15 +1970,6 @@ class EventBridge {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.TagResource'
@@ -2498,8 +2008,6 @@ class EventBridge {
     required String event,
     required String eventPattern,
   }) async {
-    ArgumentError.checkNotNull(event, 'event');
-    ArgumentError.checkNotNull(eventPattern, 'eventPattern');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.TestEventPattern'
@@ -2537,15 +2045,6 @@ class EventBridge {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.UntagResource'
@@ -2588,20 +2087,6 @@ class EventBridge {
     String? eventPattern,
     int? retentionDays,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'retentionDays',
       retentionDays,

--- a/generated/aws_events_api/lib/events-2015-10-07.dart
+++ b/generated/aws_events_api/lib/events-2015-10-07.dart
@@ -85,14 +85,6 @@ class CloudWatchEvents {
   Future<void> activateEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ActivateEventSource'
@@ -121,14 +113,6 @@ class CloudWatchEvents {
   Future<CancelReplayResponse> cancelReplay({
     required String replayName,
   }) async {
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CancelReplay'
@@ -183,28 +167,6 @@ class CloudWatchEvents {
     String? eventPattern,
     int? retentionDays,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventSourceArn, 'eventSourceArn');
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'retentionDays',
       retentionDays,
@@ -267,20 +229,6 @@ class CloudWatchEvents {
     String? eventSourceName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventSourceName',
-      eventSourceName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CreateEventBus'
@@ -351,22 +299,6 @@ class CloudWatchEvents {
     required String account,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(account, 'account');
-    _s.validateStringLength(
-      'account',
-      account,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.CreatePartnerEventSource'
@@ -407,14 +339,6 @@ class CloudWatchEvents {
   Future<void> deactivateEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeactivateEventSource'
@@ -442,14 +366,6 @@ class CloudWatchEvents {
   Future<void> deleteArchive({
     required String archiveName,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteArchive'
@@ -478,14 +394,6 @@ class CloudWatchEvents {
   Future<void> deleteEventBus({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteEventBus'
@@ -523,22 +431,6 @@ class CloudWatchEvents {
     required String account,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(account, 'account');
-    _s.validateStringLength(
-      'account',
-      account,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeletePartnerEventSource'
@@ -594,20 +486,6 @@ class CloudWatchEvents {
     String? eventBusName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DeleteRule'
@@ -637,14 +515,6 @@ class CloudWatchEvents {
   Future<DescribeArchiveResponse> describeArchive({
     required String archiveName,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeArchive'
@@ -682,12 +552,6 @@ class CloudWatchEvents {
   Future<DescribeEventBusResponse> describeEventBus({
     String? name,
   }) async {
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeEventBus'
@@ -718,14 +582,6 @@ class CloudWatchEvents {
   Future<DescribeEventSourceResponse> describeEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeEventSource'
@@ -758,14 +614,6 @@ class CloudWatchEvents {
   Future<DescribePartnerEventSourceResponse> describePartnerEventSource({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribePartnerEventSource'
@@ -804,14 +652,6 @@ class CloudWatchEvents {
   Future<DescribeReplayResponse> describeReplay({
     required String replayName,
   }) async {
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeReplay'
@@ -848,20 +688,6 @@ class CloudWatchEvents {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DescribeRule'
@@ -902,20 +728,6 @@ class CloudWatchEvents {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.DisableRule'
@@ -955,20 +767,6 @@ class CloudWatchEvents {
     required String name,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.EnableRule'
@@ -1015,29 +813,11 @@ class CloudWatchEvents {
     String? nextToken,
     ArchiveState? state,
   }) async {
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      48,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1088,18 +868,6 @@ class CloudWatchEvents {
       1,
       100,
     );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListEventBuses'
@@ -1149,18 +917,6 @@ class CloudWatchEvents {
       1,
       100,
     );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListEventSources'
@@ -1206,25 +962,11 @@ class CloudWatchEvents {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(eventSourceName, 'eventSourceName');
-    _s.validateStringLength(
-      'eventSourceName',
-      eventSourceName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1270,25 +1012,11 @@ class CloudWatchEvents {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(namePrefix, 'namePrefix');
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1337,29 +1065,11 @@ class CloudWatchEvents {
     String? nextToken,
     ReplayState? state,
   }) async {
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1407,31 +1117,11 @@ class CloudWatchEvents {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(targetArn, 'targetArn');
-    _s.validateStringLength(
-      'targetArn',
-      targetArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1481,29 +1171,11 @@ class CloudWatchEvents {
     String? namePrefix,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'namePrefix',
-      namePrefix,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1537,14 +1209,6 @@ class CloudWatchEvents {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.ListTagsForResource'
@@ -1586,31 +1250,11 @@ class CloudWatchEvents {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1645,7 +1289,6 @@ class CloudWatchEvents {
   Future<PutEventsResponse> putEvents({
     required List<PutEventsRequestEntry> entries,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutEvents'
@@ -1675,7 +1318,6 @@ class CloudWatchEvents {
   Future<PutPartnerEventsResponse> putPartnerEvents({
     required List<PutPartnerEventsRequestEntry> entries,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutPartnerEvents'
@@ -1779,30 +1421,6 @@ class CloudWatchEvents {
     String? principal,
     String? statementId,
   }) async {
-    _s.validateStringLength(
-      'action',
-      action,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'principal',
-      principal,
-      1,
-      12,
-    );
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutPermission'
@@ -1928,38 +1546,6 @@ class CloudWatchEvents {
     RuleState? state,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'scheduleExpression',
-      scheduleExpression,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutRule'
@@ -2157,21 +1743,6 @@ class CloudWatchEvents {
     required List<Target> targets,
     String? eventBusName,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.PutTargets'
@@ -2218,18 +1789,6 @@ class CloudWatchEvents {
     bool? removeAllPermissions,
     String? statementId,
   }) async {
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.RemovePermission'
@@ -2289,21 +1848,6 @@ class CloudWatchEvents {
     String? eventBusName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'rule',
-      rule,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventBusName',
-      eventBusName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.RemoveTargets'
@@ -2372,31 +1916,6 @@ class CloudWatchEvents {
     required String replayName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(eventEndTime, 'eventEndTime');
-    ArgumentError.checkNotNull(eventSourceArn, 'eventSourceArn');
-    _s.validateStringLength(
-      'eventSourceArn',
-      eventSourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventStartTime, 'eventStartTime');
-    ArgumentError.checkNotNull(replayName, 'replayName');
-    _s.validateStringLength(
-      'replayName',
-      replayName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.StartReplay'
@@ -2451,15 +1970,6 @@ class CloudWatchEvents {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.TagResource'
@@ -2498,8 +2008,6 @@ class CloudWatchEvents {
     required String event,
     required String eventPattern,
   }) async {
-    ArgumentError.checkNotNull(event, 'event');
-    ArgumentError.checkNotNull(eventPattern, 'eventPattern');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.TestEventPattern'
@@ -2537,15 +2045,6 @@ class CloudWatchEvents {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSEvents.UntagResource'
@@ -2588,20 +2087,6 @@ class CloudWatchEvents {
     String? eventPattern,
     int? retentionDays,
   }) async {
-    ArgumentError.checkNotNull(archiveName, 'archiveName');
-    _s.validateStringLength(
-      'archiveName',
-      archiveName,
-      1,
-      48,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'retentionDays',
       retentionDays,

--- a/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
+++ b/generated/aws_firehose_api/lib/firehose-2015-08-04.dart
@@ -215,14 +215,6 @@ class Firehose {
     SplunkDestinationConfiguration? splunkDestinationConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.CreateDeliveryStream'
@@ -302,14 +294,6 @@ class Firehose {
     required String deliveryStreamName,
     bool? allowForceDelete,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.DeleteDeliveryStream'
@@ -356,20 +340,6 @@ class Firehose {
     String? exclusiveStartDestinationId,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'exclusiveStartDestinationId',
-      exclusiveStartDestinationId,
-      1,
-      100,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -438,12 +408,6 @@ class Firehose {
     String? exclusiveStartDeliveryStreamName,
     int? limit,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartDeliveryStreamName',
-      exclusiveStartDeliveryStreamName,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -497,20 +461,6 @@ class Firehose {
     String? exclusiveStartTagKey,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'exclusiveStartTagKey',
-      exclusiveStartTagKey,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -597,15 +547,6 @@ class Firehose {
     required String deliveryStreamName,
     required Record record,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(record, 'record');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.PutRecord'
@@ -709,15 +650,6 @@ class Firehose {
     required String deliveryStreamName,
     required List<Record> records,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(records, 'records');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.PutRecordBatch'
@@ -805,14 +737,6 @@ class Firehose {
     DeliveryStreamEncryptionConfigurationInput?
         deliveryStreamEncryptionConfigurationInput,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.StartDeliveryStreamEncryption'
@@ -871,14 +795,6 @@ class Firehose {
   Future<void> stopDeliveryStreamEncryption({
     required String deliveryStreamName,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.StopDeliveryStreamEncryption'
@@ -924,15 +840,6 @@ class Firehose {
     required String deliveryStreamName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.TagDeliveryStream'
@@ -972,15 +879,6 @@ class Firehose {
     required String deliveryStreamName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.UntagDeliveryStream'
@@ -1081,31 +979,6 @@ class Firehose {
     S3DestinationUpdate? s3DestinationUpdate,
     SplunkDestinationUpdate? splunkDestinationUpdate,
   }) async {
-    ArgumentError.checkNotNull(
-        currentDeliveryStreamVersionId, 'currentDeliveryStreamVersionId');
-    _s.validateStringLength(
-      'currentDeliveryStreamVersionId',
-      currentDeliveryStreamVersionId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deliveryStreamName, 'deliveryStreamName');
-    _s.validateStringLength(
-      'deliveryStreamName',
-      deliveryStreamName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(destinationId, 'destinationId');
-    _s.validateStringLength(
-      'destinationId',
-      destinationId,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Firehose_20150804.UpdateDestination'

--- a/generated/aws_fms_api/lib/fms-2018-01-01.dart
+++ b/generated/aws_fms_api/lib/fms-2018-01-01.dart
@@ -77,14 +77,6 @@ class FMS {
   Future<void> associateAdminAccount({
     required String adminAccount,
   }) async {
-    ArgumentError.checkNotNull(adminAccount, 'adminAccount');
-    _s.validateStringLength(
-      'adminAccount',
-      adminAccount,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.AssociateAdminAccount'
@@ -114,14 +106,6 @@ class FMS {
   Future<void> deleteAppsList({
     required String listId,
   }) async {
-    ArgumentError.checkNotNull(listId, 'listId');
-    _s.validateStringLength(
-      'listId',
-      listId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.DeleteAppsList'
@@ -212,14 +196,6 @@ class FMS {
     required String policyId,
     bool? deleteAllPolicyResources,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.DeletePolicy'
@@ -251,14 +227,6 @@ class FMS {
   Future<void> deleteProtocolsList({
     required String listId,
   }) async {
-    ArgumentError.checkNotNull(listId, 'listId');
-    _s.validateStringLength(
-      'listId',
-      listId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.DeleteProtocolsList'
@@ -336,14 +304,6 @@ class FMS {
     required String listId,
     bool? defaultList,
   }) async {
-    ArgumentError.checkNotNull(listId, 'listId');
-    _s.validateStringLength(
-      'listId',
-      listId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.GetAppsList'
@@ -393,22 +353,6 @@ class FMS {
     required String memberAccount,
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(memberAccount, 'memberAccount');
-    _s.validateStringLength(
-      'memberAccount',
-      memberAccount,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.GetComplianceDetail'
@@ -462,14 +406,6 @@ class FMS {
   Future<GetPolicyResponse> getPolicy({
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.GetPolicy'
@@ -540,31 +476,11 @@ class FMS {
     String? nextToken,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'memberAccountId',
-      memberAccountId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -607,14 +523,6 @@ class FMS {
     required String listId,
     bool? defaultList,
   }) async {
-    ArgumentError.checkNotNull(listId, 'listId');
-    _s.validateStringLength(
-      'listId',
-      listId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.GetProtocolsList'
@@ -665,38 +573,6 @@ class FMS {
     required String resourceId,
     required String resourceType,
   }) async {
-    ArgumentError.checkNotNull(memberAccount, 'memberAccount');
-    _s.validateStringLength(
-      'memberAccount',
-      memberAccount,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.GetViolationDetails'
@@ -749,19 +625,12 @@ class FMS {
     bool? defaultLists,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -816,25 +685,11 @@ class FMS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -890,12 +745,6 @@ class FMS {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.ListMemberAccounts'
@@ -949,12 +798,6 @@ class FMS {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.ListPolicies'
@@ -1004,19 +847,12 @@ class FMS {
     bool? defaultLists,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(maxResults, 'maxResults');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1052,14 +888,6 @@ class FMS {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.ListTagsForResource'
@@ -1095,7 +923,6 @@ class FMS {
     required AppsListData appsList,
     List<Tag>? tagList,
   }) async {
-    ArgumentError.checkNotNull(appsList, 'appsList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.PutAppsList'
@@ -1140,22 +967,6 @@ class FMS {
     required String snsRoleName,
     required String snsTopicArn,
   }) async {
-    ArgumentError.checkNotNull(snsRoleName, 'snsRoleName');
-    _s.validateStringLength(
-      'snsRoleName',
-      snsRoleName,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    _s.validateStringLength(
-      'snsTopicArn',
-      snsTopicArn,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.PutNotificationChannel'
@@ -1223,7 +1034,6 @@ class FMS {
     required Policy policy,
     List<Tag>? tagList,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.PutPolicy'
@@ -1260,7 +1070,6 @@ class FMS {
     required ProtocolsListData protocolsList,
     List<Tag>? tagList,
   }) async {
-    ArgumentError.checkNotNull(protocolsList, 'protocolsList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.PutProtocolsList'
@@ -1299,15 +1108,6 @@ class FMS {
     required String resourceArn,
     required List<Tag> tagList,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagList, 'tagList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.TagResource'
@@ -1343,15 +1143,6 @@ class FMS {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSFMS_20180101.UntagResource'

--- a/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
+++ b/generated/aws_forecast_api/lib/forecast-2018-06-26.dart
@@ -179,17 +179,6 @@ class ForecastService {
     EncryptionConfig? encryptionConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(datasetType, 'datasetType');
-    ArgumentError.checkNotNull(domain, 'domain');
-    ArgumentError.checkNotNull(schema, 'schema');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreateDataset'
@@ -303,15 +292,6 @@ class ForecastService {
     List<String>? datasetArns,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupName, 'datasetGroupName');
-    _s.validateStringLength(
-      'datasetGroupName',
-      datasetGroupName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domain, 'domain');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreateDatasetGroup'
@@ -487,41 +467,6 @@ class ForecastService {
     String? timestampFormat,
     bool? useGeolocationForTimeZone,
   }) async {
-    ArgumentError.checkNotNull(dataSource, 'dataSource');
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(datasetImportJobName, 'datasetImportJobName');
-    _s.validateStringLength(
-      'datasetImportJobName',
-      datasetImportJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'geolocationFormat',
-      geolocationFormat,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'timeZone',
-      timeZone,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'timestampFormat',
-      timestampFormat,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreateDatasetImportJob'
@@ -640,22 +585,6 @@ class ForecastService {
     List<String>? forecastTypes,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(forecastName, 'forecastName');
-    _s.validateStringLength(
-      'forecastName',
-      forecastName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(predictorArn, 'predictorArn');
-    _s.validateStringLength(
-      'predictorArn',
-      predictorArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreateForecast'
@@ -769,23 +698,6 @@ class ForecastService {
     required String forecastExportJobName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(forecastArn, 'forecastArn');
-    _s.validateStringLength(
-      'forecastArn',
-      forecastArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(forecastExportJobName, 'forecastExportJobName');
-    _s.validateStringLength(
-      'forecastExportJobName',
-      forecastExportJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreateForecastExportJob'
@@ -1053,23 +965,6 @@ class ForecastService {
     List<Tag>? tags,
     Map<String, String>? trainingParameters,
   }) async {
-    ArgumentError.checkNotNull(featurizationConfig, 'featurizationConfig');
-    ArgumentError.checkNotNull(forecastHorizon, 'forecastHorizon');
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(predictorName, 'predictorName');
-    _s.validateStringLength(
-      'predictorName',
-      predictorName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'algorithmArn',
-      algorithmArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreatePredictor'
@@ -1179,24 +1074,6 @@ class ForecastService {
     required String predictorBacktestExportJobName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(predictorArn, 'predictorArn');
-    _s.validateStringLength(
-      'predictorArn',
-      predictorArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        predictorBacktestExportJobName, 'predictorBacktestExportJobName');
-    _s.validateStringLength(
-      'predictorBacktestExportJobName',
-      predictorBacktestExportJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.CreatePredictorBacktestExportJob'
@@ -1237,14 +1114,6 @@ class ForecastService {
   Future<void> deleteDataset({
     required String datasetArn,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeleteDataset'
@@ -1279,14 +1148,6 @@ class ForecastService {
   Future<void> deleteDatasetGroup({
     required String datasetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeleteDatasetGroup'
@@ -1318,14 +1179,6 @@ class ForecastService {
   Future<void> deleteDatasetImportJob({
     required String datasetImportJobArn,
   }) async {
-    ArgumentError.checkNotNull(datasetImportJobArn, 'datasetImportJobArn');
-    _s.validateStringLength(
-      'datasetImportJobArn',
-      datasetImportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeleteDatasetImportJob'
@@ -1359,14 +1212,6 @@ class ForecastService {
   Future<void> deleteForecast({
     required String forecastArn,
   }) async {
-    ArgumentError.checkNotNull(forecastArn, 'forecastArn');
-    _s.validateStringLength(
-      'forecastArn',
-      forecastArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeleteForecast'
@@ -1397,14 +1242,6 @@ class ForecastService {
   Future<void> deleteForecastExportJob({
     required String forecastExportJobArn,
   }) async {
-    ArgumentError.checkNotNull(forecastExportJobArn, 'forecastExportJobArn');
-    _s.validateStringLength(
-      'forecastExportJobArn',
-      forecastExportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeleteForecastExportJob'
@@ -1435,14 +1272,6 @@ class ForecastService {
   Future<void> deletePredictor({
     required String predictorArn,
   }) async {
-    ArgumentError.checkNotNull(predictorArn, 'predictorArn');
-    _s.validateStringLength(
-      'predictorArn',
-      predictorArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeletePredictor'
@@ -1471,15 +1300,6 @@ class ForecastService {
   Future<void> deletePredictorBacktestExportJob({
     required String predictorBacktestExportJobArn,
   }) async {
-    ArgumentError.checkNotNull(
-        predictorBacktestExportJobArn, 'predictorBacktestExportJobArn');
-    _s.validateStringLength(
-      'predictorBacktestExportJobArn',
-      predictorBacktestExportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DeletePredictorBacktestExportJob'
@@ -1523,14 +1343,6 @@ class ForecastService {
   Future<DescribeDatasetResponse> describeDataset({
     required String datasetArn,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribeDataset'
@@ -1579,14 +1391,6 @@ class ForecastService {
   Future<DescribeDatasetGroupResponse> describeDatasetGroup({
     required String datasetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribeDatasetGroup'
@@ -1641,14 +1445,6 @@ class ForecastService {
   Future<DescribeDatasetImportJobResponse> describeDatasetImportJob({
     required String datasetImportJobArn,
   }) async {
-    ArgumentError.checkNotNull(datasetImportJobArn, 'datasetImportJobArn');
-    _s.validateStringLength(
-      'datasetImportJobArn',
-      datasetImportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribeDatasetImportJob'
@@ -1700,14 +1496,6 @@ class ForecastService {
   Future<DescribeForecastResponse> describeForecast({
     required String forecastArn,
   }) async {
-    ArgumentError.checkNotNull(forecastArn, 'forecastArn');
-    _s.validateStringLength(
-      'forecastArn',
-      forecastArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribeForecast'
@@ -1756,14 +1544,6 @@ class ForecastService {
   Future<DescribeForecastExportJobResponse> describeForecastExportJob({
     required String forecastExportJobArn,
   }) async {
-    ArgumentError.checkNotNull(forecastExportJobArn, 'forecastExportJobArn');
-    _s.validateStringLength(
-      'forecastExportJobArn',
-      forecastExportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribeForecastExportJob'
@@ -1820,14 +1600,6 @@ class ForecastService {
   Future<DescribePredictorResponse> describePredictor({
     required String predictorArn,
   }) async {
-    ArgumentError.checkNotNull(predictorArn, 'predictorArn');
-    _s.validateStringLength(
-      'predictorArn',
-      predictorArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribePredictor'
@@ -1877,15 +1649,6 @@ class ForecastService {
       describePredictorBacktestExportJob({
     required String predictorBacktestExportJobArn,
   }) async {
-    ArgumentError.checkNotNull(
-        predictorBacktestExportJobArn, 'predictorBacktestExportJobArn');
-    _s.validateStringLength(
-      'predictorBacktestExportJobArn',
-      predictorBacktestExportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.DescribePredictorBacktestExportJob'
@@ -1940,14 +1703,6 @@ class ForecastService {
   Future<GetAccuracyMetricsResponse> getAccuracyMetrics({
     required String predictorArn,
   }) async {
-    ArgumentError.checkNotNull(predictorArn, 'predictorArn');
-    _s.validateStringLength(
-      'predictorArn',
-      predictorArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.GetAccuracyMetrics'
@@ -1991,12 +1746,6 @@ class ForecastService {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2075,12 +1824,6 @@ class ForecastService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.ListDatasetImportJobs'
@@ -2124,12 +1867,6 @@ class ForecastService {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2208,12 +1945,6 @@ class ForecastService {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2294,12 +2025,6 @@ class ForecastService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.ListForecasts'
@@ -2375,12 +2100,6 @@ class ForecastService {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2460,12 +2179,6 @@ class ForecastService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.ListPredictors'
@@ -2499,14 +2212,6 @@ class ForecastService {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.ListTagsForResource'
@@ -2582,15 +2287,6 @@ class ForecastService {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.TagResource'
@@ -2625,15 +2321,6 @@ class ForecastService {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.UntagResource'
@@ -2672,15 +2359,6 @@ class ForecastService {
     required List<String> datasetArns,
     required String datasetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(datasetArns, 'datasetArns');
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecast.UpdateDatasetGroup'

--- a/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
+++ b/generated/aws_forecastquery_api/lib/forecastquery-2018-06-26.dart
@@ -105,21 +105,6 @@ class ForecastQueryService {
     String? nextToken,
     String? startDate,
   }) async {
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(forecastArn, 'forecastArn');
-    _s.validateStringLength(
-      'forecastArn',
-      forecastArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonForecastRuntime.QueryForecast'

--- a/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
+++ b/generated/aws_frauddetector_api/lib/frauddetector-2019-11-15.dart
@@ -68,7 +68,6 @@ class FraudDetector {
     required List<VariableEntry> variableEntries,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(variableEntries, 'variableEntries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.BatchCreateVariable'
@@ -100,7 +99,6 @@ class FraudDetector {
   Future<BatchGetVariableResult> batchGetVariable({
     required List<String> names,
   }) async {
-    ArgumentError.checkNotNull(names, 'names');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.BatchGetVariable'
@@ -169,21 +167,6 @@ class FraudDetector {
     RuleExecutionMode? ruleExecutionMode,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rules, 'rules');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.CreateDetectorVersion'
@@ -237,22 +220,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(eventTypeName, 'eventTypeName');
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.CreateModel'
@@ -308,17 +275,6 @@ class FraudDetector {
     ExternalEventsDetail? externalEventsDetail,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    ArgumentError.checkNotNull(trainingDataSchema, 'trainingDataSchema');
-    ArgumentError.checkNotNull(trainingDataSource, 'trainingDataSource');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.CreateModelVersion'
@@ -379,38 +335,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(expression, 'expression');
-    _s.validateStringLength(
-      'expression',
-      expression,
-      1,
-      4096,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(language, 'language');
-    ArgumentError.checkNotNull(outcomes, 'outcomes');
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.CreateRule'
@@ -482,10 +406,6 @@ class FraudDetector {
     List<Tag>? tags,
     String? variableType,
   }) async {
-    ArgumentError.checkNotNull(dataSource, 'dataSource');
-    ArgumentError.checkNotNull(dataType, 'dataType');
-    ArgumentError.checkNotNull(defaultValue, 'defaultValue');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.CreateVariable'
@@ -525,14 +445,6 @@ class FraudDetector {
   Future<void> deleteDetector({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteDetector'
@@ -572,22 +484,6 @@ class FraudDetector {
     required String detectorId,
     required String detectorVersionId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorVersionId, 'detectorVersionId');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteDetectorVersion'
@@ -623,14 +519,6 @@ class FraudDetector {
   Future<void> deleteEntityType({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteEntityType'
@@ -667,22 +555,6 @@ class FraudDetector {
     required String eventId,
     required String eventTypeName,
   }) async {
-    ArgumentError.checkNotNull(eventId, 'eventId');
-    _s.validateStringLength(
-      'eventId',
-      eventId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventTypeName, 'eventTypeName');
-    _s.validateStringLength(
-      'eventTypeName',
-      eventTypeName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteEvent'
@@ -718,14 +590,6 @@ class FraudDetector {
   Future<void> deleteEventType({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteEventType'
@@ -759,14 +623,6 @@ class FraudDetector {
   Future<void> deleteExternalModel({
     required String modelEndpoint,
   }) async {
-    ArgumentError.checkNotNull(modelEndpoint, 'modelEndpoint');
-    _s.validateStringLength(
-      'modelEndpoint',
-      modelEndpoint,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteExternalModel'
@@ -804,14 +660,6 @@ class FraudDetector {
   Future<void> deleteLabel({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteLabel'
@@ -851,15 +699,6 @@ class FraudDetector {
     required String modelId,
     required ModelTypeEnum modelType,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteModel'
@@ -904,23 +743,6 @@ class FraudDetector {
     required ModelTypeEnum modelType,
     required String modelVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    ArgumentError.checkNotNull(modelVersionNumber, 'modelVersionNumber');
-    _s.validateStringLength(
-      'modelVersionNumber',
-      modelVersionNumber,
-      3,
-      7,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteModelVersion'
@@ -958,14 +780,6 @@ class FraudDetector {
   Future<void> deleteOutcome({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteOutcome'
@@ -997,7 +811,6 @@ class FraudDetector {
   Future<void> deleteRule({
     required Rule rule,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteRule'
@@ -1038,7 +851,6 @@ class FraudDetector {
   Future<void> deleteVariable({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DeleteVariable'
@@ -1076,14 +888,6 @@ class FraudDetector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1146,18 +950,6 @@ class FraudDetector {
       1,
       10,
     );
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'modelVersionNumber',
-      modelVersionNumber,
-      3,
-      7,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.DescribeModelVersions'
@@ -1198,22 +990,6 @@ class FraudDetector {
     required String detectorId,
     required String detectorVersionId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorVersionId, 'detectorVersionId');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.GetDetectorVersion'
@@ -1260,12 +1036,6 @@ class FraudDetector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1323,12 +1093,6 @@ class FraudDetector {
       maxResults,
       5,
       10,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1397,18 +1161,6 @@ class FraudDetector {
     String? detectorVersionId,
     Map<String, ModelEndpointDataBlob>? externalModelEndpointDataBlobs,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    ArgumentError.checkNotNull(entities, 'entities');
-    ArgumentError.checkNotNull(eventId, 'eventId');
-    ArgumentError.checkNotNull(eventTimestamp, 'eventTimestamp');
-    ArgumentError.checkNotNull(eventTypeName, 'eventTypeName');
-    ArgumentError.checkNotNull(eventVariables, 'eventVariables');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.GetEventPrediction'
@@ -1466,12 +1218,6 @@ class FraudDetector {
       maxResults,
       5,
       10,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1601,12 +1347,6 @@ class FraudDetector {
       10,
       50,
     );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.GetLabels'
@@ -1647,23 +1387,6 @@ class FraudDetector {
     required ModelTypeEnum modelType,
     required String modelVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    ArgumentError.checkNotNull(modelVersionNumber, 'modelVersionNumber');
-    _s.validateStringLength(
-      'modelVersionNumber',
-      modelVersionNumber,
-      3,
-      7,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.GetModelVersion'
@@ -1724,12 +1447,6 @@ class FraudDetector {
       1,
       10,
     );
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.GetModels'
@@ -1782,12 +1499,6 @@ class FraudDetector {
       maxResults,
       50,
       100,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1848,31 +1559,11 @@ class FraudDetector {
     String? ruleId,
     String? ruleVersion,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       50,
       100,
-    );
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'ruleVersion',
-      ruleVersion,
-      1,
-      5,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1971,14 +1662,6 @@ class FraudDetector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2029,28 +1712,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(eventTypeName, 'eventTypeName');
-    _s.validateStringLength(
-      'eventTypeName',
-      eventTypeName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutDetector'
@@ -2093,20 +1754,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutEntityType'
@@ -2163,22 +1810,6 @@ class FraudDetector {
     List<String>? labels,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(entityTypes, 'entityTypes');
-    ArgumentError.checkNotNull(eventVariables, 'eventVariables');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutEventType'
@@ -2238,20 +1869,6 @@ class FraudDetector {
     required ModelOutputConfiguration outputConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(inputConfiguration, 'inputConfiguration');
-    ArgumentError.checkNotNull(
-        invokeModelEndpointRoleArn, 'invokeModelEndpointRoleArn');
-    ArgumentError.checkNotNull(modelEndpoint, 'modelEndpoint');
-    _s.validateStringLength(
-      'modelEndpoint',
-      modelEndpoint,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelEndpointStatus, 'modelEndpointStatus');
-    ArgumentError.checkNotNull(modelSource, 'modelSource');
-    ArgumentError.checkNotNull(outputConfiguration, 'outputConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutExternalModel'
@@ -2287,14 +1904,6 @@ class FraudDetector {
   Future<void> putKMSEncryptionKey({
     required String kmsEncryptionKeyArn,
   }) async {
-    ArgumentError.checkNotNull(kmsEncryptionKeyArn, 'kmsEncryptionKeyArn');
-    _s.validateStringLength(
-      'kmsEncryptionKeyArn',
-      kmsEncryptionKeyArn,
-      7,
-      90,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutKMSEncryptionKey'
@@ -2332,20 +1941,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutLabel'
@@ -2384,20 +1979,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.PutOutcome'
@@ -2431,15 +2012,6 @@ class FraudDetector {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.TagResource'
@@ -2472,15 +2044,6 @@ class FraudDetector {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UntagResource'
@@ -2549,31 +2112,6 @@ class FraudDetector {
     List<ModelVersion>? modelVersions,
     RuleExecutionMode? ruleExecutionMode,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorVersionId, 'detectorVersionId');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        externalModelEndpoints, 'externalModelEndpoints');
-    ArgumentError.checkNotNull(rules, 'rules');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateDetectorVersion'
@@ -2619,30 +2157,6 @@ class FraudDetector {
     required String detectorId,
     required String detectorVersionId,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorVersionId, 'detectorVersionId');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateDetectorVersionMetadata'
@@ -2685,23 +2199,6 @@ class FraudDetector {
     required String detectorVersionId,
     required DetectorVersionStatus status,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(detectorVersionId, 'detectorVersionId');
-    _s.validateStringLength(
-      'detectorVersionId',
-      detectorVersionId,
-      1,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateDetectorVersionStatus'
@@ -2741,21 +2238,6 @@ class FraudDetector {
     required ModelTypeEnum modelType,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateModel'
@@ -2806,23 +2288,6 @@ class FraudDetector {
     ExternalEventsDetail? externalEventsDetail,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(majorVersionNumber, 'majorVersionNumber');
-    _s.validateStringLength(
-      'majorVersionNumber',
-      majorVersionNumber,
-      1,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateModelVersion'
@@ -2879,24 +2344,6 @@ class FraudDetector {
     required String modelVersionNumber,
     required ModelVersionStatus status,
   }) async {
-    ArgumentError.checkNotNull(modelId, 'modelId');
-    _s.validateStringLength(
-      'modelId',
-      modelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelType, 'modelType');
-    ArgumentError.checkNotNull(modelVersionNumber, 'modelVersionNumber');
-    _s.validateStringLength(
-      'modelVersionNumber',
-      modelVersionNumber,
-      3,
-      7,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateModelVersionStatus'
@@ -2933,15 +2380,6 @@ class FraudDetector {
     required String description,
     required Rule rule,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rule, 'rule');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateRuleMetadata'
@@ -2993,23 +2431,6 @@ class FraudDetector {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(expression, 'expression');
-    _s.validateStringLength(
-      'expression',
-      expression,
-      1,
-      4096,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(language, 'language');
-    ArgumentError.checkNotNull(outcomes, 'outcomes');
-    ArgumentError.checkNotNull(rule, 'rule');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateRuleVersion'
@@ -3060,7 +2481,6 @@ class FraudDetector {
     String? description,
     String? variableType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHawksNestServiceFacade.UpdateVariable'

--- a/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
+++ b/generated/aws_fsx_api/lib/fsx-2018-03-01.dart
@@ -102,21 +102,6 @@ class FSx {
     required String fileSystemId,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(aliases, 'aliases');
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.AssociateFileSystemAliases'
@@ -166,14 +151,6 @@ class FSx {
   Future<CancelDataRepositoryTaskResponse> cancelDataRepositoryTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      12,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.CancelDataRepositoryTask'
@@ -275,20 +252,6 @@ class FSx {
     String? clientRequestToken,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.CreateBackup'
@@ -360,22 +323,6 @@ class FSx {
     List<String>? paths,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(report, 'report');
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.CreateDataRepositoryTask'
@@ -549,27 +496,12 @@ class FSx {
     List<Tag>? tags,
     CreateFileSystemWindowsConfiguration? windowsConfiguration,
   }) async {
-    ArgumentError.checkNotNull(fileSystemType, 'fileSystemType');
-    ArgumentError.checkNotNull(storageCapacity, 'storageCapacity');
     _s.validateNumRange(
       'storageCapacity',
       storageCapacity,
       0,
       2147483647,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -714,21 +646,6 @@ class FSx {
     List<Tag>? tags,
     CreateFileSystemWindowsConfiguration? windowsConfiguration,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      12,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup'
@@ -785,20 +702,6 @@ class FSx {
     required String backupId,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      12,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.DeleteBackup'
@@ -862,20 +765,6 @@ class FSx {
     DeleteFileSystemLustreConfiguration? lustreConfiguration,
     DeleteFileSystemWindowsConfiguration? windowsConfiguration,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.DeleteFileSystem'
@@ -968,12 +857,6 @@ class FSx {
       1,
       2147483647,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.DescribeBackups'
@@ -1035,12 +918,6 @@ class FSx {
       1,
       2147483647,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.DescribeDataRepositoryTasks'
@@ -1094,31 +971,11 @@ class FSx {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       2147483647,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1204,12 +1061,6 @@ class FSx {
       1,
       2147483647,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.DescribeFileSystems'
@@ -1258,21 +1109,6 @@ class FSx {
     required String fileSystemId,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(aliases, 'aliases');
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1350,25 +1186,11 @@ class FSx {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      8,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       2147483647,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1409,15 +1231,6 @@ class FSx {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      8,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.TagResource'
@@ -1453,15 +1266,6 @@ class FSx {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      8,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSimbaAPIService_v20180301.UntagResource'
@@ -1592,20 +1396,6 @@ class FSx {
     int? storageCapacity,
     UpdateFileSystemWindowsConfiguration? windowsConfiguration,
   }) async {
-    ArgumentError.checkNotNull(fileSystemId, 'fileSystemId');
-    _s.validateStringLength(
-      'fileSystemId',
-      fileSystemId,
-      11,
-      21,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      63,
-    );
     _s.validateNumRange(
       'storageCapacity',
       storageCapacity,

--- a/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
+++ b/generated/aws_gamelift_api/lib/gamelift-2015-10-01.dart
@@ -126,16 +126,6 @@ class GameLift {
     required List<String> playerIds,
     required String ticketId,
   }) async {
-    ArgumentError.checkNotNull(acceptanceType, 'acceptanceType');
-    ArgumentError.checkNotNull(playerIds, 'playerIds');
-    ArgumentError.checkNotNull(ticketId, 'ticketId');
-    _s.validateStringLength(
-      'ticketId',
-      ticketId,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.AcceptMatch'
@@ -254,26 +244,6 @@ class GameLift {
     String? gameServerData,
     String? gameServerId,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'gameServerData',
-      gameServerData,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'gameServerId',
-      gameServerId,
-      3,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ClaimGameServer'
@@ -368,21 +338,6 @@ class GameLift {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(routingStrategy, 'routingStrategy');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateAlias'
@@ -526,18 +481,6 @@ class GameLift {
     List<Tag>? tags,
     String? version,
   }) async {
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateBuild'
@@ -842,51 +785,6 @@ class GameLift {
     String? serverLaunchPath,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(eC2InstanceType, 'eC2InstanceType');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'instanceRoleArn',
-      instanceRoleArn,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'peerVpcAwsAccountId',
-      peerVpcAwsAccountId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'peerVpcId',
-      peerVpcId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'serverLaunchParameters',
-      serverLaunchParameters,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'serverLaunchPath',
-      serverLaunchPath,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateFleet'
@@ -1148,17 +1046,6 @@ class GameLift {
     List<Tag>? tags,
     List<String>? vpcSubnets,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceDefinitions, 'instanceDefinitions');
-    ArgumentError.checkNotNull(launchTemplate, 'launchTemplate');
-    ArgumentError.checkNotNull(maxSize, 'maxSize');
     _s.validateNumRange(
       'maxSize',
       maxSize,
@@ -1166,20 +1053,11 @@ class GameLift {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(minSize, 'minSize');
     _s.validateNumRange(
       'minSize',
       minSize,
       0,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      256,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1359,44 +1237,12 @@ class GameLift {
     String? idempotencyToken,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(
-        maximumPlayerSessionCount, 'maximumPlayerSessionCount');
     _s.validateNumRange(
       'maximumPlayerSessionCount',
       maximumPlayerSessionCount,
       0,
       1152921504606846976,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorId',
-      creatorId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'gameSessionData',
-      gameSessionData,
-      1,
-      4096,
-    );
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      48,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      48,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1535,14 +1381,6 @@ class GameLift {
     List<Tag>? tags,
     int? timeoutInSeconds,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'timeoutInSeconds',
       timeoutInSeconds,
@@ -1782,29 +1620,11 @@ class GameLift {
     String? notificationTarget,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(acceptanceRequired, 'acceptanceRequired');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(requestTimeoutSeconds, 'requestTimeoutSeconds');
     _s.validateNumRange(
       'requestTimeoutSeconds',
       requestTimeoutSeconds,
       1,
       43200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
-    _s.validateStringLength(
-      'ruleSetName',
-      ruleSetName,
-      1,
-      256,
       isRequired: true,
     );
     _s.validateNumRange(
@@ -1818,30 +1638,6 @@ class GameLift {
       additionalPlayerCount,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'customEventData',
-      customEventData,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'gameSessionData',
-      gameSessionData,
-      1,
-      4096,
-    );
-    _s.validateStringLength(
-      'notificationTarget',
-      notificationTarget,
-      0,
-      300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1972,22 +1768,6 @@ class GameLift {
     required String ruleSetBody,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleSetBody, 'ruleSetBody');
-    _s.validateStringLength(
-      'ruleSetBody',
-      ruleSetBody,
-      1,
-      65535,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateMatchmakingRuleSet'
@@ -2071,28 +1851,6 @@ class GameLift {
     required String playerId,
     String? playerData,
   }) async {
-    ArgumentError.checkNotNull(gameSessionId, 'gameSessionId');
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(playerId, 'playerId');
-    _s.validateStringLength(
-      'playerId',
-      playerId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'playerData',
-      playerData,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreatePlayerSession'
@@ -2180,15 +1938,6 @@ class GameLift {
     required List<String> playerIds,
     Map<String, String>? playerDataMap,
   }) async {
-    ArgumentError.checkNotNull(gameSessionId, 'gameSessionId');
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(playerIds, 'playerIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreatePlayerSessions'
@@ -2325,18 +2074,6 @@ class GameLift {
     String? version,
     Uint8List? zipFile,
   }) async {
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateScript'
@@ -2433,22 +2170,6 @@ class GameLift {
     required String gameLiftAwsAccountId,
     required String peerVpcId,
   }) async {
-    ArgumentError.checkNotNull(gameLiftAwsAccountId, 'gameLiftAwsAccountId');
-    _s.validateStringLength(
-      'gameLiftAwsAccountId',
-      gameLiftAwsAccountId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(peerVpcId, 'peerVpcId');
-    _s.validateStringLength(
-      'peerVpcId',
-      peerVpcId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateVpcPeeringAuthorization'
@@ -2543,23 +2264,6 @@ class GameLift {
     required String peerVpcAwsAccountId,
     required String peerVpcId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(peerVpcAwsAccountId, 'peerVpcAwsAccountId');
-    _s.validateStringLength(
-      'peerVpcAwsAccountId',
-      peerVpcAwsAccountId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(peerVpcId, 'peerVpcId');
-    _s.validateStringLength(
-      'peerVpcId',
-      peerVpcId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.CreateVpcPeeringConnection'
@@ -2615,7 +2319,6 @@ class GameLift {
   Future<void> deleteAlias({
     required String aliasId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteAlias'
@@ -2677,7 +2380,6 @@ class GameLift {
   Future<void> deleteBuild({
     required String buildId,
   }) async {
-    ArgumentError.checkNotNull(buildId, 'buildId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteBuild'
@@ -2748,7 +2450,6 @@ class GameLift {
   Future<void> deleteFleet({
     required String fleetId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteFleet'
@@ -2866,14 +2567,6 @@ class GameLift {
     required String gameServerGroupName,
     GameServerGroupDeleteOption? deleteOption,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteGameServerGroup'
@@ -2933,14 +2626,6 @@ class GameLift {
   Future<void> deleteGameSessionQueue({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteGameSessionQueue'
@@ -3002,14 +2687,6 @@ class GameLift {
   Future<void> deleteMatchmakingConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteMatchmakingConfiguration'
@@ -3081,14 +2758,6 @@ class GameLift {
   Future<void> deleteMatchmakingRuleSet({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteMatchmakingRuleSet'
@@ -3166,15 +2835,6 @@ class GameLift {
     required String fleetId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteScalingPolicy'
@@ -3240,7 +2900,6 @@ class GameLift {
   Future<void> deleteScript({
     required String scriptId,
   }) async {
-    ArgumentError.checkNotNull(scriptId, 'scriptId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteScript'
@@ -3304,22 +2963,6 @@ class GameLift {
     required String gameLiftAwsAccountId,
     required String peerVpcId,
   }) async {
-    ArgumentError.checkNotNull(gameLiftAwsAccountId, 'gameLiftAwsAccountId');
-    _s.validateStringLength(
-      'gameLiftAwsAccountId',
-      gameLiftAwsAccountId,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(peerVpcId, 'peerVpcId');
-    _s.validateStringLength(
-      'peerVpcId',
-      peerVpcId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteVpcPeeringAuthorization'
@@ -3387,16 +3030,6 @@ class GameLift {
     required String fleetId,
     required String vpcPeeringConnectionId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(
-        vpcPeeringConnectionId, 'vpcPeeringConnectionId');
-    _s.validateStringLength(
-      'vpcPeeringConnectionId',
-      vpcPeeringConnectionId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeleteVpcPeeringConnection'
@@ -3469,22 +3102,6 @@ class GameLift {
     required String gameServerGroupName,
     required String gameServerId,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gameServerId, 'gameServerId');
-    _s.validateStringLength(
-      'gameServerId',
-      gameServerId,
-      3,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DeregisterGameServer'
@@ -3541,7 +3158,6 @@ class GameLift {
   Future<DescribeAliasOutput> describeAlias({
     required String aliasId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeAlias'
@@ -3601,7 +3217,6 @@ class GameLift {
   Future<DescribeBuildOutput> describeBuild({
     required String buildId,
   }) async {
-    ArgumentError.checkNotNull(buildId, 'buildId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeBuild'
@@ -3799,12 +3414,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeFleetAttributes'
@@ -3929,12 +3538,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeFleetCapacity'
@@ -4048,18 +3651,11 @@ class GameLift {
     String? nextToken,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4156,7 +3752,6 @@ class GameLift {
   Future<DescribeFleetPortSettingsOutput> describeFleetPortSettings({
     required String fleetId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeFleetPortSettings'
@@ -4281,12 +3876,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeFleetUtilization'
@@ -4362,22 +3951,6 @@ class GameLift {
     required String gameServerGroupName,
     required String gameServerId,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gameServerId, 'gameServerId');
-    _s.validateStringLength(
-      'gameServerId',
-      gameServerId,
-      3,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeGameServer'
@@ -4455,14 +4028,6 @@ class GameLift {
   Future<DescribeGameServerGroupOutput> describeGameServerGroup({
     required String gameServerGroupName,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeGameServerGroup'
@@ -4567,25 +4132,11 @@ class GameLift {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4695,29 +4246,11 @@ class GameLift {
     String? nextToken,
     String? statusFilter,
   }) async {
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'statusFilter',
-      statusFilter,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4791,14 +4324,6 @@ class GameLift {
   Future<DescribeGameSessionPlacementOutput> describeGameSessionPlacement({
     required String placementId,
   }) async {
-    ArgumentError.checkNotNull(placementId, 'placementId');
-    _s.validateStringLength(
-      'placementId',
-      placementId,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeGameSessionPlacement'
@@ -4876,12 +4401,6 @@ class GameLift {
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4991,29 +4510,11 @@ class GameLift {
     String? nextToken,
     String? statusFilter,
   }) async {
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'statusFilter',
-      statusFilter,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5095,18 +4596,11 @@ class GameLift {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5185,7 +4679,6 @@ class GameLift {
   Future<DescribeMatchmakingOutput> describeMatchmaking({
     required List<String> ticketIds,
   }) async {
-    ArgumentError.checkNotNull(ticketIds, 'ticketIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeMatchmaking'
@@ -5287,18 +4780,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'ruleSetName',
-      ruleSetName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeMatchmakingConfigurations'
@@ -5392,12 +4873,6 @@ class GameLift {
       limit,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5517,35 +4992,11 @@ class GameLift {
     String? playerSessionId,
     String? playerSessionStatusFilter,
   }) async {
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'playerId',
-      playerId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'playerSessionStatusFilter',
-      playerSessionStatusFilter,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5647,7 +5098,6 @@ class GameLift {
   Future<DescribeRuntimeConfigurationOutput> describeRuntimeConfiguration({
     required String fleetId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeRuntimeConfiguration'
@@ -5771,18 +5221,11 @@ class GameLift {
     String? nextToken,
     ScalingStatusType? statusFilter,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5847,7 +5290,6 @@ class GameLift {
   Future<DescribeScriptOutput> describeScript({
     required String scriptId,
   }) async {
-    ArgumentError.checkNotNull(scriptId, 'scriptId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.DescribeScript'
@@ -6027,14 +5469,6 @@ class GameLift {
   Future<GetGameSessionLogUrlOutput> getGameSessionLogUrl({
     required String gameSessionId,
   }) async {
-    ArgumentError.checkNotNull(gameSessionId, 'gameSessionId');
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.GetGameSessionLogUrl'
@@ -6113,8 +5547,6 @@ class GameLift {
     required String fleetId,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.GetInstanceAccess'
@@ -6206,18 +5638,6 @@ class GameLift {
     _s.validateNumRange(
       'limit',
       limit,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
       1,
       1152921504606846976,
     );
@@ -6322,12 +5742,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ListBuilds'
@@ -6421,12 +5835,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ListFleets'
@@ -6512,12 +5920,6 @@ class GameLift {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ListGameServerGroups'
@@ -6602,25 +6004,11 @@ class GameLift {
     String? nextToken,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6691,12 +6079,6 @@ class GameLift {
     _s.validateNumRange(
       'limit',
       limit,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
       1,
       1152921504606846976,
     );
@@ -6789,14 +6171,6 @@ class GameLift {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ListTagsForResource'
@@ -7064,16 +6438,6 @@ class GameLift {
     TargetConfiguration? targetConfiguration,
     double? threshold,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'evaluationPeriods',
       evaluationPeriods,
@@ -7197,42 +6561,6 @@ class GameLift {
     String? connectionInfo,
     String? gameServerData,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gameServerId, 'gameServerId');
-    _s.validateStringLength(
-      'gameServerId',
-      gameServerId,
-      3,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      19,
-      19,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'connectionInfo',
-      connectionInfo,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'gameServerData',
-      gameServerData,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.RegisterGameServer'
@@ -7301,7 +6629,6 @@ class GameLift {
   Future<RequestUploadCredentialsOutput> requestUploadCredentials({
     required String buildId,
   }) async {
-    ArgumentError.checkNotNull(buildId, 'buildId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.RequestUploadCredentials'
@@ -7355,7 +6682,6 @@ class GameLift {
   Future<ResolveAliasOutput> resolveAlias({
     required String aliasId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ResolveAlias'
@@ -7440,15 +6766,6 @@ class GameLift {
     required String gameServerGroupName,
     required List<GameServerGroupAction> resumeActions,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resumeActions, 'resumeActions');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ResumeGameServerGroup'
@@ -7685,29 +7002,11 @@ class GameLift {
     String? nextToken,
     String? sortExpression,
   }) async {
-    _s.validateStringLength(
-      'filterExpression',
-      filterExpression,
-      1,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'sortExpression',
-      sortExpression,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -7787,8 +7086,6 @@ class GameLift {
     required List<FleetAction> actions,
     required String fleetId,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StartFleetActions'
@@ -7949,42 +7246,12 @@ class GameLift {
     String? gameSessionName,
     List<PlayerLatency>? playerLatencies,
   }) async {
-    ArgumentError.checkNotNull(gameSessionQueueName, 'gameSessionQueueName');
-    _s.validateStringLength(
-      'gameSessionQueueName',
-      gameSessionQueueName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        maximumPlayerSessionCount, 'maximumPlayerSessionCount');
     _s.validateNumRange(
       'maximumPlayerSessionCount',
       maximumPlayerSessionCount,
       0,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(placementId, 'placementId');
-    _s.validateStringLength(
-      'placementId',
-      placementId,
-      1,
-      48,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'gameSessionData',
-      gameSessionData,
-      1,
-      4096,
-    );
-    _s.validateStringLength(
-      'gameSessionName',
-      gameSessionName,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -8118,27 +7385,6 @@ class GameLift {
     String? gameSessionArn,
     String? ticketId,
   }) async {
-    ArgumentError.checkNotNull(configurationName, 'configurationName');
-    _s.validateStringLength(
-      'configurationName',
-      configurationName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(players, 'players');
-    _s.validateStringLength(
-      'gameSessionArn',
-      gameSessionArn,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'ticketId',
-      ticketId,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StartMatchBackfill'
@@ -8246,21 +7492,6 @@ class GameLift {
     required List<Player> players,
     String? ticketId,
   }) async {
-    ArgumentError.checkNotNull(configurationName, 'configurationName');
-    _s.validateStringLength(
-      'configurationName',
-      configurationName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(players, 'players');
-    _s.validateStringLength(
-      'ticketId',
-      ticketId,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StartMatchmaking'
@@ -8336,8 +7567,6 @@ class GameLift {
     required List<FleetAction> actions,
     required String fleetId,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StopFleetActions'
@@ -8404,14 +7633,6 @@ class GameLift {
   Future<StopGameSessionPlacementOutput> stopGameSessionPlacement({
     required String placementId,
   }) async {
-    ArgumentError.checkNotNull(placementId, 'placementId');
-    _s.validateStringLength(
-      'placementId',
-      placementId,
-      1,
-      48,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StopGameSessionPlacement'
@@ -8480,14 +7701,6 @@ class GameLift {
   Future<void> stopMatchmaking({
     required String ticketId,
   }) async {
-    ArgumentError.checkNotNull(ticketId, 'ticketId');
-    _s.validateStringLength(
-      'ticketId',
-      ticketId,
-      0,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.StopMatchmaking'
@@ -8579,15 +7792,6 @@ class GameLift {
     required String gameServerGroupName,
     required List<GameServerGroupAction> suspendActions,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(suspendActions, 'suspendActions');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.SuspendGameServerGroup'
@@ -8688,15 +7892,6 @@ class GameLift {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.TagResource'
@@ -8792,15 +7987,6 @@ class GameLift {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UntagResource'
@@ -8869,19 +8055,6 @@ class GameLift {
     String? name,
     RoutingStrategy? routingStrategy,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateAlias'
@@ -8955,19 +8128,6 @@ class GameLift {
     String? name,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(buildId, 'buildId');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateBuild'
@@ -9089,19 +8249,6 @@ class GameLift {
     ProtectionPolicy? newGameSessionProtectionPolicy,
     ResourceCreationLimitPolicy? resourceCreationLimitPolicy,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateFleetAttributes'
@@ -9219,7 +8366,6 @@ class GameLift {
     int? maxSize,
     int? minSize,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     _s.validateNumRange(
       'desiredInstances',
       desiredInstances,
@@ -9332,7 +8478,6 @@ class GameLift {
     List<IpPermission>? inboundPermissionAuthorizations,
     List<IpPermission>? inboundPermissionRevocations,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateFleetPortSettings'
@@ -9448,28 +8593,6 @@ class GameLift {
     GameServerHealthCheck? healthCheck,
     GameServerUtilizationStatus? utilizationStatus,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gameServerId, 'gameServerId');
-    _s.validateStringLength(
-      'gameServerId',
-      gameServerId,
-      3,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'gameServerData',
-      gameServerData,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateGameServer'
@@ -9618,20 +8741,6 @@ class GameLift {
     List<InstanceDefinition>? instanceDefinitions,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(gameServerGroupName, 'gameServerGroupName');
-    _s.validateStringLength(
-      'gameServerGroupName',
-      gameServerGroupName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateGameServerGroup'
@@ -9741,25 +8850,11 @@ class GameLift {
     PlayerSessionCreationPolicy? playerSessionCreationPolicy,
     ProtectionPolicy? protectionPolicy,
   }) async {
-    ArgumentError.checkNotNull(gameSessionId, 'gameSessionId');
-    _s.validateStringLength(
-      'gameSessionId',
-      gameSessionId,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maximumPlayerSessionCount',
       maximumPlayerSessionCount,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9851,14 +8946,6 @@ class GameLift {
     List<PlayerLatencyPolicy>? playerLatencyPolicies,
     int? timeoutInSeconds,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'timeoutInSeconds',
       timeoutInSeconds,
@@ -10054,14 +9141,6 @@ class GameLift {
     int? requestTimeoutSeconds,
     String? ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'acceptanceTimeoutSeconds',
       acceptanceTimeoutSeconds,
@@ -10074,41 +9153,11 @@ class GameLift {
       0,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'customEventData',
-      customEventData,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'gameSessionData',
-      gameSessionData,
-      1,
-      4096,
-    );
-    _s.validateStringLength(
-      'notificationTarget',
-      notificationTarget,
-      0,
-      300,
-    );
     _s.validateNumRange(
       'requestTimeoutSeconds',
       requestTimeoutSeconds,
       1,
       43200,
-    );
-    _s.validateStringLength(
-      'ruleSetName',
-      ruleSetName,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10230,8 +9279,6 @@ class GameLift {
     required String fleetId,
     required RuntimeConfiguration runtimeConfiguration,
   }) async {
-    ArgumentError.checkNotNull(fleetId, 'fleetId');
-    ArgumentError.checkNotNull(runtimeConfiguration, 'runtimeConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateRuntimeConfiguration'
@@ -10338,19 +9385,6 @@ class GameLift {
     String? version,
     Uint8List? zipFile,
   }) async {
-    ArgumentError.checkNotNull(scriptId, 'scriptId');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.UpdateScript'
@@ -10425,14 +9459,6 @@ class GameLift {
   Future<ValidateMatchmakingRuleSetOutput> validateMatchmakingRuleSet({
     required String ruleSetBody,
   }) async {
-    ArgumentError.checkNotNull(ruleSetBody, 'ruleSetBody');
-    _s.validateStringLength(
-      'ruleSetBody',
-      ruleSetBody,
-      1,
-      65535,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GameLift.ValidateMatchmakingRuleSet'

--- a/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
+++ b/generated/aws_glacier_api/lib/glacier-2012-06-01.dart
@@ -131,9 +131,6 @@ class Glacier {
     required String uploadId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -183,8 +180,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -227,8 +222,6 @@ class Glacier {
     required String vaultName,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final $payload = <String, dynamic>{
       if (tags != null) 'Tags': tags,
     };
@@ -325,9 +318,6 @@ class Glacier {
     String? archiveSize,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (archiveSize != null) 'x-amz-archive-size': archiveSize.toString(),
       if (checksum != null) 'x-amz-sha256-tree-hash': checksum.toString(),
@@ -394,9 +384,6 @@ class Glacier {
     required String lockId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(lockId, 'lockId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'POST',
@@ -456,8 +443,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'PUT',
@@ -526,9 +511,6 @@ class Glacier {
     required String archiveId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(archiveId, 'archiveId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -584,8 +566,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -625,8 +605,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -674,8 +652,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -733,9 +709,6 @@ class Glacier {
     required String jobId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -789,8 +762,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -821,7 +792,6 @@ class Glacier {
   Future<GetDataRetrievalPolicyOutput> getDataRetrievalPolicy({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -942,9 +912,6 @@ class Glacier {
     required String vaultName,
     String? range,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (range != null) 'Range': range.toString(),
     };
@@ -999,8 +966,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1066,8 +1031,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1120,8 +1083,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1166,8 +1127,6 @@ class Glacier {
     required String vaultName,
     JobParameters? jobParameters,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.sendRaw(
       payload: jobParameters,
       method: 'POST',
@@ -1255,8 +1214,6 @@ class Glacier {
     String? archiveDescription,
     String? partSize,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (archiveDescription != null)
         'x-amz-archive-description': archiveDescription.toString(),
@@ -1342,8 +1299,6 @@ class Glacier {
     required String vaultName,
     VaultLockPolicy? policy,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.sendRaw(
       payload: policy,
       method: 'POST',
@@ -1441,8 +1396,6 @@ class Glacier {
     String? marker,
     String? statuscode,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final $query = <String, List<String>>{
       if (completed != null) 'completed': [completed],
       if (limit != null) 'limit': [limit],
@@ -1527,8 +1480,6 @@ class Glacier {
     String? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit],
       if (marker != null) 'marker': [marker],
@@ -1610,9 +1561,6 @@ class Glacier {
     String? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit],
       if (marker != null) 'marker': [marker],
@@ -1644,7 +1592,6 @@ class Glacier {
   Future<ListProvisionedCapacityOutput> listProvisionedCapacity({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1678,8 +1625,6 @@ class Glacier {
     required String accountId,
     required String vaultName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1742,7 +1687,6 @@ class Glacier {
     String? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit],
       if (marker != null) 'marker': [marker],
@@ -1773,7 +1717,6 @@ class Glacier {
   Future<PurchaseProvisionedCapacityOutput> purchaseProvisionedCapacity({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'POST',
@@ -1816,8 +1759,6 @@ class Glacier {
     required String vaultName,
     List<String>? tagKeys,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final $payload = <String, dynamic>{
       if (tagKeys != null) 'TagKeys': tagKeys,
     };
@@ -1859,7 +1800,6 @@ class Glacier {
     required String accountId,
     DataRetrievalPolicy? policy,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
     final $payload = <String, dynamic>{
       if (policy != null) 'Policy': policy,
     };
@@ -1902,8 +1842,6 @@ class Glacier {
     required String vaultName,
     VaultAccessPolicy? policy,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: policy,
       method: 'PUT',
@@ -1978,8 +1916,6 @@ class Glacier {
     required String vaultName,
     VaultNotificationConfig? vaultNotificationConfig,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     await _protocol.send(
       payload: vaultNotificationConfig,
       method: 'PUT',
@@ -2063,8 +1999,6 @@ class Glacier {
     Uint8List? body,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (archiveDescription != null)
         'x-amz-archive-description': archiveDescription.toString(),
@@ -2181,9 +2115,6 @@ class Glacier {
     String? checksum,
     String? range,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (checksum != null) 'x-amz-sha256-tree-hash': checksum.toString(),
       if (range != null) 'Content-Range': range.toString(),

--- a/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
+++ b/generated/aws_globalaccelerator_api/lib/globalaccelerator-2018-08-08.dart
@@ -89,16 +89,6 @@ class GlobalAccelerator {
     required List<CustomRoutingEndpointConfiguration> endpointConfigurations,
     required String endpointGroupArn,
   }) async {
-    ArgumentError.checkNotNull(
-        endpointConfigurations, 'endpointConfigurations');
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.AddCustomRoutingEndpoints'
@@ -144,14 +134,6 @@ class GlobalAccelerator {
   Future<AdvertiseByoipCidrResponse> advertiseByoipCidr({
     required String cidr,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
-    _s.validateStringLength(
-      'cidr',
-      cidr,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.AdvertiseByoipCidr'
@@ -228,22 +210,6 @@ class GlobalAccelerator {
     List<String>? destinationAddresses,
     List<int>? destinationPorts,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
-    _s.validateStringLength(
-      'endpointId',
-      endpointId,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.AllowCustomRoutingTraffic'
@@ -333,20 +299,6 @@ class GlobalAccelerator {
     List<String>? ipAddresses,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.CreateAccelerator'
@@ -421,20 +373,6 @@ class GlobalAccelerator {
     IpAddressType? ipAddressType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -494,30 +432,6 @@ class GlobalAccelerator {
     required String listenerArn,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationConfigurations, 'destinationConfigurations');
-    ArgumentError.checkNotNull(endpointGroupRegion, 'endpointGroupRegion');
-    _s.validateStringLength(
-      'endpointGroupRegion',
-      endpointGroupRegion,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -571,21 +485,6 @@ class GlobalAccelerator {
     required List<PortRange> portRanges,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(portRanges, 'portRanges');
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.CreateCustomRoutingListener'
@@ -688,45 +587,17 @@ class GlobalAccelerator {
     int? thresholdCount,
     double? trafficDialPercentage,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupRegion, 'endpointGroupRegion');
-    _s.validateStringLength(
-      'endpointGroupRegion',
-      endpointGroupRegion,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'healthCheckIntervalSeconds',
       healthCheckIntervalSeconds,
       10,
       30,
     );
-    _s.validateStringLength(
-      'healthCheckPath',
-      healthCheckPath,
-      0,
-      255,
-    );
     _s.validateNumRange(
       'healthCheckPort',
       healthCheckPort,
       1,
       65535,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
     );
     _s.validateNumRange(
       'thresholdCount',
@@ -825,22 +696,6 @@ class GlobalAccelerator {
     ClientAffinity? clientAffinity,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(portRanges, 'portRanges');
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.CreateListener'
@@ -897,14 +752,6 @@ class GlobalAccelerator {
   Future<void> deleteAccelerator({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DeleteAccelerator'
@@ -954,14 +801,6 @@ class GlobalAccelerator {
   Future<void> deleteCustomRoutingAccelerator({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -990,14 +829,6 @@ class GlobalAccelerator {
   Future<void> deleteCustomRoutingEndpointGroup({
     required String endpointGroupArn,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1027,14 +858,6 @@ class GlobalAccelerator {
   Future<void> deleteCustomRoutingListener({
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DeleteCustomRoutingListener'
@@ -1062,14 +885,6 @@ class GlobalAccelerator {
   Future<void> deleteEndpointGroup({
     required String endpointGroupArn,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DeleteEndpointGroup'
@@ -1098,14 +913,6 @@ class GlobalAccelerator {
   Future<void> deleteListener({
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DeleteListener'
@@ -1175,22 +982,6 @@ class GlobalAccelerator {
     List<String>? destinationAddresses,
     List<int>? destinationPorts,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
-    _s.validateStringLength(
-      'endpointId',
-      endpointId,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DenyCustomRoutingTraffic'
@@ -1240,14 +1031,6 @@ class GlobalAccelerator {
   Future<DeprovisionByoipCidrResponse> deprovisionByoipCidr({
     required String cidr,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
-    _s.validateStringLength(
-      'cidr',
-      cidr,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DeprovisionByoipCidr'
@@ -1277,14 +1060,6 @@ class GlobalAccelerator {
   Future<DescribeAcceleratorResponse> describeAccelerator({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DescribeAccelerator'
@@ -1315,14 +1090,6 @@ class GlobalAccelerator {
   Future<DescribeAcceleratorAttributesResponse> describeAcceleratorAttributes({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1354,14 +1121,6 @@ class GlobalAccelerator {
       describeCustomRoutingAccelerator({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1394,14 +1153,6 @@ class GlobalAccelerator {
       describeCustomRoutingAcceleratorAttributes({
     required String acceleratorArn,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1434,14 +1185,6 @@ class GlobalAccelerator {
       describeCustomRoutingEndpointGroup({
     required String endpointGroupArn,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1473,14 +1216,6 @@ class GlobalAccelerator {
   Future<DescribeCustomRoutingListenerResponse> describeCustomRoutingListener({
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1511,14 +1246,6 @@ class GlobalAccelerator {
   Future<DescribeEndpointGroupResponse> describeEndpointGroup({
     required String endpointGroupArn,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DescribeEndpointGroup'
@@ -1548,14 +1275,6 @@ class GlobalAccelerator {
   Future<DescribeListenerResponse> describeListener({
     required String listenerArn,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.DescribeListener'
@@ -1596,12 +1315,6 @@ class GlobalAccelerator {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1648,12 +1361,6 @@ class GlobalAccelerator {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.ListByoipCidrs'
@@ -1695,12 +1402,6 @@ class GlobalAccelerator {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1747,25 +1448,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1810,25 +1497,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1895,31 +1568,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1976,33 +1629,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(destinationAddress, 'destinationAddress');
-    _s.validateStringLength(
-      'destinationAddress',
-      destinationAddress,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
-    _s.validateStringLength(
-      'endpointId',
-      endpointId,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2049,25 +1680,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2112,25 +1729,11 @@ class GlobalAccelerator {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2169,14 +1772,6 @@ class GlobalAccelerator {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.ListTagsForResource'
@@ -2225,16 +1820,6 @@ class GlobalAccelerator {
     required String cidr,
     required CidrAuthorizationContext cidrAuthorizationContext,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
-    _s.validateStringLength(
-      'cidr',
-      cidr,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        cidrAuthorizationContext, 'cidrAuthorizationContext');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.ProvisionByoipCidr'
@@ -2274,15 +1859,6 @@ class GlobalAccelerator {
     required String endpointGroupArn,
     required List<String> endpointIds,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointIds, 'endpointIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.RemoveCustomRoutingEndpoints'
@@ -2322,15 +1898,6 @@ class GlobalAccelerator {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.TagResource'
@@ -2372,15 +1939,6 @@ class GlobalAccelerator {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.UntagResource'
@@ -2432,20 +1990,6 @@ class GlobalAccelerator {
     IpAddressType? ipAddressType,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.UpdateAccelerator'
@@ -2509,26 +2053,6 @@ class GlobalAccelerator {
     String? flowLogsS3Bucket,
     String? flowLogsS3Prefix,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'flowLogsS3Bucket',
-      flowLogsS3Bucket,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'flowLogsS3Prefix',
-      flowLogsS3Prefix,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.UpdateAcceleratorAttributes'
@@ -2580,20 +2104,6 @@ class GlobalAccelerator {
     IpAddressType? ipAddressType,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2660,26 +2170,6 @@ class GlobalAccelerator {
     String? flowLogsS3Bucket,
     String? flowLogsS3Prefix,
   }) async {
-    ArgumentError.checkNotNull(acceleratorArn, 'acceleratorArn');
-    _s.validateStringLength(
-      'acceleratorArn',
-      acceleratorArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'flowLogsS3Bucket',
-      flowLogsS3Bucket,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'flowLogsS3Prefix',
-      flowLogsS3Prefix,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2727,15 +2217,6 @@ class GlobalAccelerator {
     required String listenerArn,
     required List<PortRange> portRanges,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(portRanges, 'portRanges');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.UpdateCustomRoutingListener'
@@ -2825,25 +2306,11 @@ class GlobalAccelerator {
     int? thresholdCount,
     double? trafficDialPercentage,
   }) async {
-    ArgumentError.checkNotNull(endpointGroupArn, 'endpointGroupArn');
-    _s.validateStringLength(
-      'endpointGroupArn',
-      endpointGroupArn,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'healthCheckIntervalSeconds',
       healthCheckIntervalSeconds,
       10,
       30,
-    );
-    _s.validateStringLength(
-      'healthCheckPath',
-      healthCheckPath,
-      0,
-      255,
     );
     _s.validateNumRange(
       'healthCheckPort',
@@ -2939,14 +2406,6 @@ class GlobalAccelerator {
     List<PortRange>? portRanges,
     Protocol? protocol,
   }) async {
-    ArgumentError.checkNotNull(listenerArn, 'listenerArn');
-    _s.validateStringLength(
-      'listenerArn',
-      listenerArn,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.UpdateListener'
@@ -2991,14 +2450,6 @@ class GlobalAccelerator {
   Future<WithdrawByoipCidrResponse> withdrawByoipCidr({
     required String cidr,
   }) async {
-    ArgumentError.checkNotNull(cidr, 'cidr');
-    _s.validateStringLength(
-      'cidr',
-      cidr,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'GlobalAccelerator_V20180706.WithdrawByoipCidr'

--- a/generated/aws_glue_api/lib/glue-2017-03-31.dart
+++ b/generated/aws_glue_api/lib/glue-2017-03-31.dart
@@ -76,29 +76,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionInputList, 'partitionInputList');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchCreatePartition'
@@ -135,13 +112,6 @@ class Glue {
     required List<String> connectionNameList,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(connectionNameList, 'connectionNameList');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchDeleteConnection'
@@ -187,29 +157,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionsToDelete, 'partitionsToDelete');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchDeletePartition'
@@ -265,21 +212,6 @@ class Glue {
     required List<String> tablesToDelete,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tablesToDelete, 'tablesToDelete');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchDeleteTable'
@@ -328,29 +260,6 @@ class Glue {
     required List<String> versionIds,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionIds, 'versionIds');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchDeleteTableVersion'
@@ -387,7 +296,6 @@ class Glue {
   Future<BatchGetCrawlersResponse> batchGetCrawlers({
     required List<String> crawlerNames,
   }) async {
-    ArgumentError.checkNotNull(crawlerNames, 'crawlerNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetCrawlers'
@@ -423,7 +331,6 @@ class Glue {
   Future<BatchGetDevEndpointsResponse> batchGetDevEndpoints({
     required List<String> devEndpointNames,
   }) async {
-    ArgumentError.checkNotNull(devEndpointNames, 'devEndpointNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetDevEndpoints'
@@ -458,7 +365,6 @@ class Glue {
   Future<BatchGetJobsResponse> batchGetJobs({
     required List<String> jobNames,
   }) async {
-    ArgumentError.checkNotNull(jobNames, 'jobNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetJobs'
@@ -503,29 +409,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionsToGet, 'partitionsToGet');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetPartition'
@@ -563,7 +446,6 @@ class Glue {
   Future<BatchGetTriggersResponse> batchGetTriggers({
     required List<String> triggerNames,
   }) async {
-    ArgumentError.checkNotNull(triggerNames, 'triggerNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetTriggers'
@@ -603,7 +485,6 @@ class Glue {
     required List<String> names,
     bool? includeGraph,
   }) async {
-    ArgumentError.checkNotNull(names, 'names');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchGetWorkflows'
@@ -639,15 +520,6 @@ class Glue {
     required String jobName,
     required List<String> jobRunIds,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobRunIds, 'jobRunIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchStopJobRun'
@@ -694,29 +566,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entries, 'entries');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.BatchUpdatePartition'
@@ -759,22 +608,6 @@ class Glue {
     required String taskRunId,
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(taskRunId, 'taskRunId');
-    _s.validateStringLength(
-      'taskRunId',
-      taskRunId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CancelMLTaskRun'
@@ -813,15 +646,6 @@ class Glue {
     required DataFormat dataFormat,
     required String schemaDefinition,
   }) async {
-    ArgumentError.checkNotNull(dataFormat, 'dataFormat');
-    ArgumentError.checkNotNull(schemaDefinition, 'schemaDefinition');
-    _s.validateStringLength(
-      'schemaDefinition',
-      schemaDefinition,
-      1,
-      170000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CheckSchemaVersionValidity'
@@ -904,13 +728,6 @@ class Glue {
     required ConnectionInput connectionInput,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(connectionInput, 'connectionInput');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateConnection'
@@ -1010,34 +827,6 @@ class Glue {
     String? tablePrefix,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'crawlerSecurityConfiguration',
-      crawlerSecurityConfiguration,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'tablePrefix',
-      tablePrefix,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateCrawler'
@@ -1089,13 +878,6 @@ class Glue {
     required DatabaseInput databaseInput,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseInput, 'databaseInput');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateDatabase'
@@ -1253,20 +1035,6 @@ class Glue {
     Map<String, String>? tags,
     WorkerType? workerType,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'glueVersion',
-      glueVersion,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'securityConfiguration',
-      securityConfiguration,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateDevEndpoint'
@@ -1473,34 +1241,6 @@ class Glue {
     int? timeout,
     WorkerType? workerType,
   }) async {
-    ArgumentError.checkNotNull(command, 'command');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'glueVersion',
-      glueVersion,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'securityConfiguration',
-      securityConfiguration,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'timeout',
       timeout,
@@ -1732,29 +1472,6 @@ class Glue {
     TransformEncryption? transformEncryption,
     WorkerType? workerType,
   }) async {
-    ArgumentError.checkNotNull(inputRecordTables, 'inputRecordTables');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parameters, 'parameters');
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'glueVersion',
-      glueVersion,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'timeout',
       timeout,
@@ -1820,29 +1537,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionInput, 'partitionInput');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreatePartition'
@@ -1892,29 +1586,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionIndex, 'partitionIndex');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreatePartitionIndex'
@@ -1959,20 +1630,6 @@ class Glue {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    _s.validateStringLength(
-      'registryName',
-      registryName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateRegistry'
@@ -2107,27 +1764,6 @@ class Glue {
     String? schemaDefinition,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(dataFormat, 'dataFormat');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
-    _s.validateStringLength(
-      'schemaName',
-      schemaName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'schemaDefinition',
-      schemaDefinition,
-      1,
-      170000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateSchema'
@@ -2213,16 +1849,6 @@ class Glue {
     required EncryptionConfiguration encryptionConfiguration,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(
-        encryptionConfiguration, 'encryptionConfiguration');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateSecurityConfiguration'
@@ -2273,21 +1899,6 @@ class Glue {
     String? catalogId,
     List<PartitionIndex>? partitionIndexes,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableInput, 'tableInput');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateTable'
@@ -2367,28 +1978,6 @@ class Glue {
     Map<String, String>? tags,
     String? workflowName,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'workflowName',
-      workflowName,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateTrigger'
@@ -2440,21 +2029,6 @@ class Glue {
     required UserDefinedFunctionInput functionInput,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionInput, 'functionInput');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateUserDefinedFunction'
@@ -2509,14 +2083,6 @@ class Glue {
     int? maxConcurrentRuns,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.CreateWorkflow'
@@ -2550,14 +2116,6 @@ class Glue {
   Future<void> deleteClassifier({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteClassifier'
@@ -2607,37 +2165,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnName, 'columnName');
-    _s.validateStringLength(
-      'columnName',
-      columnName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionValues, 'partitionValues');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteColumnStatisticsForPartition'
@@ -2687,36 +2214,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnName, 'columnName');
-    _s.validateStringLength(
-      'columnName',
-      columnName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteColumnStatisticsForTable'
@@ -2751,20 +2248,6 @@ class Glue {
     required String connectionName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(connectionName, 'connectionName');
-    _s.validateStringLength(
-      'connectionName',
-      connectionName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteConnection'
@@ -2795,14 +2278,6 @@ class Glue {
   Future<void> deleteCrawler({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteCrawler'
@@ -2851,20 +2326,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteDatabase'
@@ -2894,7 +2355,6 @@ class Glue {
   Future<void> deleteDevEndpoint({
     required String endpointName,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteDevEndpoint'
@@ -2923,14 +2383,6 @@ class Glue {
   Future<DeleteJobResponse> deleteJob({
     required String jobName,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteJob'
@@ -2967,14 +2419,6 @@ class Glue {
   Future<DeleteMLTransformResponse> deleteMLTransform({
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteMLTransform'
@@ -3018,29 +2462,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionValues, 'partitionValues');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeletePartition'
@@ -3088,36 +2509,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexName, 'indexName');
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeletePartitionIndex'
@@ -3155,7 +2546,6 @@ class Glue {
   Future<DeleteRegistryResponse> deleteRegistry({
     required RegistryId registryId,
   }) async {
-    ArgumentError.checkNotNull(registryId, 'registryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteRegistry'
@@ -3191,18 +2581,6 @@ class Glue {
     String? policyHashCondition,
     String? resourceArn,
   }) async {
-    _s.validateStringLength(
-      'policyHashCondition',
-      policyHashCondition,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteResourcePolicy'
@@ -3239,7 +2617,6 @@ class Glue {
   Future<DeleteSchemaResponse> deleteSchema({
     required SchemaId schemaId,
   }) async {
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteSchema'
@@ -3302,15 +2679,6 @@ class Glue {
     required SchemaId schemaId,
     required String versions,
   }) async {
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
-    ArgumentError.checkNotNull(versions, 'versions');
-    _s.validateStringLength(
-      'versions',
-      versions,
-      1,
-      100000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteSchemaVersions'
@@ -3342,14 +2710,6 @@ class Glue {
   Future<void> deleteSecurityConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteSecurityConfiguration'
@@ -3401,28 +2761,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteTable'
@@ -3469,36 +2807,6 @@ class Glue {
     required String versionId,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteTableVersion'
@@ -3531,14 +2839,6 @@ class Glue {
   Future<DeleteTriggerResponse> deleteTrigger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteTrigger'
@@ -3578,28 +2878,6 @@ class Glue {
     required String functionName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteUserDefinedFunction'
@@ -3630,14 +2908,6 @@ class Glue {
   Future<DeleteWorkflowResponse> deleteWorkflow({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.DeleteWorkflow'
@@ -3667,12 +2937,6 @@ class Glue {
   Future<GetCatalogImportStatusResponse> getCatalogImportStatus({
     String? catalogId,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetCatalogImportStatus'
@@ -3701,14 +2965,6 @@ class Glue {
   Future<GetClassifierResponse> getClassifier({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetClassifier'
@@ -3799,30 +3055,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnNames, 'columnNames');
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionValues, 'partitionValues');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetColumnStatisticsForPartition'
@@ -3874,29 +3106,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnNames, 'columnNames');
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetColumnStatisticsForTable'
@@ -3944,20 +3153,6 @@ class Glue {
     String? catalogId,
     bool? hidePassword,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetConnection'
@@ -4012,12 +3207,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4056,14 +3245,6 @@ class Glue {
   Future<GetCrawlerResponse> getCrawler({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetCrawler'
@@ -4176,12 +3357,6 @@ class Glue {
       getDataCatalogEncryptionSettings({
     String? catalogId,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetDataCatalogEncryptionSettings'
@@ -4219,20 +3394,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetDatabase'
@@ -4290,12 +3451,6 @@ class Glue {
     String? nextToken,
     ResourceShareType? resourceShareType,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4371,7 +3526,6 @@ class Glue {
   Future<GetDevEndpointResponse> getDevEndpoint({
     required String endpointName,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetDevEndpoint'
@@ -4449,14 +3603,6 @@ class Glue {
   Future<GetJobResponse> getJob({
     required String jobName,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetJob'
@@ -4492,7 +3638,6 @@ class Glue {
     required String jobName,
     String? runId,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetJobBookmark'
@@ -4532,22 +3677,6 @@ class Glue {
     required String runId,
     bool? predecessorsIncluded,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetJobRun'
@@ -4589,14 +3718,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4685,22 +3806,6 @@ class Glue {
     required String taskRunId,
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(taskRunId, 'taskRunId');
-    _s.validateStringLength(
-      'taskRunId',
-      taskRunId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetMLTaskRun'
@@ -4757,14 +3862,6 @@ class Glue {
     String? nextToken,
     TaskRunSortCriteria? sort,
   }) async {
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4811,14 +3908,6 @@ class Glue {
   Future<GetMLTransformResponse> getMLTransform({
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetMLTransform'
@@ -4913,7 +4002,6 @@ class Glue {
     Location? location,
     List<CatalogEntry>? sinks,
   }) async {
-    ArgumentError.checkNotNull(source, 'source');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetMapping'
@@ -4960,29 +4048,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionValues, 'partitionValues');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetPartition'
@@ -5031,28 +4096,6 @@ class Glue {
     String? catalogId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetPartitionIndexes'
@@ -5195,34 +4238,6 @@ class Glue {
     String? nextToken,
     Segment? segment,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'expression',
-      expression,
-      0,
-      2048,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5297,8 +4312,6 @@ class Glue {
     Location? location,
     List<CatalogEntry>? sinks,
   }) async {
-    ArgumentError.checkNotNull(mapping, 'mapping');
-    ArgumentError.checkNotNull(source, 'source');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetPlan'
@@ -5336,7 +4349,6 @@ class Glue {
   Future<GetRegistryResponse> getRegistry({
     required RegistryId registryId,
   }) async {
-    ArgumentError.checkNotNull(registryId, 'registryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetRegistry'
@@ -5417,12 +4429,6 @@ class Glue {
   Future<GetResourcePolicyResponse> getResourcePolicy({
     String? resourceArn,
   }) async {
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetResourcePolicy'
@@ -5467,7 +4473,6 @@ class Glue {
   Future<GetSchemaResponse> getSchema({
     required SchemaId schemaId,
   }) async {
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetSchema'
@@ -5519,15 +4524,6 @@ class Glue {
     required String schemaDefinition,
     required SchemaId schemaId,
   }) async {
-    ArgumentError.checkNotNull(schemaDefinition, 'schemaDefinition');
-    _s.validateStringLength(
-      'schemaDefinition',
-      schemaDefinition,
-      1,
-      170000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetSchemaByDefinition'
@@ -5585,12 +4581,6 @@ class Glue {
     String? schemaVersionId,
     SchemaVersionNumber? schemaVersionNumber,
   }) async {
-    _s.validateStringLength(
-      'schemaVersionId',
-      schemaVersionId,
-      36,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetSchemaVersion'
@@ -5653,12 +4643,6 @@ class Glue {
     required SchemaId schemaId,
     required SchemaVersionNumber secondSchemaVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(
-        firstSchemaVersionNumber, 'firstSchemaVersionNumber');
-    ArgumentError.checkNotNull(schemaDiffType, 'schemaDiffType');
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
-    ArgumentError.checkNotNull(
-        secondSchemaVersionNumber, 'secondSchemaVersionNumber');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetSchemaVersionsDiff'
@@ -5692,14 +4676,6 @@ class Glue {
   Future<GetSecurityConfigurationResponse> getSecurityConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetSecurityConfiguration'
@@ -5784,28 +4760,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetTable'
@@ -5856,34 +4810,6 @@ class Glue {
     String? catalogId,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetTableVersion'
@@ -5938,28 +4864,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6021,26 +4925,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'expression',
-      expression,
-      0,
-      2048,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6081,14 +4965,6 @@ class Glue {
   Future<GetTagsResponse> getTags({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetTags'
@@ -6119,14 +4995,6 @@ class Glue {
   Future<GetTriggerResponse> getTrigger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetTrigger'
@@ -6167,12 +5035,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'dependentJobName',
-      dependentJobName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6221,28 +5083,6 @@ class Glue {
     required String functionName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetUserDefinedFunction'
@@ -6296,26 +5136,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(pattern, 'pattern');
-    _s.validateStringLength(
-      'pattern',
-      pattern,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6361,14 +5181,6 @@ class Glue {
     required String name,
     bool? includeGraph,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetWorkflow'
@@ -6408,22 +5220,6 @@ class Glue {
     required String runId,
     bool? includeGraph,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetWorkflowRun'
@@ -6460,22 +5256,6 @@ class Glue {
     required String name,
     required String runId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.GetWorkflowRunProperties'
@@ -6519,14 +5299,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6565,12 +5337,6 @@ class Glue {
   Future<void> importCatalogToGlue({
     String? catalogId,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.ImportCatalogToGlue'
@@ -6888,7 +5654,6 @@ class Glue {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7001,12 +5766,6 @@ class Glue {
     String? nextToken,
     Map<String, String>? tags,
   }) async {
-    _s.validateStringLength(
-      'dependentJobName',
-      dependentJobName,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7092,14 +5851,6 @@ class Glue {
     required DataCatalogEncryptionSettings dataCatalogEncryptionSettings,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(
-        dataCatalogEncryptionSettings, 'dataCatalogEncryptionSettings');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.PutDataCatalogEncryptionSettings'
@@ -7162,26 +5913,6 @@ class Glue {
     String? policyHashCondition,
     String? resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policyInJson, 'policyInJson');
-    _s.validateStringLength(
-      'policyInJson',
-      policyInJson,
-      2,
-      10240,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'policyHashCondition',
-      policyHashCondition,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.PutResourcePolicy'
@@ -7233,13 +5964,6 @@ class Glue {
     String? schemaVersionId,
     SchemaVersionNumber? schemaVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(metadataKeyValue, 'metadataKeyValue');
-    _s.validateStringLength(
-      'schemaVersionId',
-      schemaVersionId,
-      36,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.PutSchemaVersionMetadata'
@@ -7287,23 +6011,6 @@ class Glue {
     required String runId,
     required Map<String, String> runProperties,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runProperties, 'runProperties');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.PutWorkflowRunProperties'
@@ -7361,12 +6068,6 @@ class Glue {
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'schemaVersionId',
-      schemaVersionId,
-      36,
-      36,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -7437,15 +6138,6 @@ class Glue {
     required String schemaDefinition,
     required SchemaId schemaId,
   }) async {
-    ArgumentError.checkNotNull(schemaDefinition, 'schemaDefinition');
-    _s.validateStringLength(
-      'schemaDefinition',
-      schemaDefinition,
-      1,
-      170000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.RegisterSchemaVersion'
@@ -7490,13 +6182,6 @@ class Glue {
     String? schemaVersionId,
     SchemaVersionNumber? schemaVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(metadataKeyValue, 'metadataKeyValue');
-    _s.validateStringLength(
-      'schemaVersionId',
-      schemaVersionId,
-      36,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.RemoveSchemaVersionMetadata'
@@ -7535,7 +6220,6 @@ class Glue {
     required String jobName,
     String? runId,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.ResetJobBookmark'
@@ -7580,23 +6264,6 @@ class Glue {
     required List<String> nodeIds,
     required String runId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeIds, 'nodeIds');
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.ResumeWorkflowRun'
@@ -7691,23 +6358,11 @@ class Glue {
     String? searchText,
     List<SortCriterion>? sortCriteria,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'searchText',
-      searchText,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -7747,14 +6402,6 @@ class Glue {
   Future<void> startCrawler({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartCrawler'
@@ -7786,14 +6433,6 @@ class Glue {
   Future<void> startCrawlerSchedule({
     required String crawlerName,
   }) async {
-    ArgumentError.checkNotNull(crawlerName, 'crawlerName');
-    _s.validateStringLength(
-      'crawlerName',
-      crawlerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartCrawlerSchedule'
@@ -7835,15 +6474,6 @@ class Glue {
     required String outputS3Path,
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(outputS3Path, 'outputS3Path');
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartExportLabelsTaskRun'
@@ -7914,15 +6544,6 @@ class Glue {
     required String transformId,
     bool? replaceAllLabels,
   }) async {
-    ArgumentError.checkNotNull(inputS3Path, 'inputS3Path');
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartImportLabelsTaskRun'
@@ -8063,26 +6684,6 @@ class Glue {
     int? timeout,
     WorkerType? workerType,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'jobRunId',
-      jobRunId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'securityConfiguration',
-      securityConfiguration,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'timeout',
       timeout,
@@ -8140,14 +6741,6 @@ class Glue {
   Future<StartMLEvaluationTaskRunResponse> startMLEvaluationTaskRun({
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartMLEvaluationTaskRun'
@@ -8201,15 +6794,6 @@ class Glue {
     required String outputS3Path,
     required String transformId,
   }) async {
-    ArgumentError.checkNotNull(outputS3Path, 'outputS3Path');
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartMLLabelingSetGenerationTaskRun'
@@ -8246,14 +6830,6 @@ class Glue {
   Future<StartTriggerResponse> startTrigger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartTrigger'
@@ -8286,14 +6862,6 @@ class Glue {
   Future<StartWorkflowRunResponse> startWorkflowRun({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StartWorkflowRun'
@@ -8324,14 +6892,6 @@ class Glue {
   Future<void> stopCrawler({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StopCrawler'
@@ -8362,14 +6922,6 @@ class Glue {
   Future<void> stopCrawlerSchedule({
     required String crawlerName,
   }) async {
-    ArgumentError.checkNotNull(crawlerName, 'crawlerName');
-    _s.validateStringLength(
-      'crawlerName',
-      crawlerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StopCrawlerSchedule'
@@ -8399,14 +6951,6 @@ class Glue {
   Future<StopTriggerResponse> stopTrigger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StopTrigger'
@@ -8442,22 +6986,6 @@ class Glue {
     required String name,
     required String runId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runId, 'runId');
-    _s.validateStringLength(
-      'runId',
-      runId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.StopWorkflowRun'
@@ -8498,15 +7026,6 @@ class Glue {
     required String resourceArn,
     required Map<String, String> tagsToAdd,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagsToAdd, 'tagsToAdd');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.TagResource'
@@ -8541,15 +7060,6 @@ class Glue {
     required String resourceArn,
     required List<String> tagsToRemove,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      10240,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagsToRemove, 'tagsToRemove');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UntagResource'
@@ -8646,30 +7156,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnStatisticsList, 'columnStatisticsList');
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionValues, 'partitionValues');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateColumnStatisticsForPartition'
@@ -8723,29 +7209,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(columnStatisticsList, 'columnStatisticsList');
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateColumnStatisticsForTable'
@@ -8790,21 +7253,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(connectionInput, 'connectionInput');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateConnection'
@@ -8897,32 +7345,6 @@ class Glue {
     String? tablePrefix,
     CrawlerTargets? targets,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'crawlerSecurityConfiguration',
-      crawlerSecurityConfiguration,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'tablePrefix',
-      tablePrefix,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateCrawler'
@@ -8975,14 +7397,6 @@ class Glue {
     required String crawlerName,
     String? schedule,
   }) async {
-    ArgumentError.checkNotNull(crawlerName, 'crawlerName');
-    _s.validateStringLength(
-      'crawlerName',
-      crawlerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateCrawlerSchedule'
@@ -9024,21 +7438,6 @@ class Glue {
     required String name,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseInput, 'databaseInput');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateDatabase'
@@ -9121,7 +7520,6 @@ class Glue {
     String? publicKey,
     bool? updateEtlLibraries,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateDevEndpoint'
@@ -9163,15 +7561,6 @@ class Glue {
     required String jobName,
     required JobUpdate jobUpdate,
   }) async {
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobUpdate, 'jobUpdate');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateJob'
@@ -9287,32 +7676,6 @@ class Glue {
     int? timeout,
     WorkerType? workerType,
   }) async {
-    ArgumentError.checkNotNull(transformId, 'transformId');
-    _s.validateStringLength(
-      'transformId',
-      transformId,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'glueVersion',
-      glueVersion,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'timeout',
       timeout,
@@ -9381,30 +7744,6 @@ class Glue {
     required String tableName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partitionInput, 'partitionInput');
-    ArgumentError.checkNotNull(partitionValueList, 'partitionValueList');
-    ArgumentError.checkNotNull(tableName, 'tableName');
-    _s.validateStringLength(
-      'tableName',
-      tableName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdatePartition'
@@ -9446,15 +7785,6 @@ class Glue {
     required String description,
     required RegistryId registryId,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(registryId, 'registryId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateRegistry'
@@ -9526,13 +7856,6 @@ class Glue {
     String? description,
     SchemaVersionNumber? schemaVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(schemaId, 'schemaId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateSchema'
@@ -9587,21 +7910,6 @@ class Glue {
     String? catalogId,
     bool? skipArchive,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tableInput, 'tableInput');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateTable'
@@ -9638,15 +7946,6 @@ class Glue {
     required String name,
     required TriggerUpdate triggerUpdate,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(triggerUpdate, 'triggerUpdate');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateTrigger'
@@ -9694,29 +7993,6 @@ class Glue {
     required String functionName,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(databaseName, 'databaseName');
-    _s.validateStringLength(
-      'databaseName',
-      databaseName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionInput, 'functionInput');
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateUserDefinedFunction'
@@ -9766,14 +8042,6 @@ class Glue {
     String? description,
     int? maxConcurrentRuns,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSGlue.UpdateWorkflow'

--- a/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
+++ b/generated/aws_greengrass_api/lib/greengrass-2017-06-07.dart
@@ -71,8 +71,6 @@ class Greengrass {
     required String groupId,
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $payload = <String, dynamic>{
       'RoleArn': roleArn,
     };
@@ -98,7 +96,6 @@ class Greengrass {
   Future<AssociateServiceRoleToAccountResponse> associateServiceRoleToAccount({
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $payload = <String, dynamic>{
       'RoleArn': roleArn,
     };
@@ -173,7 +170,6 @@ class Greengrass {
     String? amznClientToken,
     List<Connector>? connectors,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -252,7 +248,6 @@ class Greengrass {
     String? amznClientToken,
     List<Core>? cores,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -298,8 +293,6 @@ class Greengrass {
     String? deploymentId,
     String? groupVersionId,
   }) async {
-    ArgumentError.checkNotNull(deploymentType, 'deploymentType');
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -379,7 +372,6 @@ class Greengrass {
     String? amznClientToken,
     List<Device>? devices,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -467,7 +459,6 @@ class Greengrass {
     FunctionDefaultConfig? defaultConfig,
     List<$Function>? functions,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -547,7 +538,6 @@ class Greengrass {
     required String groupId,
     String? amznClientToken,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -604,7 +594,6 @@ class Greengrass {
     String? resourceDefinitionVersionArn,
     String? subscriptionDefinitionVersionArn,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -694,7 +683,6 @@ class Greengrass {
     String? amznClientToken,
     List<Logger>? loggers,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -774,7 +762,6 @@ class Greengrass {
     String? amznClientToken,
     List<Resource>? resources,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -813,13 +800,6 @@ class Greengrass {
     String? amznClientToken,
     UpdateAgentLogLevel? updateAgentLogLevel,
   }) async {
-    ArgumentError.checkNotNull(s3UrlSignerRole, 's3UrlSignerRole');
-    ArgumentError.checkNotNull(softwareToUpdate, 'softwareToUpdate');
-    ArgumentError.checkNotNull(updateTargets, 'updateTargets');
-    ArgumentError.checkNotNull(
-        updateTargetsArchitecture, 'updateTargetsArchitecture');
-    ArgumentError.checkNotNull(
-        updateTargetsOperatingSystem, 'updateTargetsOperatingSystem');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -904,8 +884,6 @@ class Greengrass {
     String? amznClientToken,
     List<Subscription>? subscriptions,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -933,7 +911,6 @@ class Greengrass {
   Future<void> deleteConnectorDefinition({
     required String connectorDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -952,7 +929,6 @@ class Greengrass {
   Future<void> deleteCoreDefinition({
     required String coreDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -971,7 +947,6 @@ class Greengrass {
   Future<void> deleteDeviceDefinition({
     required String deviceDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -990,7 +965,6 @@ class Greengrass {
   Future<void> deleteFunctionDefinition({
     required String functionDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1009,7 +983,6 @@ class Greengrass {
   Future<void> deleteGroup({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1027,7 +1000,6 @@ class Greengrass {
   Future<void> deleteLoggerDefinition({
     required String loggerDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1046,7 +1018,6 @@ class Greengrass {
   Future<void> deleteResourceDefinition({
     required String resourceDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1065,8 +1036,6 @@ class Greengrass {
   Future<void> deleteSubscriptionDefinition({
     required String subscriptionDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1086,7 +1055,6 @@ class Greengrass {
   Future<DisassociateRoleFromGroupResponse> disassociateRoleFromGroup({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1121,7 +1089,6 @@ class Greengrass {
   Future<GetAssociatedRoleResponse> getAssociatedRole({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1140,7 +1107,6 @@ class Greengrass {
   Future<GetBulkDeploymentStatusResponse> getBulkDeploymentStatus({
     required String bulkDeploymentId,
   }) async {
-    ArgumentError.checkNotNull(bulkDeploymentId, 'bulkDeploymentId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1161,7 +1127,6 @@ class Greengrass {
   Future<GetConnectivityInfoResponse> getConnectivityInfo({
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1181,7 +1146,6 @@ class Greengrass {
   Future<GetConnectorDefinitionResponse> getConnectorDefinition({
     required String connectorDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1218,9 +1182,6 @@ class Greengrass {
     required String connectorDefinitionVersionId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
-    ArgumentError.checkNotNull(
-        connectorDefinitionVersionId, 'connectorDefinitionVersionId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -1244,7 +1205,6 @@ class Greengrass {
   Future<GetCoreDefinitionResponse> getCoreDefinition({
     required String coreDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1273,9 +1233,6 @@ class Greengrass {
     required String coreDefinitionId,
     required String coreDefinitionVersionId,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
-    ArgumentError.checkNotNull(
-        coreDefinitionVersionId, 'coreDefinitionVersionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1299,8 +1256,6 @@ class Greengrass {
     required String deploymentId,
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1320,7 +1275,6 @@ class Greengrass {
   Future<GetDeviceDefinitionResponse> getDeviceDefinition({
     required String deviceDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1354,9 +1308,6 @@ class Greengrass {
     required String deviceDefinitionVersionId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
-    ArgumentError.checkNotNull(
-        deviceDefinitionVersionId, 'deviceDefinitionVersionId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -1381,7 +1332,6 @@ class Greengrass {
   Future<GetFunctionDefinitionResponse> getFunctionDefinition({
     required String functionDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1417,9 +1367,6 @@ class Greengrass {
     required String functionDefinitionVersionId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
-    ArgumentError.checkNotNull(
-        functionDefinitionVersionId, 'functionDefinitionVersionId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -1443,7 +1390,6 @@ class Greengrass {
   Future<GetGroupResponse> getGroup({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1468,9 +1414,6 @@ class Greengrass {
     required String certificateAuthorityId,
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateAuthorityId, 'certificateAuthorityId');
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1492,7 +1435,6 @@ class Greengrass {
       getGroupCertificateConfiguration({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1520,8 +1462,6 @@ class Greengrass {
     required String groupId,
     required String groupVersionId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    ArgumentError.checkNotNull(groupVersionId, 'groupVersionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1541,7 +1481,6 @@ class Greengrass {
   Future<GetLoggerDefinitionResponse> getLoggerDefinition({
     required String loggerDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1575,9 +1514,6 @@ class Greengrass {
     required String loggerDefinitionVersionId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
-    ArgumentError.checkNotNull(
-        loggerDefinitionVersionId, 'loggerDefinitionVersionId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -1602,7 +1538,6 @@ class Greengrass {
   Future<GetResourceDefinitionResponse> getResourceDefinition({
     required String resourceDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1632,9 +1567,6 @@ class Greengrass {
     required String resourceDefinitionId,
     required String resourceDefinitionVersionId,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
-    ArgumentError.checkNotNull(
-        resourceDefinitionVersionId, 'resourceDefinitionVersionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1667,8 +1599,6 @@ class Greengrass {
   Future<GetSubscriptionDefinitionResponse> getSubscriptionDefinition({
     required String subscriptionDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1703,10 +1633,6 @@ class Greengrass {
     required String subscriptionDefinitionVersionId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionVersionId, 'subscriptionDefinitionVersionId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -1731,7 +1657,6 @@ class Greengrass {
   Future<GetThingRuntimeConfigurationResponse> getThingRuntimeConfiguration({
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1762,7 +1687,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(bulkDeploymentId, 'bulkDeploymentId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -1828,7 +1752,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -1888,7 +1811,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -1948,7 +1870,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -1982,7 +1903,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2043,7 +1963,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2096,7 +2015,6 @@ class Greengrass {
       listGroupCertificateAuthorities({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2125,7 +2043,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2184,7 +2101,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2245,7 +2161,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2306,8 +2221,6 @@ class Greengrass {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -2358,7 +2271,6 @@ class Greengrass {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2385,7 +2297,6 @@ class Greengrass {
     String? amznClientToken,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -2438,8 +2349,6 @@ class Greengrass {
     String? amznClientToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(executionRoleArn, 'executionRoleArn');
-    ArgumentError.checkNotNull(inputFileUri, 'inputFileUri');
     final headers = <String, String>{
       if (amznClientToken != null)
         'X-Amzn-Client-Token': amznClientToken.toString(),
@@ -2472,7 +2381,6 @@ class Greengrass {
   Future<void> stopBulkDeployment({
     required String bulkDeploymentId,
   }) async {
-    ArgumentError.checkNotNull(bulkDeploymentId, 'bulkDeploymentId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -2495,7 +2403,6 @@ class Greengrass {
     required String resourceArn,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
     };
@@ -2520,8 +2427,6 @@ class Greengrass {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2550,7 +2455,6 @@ class Greengrass {
     required String thingName,
     List<ConnectivityInfo>? connectivityInfo,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
     final $payload = <String, dynamic>{
       if (connectivityInfo != null) 'ConnectivityInfo': connectivityInfo,
     };
@@ -2577,7 +2481,6 @@ class Greengrass {
     required String connectorDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(connectorDefinitionId, 'connectorDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2603,7 +2506,6 @@ class Greengrass {
     required String coreDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(coreDefinitionId, 'coreDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2629,7 +2531,6 @@ class Greengrass {
     required String deviceDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(deviceDefinitionId, 'deviceDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2655,7 +2556,6 @@ class Greengrass {
     required String functionDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(functionDefinitionId, 'functionDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2681,7 +2581,6 @@ class Greengrass {
     required String groupId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2709,7 +2608,6 @@ class Greengrass {
     required String groupId,
     String? certificateExpiryInMilliseconds,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final $payload = <String, dynamic>{
       if (certificateExpiryInMilliseconds != null)
         'CertificateExpiryInMilliseconds': certificateExpiryInMilliseconds,
@@ -2737,7 +2635,6 @@ class Greengrass {
     required String loggerDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(loggerDefinitionId, 'loggerDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2763,7 +2660,6 @@ class Greengrass {
     required String resourceDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(resourceDefinitionId, 'resourceDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2789,8 +2685,6 @@ class Greengrass {
     required String subscriptionDefinitionId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(
-        subscriptionDefinitionId, 'subscriptionDefinitionId');
     final $payload = <String, dynamic>{
       if (name != null) 'Name': name,
     };
@@ -2817,7 +2711,6 @@ class Greengrass {
     required String thingName,
     TelemetryConfigurationUpdate? telemetryConfiguration,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
     final $payload = <String, dynamic>{
       if (telemetryConfiguration != null)
         'TelemetryConfiguration': telemetryConfiguration,

--- a/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
+++ b/generated/aws_greengrass_api/lib/greengrassv2-2020-11-30.dart
@@ -80,14 +80,6 @@ class GreengrassV2 {
   Future<CancelDeploymentResponse> cancelDeployment({
     required String deploymentId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    _s.validateStringLength(
-      'deploymentId',
-      deploymentId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -266,13 +258,6 @@ class GreengrassV2 {
     DeploymentIoTJobConfiguration? iotJobConfiguration,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(targetArn, 'targetArn');
-    _s.validateStringLength(
-      'deploymentName',
-      deploymentName,
-      1,
-      1152921504606846976,
-    );
     final $payload = <String, dynamic>{
       'targetArn': targetArn,
       if (components != null) 'components': components,
@@ -313,7 +298,6 @@ class GreengrassV2 {
   Future<void> deleteComponent({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -341,14 +325,6 @@ class GreengrassV2 {
   Future<void> deleteCoreDevice({
     required String coreDeviceThingName,
   }) async {
-    ArgumentError.checkNotNull(coreDeviceThingName, 'coreDeviceThingName');
-    _s.validateStringLength(
-      'coreDeviceThingName',
-      coreDeviceThingName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -373,7 +349,6 @@ class GreengrassV2 {
   Future<DescribeComponentResponse> describeComponent({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -405,7 +380,6 @@ class GreengrassV2 {
     required String arn,
     RecipeOutputFormat? recipeOutputFormat,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $query = <String, List<String>>{
       if (recipeOutputFormat != null)
         'recipeOutputFormat': [recipeOutputFormat.toValue()],
@@ -441,15 +415,6 @@ class GreengrassV2 {
     required String arn,
     required String artifactName,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(artifactName, 'artifactName');
-    _s.validateStringLength(
-      'artifactName',
-      artifactName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -473,14 +438,6 @@ class GreengrassV2 {
   Future<GetCoreDeviceResponse> getCoreDevice({
     required String coreDeviceThingName,
   }) async {
-    ArgumentError.checkNotNull(coreDeviceThingName, 'coreDeviceThingName');
-    _s.validateStringLength(
-      'coreDeviceThingName',
-      coreDeviceThingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -505,14 +462,6 @@ class GreengrassV2 {
   Future<GetDeploymentResponse> getDeployment({
     required String deploymentId,
   }) async {
-    ArgumentError.checkNotNull(deploymentId, 'deploymentId');
-    _s.validateStringLength(
-      'deploymentId',
-      deploymentId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -546,7 +495,6 @@ class GreengrassV2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -757,14 +705,6 @@ class GreengrassV2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(coreDeviceThingName, 'coreDeviceThingName');
-    _s.validateStringLength(
-      'coreDeviceThingName',
-      coreDeviceThingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -808,14 +748,6 @@ class GreengrassV2 {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(coreDeviceThingName, 'coreDeviceThingName');
-    _s.validateStringLength(
-      'coreDeviceThingName',
-      coreDeviceThingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -850,7 +782,6 @@ class GreengrassV2 {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -900,8 +831,6 @@ class GreengrassV2 {
     required List<ComponentCandidate> componentCandidates,
     required ComponentPlatform platform,
   }) async {
-    ArgumentError.checkNotNull(componentCandidates, 'componentCandidates');
-    ArgumentError.checkNotNull(platform, 'platform');
     final $payload = <String, dynamic>{
       'componentCandidates': componentCandidates,
       'platform': platform,
@@ -936,8 +865,6 @@ class GreengrassV2 {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -966,8 +893,6 @@ class GreengrassV2 {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
+++ b/generated/aws_groundstation_api/lib/groundstation-2019-05-23.dart
@@ -63,7 +63,6 @@ class GroundStation {
   Future<ContactIdResponse> cancelContact({
     required String contactId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -96,15 +95,6 @@ class GroundStation {
     required String name,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(configData, 'configData');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'configData': configData,
       'name': name,
@@ -143,7 +133,6 @@ class GroundStation {
     required List<EndpointDetails> endpointDetails,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(endpointDetails, 'endpointDetails');
     final $payload = <String, dynamic>{
       'endpointDetails': endpointDetails,
       if (tags != null) 'tags': tags,
@@ -200,9 +189,6 @@ class GroundStation {
     int? contactPrePassDurationSeconds,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(dataflowEdges, 'dataflowEdges');
-    ArgumentError.checkNotNull(minimumViableContactDurationSeconds,
-        'minimumViableContactDurationSeconds');
     _s.validateNumRange(
       'minimumViableContactDurationSeconds',
       minimumViableContactDurationSeconds,
@@ -210,15 +196,6 @@ class GroundStation {
       21600,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trackingConfigArn, 'trackingConfigArn');
     _s.validateNumRange(
       'contactPostPassDurationSeconds',
       contactPostPassDurationSeconds,
@@ -267,8 +244,6 @@ class GroundStation {
     required String configId,
     required ConfigCapabilityType configType,
   }) async {
-    ArgumentError.checkNotNull(configId, 'configId');
-    ArgumentError.checkNotNull(configType, 'configType');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -290,8 +265,6 @@ class GroundStation {
   Future<DataflowEndpointGroupIdResponse> deleteDataflowEndpointGroup({
     required String dataflowEndpointGroupId,
   }) async {
-    ArgumentError.checkNotNull(
-        dataflowEndpointGroupId, 'dataflowEndpointGroupId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -313,7 +286,6 @@ class GroundStation {
   Future<MissionProfileIdResponse> deleteMissionProfile({
     required String missionProfileId,
   }) async {
-    ArgumentError.checkNotNull(missionProfileId, 'missionProfileId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -334,7 +306,6 @@ class GroundStation {
   Future<DescribeContactResponse> describeContact({
     required String contactId,
   }) async {
-    ArgumentError.checkNotNull(contactId, 'contactId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -361,8 +332,6 @@ class GroundStation {
     required String configId,
     required ConfigCapabilityType configType,
   }) async {
-    ArgumentError.checkNotNull(configId, 'configId');
-    ArgumentError.checkNotNull(configType, 'configType');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -384,8 +353,6 @@ class GroundStation {
   Future<GetDataflowEndpointGroupResponse> getDataflowEndpointGroup({
     required String dataflowEndpointGroupId,
   }) async {
-    ArgumentError.checkNotNull(
-        dataflowEndpointGroupId, 'dataflowEndpointGroupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -411,8 +378,6 @@ class GroundStation {
     required int month,
     required int year,
   }) async {
-    ArgumentError.checkNotNull(month, 'month');
-    ArgumentError.checkNotNull(year, 'year');
     final $payload = <String, dynamic>{
       'month': month,
       'year': year,
@@ -437,7 +402,6 @@ class GroundStation {
   Future<GetMissionProfileResponse> getMissionProfile({
     required String missionProfileId,
   }) async {
-    ArgumentError.checkNotNull(missionProfileId, 'missionProfileId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -458,7 +422,6 @@ class GroundStation {
   Future<GetSatelliteResponse> getSatellite({
     required String satelliteId,
   }) async {
-    ArgumentError.checkNotNull(satelliteId, 'satelliteId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -542,9 +505,6 @@ class GroundStation {
     String? nextToken,
     String? satelliteArn,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statusList, 'statusList');
     final $payload = <String, dynamic>{
       'endTime': unixTimestampToJson(endTime),
       'startTime': unixTimestampToJson(startTime),
@@ -702,7 +662,6 @@ class GroundStation {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -743,11 +702,6 @@ class GroundStation {
     required DateTime startTime,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(groundStation, 'groundStation');
-    ArgumentError.checkNotNull(missionProfileArn, 'missionProfileArn');
-    ArgumentError.checkNotNull(satelliteArn, 'satelliteArn');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $payload = <String, dynamic>{
       'endTime': unixTimestampToJson(endTime),
       'groundStation': groundStation,
@@ -780,8 +734,6 @@ class GroundStation {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -808,8 +760,6 @@ class GroundStation {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -848,17 +798,6 @@ class GroundStation {
     required ConfigCapabilityType configType,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(configData, 'configData');
-    ArgumentError.checkNotNull(configId, 'configId');
-    ArgumentError.checkNotNull(configType, 'configType');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'configData': configData,
       'name': name,
@@ -916,7 +855,6 @@ class GroundStation {
     String? name,
     String? trackingConfigArn,
   }) async {
-    ArgumentError.checkNotNull(missionProfileId, 'missionProfileId');
     _s.validateNumRange(
       'contactPostPassDurationSeconds',
       contactPostPassDurationSeconds,
@@ -934,12 +872,6 @@ class GroundStation {
       minimumViableContactDurationSeconds,
       1,
       21600,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
     );
     final $payload = <String, dynamic>{
       if (contactPostPassDurationSeconds != null)

--- a/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
+++ b/generated/aws_guardduty_api/lib/guardduty-2017-11-28.dart
@@ -88,16 +88,6 @@ class GuardDuty {
     required String invitationId,
     required String masterId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(invitationId, 'invitationId');
-    ArgumentError.checkNotNull(masterId, 'masterId');
     final $payload = <String, dynamic>{
       'invitationId': invitationId,
       'masterId': masterId,
@@ -129,15 +119,6 @@ class GuardDuty {
     required String detectorId,
     required List<String> findingIds,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(findingIds, 'findingIds');
     final $payload = <String, dynamic>{
       'findingIds': findingIds,
     };
@@ -180,13 +161,6 @@ class GuardDuty {
     FindingPublishingFrequency? findingPublishingFrequency,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(enable, 'enable');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'enable': enable,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -412,35 +386,6 @@ class GuardDuty {
     int? rank,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(findingCriteria, 'findingCriteria');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'rank',
       rank,
@@ -509,38 +454,6 @@ class GuardDuty {
     String? clientToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(activate, 'activate');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(format, 'format');
-    ArgumentError.checkNotNull(location, 'location');
-    _s.validateStringLength(
-      'location',
-      location,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'activate': activate,
       'format': format.toValue(),
@@ -586,15 +499,6 @@ class GuardDuty {
     required List<AccountDetail> accountDetails,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountDetails, 'accountDetails');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountDetails': accountDetails,
     };
@@ -633,22 +537,6 @@ class GuardDuty {
     required String detectorId,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(destinationProperties, 'destinationProperties');
-    ArgumentError.checkNotNull(destinationType, 'destinationType');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'destinationProperties': destinationProperties,
       'destinationType': destinationType.toValue(),
@@ -680,14 +568,6 @@ class GuardDuty {
     required String detectorId,
     List<String>? findingTypes,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (findingTypes != null) 'findingTypes': findingTypes,
     };
@@ -741,38 +621,6 @@ class GuardDuty {
     String? clientToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(activate, 'activate');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(format, 'format');
-    ArgumentError.checkNotNull(location, 'location');
-    _s.validateStringLength(
-      'location',
-      location,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'activate': activate,
       'format': format.toValue(),
@@ -802,7 +650,6 @@ class GuardDuty {
   Future<DeclineInvitationsResponse> declineInvitations({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -825,14 +672,6 @@ class GuardDuty {
   Future<void> deleteDetector({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -855,15 +694,6 @@ class GuardDuty {
     required String detectorId,
     required String filterName,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterName, 'filterName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -888,15 +718,6 @@ class GuardDuty {
     required String detectorId,
     required String ipSetId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ipSetId, 'ipSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -918,7 +739,6 @@ class GuardDuty {
   Future<DeleteInvitationsResponse> deleteInvitations({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -948,15 +768,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -985,15 +796,6 @@ class GuardDuty {
     required String destinationId,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(destinationId, 'destinationId');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1017,15 +819,6 @@ class GuardDuty {
     required String detectorId,
     required String threatIntelSetId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(threatIntelSetId, 'threatIntelSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1048,14 +841,6 @@ class GuardDuty {
       describeOrganizationConfiguration({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1081,15 +866,6 @@ class GuardDuty {
     required String destinationId,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(destinationId, 'destinationId');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1112,7 +888,6 @@ class GuardDuty {
   Future<void> disableOrganizationAdminAccount({
     required String adminAccountId,
   }) async {
-    ArgumentError.checkNotNull(adminAccountId, 'adminAccountId');
     final $payload = <String, dynamic>{
       'adminAccountId': adminAccountId,
     };
@@ -1135,14 +910,6 @@ class GuardDuty {
   Future<void> disassociateFromMasterAccount({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1169,15 +936,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -1203,7 +961,6 @@ class GuardDuty {
   Future<void> enableOrganizationAdminAccount({
     required String adminAccountId,
   }) async {
-    ArgumentError.checkNotNull(adminAccountId, 'adminAccountId');
     final $payload = <String, dynamic>{
       'adminAccountId': adminAccountId,
     };
@@ -1225,14 +982,6 @@ class GuardDuty {
   Future<GetDetectorResponse> getDetector({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1256,15 +1005,6 @@ class GuardDuty {
     required String detectorId,
     required String filterName,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterName, 'filterName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1294,15 +1034,6 @@ class GuardDuty {
     required List<String> findingIds,
     SortCriteria? sortCriteria,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(findingIds, 'findingIds');
     final $payload = <String, dynamic>{
       'findingIds': findingIds,
       if (sortCriteria != null) 'sortCriteria': sortCriteria,
@@ -1335,15 +1066,6 @@ class GuardDuty {
     required List<FindingStatisticType> findingStatisticTypes,
     FindingCriteria? findingCriteria,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(findingStatisticTypes, 'findingStatisticTypes');
     final $payload = <String, dynamic>{
       'findingStatisticTypes':
           findingStatisticTypes.map((e) => e.toValue()).toList(),
@@ -1373,15 +1095,6 @@ class GuardDuty {
     required String detectorId,
     required String ipSetId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ipSetId, 'ipSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1418,14 +1131,6 @@ class GuardDuty {
   Future<GetMasterAccountResponse> getMasterAccount({
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1450,15 +1155,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -1489,15 +1185,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -1524,15 +1211,6 @@ class GuardDuty {
     required String detectorId,
     required String threatIntelSetId,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(threatIntelSetId, 'threatIntelSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1584,16 +1262,6 @@ class GuardDuty {
     String? nextToken,
     String? unit,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(usageCriteria, 'usageCriteria');
-    ArgumentError.checkNotNull(usageStatisticType, 'usageStatisticType');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1647,15 +1315,6 @@ class GuardDuty {
     bool? disableEmailNotification,
     String? message,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
       if (disableEmailNotification != null)
@@ -1733,14 +1392,6 @@ class GuardDuty {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1948,14 +1599,6 @@ class GuardDuty {
     String? nextToken,
     SortCriteria? sortCriteria,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2001,14 +1644,6 @@ class GuardDuty {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2098,14 +1733,6 @@ class GuardDuty {
     String? nextToken,
     String? onlyAssociated,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2188,14 +1815,6 @@ class GuardDuty {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2230,7 +1849,6 @@ class GuardDuty {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2265,14 +1883,6 @@ class GuardDuty {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2311,15 +1921,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -2349,15 +1950,6 @@ class GuardDuty {
     required List<String> accountIds,
     required String detectorId,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
     };
@@ -2385,8 +1977,6 @@ class GuardDuty {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -2412,15 +2002,6 @@ class GuardDuty {
     required String detectorId,
     required List<String> findingIds,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(findingIds, 'findingIds');
     final $payload = <String, dynamic>{
       'findingIds': findingIds,
     };
@@ -2447,8 +2028,6 @@ class GuardDuty {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2484,14 +2063,6 @@ class GuardDuty {
     bool? enable,
     FindingPublishingFrequency? findingPublishingFrequency,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (dataSources != null) 'dataSources': dataSources,
       if (enable != null) 'enable': enable,
@@ -2539,21 +2110,6 @@ class GuardDuty {
     FindingCriteria? findingCriteria,
     int? rank,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterName, 'filterName');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     _s.validateNumRange(
       'rank',
       rank,
@@ -2599,16 +2155,6 @@ class GuardDuty {
     required List<String> findingIds,
     String? comments,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(feedback, 'feedback');
-    ArgumentError.checkNotNull(findingIds, 'findingIds');
     final $payload = <String, dynamic>{
       'feedback': feedback.toValue(),
       'findingIds': findingIds,
@@ -2652,27 +2198,6 @@ class GuardDuty {
     String? location,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ipSetId, 'ipSetId');
-    _s.validateStringLength(
-      'location',
-      location,
-      1,
-      300,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      300,
-    );
     final $payload = <String, dynamic>{
       if (activate != null) 'activate': activate,
       if (location != null) 'location': location,
@@ -2705,15 +2230,6 @@ class GuardDuty {
     required String detectorId,
     DataSourceConfigurations? dataSources,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'accountIds': accountIds,
       if (dataSources != null) 'dataSources': dataSources,
@@ -2747,15 +2263,6 @@ class GuardDuty {
     required String detectorId,
     OrganizationDataSourceConfigurations? dataSources,
   }) async {
-    ArgumentError.checkNotNull(autoEnable, 'autoEnable');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'autoEnable': autoEnable,
       if (dataSources != null) 'dataSources': dataSources,
@@ -2790,15 +2297,6 @@ class GuardDuty {
     required String detectorId,
     DestinationProperties? destinationProperties,
   }) async {
-    ArgumentError.checkNotNull(destinationId, 'destinationId');
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (destinationProperties != null)
         'destinationProperties': destinationProperties,
@@ -2840,27 +2338,6 @@ class GuardDuty {
     String? location,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(detectorId, 'detectorId');
-    _s.validateStringLength(
-      'detectorId',
-      detectorId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(threatIntelSetId, 'threatIntelSetId');
-    _s.validateStringLength(
-      'location',
-      location,
-      1,
-      300,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      300,
-    );
     final $payload = <String, dynamic>{
       if (activate != null) 'activate': activate,
       if (location != null) 'location': location,

--- a/generated/aws_health_api/lib/health-2016-08-04.dart
+++ b/generated/aws_health_api/lib/health-2016-08-04.dart
@@ -98,25 +98,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(eventArn, 'eventArn');
-    _s.validateStringLength(
-      'eventArn',
-      eventArn,
-      0,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -180,24 +166,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(filter, 'filter');
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -267,25 +240,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationEntityFilters, 'organizationEntityFilters');
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -371,18 +330,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(aggregateField, 'aggregateField');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -432,13 +384,6 @@ class Health {
     required List<String> eventArns,
     String? locale,
   }) async {
-    ArgumentError.checkNotNull(eventArns, 'eventArns');
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHealth_20160804.DescribeEventDetails'
@@ -509,14 +454,6 @@ class Health {
     required List<EventAccountFilter> organizationEventDetailFilters,
     String? locale,
   }) async {
-    ArgumentError.checkNotNull(
-        organizationEventDetailFilters, 'organizationEventDetailFilters');
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSHealth_20160804.DescribeEventDetailsForOrganization'
@@ -571,23 +508,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -667,23 +592,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -771,23 +684,11 @@ class Health {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'locale',
-      locale,
-      2,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       10,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',

--- a/generated/aws_iam_api/lib/iam-2010-05-08.dart
+++ b/generated/aws_iam_api/lib/iam-2010-05-08.dart
@@ -83,23 +83,6 @@ class IAM {
     required String clientID,
     required String openIDConnectProviderArn,
   }) async {
-    ArgumentError.checkNotNull(clientID, 'clientID');
-    _s.validateStringLength(
-      'clientID',
-      clientID,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        openIDConnectProviderArn, 'openIDConnectProviderArn');
-    _s.validateStringLength(
-      'openIDConnectProviderArn',
-      openIDConnectProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClientID'] = clientID;
     $request['OpenIDConnectProviderArn'] = openIDConnectProviderArn;
@@ -164,22 +147,6 @@ class IAM {
     required String instanceProfileName,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['InstanceProfileName'] = instanceProfileName;
     $request['RoleName'] = roleName;
@@ -220,22 +187,6 @@ class IAM {
     required String groupName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['UserName'] = userName;
@@ -285,22 +236,6 @@ class IAM {
     required String groupName,
     required String policyArn,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['PolicyArn'] = policyArn;
@@ -357,22 +292,6 @@ class IAM {
     required String policyArn,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['RoleName'] = roleName;
@@ -422,22 +341,6 @@ class IAM {
     required String policyArn,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['UserName'] = userName;
@@ -490,22 +393,6 @@ class IAM {
     required String newPassword,
     required String oldPassword,
   }) async {
-    ArgumentError.checkNotNull(newPassword, 'newPassword');
-    _s.validateStringLength(
-      'newPassword',
-      newPassword,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(oldPassword, 'oldPassword');
-    _s.validateStringLength(
-      'oldPassword',
-      oldPassword,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['NewPassword'] = newPassword;
     $request['OldPassword'] = oldPassword;
@@ -557,12 +444,6 @@ class IAM {
   Future<CreateAccessKeyResponse> createAccessKey({
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     userName?.also((arg) => $request['UserName'] = arg);
     final $result = await _protocol.send(
@@ -598,14 +479,6 @@ class IAM {
   Future<void> createAccountAlias({
     required String accountAlias,
   }) async {
-    ArgumentError.checkNotNull(accountAlias, 'accountAlias');
-    _s.validateStringLength(
-      'accountAlias',
-      accountAlias,
-      3,
-      63,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccountAlias'] = accountAlias;
     await _protocol.send(
@@ -658,20 +531,6 @@ class IAM {
     required String groupName,
     String? path,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     path?.also((arg) => $request['Path'] = arg);
@@ -730,20 +589,6 @@ class IAM {
     required String instanceProfileName,
     String? path,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['InstanceProfileName'] = instanceProfileName;
     path?.also((arg) => $request['Path'] = arg);
@@ -804,22 +649,6 @@ class IAM {
     required String userName,
     bool? passwordResetRequired,
   }) async {
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Password'] = password;
     $request['UserName'] = userName;
@@ -928,15 +757,6 @@ class IAM {
     required String url,
     List<String>? clientIDList,
   }) async {
-    ArgumentError.checkNotNull(thumbprintList, 'thumbprintList');
-    ArgumentError.checkNotNull(url, 'url');
-    _s.validateStringLength(
-      'url',
-      url,
-      1,
-      255,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ThumbprintList'] = thumbprintList;
     $request['Url'] = url;
@@ -1040,34 +860,6 @@ class IAM {
     String? description,
     String? path,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyDocument'] = policyDocument;
     $request['PolicyName'] = policyName;
@@ -1159,22 +951,6 @@ class IAM {
     required String policyDocument,
     bool? setAsDefault,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['PolicyDocument'] = policyDocument;
@@ -1306,46 +1082,11 @@ class IAM {
     String? permissionsBoundary,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        assumeRolePolicyDocument, 'assumeRolePolicyDocument');
-    _s.validateStringLength(
-      'assumeRolePolicyDocument',
-      assumeRolePolicyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     _s.validateNumRange(
       'maxSessionDuration',
       maxSessionDuration,
       3600,
       43200,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'permissionsBoundary',
-      permissionsBoundary,
-      20,
-      2048,
     );
     final $request = <String, dynamic>{};
     $request['AssumeRolePolicyDocument'] = assumeRolePolicyDocument;
@@ -1423,22 +1164,6 @@ class IAM {
     required String name,
     required String sAMLMetadataDocument,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sAMLMetadataDocument, 'sAMLMetadataDocument');
-    _s.validateStringLength(
-      'sAMLMetadataDocument',
-      sAMLMetadataDocument,
-      1000,
-      10000000,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Name'] = name;
     $request['SAMLMetadataDocument'] = sAMLMetadataDocument;
@@ -1507,26 +1232,6 @@ class IAM {
     String? customSuffix,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(awsServiceName, 'awsServiceName');
-    _s.validateStringLength(
-      'awsServiceName',
-      awsServiceName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'customSuffix',
-      customSuffix,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final $request = <String, dynamic>{};
     $request['AWSServiceName'] = awsServiceName;
     customSuffix?.also((arg) => $request['CustomSuffix'] = arg);
@@ -1587,15 +1292,6 @@ class IAM {
     required String serviceName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ServiceName'] = serviceName;
     $request['UserName'] = userName;
@@ -1670,26 +1366,6 @@ class IAM {
     String? permissionsBoundary,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'permissionsBoundary',
-      permissionsBoundary,
-      20,
-      2048,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     path?.also((arg) => $request['Path'] = arg);
@@ -1761,20 +1437,6 @@ class IAM {
     required String virtualMFADeviceName,
     String? path,
   }) async {
-    ArgumentError.checkNotNull(virtualMFADeviceName, 'virtualMFADeviceName');
-    _s.validateStringLength(
-      'virtualMFADeviceName',
-      virtualMFADeviceName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['VirtualMFADeviceName'] = virtualMFADeviceName;
     path?.also((arg) => $request['Path'] = arg);
@@ -1826,22 +1488,6 @@ class IAM {
     required String serialNumber,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serialNumber, 'serialNumber');
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SerialNumber'] = serialNumber;
     $request['UserName'] = userName;
@@ -1888,20 +1534,6 @@ class IAM {
     required String accessKeyId,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(accessKeyId, 'accessKeyId');
-    _s.validateStringLength(
-      'accessKeyId',
-      accessKeyId,
-      16,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['AccessKeyId'] = accessKeyId;
     userName?.also((arg) => $request['UserName'] = arg);
@@ -1936,14 +1568,6 @@ class IAM {
   Future<void> deleteAccountAlias({
     required String accountAlias,
   }) async {
-    ArgumentError.checkNotNull(accountAlias, 'accountAlias');
-    _s.validateStringLength(
-      'accountAlias',
-      accountAlias,
-      3,
-      63,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccountAlias'] = accountAlias;
     await _protocol.send(
@@ -1994,14 +1618,6 @@ class IAM {
   Future<void> deleteGroup({
     required String groupName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     await _protocol.send(
@@ -2049,22 +1665,6 @@ class IAM {
     required String groupName,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['PolicyName'] = policyName;
@@ -2107,14 +1707,6 @@ class IAM {
   Future<void> deleteInstanceProfile({
     required String instanceProfileName,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['InstanceProfileName'] = instanceProfileName;
     await _protocol.send(
@@ -2154,14 +1746,6 @@ class IAM {
   Future<void> deleteLoginProfile({
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     await _protocol.send(
@@ -2196,15 +1780,6 @@ class IAM {
   Future<void> deleteOpenIDConnectProvider({
     required String openIDConnectProviderArn,
   }) async {
-    ArgumentError.checkNotNull(
-        openIDConnectProviderArn, 'openIDConnectProviderArn');
-    _s.validateStringLength(
-      'openIDConnectProviderArn',
-      openIDConnectProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['OpenIDConnectProviderArn'] = openIDConnectProviderArn;
     await _protocol.send(
@@ -2265,14 +1840,6 @@ class IAM {
   Future<void> deletePolicy({
     required String policyArn,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     await _protocol.send(
@@ -2329,15 +1896,6 @@ class IAM {
     required String policyArn,
     required String versionId,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['VersionId'] = versionId;
@@ -2381,14 +1939,6 @@ class IAM {
   Future<void> deleteRole({
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     await _protocol.send(
@@ -2420,14 +1970,6 @@ class IAM {
   Future<void> deleteRolePermissionsBoundary({
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     await _protocol.send(
@@ -2476,22 +2018,6 @@ class IAM {
     required String policyName,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     $request['RoleName'] = roleName;
@@ -2529,14 +2055,6 @@ class IAM {
   Future<void> deleteSAMLProvider({
     required String sAMLProviderArn,
   }) async {
-    ArgumentError.checkNotNull(sAMLProviderArn, 'sAMLProviderArn');
-    _s.validateStringLength(
-      'sAMLProviderArn',
-      sAMLProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SAMLProviderArn'] = sAMLProviderArn;
     await _protocol.send(
@@ -2581,22 +2099,6 @@ class IAM {
     required String sSHPublicKeyId,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(sSHPublicKeyId, 'sSHPublicKeyId');
-    _s.validateStringLength(
-      'sSHPublicKeyId',
-      sSHPublicKeyId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SSHPublicKeyId'] = sSHPublicKeyId;
     $request['UserName'] = userName;
@@ -2646,14 +2148,6 @@ class IAM {
   Future<void> deleteServerCertificate({
     required String serverCertificateName,
   }) async {
-    ArgumentError.checkNotNull(serverCertificateName, 'serverCertificateName');
-    _s.validateStringLength(
-      'serverCertificateName',
-      serverCertificateName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ServerCertificateName'] = serverCertificateName;
     await _protocol.send(
@@ -2700,14 +2194,6 @@ class IAM {
   Future<DeleteServiceLinkedRoleResponse> deleteServiceLinkedRole({
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     final $result = await _protocol.send(
@@ -2749,21 +2235,6 @@ class IAM {
     required String serviceSpecificCredentialId,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(
-        serviceSpecificCredentialId, 'serviceSpecificCredentialId');
-    _s.validateStringLength(
-      'serviceSpecificCredentialId',
-      serviceSpecificCredentialId,
-      20,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     $request['ServiceSpecificCredentialId'] = serviceSpecificCredentialId;
     userName?.also((arg) => $request['UserName'] = arg);
@@ -2809,20 +2280,6 @@ class IAM {
     required String certificateId,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      24,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['CertificateId'] = certificateId;
     userName?.also((arg) => $request['UserName'] = arg);
@@ -2892,14 +2349,6 @@ class IAM {
   Future<void> deleteUser({
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     await _protocol.send(
@@ -2930,14 +2379,6 @@ class IAM {
   Future<void> deleteUserPermissionsBoundary({
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     await _protocol.send(
@@ -2985,22 +2426,6 @@ class IAM {
     required String policyName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     $request['UserName'] = userName;
@@ -3039,14 +2464,6 @@ class IAM {
   Future<void> deleteVirtualMFADevice({
     required String serialNumber,
   }) async {
-    ArgumentError.checkNotNull(serialNumber, 'serialNumber');
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SerialNumber'] = serialNumber;
     await _protocol.send(
@@ -3094,22 +2511,6 @@ class IAM {
     required String groupName,
     required String policyArn,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['PolicyArn'] = policyArn;
@@ -3159,22 +2560,6 @@ class IAM {
     required String policyArn,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['RoleName'] = roleName;
@@ -3223,22 +2608,6 @@ class IAM {
     required String policyArn,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['UserName'] = userName;
@@ -3315,38 +2684,6 @@ class IAM {
     required String serialNumber,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(authenticationCode1, 'authenticationCode1');
-    _s.validateStringLength(
-      'authenticationCode1',
-      authenticationCode1,
-      6,
-      6,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(authenticationCode2, 'authenticationCode2');
-    _s.validateStringLength(
-      'authenticationCode2',
-      authenticationCode2,
-      6,
-      6,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serialNumber, 'serialNumber');
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AuthenticationCode1'] = authenticationCode1;
     $request['AuthenticationCode2'] = authenticationCode2;
@@ -3546,14 +2883,6 @@ class IAM {
     required String entityPath,
     String? organizationsPolicyId,
   }) async {
-    ArgumentError.checkNotNull(entityPath, 'entityPath');
-    _s.validateStringLength(
-      'entityPath',
-      entityPath,
-      19,
-      427,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['EntityPath'] = entityPath;
     organizationsPolicyId
@@ -3656,14 +2985,6 @@ class IAM {
     required String arn,
     AccessAdvisorUsageGranularityType? granularity,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Arn'] = arn;
     granularity?.also((arg) => $request['Granularity'] = arg.toValue());
@@ -3695,14 +3016,6 @@ class IAM {
   Future<GetAccessKeyLastUsedResponse> getAccessKeyLastUsed({
     required String accessKeyId,
   }) async {
-    ArgumentError.checkNotNull(accessKeyId, 'accessKeyId');
-    _s.validateStringLength(
-      'accessKeyId',
-      accessKeyId,
-      16,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccessKeyId'] = accessKeyId;
     final $result = await _protocol.send(
@@ -3770,12 +3083,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -3888,7 +3195,6 @@ class IAM {
   Future<GetContextKeysForPolicyResponse> getContextKeysForCustomPolicy({
     required List<String> policyInputList,
   }) async {
-    ArgumentError.checkNotNull(policyInputList, 'policyInputList');
     final $request = <String, dynamic>{};
     $request['PolicyInputList'] = policyInputList;
     final $result = await _protocol.send(
@@ -3970,14 +3276,6 @@ class IAM {
     required String policySourceArn,
     List<String>? policyInputList,
   }) async {
-    ArgumentError.checkNotNull(policySourceArn, 'policySourceArn');
-    _s.validateStringLength(
-      'policySourceArn',
-      policySourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicySourceArn'] = policySourceArn;
     policyInputList?.also((arg) => $request['PolicyInputList'] = arg);
@@ -4057,20 +3355,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -4136,22 +3420,6 @@ class IAM {
     required String groupName,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['PolicyName'] = policyName;
@@ -4188,14 +3456,6 @@ class IAM {
   Future<GetInstanceProfileResponse> getInstanceProfile({
     required String instanceProfileName,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['InstanceProfileName'] = instanceProfileName;
     final $result = await _protocol.send(
@@ -4229,14 +3489,6 @@ class IAM {
   Future<GetLoginProfileResponse> getLoginProfile({
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     final $result = await _protocol.send(
@@ -4272,15 +3524,6 @@ class IAM {
   Future<GetOpenIDConnectProviderResponse> getOpenIDConnectProvider({
     required String openIDConnectProviderArn,
   }) async {
-    ArgumentError.checkNotNull(
-        openIDConnectProviderArn, 'openIDConnectProviderArn');
-    _s.validateStringLength(
-      'openIDConnectProviderArn',
-      openIDConnectProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['OpenIDConnectProviderArn'] = openIDConnectProviderArn;
     final $result = await _protocol.send(
@@ -4357,20 +3600,6 @@ class IAM {
     int? maxItems,
     SortKeyType? sortKey,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -4428,14 +3657,6 @@ class IAM {
   Future<GetPolicyResponse> getPolicy({
     required String policyArn,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     final $result = await _protocol.send(
@@ -4503,15 +3724,6 @@ class IAM {
     required String policyArn,
     required String versionId,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['VersionId'] = versionId;
@@ -4556,14 +3768,6 @@ class IAM {
   Future<GetRoleResponse> getRole({
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     final $result = await _protocol.send(
@@ -4625,22 +3829,6 @@ class IAM {
     required String policyName,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     $request['RoleName'] = roleName;
@@ -4681,14 +3869,6 @@ class IAM {
   Future<GetSAMLProviderResponse> getSAMLProvider({
     required String sAMLProviderArn,
   }) async {
-    ArgumentError.checkNotNull(sAMLProviderArn, 'sAMLProviderArn');
-    _s.validateStringLength(
-      'sAMLProviderArn',
-      sAMLProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SAMLProviderArn'] = sAMLProviderArn;
     final $result = await _protocol.send(
@@ -4742,23 +3922,6 @@ class IAM {
     required String sSHPublicKeyId,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(encoding, 'encoding');
-    ArgumentError.checkNotNull(sSHPublicKeyId, 'sSHPublicKeyId');
-    _s.validateStringLength(
-      'sSHPublicKeyId',
-      sSHPublicKeyId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Encoding'] = encoding.toValue();
     $request['SSHPublicKeyId'] = sSHPublicKeyId;
@@ -4799,14 +3962,6 @@ class IAM {
   Future<GetServerCertificateResponse> getServerCertificate({
     required String serverCertificateName,
   }) async {
-    ArgumentError.checkNotNull(serverCertificateName, 'serverCertificateName');
-    _s.validateStringLength(
-      'serverCertificateName',
-      serverCertificateName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ServerCertificateName'] = serverCertificateName;
     final $result = await _protocol.send(
@@ -4915,20 +4070,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -5028,28 +4169,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceNamespace, 'serviceNamespace');
-    _s.validateStringLength(
-      'serviceNamespace',
-      serviceNamespace,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -5095,14 +4214,6 @@ class IAM {
       getServiceLinkedRoleDeletionStatus({
     required String deletionTaskId,
   }) async {
-    ArgumentError.checkNotNull(deletionTaskId, 'deletionTaskId');
-    _s.validateStringLength(
-      'deletionTaskId',
-      deletionTaskId,
-      1,
-      1000,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['DeletionTaskId'] = deletionTaskId;
     final $result = await _protocol.send(
@@ -5139,12 +4250,6 @@ class IAM {
   Future<GetUserResponse> getUser({
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     userName?.also((arg) => $request['UserName'] = arg);
     final $result = await _protocol.send(
@@ -5202,22 +4307,6 @@ class IAM {
     required String policyName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyName'] = policyName;
     $request['UserName'] = userName;
@@ -5286,23 +4375,11 @@ class IAM {
     int? maxItems,
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -5351,12 +4428,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -5444,31 +4515,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
@@ -5553,31 +4604,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
@@ -5662,31 +4693,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
@@ -5789,31 +4800,11 @@ class IAM {
     String? pathPrefix,
     PolicyUsageType? policyUsageFilter,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
@@ -5885,20 +4876,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -5967,23 +4944,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6042,20 +5007,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -6128,23 +5079,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6207,20 +5146,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -6288,23 +5213,11 @@ class IAM {
     int? maxItems,
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6430,23 +5343,11 @@ class IAM {
     PolicyUsageType? policyUsageFilter,
     PolicyScopeType? scope,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6546,21 +5447,6 @@ class IAM {
     required List<String> serviceNamespaces,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceNamespaces, 'serviceNamespaces');
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     final $request = <String, dynamic>{};
     $request['Arn'] = arn;
     $request['ServiceNamespaces'] = serviceNamespaces;
@@ -6623,20 +5509,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -6709,20 +5581,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -6786,20 +5644,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -6872,23 +5716,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6982,23 +5814,11 @@ class IAM {
     int? maxItems,
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -7069,23 +5889,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -7136,12 +5944,6 @@ class IAM {
     String? serviceName,
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     serviceName?.also((arg) => $request['ServiceName'] = arg);
     userName?.also((arg) => $request['UserName'] = arg);
@@ -7206,23 +6008,11 @@ class IAM {
     int? maxItems,
     String? userName,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -7289,20 +6079,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -7366,20 +6142,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -7450,23 +6212,11 @@ class IAM {
     int? maxItems,
     String? pathPrefix,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'pathPrefix',
-      pathPrefix,
-      1,
-      512,
     );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
@@ -7523,12 +6273,6 @@ class IAM {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -7627,30 +6371,6 @@ class IAM {
     required String policyDocument,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['PolicyDocument'] = policyDocument;
@@ -7699,22 +6419,6 @@ class IAM {
     required String permissionsBoundary,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(permissionsBoundary, 'permissionsBoundary');
-    _s.validateStringLength(
-      'permissionsBoundary',
-      permissionsBoundary,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PermissionsBoundary'] = permissionsBoundary;
     $request['RoleName'] = roleName;
@@ -7812,30 +6516,6 @@ class IAM {
     required String policyName,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyDocument'] = policyDocument;
     $request['PolicyName'] = policyName;
@@ -7881,22 +6561,6 @@ class IAM {
     required String permissionsBoundary,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(permissionsBoundary, 'permissionsBoundary');
-    _s.validateStringLength(
-      'permissionsBoundary',
-      permissionsBoundary,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PermissionsBoundary'] = permissionsBoundary;
     $request['UserName'] = userName;
@@ -7986,30 +6650,6 @@ class IAM {
     required String policyName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyDocument'] = policyDocument;
     $request['PolicyName'] = policyName;
@@ -8055,23 +6695,6 @@ class IAM {
     required String clientID,
     required String openIDConnectProviderArn,
   }) async {
-    ArgumentError.checkNotNull(clientID, 'clientID');
-    _s.validateStringLength(
-      'clientID',
-      clientID,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        openIDConnectProviderArn, 'openIDConnectProviderArn');
-    _s.validateStringLength(
-      'openIDConnectProviderArn',
-      openIDConnectProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClientID'] = clientID;
     $request['OpenIDConnectProviderArn'] = openIDConnectProviderArn;
@@ -8124,22 +6747,6 @@ class IAM {
     required String instanceProfileName,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['InstanceProfileName'] = instanceProfileName;
     $request['RoleName'] = roleName;
@@ -8180,22 +6787,6 @@ class IAM {
     required String groupName,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     $request['UserName'] = userName;
@@ -8239,21 +6830,6 @@ class IAM {
     required String serviceSpecificCredentialId,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(
-        serviceSpecificCredentialId, 'serviceSpecificCredentialId');
-    _s.validateStringLength(
-      'serviceSpecificCredentialId',
-      serviceSpecificCredentialId,
-      20,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     $request['ServiceSpecificCredentialId'] = serviceSpecificCredentialId;
     userName?.also((arg) => $request['UserName'] = arg);
@@ -8315,38 +6891,6 @@ class IAM {
     required String serialNumber,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(authenticationCode1, 'authenticationCode1');
-    _s.validateStringLength(
-      'authenticationCode1',
-      authenticationCode1,
-      6,
-      6,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(authenticationCode2, 'authenticationCode2');
-    _s.validateStringLength(
-      'authenticationCode2',
-      authenticationCode2,
-      6,
-      6,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serialNumber, 'serialNumber');
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AuthenticationCode1'] = authenticationCode1;
     $request['AuthenticationCode2'] = authenticationCode2;
@@ -8399,15 +6943,6 @@ class IAM {
     required String policyArn,
     required String versionId,
   }) async {
-    ArgumentError.checkNotNull(policyArn, 'policyArn');
-    _s.validateStringLength(
-      'policyArn',
-      policyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
     final $request = <String, dynamic>{};
     $request['PolicyArn'] = policyArn;
     $request['VersionId'] = versionId;
@@ -8465,8 +7000,6 @@ class IAM {
   Future<void> setSecurityTokenServicePreferences({
     required GlobalEndpointTokenVersion globalEndpointTokenVersion,
   }) async {
-    ArgumentError.checkNotNull(
-        globalEndpointTokenVersion, 'globalEndpointTokenVersion');
     final $request = <String, dynamic>{};
     $request['GlobalEndpointTokenVersion'] =
         globalEndpointTokenVersion.toValue();
@@ -8733,43 +7266,11 @@ class IAM {
     String? resourceOwner,
     String? resourcePolicy,
   }) async {
-    ArgumentError.checkNotNull(actionNames, 'actionNames');
-    ArgumentError.checkNotNull(policyInputList, 'policyInputList');
-    _s.validateStringLength(
-      'callerArn',
-      callerArn,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'resourceHandlingOption',
-      resourceHandlingOption,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'resourceOwner',
-      resourceOwner,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'resourcePolicy',
-      resourcePolicy,
-      1,
-      131072,
     );
     final $request = <String, dynamic>{};
     $request['ActionNames'] = actionNames;
@@ -9078,50 +7579,11 @@ class IAM {
     String? resourceOwner,
     String? resourcePolicy,
   }) async {
-    ArgumentError.checkNotNull(actionNames, 'actionNames');
-    ArgumentError.checkNotNull(policySourceArn, 'policySourceArn');
-    _s.validateStringLength(
-      'policySourceArn',
-      policySourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'callerArn',
-      callerArn,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      320,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'resourceHandlingOption',
-      resourceHandlingOption,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'resourceOwner',
-      resourceOwner,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'resourcePolicy',
-      resourcePolicy,
-      1,
-      131072,
     );
     final $request = <String, dynamic>{};
     $request['ActionNames'] = actionNames;
@@ -9220,15 +7682,6 @@ class IAM {
     required String roleName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     $request['Tags'] = tags;
@@ -9311,15 +7764,6 @@ class IAM {
     required List<Tag> tags,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(tags, 'tags');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Tags'] = tags;
     $request['UserName'] = userName;
@@ -9360,15 +7804,6 @@ class IAM {
     required String roleName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['RoleName'] = roleName;
     $request['TagKeys'] = tagKeys;
@@ -9409,15 +7844,6 @@ class IAM {
     required List<String> tagKeys,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['TagKeys'] = tagKeys;
     $request['UserName'] = userName;
@@ -9475,21 +7901,6 @@ class IAM {
     required StatusType status,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(accessKeyId, 'accessKeyId');
-    _s.validateStringLength(
-      'accessKeyId',
-      accessKeyId,
-      16,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['AccessKeyId'] = accessKeyId;
     $request['Status'] = status.toValue();
@@ -9709,22 +8120,6 @@ class IAM {
     required String policyDocument,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['PolicyDocument'] = policyDocument;
     $request['RoleName'] = roleName;
@@ -9796,26 +8191,6 @@ class IAM {
     String? newGroupName,
     String? newPath,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'newGroupName',
-      newGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'newPath',
-      newPath,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['GroupName'] = groupName;
     newGroupName?.also((arg) => $request['NewGroupName'] = arg);
@@ -9886,20 +8261,6 @@ class IAM {
     String? password,
     bool? passwordResetRequired,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     password?.also((arg) => $request['Password'] = arg);
@@ -9958,16 +8319,6 @@ class IAM {
     required String openIDConnectProviderArn,
     required List<String> thumbprintList,
   }) async {
-    ArgumentError.checkNotNull(
-        openIDConnectProviderArn, 'openIDConnectProviderArn');
-    _s.validateStringLength(
-      'openIDConnectProviderArn',
-      openIDConnectProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thumbprintList, 'thumbprintList');
     final $request = <String, dynamic>{};
     $request['OpenIDConnectProviderArn'] = openIDConnectProviderArn;
     $request['ThumbprintList'] = thumbprintList;
@@ -10019,20 +8370,6 @@ class IAM {
     String? description,
     int? maxSessionDuration,
   }) async {
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     _s.validateNumRange(
       'maxSessionDuration',
       maxSessionDuration,
@@ -10075,22 +8412,6 @@ class IAM {
     required String description,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleName, 'roleName');
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Description'] = description;
     $request['RoleName'] = roleName;
@@ -10140,22 +8461,6 @@ class IAM {
     required String sAMLMetadataDocument,
     required String sAMLProviderArn,
   }) async {
-    ArgumentError.checkNotNull(sAMLMetadataDocument, 'sAMLMetadataDocument');
-    _s.validateStringLength(
-      'sAMLMetadataDocument',
-      sAMLMetadataDocument,
-      1000,
-      10000000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sAMLProviderArn, 'sAMLProviderArn');
-    _s.validateStringLength(
-      'sAMLProviderArn',
-      sAMLProviderArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SAMLMetadataDocument'] = sAMLMetadataDocument;
     $request['SAMLProviderArn'] = sAMLProviderArn;
@@ -10212,23 +8517,6 @@ class IAM {
     required StatusType status,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(sSHPublicKeyId, 'sSHPublicKeyId');
-    _s.validateStringLength(
-      'sSHPublicKeyId',
-      sSHPublicKeyId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SSHPublicKeyId'] = sSHPublicKeyId;
     $request['Status'] = status.toValue();
@@ -10310,26 +8598,6 @@ class IAM {
     String? newPath,
     String? newServerCertificateName,
   }) async {
-    ArgumentError.checkNotNull(serverCertificateName, 'serverCertificateName');
-    _s.validateStringLength(
-      'serverCertificateName',
-      serverCertificateName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'newPath',
-      newPath,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'newServerCertificateName',
-      newServerCertificateName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['ServerCertificateName'] = serverCertificateName;
     newPath?.also((arg) => $request['NewPath'] = arg);
@@ -10379,22 +8647,6 @@ class IAM {
     required StatusType status,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(
-        serviceSpecificCredentialId, 'serviceSpecificCredentialId');
-    _s.validateStringLength(
-      'serviceSpecificCredentialId',
-      serviceSpecificCredentialId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     $request['ServiceSpecificCredentialId'] = serviceSpecificCredentialId;
     $request['Status'] = status.toValue();
@@ -10449,21 +8701,6 @@ class IAM {
     required StatusType status,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      24,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['CertificateId'] = certificateId;
     $request['Status'] = status.toValue();
@@ -10538,26 +8775,6 @@ class IAM {
     String? newPath,
     String? newUserName,
   }) async {
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'newPath',
-      newPath,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'newUserName',
-      newUserName,
-      1,
-      64,
-    );
     final $request = <String, dynamic>{};
     $request['UserName'] = userName;
     newPath?.also((arg) => $request['NewPath'] = arg);
@@ -10626,22 +8843,6 @@ class IAM {
     required String sSHPublicKeyBody,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(sSHPublicKeyBody, 'sSHPublicKeyBody');
-    _s.validateStringLength(
-      'sSHPublicKeyBody',
-      sSHPublicKeyBody,
-      1,
-      16384,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SSHPublicKeyBody'] = sSHPublicKeyBody;
     $request['UserName'] = userName;
@@ -10803,42 +9004,6 @@ class IAM {
     String? certificateChain,
     String? path,
   }) async {
-    ArgumentError.checkNotNull(certificateBody, 'certificateBody');
-    _s.validateStringLength(
-      'certificateBody',
-      certificateBody,
-      1,
-      16384,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(privateKey, 'privateKey');
-    _s.validateStringLength(
-      'privateKey',
-      privateKey,
-      1,
-      16384,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverCertificateName, 'serverCertificateName');
-    _s.validateStringLength(
-      'serverCertificateName',
-      serverCertificateName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'certificateChain',
-      certificateChain,
-      1,
-      2097152,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      512,
-    );
     final $request = <String, dynamic>{};
     $request['CertificateBody'] = certificateBody;
     $request['PrivateKey'] = privateKey;
@@ -10922,20 +9087,6 @@ class IAM {
     required String certificateBody,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(certificateBody, 'certificateBody');
-    _s.validateStringLength(
-      'certificateBody',
-      certificateBody,
-      1,
-      16384,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      128,
-    );
     final $request = <String, dynamic>{};
     $request['CertificateBody'] = certificateBody;
     userName?.also((arg) => $request['UserName'] = arg);

--- a/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
+++ b/generated/aws_imagebuilder_api/lib/imagebuilder-2019-12-02.dart
@@ -73,13 +73,6 @@ class Imagebuilder {
     required String imageBuildVersionArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(imageBuildVersionArn, 'imageBuildVersionArn');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
     final $payload = <String, dynamic>{
       'imageBuildVersionArn': imageBuildVersionArn,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -164,39 +157,6 @@ class Imagebuilder {
     Map<String, String>? tags,
     String? uri,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(platform, 'platform');
-    ArgumentError.checkNotNull(semanticVersion, 'semanticVersion');
-    _s.validateStringLength(
-      'changeDescription',
-      changeDescription,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'data',
-      data,
-      1,
-      16000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'name': name,
       'platform': platform.toValue(),
@@ -299,58 +259,6 @@ class Imagebuilder {
     Map<String, String>? tags,
     String? workingDirectory,
   }) async {
-    ArgumentError.checkNotNull(components, 'components');
-    ArgumentError.checkNotNull(containerType, 'containerType');
-    ArgumentError.checkNotNull(
-        dockerfileTemplateData, 'dockerfileTemplateData');
-    _s.validateStringLength(
-      'dockerfileTemplateData',
-      dockerfileTemplateData,
-      1,
-      16000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(parentImage, 'parentImage');
-    _s.validateStringLength(
-      'parentImage',
-      parentImage,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(semanticVersion, 'semanticVersion');
-    ArgumentError.checkNotNull(targetRepository, 'targetRepository');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'imageOsVersionOverride',
-      imageOsVersionOverride,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'workingDirectory',
-      workingDirectory,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'components': components,
       'containerType': containerType.toValue(),
@@ -417,20 +325,6 @@ class Imagebuilder {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(distributions, 'distributions');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'distributions': distributions,
       'name': name,
@@ -501,14 +395,6 @@ class Imagebuilder {
     ImageTestsConfiguration? imageTestsConfiguration,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
     final $payload = <String, dynamic>{
       'infrastructureConfigurationArn': infrastructureConfigurationArn,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -601,21 +487,6 @@ class Imagebuilder {
     PipelineStatus? status,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'infrastructureConfigurationArn': infrastructureConfigurationArn,
       'name': name,
@@ -701,35 +572,6 @@ class Imagebuilder {
     Map<String, String>? tags,
     String? workingDirectory,
   }) async {
-    ArgumentError.checkNotNull(components, 'components');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(parentImage, 'parentImage');
-    _s.validateStringLength(
-      'parentImage',
-      parentImage,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(semanticVersion, 'semanticVersion');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'workingDirectory',
-      workingDirectory,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'components': components,
       'name': name,
@@ -829,39 +671,6 @@ class Imagebuilder {
     Map<String, String>? tags,
     bool? terminateInstanceOnFailure,
   }) async {
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'keyPair',
-      keyPair,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'subnetId',
-      subnetId,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'instanceProfileName': instanceProfileName,
       'name': name,
@@ -902,8 +711,6 @@ class Imagebuilder {
   Future<DeleteComponentResponse> deleteComponent({
     required String componentBuildVersionArn,
   }) async {
-    ArgumentError.checkNotNull(
-        componentBuildVersionArn, 'componentBuildVersionArn');
     final $query = <String, List<String>>{
       'componentBuildVersionArn': [componentBuildVersionArn],
     };
@@ -932,7 +739,6 @@ class Imagebuilder {
   Future<DeleteContainerRecipeResponse> deleteContainerRecipe({
     required String containerRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(containerRecipeArn, 'containerRecipeArn');
     final $query = <String, List<String>>{
       'containerRecipeArn': [containerRecipeArn],
     };
@@ -963,8 +769,6 @@ class Imagebuilder {
       deleteDistributionConfiguration({
     required String distributionConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigurationArn, 'distributionConfigurationArn');
     final $query = <String, List<String>>{
       'distributionConfigurationArn': [distributionConfigurationArn],
     };
@@ -993,7 +797,6 @@ class Imagebuilder {
   Future<DeleteImageResponse> deleteImage({
     required String imageBuildVersionArn,
   }) async {
-    ArgumentError.checkNotNull(imageBuildVersionArn, 'imageBuildVersionArn');
     final $query = <String, List<String>>{
       'imageBuildVersionArn': [imageBuildVersionArn],
     };
@@ -1022,7 +825,6 @@ class Imagebuilder {
   Future<DeleteImagePipelineResponse> deleteImagePipeline({
     required String imagePipelineArn,
   }) async {
-    ArgumentError.checkNotNull(imagePipelineArn, 'imagePipelineArn');
     final $query = <String, List<String>>{
       'imagePipelineArn': [imagePipelineArn],
     };
@@ -1051,7 +853,6 @@ class Imagebuilder {
   Future<DeleteImageRecipeResponse> deleteImageRecipe({
     required String imageRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(imageRecipeArn, 'imageRecipeArn');
     final $query = <String, List<String>>{
       'imageRecipeArn': [imageRecipeArn],
     };
@@ -1082,8 +883,6 @@ class Imagebuilder {
       deleteInfrastructureConfiguration({
     required String infrastructureConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
     final $query = <String, List<String>>{
       'infrastructureConfigurationArn': [infrastructureConfigurationArn],
     };
@@ -1112,8 +911,6 @@ class Imagebuilder {
   Future<GetComponentResponse> getComponent({
     required String componentBuildVersionArn,
   }) async {
-    ArgumentError.checkNotNull(
-        componentBuildVersionArn, 'componentBuildVersionArn');
     final $query = <String, List<String>>{
       'componentBuildVersionArn': [componentBuildVersionArn],
     };
@@ -1142,7 +939,6 @@ class Imagebuilder {
   Future<GetComponentPolicyResponse> getComponentPolicy({
     required String componentArn,
   }) async {
-    ArgumentError.checkNotNull(componentArn, 'componentArn');
     final $query = <String, List<String>>{
       'componentArn': [componentArn],
     };
@@ -1170,7 +966,6 @@ class Imagebuilder {
   Future<GetContainerRecipeResponse> getContainerRecipe({
     required String containerRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(containerRecipeArn, 'containerRecipeArn');
     final $query = <String, List<String>>{
       'containerRecipeArn': [containerRecipeArn],
     };
@@ -1199,7 +994,6 @@ class Imagebuilder {
   Future<GetContainerRecipePolicyResponse> getContainerRecipePolicy({
     required String containerRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(containerRecipeArn, 'containerRecipeArn');
     final $query = <String, List<String>>{
       'containerRecipeArn': [containerRecipeArn],
     };
@@ -1228,8 +1022,6 @@ class Imagebuilder {
   Future<GetDistributionConfigurationResponse> getDistributionConfiguration({
     required String distributionConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigurationArn, 'distributionConfigurationArn');
     final $query = <String, List<String>>{
       'distributionConfigurationArn': [distributionConfigurationArn],
     };
@@ -1257,7 +1049,6 @@ class Imagebuilder {
   Future<GetImageResponse> getImage({
     required String imageBuildVersionArn,
   }) async {
-    ArgumentError.checkNotNull(imageBuildVersionArn, 'imageBuildVersionArn');
     final $query = <String, List<String>>{
       'imageBuildVersionArn': [imageBuildVersionArn],
     };
@@ -1286,7 +1077,6 @@ class Imagebuilder {
   Future<GetImagePipelineResponse> getImagePipeline({
     required String imagePipelineArn,
   }) async {
-    ArgumentError.checkNotNull(imagePipelineArn, 'imagePipelineArn');
     final $query = <String, List<String>>{
       'imagePipelineArn': [imagePipelineArn],
     };
@@ -1315,7 +1105,6 @@ class Imagebuilder {
   Future<GetImagePolicyResponse> getImagePolicy({
     required String imageArn,
   }) async {
-    ArgumentError.checkNotNull(imageArn, 'imageArn');
     final $query = <String, List<String>>{
       'imageArn': [imageArn],
     };
@@ -1344,7 +1133,6 @@ class Imagebuilder {
   Future<GetImageRecipeResponse> getImageRecipe({
     required String imageRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(imageRecipeArn, 'imageRecipeArn');
     final $query = <String, List<String>>{
       'imageRecipeArn': [imageRecipeArn],
     };
@@ -1373,7 +1161,6 @@ class Imagebuilder {
   Future<GetImageRecipePolicyResponse> getImageRecipePolicy({
     required String imageRecipeArn,
   }) async {
-    ArgumentError.checkNotNull(imageRecipeArn, 'imageRecipeArn');
     final $query = <String, List<String>>{
       'imageRecipeArn': [imageRecipeArn],
     };
@@ -1403,8 +1190,6 @@ class Imagebuilder {
       getInfrastructureConfiguration({
     required String infrastructureConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
     final $query = <String, List<String>>{
       'infrastructureConfigurationArn': [infrastructureConfigurationArn],
     };
@@ -1490,41 +1275,6 @@ class Imagebuilder {
     Map<String, String>? tags,
     String? uri,
   }) async {
-    ArgumentError.checkNotNull(format, 'format');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(platform, 'platform');
-    ArgumentError.checkNotNull(semanticVersion, 'semanticVersion');
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'changeDescription',
-      changeDescription,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'data',
-      data,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'format': format.toValue(),
       'name': name,
@@ -1574,18 +1324,11 @@ class Imagebuilder {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(componentVersionArn, 'componentVersionArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final $payload = <String, dynamic>{
       'componentVersionArn': componentVersionArn,
@@ -1645,12 +1388,6 @@ class Imagebuilder {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
-    );
     final $payload = <String, dynamic>{
       if (byName != null) 'byName': byName,
       if (filters != null) 'filters': filters,
@@ -1704,12 +1441,6 @@ class Imagebuilder {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1762,12 +1493,6 @@ class Imagebuilder {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1811,18 +1536,11 @@ class Imagebuilder {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(imageVersionArn, 'imageVersionArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final $payload = <String, dynamic>{
       'imageVersionArn': imageVersionArn,
@@ -1869,18 +1587,11 @@ class Imagebuilder {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(imagePipelineArn, 'imagePipelineArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final $payload = <String, dynamic>{
       'imagePipelineArn': imagePipelineArn,
@@ -1926,12 +1637,6 @@ class Imagebuilder {
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
@@ -1984,12 +1689,6 @@ class Imagebuilder {
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
     );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
@@ -2051,12 +1750,6 @@ class Imagebuilder {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
-    );
     final $payload = <String, dynamic>{
       if (byName != null) 'byName': byName,
       if (filters != null) 'filters': filters,
@@ -2105,12 +1798,6 @@ class Imagebuilder {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      65535,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -2137,7 +1824,6 @@ class Imagebuilder {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2174,15 +1860,6 @@ class Imagebuilder {
     required String componentArn,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(componentArn, 'componentArn');
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      30000,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'componentArn': componentArn,
       'policy': policy,
@@ -2225,15 +1902,6 @@ class Imagebuilder {
     required String containerRecipeArn,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(containerRecipeArn, 'containerRecipeArn');
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      30000,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'containerRecipeArn': containerRecipeArn,
       'policy': policy,
@@ -2274,15 +1942,6 @@ class Imagebuilder {
     required String imageArn,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(imageArn, 'imageArn');
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      30000,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'imageArn': imageArn,
       'policy': policy,
@@ -2324,15 +1983,6 @@ class Imagebuilder {
     required String imageRecipeArn,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(imageRecipeArn, 'imageRecipeArn');
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      30000,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'imageRecipeArn': imageRecipeArn,
       'policy': policy,
@@ -2368,13 +2018,6 @@ class Imagebuilder {
     required String imagePipelineArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(imagePipelineArn, 'imagePipelineArn');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
     final $payload = <String, dynamic>{
       'imagePipelineArn': imagePipelineArn,
       'clientToken': clientToken ?? _s.generateIdempotencyToken(),
@@ -2403,8 +2046,6 @@ class Imagebuilder {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -2431,8 +2072,6 @@ class Imagebuilder {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2477,21 +2116,6 @@ class Imagebuilder {
     String? clientToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(
-        distributionConfigurationArn, 'distributionConfigurationArn');
-    ArgumentError.checkNotNull(distributions, 'distributions');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'distributionConfigurationArn': distributionConfigurationArn,
       'distributions': distributions,
@@ -2571,21 +2195,6 @@ class Imagebuilder {
     Schedule? schedule,
     PipelineStatus? status,
   }) async {
-    ArgumentError.checkNotNull(imagePipelineArn, 'imagePipelineArn');
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'imagePipelineArn': imagePipelineArn,
       'infrastructureConfigurationArn': infrastructureConfigurationArn,
@@ -2683,40 +2292,6 @@ class Imagebuilder {
     String? subnetId,
     bool? terminateInstanceOnFailure,
   }) async {
-    ArgumentError.checkNotNull(
-        infrastructureConfigurationArn, 'infrastructureConfigurationArn');
-    ArgumentError.checkNotNull(instanceProfileName, 'instanceProfileName');
-    _s.validateStringLength(
-      'instanceProfileName',
-      instanceProfileName,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'keyPair',
-      keyPair,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'subnetId',
-      subnetId,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       'infrastructureConfigurationArn': infrastructureConfigurationArn,
       'instanceProfileName': instanceProfileName,

--- a/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
+++ b/generated/aws_importexport_api/lib/importexport-2010-06-01.dart
@@ -70,7 +70,6 @@ class ImportExport {
     required String jobId,
     String? aPIVersion,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final $request = <String, dynamic>{};
     $request['JobId'] = jobId;
     aPIVersion?.also((arg) => $request['APIVersion'] = arg);
@@ -118,9 +117,6 @@ class ImportExport {
     String? aPIVersion,
     String? manifestAddendum,
   }) async {
-    ArgumentError.checkNotNull(jobType, 'jobType');
-    ArgumentError.checkNotNull(manifest, 'manifest');
-    ArgumentError.checkNotNull(validateOnly, 'validateOnly');
     final $request = <String, dynamic>{};
     $request['JobType'] = jobType.toValue();
     $request['Manifest'] = manifest;
@@ -165,7 +161,6 @@ class ImportExport {
     String? street2,
     String? street3,
   }) async {
-    ArgumentError.checkNotNull(jobIds, 'jobIds');
     final $request = <String, dynamic>{};
     $request['jobIds'] = jobIds;
     aPIVersion?.also((arg) => $request['APIVersion'] = arg);
@@ -207,7 +202,6 @@ class ImportExport {
     required String jobId,
     String? aPIVersion,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final $request = <String, dynamic>{};
     $request['JobId'] = jobId;
     aPIVersion?.also((arg) => $request['APIVersion'] = arg);
@@ -288,10 +282,6 @@ class ImportExport {
     required bool validateOnly,
     String? aPIVersion,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(jobType, 'jobType');
-    ArgumentError.checkNotNull(manifest, 'manifest');
-    ArgumentError.checkNotNull(validateOnly, 'validateOnly');
     final $request = <String, dynamic>{};
     $request['JobId'] = jobId;
     $request['JobType'] = jobType.toValue();

--- a/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
+++ b/generated/aws_inspector_api/lib/inspector-2016-02-16.dart
@@ -68,8 +68,6 @@ class Inspector {
     required List<Attribute> attributes,
     required List<String> findingArns,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(findingArns, 'findingArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.AddAttributesToFindings'
@@ -123,20 +121,6 @@ class Inspector {
     required String assessmentTargetName,
     String? resourceGroupArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentTargetName, 'assessmentTargetName');
-    _s.validateStringLength(
-      'assessmentTargetName',
-      assessmentTargetName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'resourceGroupArn',
-      resourceGroupArn,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.CreateAssessmentTarget'
@@ -199,24 +183,6 @@ class Inspector {
     required List<String> rulesPackageArns,
     List<Attribute>? userAttributesForFindings,
   }) async {
-    ArgumentError.checkNotNull(assessmentTargetArn, 'assessmentTargetArn');
-    _s.validateStringLength(
-      'assessmentTargetArn',
-      assessmentTargetArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        assessmentTemplateName, 'assessmentTemplateName');
-    _s.validateStringLength(
-      'assessmentTemplateName',
-      assessmentTemplateName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(durationInSeconds, 'durationInSeconds');
     _s.validateNumRange(
       'durationInSeconds',
       durationInSeconds,
@@ -224,7 +190,6 @@ class Inspector {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(rulesPackageArns, 'rulesPackageArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.CreateAssessmentTemplate'
@@ -266,14 +231,6 @@ class Inspector {
   Future<CreateExclusionsPreviewResponse> createExclusionsPreview({
     required String assessmentTemplateArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentTemplateArn, 'assessmentTemplateArn');
-    _s.validateStringLength(
-      'assessmentTemplateArn',
-      assessmentTemplateArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.CreateExclusionsPreview'
@@ -312,7 +269,6 @@ class Inspector {
   Future<CreateResourceGroupResponse> createResourceGroup({
     required List<ResourceGroupTag> resourceGroupTags,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupTags, 'resourceGroupTags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.CreateResourceGroup'
@@ -346,14 +302,6 @@ class Inspector {
   Future<void> deleteAssessmentRun({
     required String assessmentRunArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DeleteAssessmentRun'
@@ -385,14 +333,6 @@ class Inspector {
   Future<void> deleteAssessmentTarget({
     required String assessmentTargetArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentTargetArn, 'assessmentTargetArn');
-    _s.validateStringLength(
-      'assessmentTargetArn',
-      assessmentTargetArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DeleteAssessmentTarget'
@@ -424,14 +364,6 @@ class Inspector {
   Future<void> deleteAssessmentTemplate({
     required String assessmentTemplateArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentTemplateArn, 'assessmentTemplateArn');
-    _s.validateStringLength(
-      'assessmentTemplateArn',
-      assessmentTemplateArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DeleteAssessmentTemplate'
@@ -459,7 +391,6 @@ class Inspector {
   Future<DescribeAssessmentRunsResponse> describeAssessmentRuns({
     required List<String> assessmentRunArns,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArns, 'assessmentRunArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeAssessmentRuns'
@@ -489,7 +420,6 @@ class Inspector {
   Future<DescribeAssessmentTargetsResponse> describeAssessmentTargets({
     required List<String> assessmentTargetArns,
   }) async {
-    ArgumentError.checkNotNull(assessmentTargetArns, 'assessmentTargetArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeAssessmentTargets'
@@ -516,8 +446,6 @@ class Inspector {
   Future<DescribeAssessmentTemplatesResponse> describeAssessmentTemplates({
     required List<String> assessmentTemplateArns,
   }) async {
-    ArgumentError.checkNotNull(
-        assessmentTemplateArns, 'assessmentTemplateArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeAssessmentTemplates'
@@ -572,7 +500,6 @@ class Inspector {
     required List<String> exclusionArns,
     Locale? locale,
   }) async {
-    ArgumentError.checkNotNull(exclusionArns, 'exclusionArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeExclusions'
@@ -607,7 +534,6 @@ class Inspector {
     required List<String> findingArns,
     Locale? locale,
   }) async {
-    ArgumentError.checkNotNull(findingArns, 'findingArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeFindings'
@@ -638,7 +564,6 @@ class Inspector {
   Future<DescribeResourceGroupsResponse> describeResourceGroups({
     required List<String> resourceGroupArns,
   }) async {
-    ArgumentError.checkNotNull(resourceGroupArns, 'resourceGroupArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeResourceGroups'
@@ -672,7 +597,6 @@ class Inspector {
     required List<String> rulesPackageArns,
     Locale? locale,
   }) async {
-    ArgumentError.checkNotNull(rulesPackageArns, 'rulesPackageArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.DescribeRulesPackages'
@@ -722,16 +646,6 @@ class Inspector {
     required ReportFileFormat reportFileFormat,
     required ReportType reportType,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reportFileFormat, 'reportFileFormat');
-    ArgumentError.checkNotNull(reportType, 'reportType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.GetAssessmentReport'
@@ -789,21 +703,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(assessmentTemplateArn, 'assessmentTemplateArn');
-    _s.validateStringLength(
-      'assessmentTemplateArn',
-      assessmentTemplateArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(previewToken, 'previewToken');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.GetExclusionsPreview'
@@ -840,14 +739,6 @@ class Inspector {
   Future<GetTelemetryMetadataResponse> getTelemetryMetadata({
     required String assessmentRunArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.GetTelemetryMetadata'
@@ -902,20 +793,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListAssessmentRunAgents'
@@ -974,12 +851,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListAssessmentRuns'
@@ -1034,12 +905,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListAssessmentTargets'
@@ -1096,12 +961,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListAssessmentTemplates'
@@ -1152,18 +1011,6 @@ class Inspector {
     String? nextToken,
     String? resourceArn,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListEventSubscriptions'
@@ -1209,20 +1056,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListExclusions'
@@ -1279,12 +1112,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListFindings'
@@ -1326,12 +1153,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListRulesPackages'
@@ -1364,14 +1185,6 @@ class Inspector {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.ListTagsForResource'
@@ -1417,20 +1230,6 @@ class Inspector {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(previewAgentsArn, 'previewAgentsArn');
-    _s.validateStringLength(
-      'previewAgentsArn',
-      previewAgentsArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.PreviewAgents'
@@ -1466,14 +1265,6 @@ class Inspector {
   Future<void> registerCrossAccountAccessRole({
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.RegisterCrossAccountAccessRole'
@@ -1511,8 +1302,6 @@ class Inspector {
     required List<String> attributeKeys,
     required List<String> findingArns,
   }) async {
-    ArgumentError.checkNotNull(attributeKeys, 'attributeKeys');
-    ArgumentError.checkNotNull(findingArns, 'findingArns');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.RemoveAttributesFromFindings'
@@ -1551,14 +1340,6 @@ class Inspector {
     required String resourceArn,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.SetTagsForResource'
@@ -1600,20 +1381,6 @@ class Inspector {
     required String assessmentTemplateArn,
     String? assessmentRunName,
   }) async {
-    ArgumentError.checkNotNull(assessmentTemplateArn, 'assessmentTemplateArn');
-    _s.validateStringLength(
-      'assessmentTemplateArn',
-      assessmentTemplateArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'assessmentRunName',
-      assessmentRunName,
-      1,
-      140,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.StartAssessmentRun'
@@ -1655,14 +1422,6 @@ class Inspector {
     required String assessmentRunArn,
     StopAction? stopAction,
   }) async {
-    ArgumentError.checkNotNull(assessmentRunArn, 'assessmentRunArn');
-    _s.validateStringLength(
-      'assessmentRunArn',
-      assessmentRunArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.StopAssessmentRun'
@@ -1704,23 +1463,6 @@ class Inspector {
     required String resourceArn,
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(event, 'event');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
-    _s.validateStringLength(
-      'topicArn',
-      topicArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.SubscribeToEvent'
@@ -1762,23 +1504,6 @@ class Inspector {
     required String resourceArn,
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(event, 'event');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
-    _s.validateStringLength(
-      'topicArn',
-      topicArn,
-      1,
-      300,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.UnsubscribeFromEvent'
@@ -1823,28 +1548,6 @@ class Inspector {
     required String assessmentTargetName,
     String? resourceGroupArn,
   }) async {
-    ArgumentError.checkNotNull(assessmentTargetArn, 'assessmentTargetArn');
-    _s.validateStringLength(
-      'assessmentTargetArn',
-      assessmentTargetArn,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(assessmentTargetName, 'assessmentTargetName');
-    _s.validateStringLength(
-      'assessmentTargetName',
-      assessmentTargetName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'resourceGroupArn',
-      resourceGroupArn,
-      1,
-      300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'InspectorService.UpdateAssessmentTarget'

--- a/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
+++ b/generated/aws_iot1click_devices_api/lib/devices-2018-05-14.dart
@@ -66,7 +66,6 @@ class IoT1ClickDevicesService {
   Future<ClaimDevicesByClaimCodeResponse> claimDevicesByClaimCode({
     required String claimCode,
   }) async {
-    ArgumentError.checkNotNull(claimCode, 'claimCode');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -88,7 +87,6 @@ class IoT1ClickDevicesService {
   Future<DescribeDeviceResponse> describeDevice({
     required String deviceId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -131,7 +129,6 @@ class IoT1ClickDevicesService {
     required String deviceId,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
     };
@@ -156,7 +153,6 @@ class IoT1ClickDevicesService {
   Future<GetDeviceMethodsResponse> getDeviceMethods({
     required String deviceId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -186,7 +182,6 @@ class IoT1ClickDevicesService {
   Future<InitiateDeviceClaimResponse> initiateDeviceClaim({
     required String deviceId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -220,7 +215,6 @@ class IoT1ClickDevicesService {
     DeviceMethod? deviceMethod,
     String? deviceMethodParameters,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final $payload = <String, dynamic>{
       if (deviceMethod != null) 'deviceMethod': deviceMethod,
       if (deviceMethodParameters != null)
@@ -270,9 +264,6 @@ class IoT1ClickDevicesService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(fromTimeStamp, 'fromTimeStamp');
-    ArgumentError.checkNotNull(toTimeStamp, 'toTimeStamp');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -347,7 +338,6 @@ class IoT1ClickDevicesService {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -383,8 +373,6 @@ class IoT1ClickDevicesService {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -407,7 +395,6 @@ class IoT1ClickDevicesService {
   Future<UnclaimDeviceResponse> unclaimDevice({
     required String deviceId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -434,8 +421,6 @@ class IoT1ClickDevicesService {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -465,7 +450,6 @@ class IoT1ClickDevicesService {
     required String deviceId,
     bool? enabled,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
     final $payload = <String, dynamic>{
       if (enabled != null) 'enabled': enabled,
     };

--- a/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
+++ b/generated/aws_iot1click_projects_api/lib/iot1click-projects-2018-05-14.dart
@@ -75,38 +75,6 @@ class IoT1ClickProjects {
     required String placementName,
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    _s.validateStringLength(
-      'deviceId',
-      deviceId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deviceTemplateName, 'deviceTemplateName');
-    _s.validateStringLength(
-      'deviceTemplateName',
-      deviceTemplateName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'deviceId': deviceId,
     };
@@ -140,22 +108,6 @@ class IoT1ClickProjects {
     required String projectName,
     Map<String, String>? attributes,
   }) async {
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'placementName': placementName,
       if (attributes != null) 'attributes': attributes,
@@ -201,20 +153,6 @@ class IoT1ClickProjects {
     PlacementTemplate? placementTemplate,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       'projectName': projectName,
       if (description != null) 'description': description,
@@ -249,22 +187,6 @@ class IoT1ClickProjects {
     required String placementName,
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -290,14 +212,6 @@ class IoT1ClickProjects {
   Future<void> deleteProject({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -321,22 +235,6 @@ class IoT1ClickProjects {
     required String placementName,
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -358,14 +256,6 @@ class IoT1ClickProjects {
   Future<DescribeProjectResponse> describeProject({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -395,30 +285,6 @@ class IoT1ClickProjects {
     required String placementName,
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(deviceTemplateName, 'deviceTemplateName');
-    _s.validateStringLength(
-      'deviceTemplateName',
-      deviceTemplateName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -443,22 +309,6 @@ class IoT1ClickProjects {
     required String placementName,
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -489,25 +339,11 @@ class IoT1ClickProjects {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -545,12 +381,6 @@ class IoT1ClickProjects {
       1,
       250,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -577,7 +407,6 @@ class IoT1ClickProjects {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -609,8 +438,6 @@ class IoT1ClickProjects {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -637,8 +464,6 @@ class IoT1ClickProjects {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -673,22 +498,6 @@ class IoT1ClickProjects {
     required String projectName,
     Map<String, String>? attributes,
   }) async {
-    ArgumentError.checkNotNull(placementName, 'placementName');
-    _s.validateStringLength(
-      'placementName',
-      placementName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (attributes != null) 'attributes': attributes,
     };
@@ -728,20 +537,6 @@ class IoT1ClickProjects {
     String? description,
     PlacementTemplate? placementTemplate,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (placementTemplate != null) 'placementTemplate': placementTemplate,

--- a/generated/aws_iot_api/lib/iot-2015-05-28.dart
+++ b/generated/aws_iot_api/lib/iot-2015-05-28.dart
@@ -78,14 +78,6 @@ class IoT {
     required String certificateId,
     bool? setAsActive,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (setAsActive != null) 'setAsActive': [setAsActive.toString()],
     };
@@ -123,18 +115,6 @@ class IoT {
     String? thingArn,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (billingGroupArn != null) 'billingGroupArn': billingGroupArn,
       if (billingGroupName != null) 'billingGroupName': billingGroupName,
@@ -180,18 +160,6 @@ class IoT {
     String? thingGroupName,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (overrideDynamicGroups != null)
         'overrideDynamicGroups': overrideDynamicGroups,
@@ -257,27 +225,6 @@ class IoT {
     String? comment,
     String? namespaceId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      2028,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespaceId != null) 'namespaceId': [namespaceId],
     };
@@ -316,15 +263,6 @@ class IoT {
     required String policyName,
     required String target,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(target, 'target');
     final $payload = <String, dynamic>{
       'target': target,
     };
@@ -361,15 +299,6 @@ class IoT {
     required String policyName,
     required String principal,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
     final headers = <String, String>{
       'x-amzn-iot-principal': principal.toString(),
     };
@@ -403,16 +332,6 @@ class IoT {
     required String securityProfileName,
     required String securityProfileTargetArn,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        securityProfileTargetArn, 'securityProfileTargetArn');
     final $query = <String, List<String>>{
       'securityProfileTargetArn': [securityProfileTargetArn],
     };
@@ -447,15 +366,6 @@ class IoT {
     required String principal,
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amzn-principal': principal.toString(),
     };
@@ -481,14 +391,6 @@ class IoT {
   Future<void> cancelAuditMitigationActionsTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -513,14 +415,6 @@ class IoT {
   Future<void> cancelAuditTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      40,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -555,14 +449,6 @@ class IoT {
   Future<void> cancelCertificateTransfer({
     required String certificateId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'PATCH',
@@ -584,14 +470,6 @@ class IoT {
   Future<void> cancelDetectMitigationActionsTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -632,26 +510,6 @@ class IoT {
     bool? force,
     String? reasonCode,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      2028,
-    );
-    _s.validateStringLength(
-      'reasonCode',
-      reasonCode,
-      0,
-      128,
-    );
     final $query = <String, List<String>>{
       if (force != null) 'force': [force.toString()],
     };
@@ -716,22 +574,6 @@ class IoT {
     bool? force,
     Map<String, String>? statusDetails,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (force != null) 'force': [force.toString()],
     };
@@ -784,14 +626,6 @@ class IoT {
   Future<void> confirmTopicRuleDestination({
     required String confirmationToken,
   }) async {
-    ArgumentError.checkNotNull(confirmationToken, 'confirmationToken');
-    _s.validateStringLength(
-      'confirmationToken',
-      confirmationToken,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -828,20 +662,6 @@ class IoT {
     DateTime? expirationDate,
     bool? suppressIndefinitely,
   }) async {
-    ArgumentError.checkNotNull(checkName, 'checkName');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'checkName': checkName,
       'resourceIdentifier': resourceIdentifier,
@@ -910,28 +730,6 @@ class IoT {
     String? tokenKeyName,
     Map<String, String>? tokenSigningPublicKeys,
   }) async {
-    ArgumentError.checkNotNull(authorizerFunctionArn, 'authorizerFunctionArn');
-    _s.validateStringLength(
-      'authorizerFunctionArn',
-      authorizerFunctionArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'tokenKeyName',
-      tokenKeyName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'authorizerFunctionArn': authorizerFunctionArn,
       if (signingDisabled != null) 'signingDisabled': signingDisabled,
@@ -970,14 +768,6 @@ class IoT {
     BillingGroupProperties? billingGroupProperties,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(billingGroupName, 'billingGroupName');
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (billingGroupProperties != null)
         'billingGroupProperties': billingGroupProperties,
@@ -1053,15 +843,6 @@ class IoT {
     required String certificateSigningRequest,
     bool? setAsActive,
   }) async {
-    ArgumentError.checkNotNull(
-        certificateSigningRequest, 'certificateSigningRequest');
-    _s.validateStringLength(
-      'certificateSigningRequest',
-      certificateSigningRequest,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (setAsActive != null) 'setAsActive': [setAsActive.toString()],
     };
@@ -1117,27 +898,6 @@ class IoT {
     String? displayName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricType, 'metricType');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'metricType': metricType.toValue(),
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -1193,22 +953,6 @@ class IoT {
     String? clientRequestToken,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stringValues, 'stringValues');
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'stringValues': stringValues,
       'type': type.toValue(),
@@ -1285,27 +1029,6 @@ class IoT {
     List<Tag>? tags,
     String? validationCertificateArn,
   }) async {
-    ArgumentError.checkNotNull(
-        domainConfigurationName, 'domainConfigurationName');
-    _s.validateStringLength(
-      'domainConfigurationName',
-      domainConfigurationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-    );
-    _s.validateStringLength(
-      'validationCertificateArn',
-      validationCertificateArn,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (authorizerConfig != null) 'authorizerConfig': authorizerConfig,
       if (domainName != null) 'domainName': domainName,
@@ -1372,28 +1095,6 @@ class IoT {
     List<Tag>? tags,
     ThingGroupProperties? thingGroupProperties,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'queryString': queryString,
       if (indexName != null) 'indexName': indexName,
@@ -1501,39 +1202,6 @@ class IoT {
     TargetSelection? targetSelection,
     TimeoutConfig? timeoutConfig,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2028,
-    );
-    _s.validateStringLength(
-      'document',
-      document,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'documentSource',
-      documentSource,
-      1,
-      1350,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'targets': targets,
       if (abortConfig != null) 'abortConfig': abortConfig,
@@ -1620,23 +1288,6 @@ class IoT {
     required String roleArn,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionParams, 'actionParams');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'actionParams': actionParams,
       'roleArn': roleArn,
@@ -1729,30 +1380,6 @@ class IoT {
     List<Tag>? tags,
     TargetSelection? targetSelection,
   }) async {
-    ArgumentError.checkNotNull(files, 'files');
-    ArgumentError.checkNotNull(otaUpdateId, 'otaUpdateId');
-    _s.validateStringLength(
-      'otaUpdateId',
-      otaUpdateId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targets, 'targets');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2028,
-    );
     final $payload = <String, dynamic>{
       'files': files,
       'roleArn': roleArn,
@@ -1819,15 +1446,6 @@ class IoT {
     required String policyName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'policyDocument': policyDocument,
       if (tags != null) 'tags': tags,
@@ -1877,15 +1495,6 @@ class IoT {
     required String policyName,
     bool? setAsDefault,
   }) async {
-    ArgumentError.checkNotNull(policyDocument, 'policyDocument');
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (setAsDefault != null) 'setAsDefault': [setAsDefault.toString()],
     };
@@ -1916,14 +1525,6 @@ class IoT {
   Future<CreateProvisioningClaimResponse> createProvisioningClaim({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1982,29 +1583,6 @@ class IoT {
     ProvisioningHook? preProvisioningHook,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(provisioningRoleArn, 'provisioningRoleArn');
-    _s.validateStringLength(
-      'provisioningRoleArn',
-      provisioningRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateBody, 'templateBody');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       'provisioningRoleArn': provisioningRoleArn,
       'templateBody': templateBody,
@@ -2048,15 +1626,6 @@ class IoT {
     required String templateName,
     bool? setAsDefault,
   }) async {
-    ArgumentError.checkNotNull(templateBody, 'templateBody');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (setAsDefault != null) 'setAsDefault': [setAsDefault.toString()],
     };
@@ -2111,22 +1680,6 @@ class IoT {
     int? credentialDurationSeconds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(roleAlias, 'roleAlias');
-    _s.validateStringLength(
-      'roleAlias',
-      roleAlias,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'credentialDurationSeconds',
       credentialDurationSeconds,
@@ -2196,16 +1749,6 @@ class IoT {
     DayOfWeek? dayOfWeek,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(frequency, 'frequency');
-    ArgumentError.checkNotNull(scheduledAuditName, 'scheduledAuditName');
-    _s.validateStringLength(
-      'scheduledAuditName',
-      scheduledAuditName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetCheckNames, 'targetCheckNames');
     final $payload = <String, dynamic>{
       'frequency': frequency.toValue(),
       'targetCheckNames': targetCheckNames,
@@ -2272,20 +1815,6 @@ class IoT {
     String? securityProfileDescription,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'securityProfileDescription',
-      securityProfileDescription,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       if (additionalMetricsToRetain != null)
         'additionalMetricsToRetain': additionalMetricsToRetain,
@@ -2344,29 +1873,6 @@ class IoT {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(files, 'files');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2028,
-    );
     final $payload = <String, dynamic>{
       'files': files,
       'roleArn': roleArn,
@@ -2424,26 +1930,6 @@ class IoT {
     String? billingGroupName,
     String? thingTypeName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (attributePayload != null) 'attributePayload': attributePayload,
       if (billingGroupName != null) 'billingGroupName': billingGroupName,
@@ -2487,20 +1973,6 @@ class IoT {
     List<Tag>? tags,
     ThingGroupProperties? thingGroupProperties,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'parentGroupName',
-      parentGroupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (parentGroupName != null) 'parentGroupName': parentGroupName,
       if (tags != null) 'tags': tags,
@@ -2540,14 +2012,6 @@ class IoT {
     List<Tag>? tags,
     ThingTypeProperties? thingTypeProperties,
   }) async {
-    ArgumentError.checkNotNull(thingTypeName, 'thingTypeName');
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
       if (thingTypeProperties != null)
@@ -2595,15 +2059,6 @@ class IoT {
     required TopicRulePayload topicRulePayload,
     String? tags,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(topicRulePayload, 'topicRulePayload');
     final headers = <String, String>{
       if (tags != null) 'x-amz-tagging': tags.toString(),
     };
@@ -2630,8 +2085,6 @@ class IoT {
   Future<CreateTopicRuleDestinationResponse> createTopicRuleDestination({
     required TopicRuleDestinationConfiguration destinationConfiguration,
   }) async {
-    ArgumentError.checkNotNull(
-        destinationConfiguration, 'destinationConfiguration');
     final $payload = <String, dynamic>{
       'destinationConfiguration': destinationConfiguration,
     };
@@ -2680,8 +2133,6 @@ class IoT {
     required String checkName,
     required ResourceIdentifier resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(checkName, 'checkName');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final $payload = <String, dynamic>{
       'checkName': checkName,
       'resourceIdentifier': resourceIdentifier,
@@ -2709,14 +2160,6 @@ class IoT {
   Future<void> deleteAuthorizer({
     required String authorizerName,
   }) async {
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2744,14 +2187,6 @@ class IoT {
     required String billingGroupName,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(billingGroupName, 'billingGroupName');
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -2781,14 +2216,6 @@ class IoT {
   Future<void> deleteCACertificate({
     required String certificateId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2825,14 +2252,6 @@ class IoT {
     required String certificateId,
     bool? forceDelete,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (forceDelete != null) 'forceDelete': [forceDelete.toString()],
     };
@@ -2863,14 +2282,6 @@ class IoT {
   Future<void> deleteCustomMetric({
     required String metricName,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2890,14 +2301,6 @@ class IoT {
   Future<void> deleteDimension({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2924,15 +2327,6 @@ class IoT {
   Future<void> deleteDomainConfiguration({
     required String domainConfigurationName,
   }) async {
-    ArgumentError.checkNotNull(
-        domainConfigurationName, 'domainConfigurationName');
-    _s.validateStringLength(
-      'domainConfigurationName',
-      domainConfigurationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2958,14 +2352,6 @@ class IoT {
     required String thingGroupName,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -3033,20 +2419,6 @@ class IoT {
     bool? force,
     String? namespaceId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (force != null) 'force': [force.toString()],
       if (namespaceId != null) 'namespaceId': [namespaceId],
@@ -3113,29 +2485,6 @@ class IoT {
     bool? force,
     String? namespaceId,
   }) async {
-    ArgumentError.checkNotNull(executionNumber, 'executionNumber');
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (force != null) 'force': [force.toString()],
       if (namespaceId != null) 'namespaceId': [namespaceId],
@@ -3161,14 +2510,6 @@ class IoT {
   Future<void> deleteMitigationAction({
     required String actionName,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      0,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3203,14 +2544,6 @@ class IoT {
     bool? deleteStream,
     bool? forceDeleteAWSJob,
   }) async {
-    ArgumentError.checkNotNull(otaUpdateId, 'otaUpdateId');
-    _s.validateStringLength(
-      'otaUpdateId',
-      otaUpdateId,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (deleteStream != null) 'deleteStream': [deleteStream.toString()],
       if (forceDeleteAWSJob != null)
@@ -3251,14 +2584,6 @@ class IoT {
   Future<void> deletePolicy({
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3289,15 +2614,6 @@ class IoT {
     required String policyName,
     required String policyVersionId,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyVersionId, 'policyVersionId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3322,14 +2638,6 @@ class IoT {
   Future<void> deleteProvisioningTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3358,15 +2666,6 @@ class IoT {
     required String templateName,
     required int versionId,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3407,14 +2706,6 @@ class IoT {
   Future<void> deleteRoleAlias({
     required String roleAlias,
   }) async {
-    ArgumentError.checkNotNull(roleAlias, 'roleAlias');
-    _s.validateStringLength(
-      'roleAlias',
-      roleAlias,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3435,14 +2726,6 @@ class IoT {
   Future<void> deleteScheduledAudit({
     required String scheduledAuditName,
   }) async {
-    ArgumentError.checkNotNull(scheduledAuditName, 'scheduledAuditName');
-    _s.validateStringLength(
-      'scheduledAuditName',
-      scheduledAuditName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3471,14 +2754,6 @@ class IoT {
     required String securityProfileName,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -3508,14 +2783,6 @@ class IoT {
   Future<void> deleteStream({
     required String streamId,
   }) async {
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3547,14 +2814,6 @@ class IoT {
     required String thingName,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -3584,14 +2843,6 @@ class IoT {
     required String thingGroupName,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -3624,14 +2875,6 @@ class IoT {
   Future<void> deleteThingType({
     required String thingTypeName,
   }) async {
-    ArgumentError.checkNotNull(thingTypeName, 'thingTypeName');
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3653,14 +2896,6 @@ class IoT {
   Future<void> deleteTopicRule({
     required String ruleName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3682,7 +2917,6 @@ class IoT {
   Future<void> deleteTopicRuleDestination({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -3708,8 +2942,6 @@ class IoT {
     required String targetName,
     required LogTargetType targetType,
   }) async {
-    ArgumentError.checkNotNull(targetName, 'targetName');
-    ArgumentError.checkNotNull(targetType, 'targetType');
     final $query = <String, List<String>>{
       'targetName': [targetName],
       'targetType': [targetType.toValue()],
@@ -3743,14 +2975,6 @@ class IoT {
     required String thingTypeName,
     bool? undoDeprecate,
   }) async {
-    ArgumentError.checkNotNull(thingTypeName, 'thingTypeName');
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (undoDeprecate != null) 'undoDeprecate': undoDeprecate,
     };
@@ -3795,14 +3019,6 @@ class IoT {
   Future<DescribeAuditFindingResponse> describeAuditFinding({
     required String findingId,
   }) async {
-    ArgumentError.checkNotNull(findingId, 'findingId');
-    _s.validateStringLength(
-      'findingId',
-      findingId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3828,14 +3044,6 @@ class IoT {
       describeAuditMitigationActionsTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3856,8 +3064,6 @@ class IoT {
     required String checkName,
     required ResourceIdentifier resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(checkName, 'checkName');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final $payload = <String, dynamic>{
       'checkName': checkName,
       'resourceIdentifier': resourceIdentifier,
@@ -3883,14 +3089,6 @@ class IoT {
   Future<DescribeAuditTaskResponse> describeAuditTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      40,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3914,14 +3112,6 @@ class IoT {
   Future<DescribeAuthorizerResponse> describeAuthorizer({
     required String authorizerName,
   }) async {
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3943,14 +3133,6 @@ class IoT {
   Future<DescribeBillingGroupResponse> describeBillingGroup({
     required String billingGroupName,
   }) async {
-    ArgumentError.checkNotNull(billingGroupName, 'billingGroupName');
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3974,14 +3156,6 @@ class IoT {
   Future<DescribeCACertificateResponse> describeCACertificate({
     required String certificateId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4006,14 +3180,6 @@ class IoT {
   Future<DescribeCertificateResponse> describeCertificate({
     required String certificateId,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4035,14 +3201,6 @@ class IoT {
   Future<DescribeCustomMetricResponse> describeCustomMetric({
     required String metricName,
   }) async {
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4083,14 +3241,6 @@ class IoT {
       describeDetectMitigationActionsTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4113,14 +3263,6 @@ class IoT {
   Future<DescribeDimensionResponse> describeDimension({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4148,15 +3290,6 @@ class IoT {
   Future<DescribeDomainConfigurationResponse> describeDomainConfiguration({
     required String domainConfigurationName,
   }) async {
-    ArgumentError.checkNotNull(
-        domainConfigurationName, 'domainConfigurationName');
-    _s.validateStringLength(
-      'domainConfigurationName',
-      domainConfigurationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4205,12 +3338,6 @@ class IoT {
   Future<DescribeEndpointResponse> describeEndpoint({
     String? endpointType,
   }) async {
-    _s.validateStringLength(
-      'endpointType',
-      endpointType,
-      0,
-      128,
-    );
     final $query = <String, List<String>>{
       if (endpointType != null) 'endpointType': [endpointType],
     };
@@ -4253,14 +3380,6 @@ class IoT {
   Future<DescribeIndexResponse> describeIndex({
     required String indexName,
   }) async {
-    ArgumentError.checkNotNull(indexName, 'indexName');
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4282,14 +3401,6 @@ class IoT {
   Future<DescribeJobResponse> describeJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4320,22 +3431,6 @@ class IoT {
     required String thingName,
     int? executionNumber,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (executionNumber != null)
         'executionNumber': [executionNumber.toString()],
@@ -4363,14 +3458,6 @@ class IoT {
   Future<DescribeMitigationActionResponse> describeMitigationAction({
     required String actionName,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      0,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4394,14 +3481,6 @@ class IoT {
   Future<DescribeProvisioningTemplateResponse> describeProvisioningTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4430,15 +3509,6 @@ class IoT {
     required String templateName,
     required int versionId,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4463,14 +3533,6 @@ class IoT {
   Future<DescribeRoleAliasResponse> describeRoleAlias({
     required String roleAlias,
   }) async {
-    ArgumentError.checkNotNull(roleAlias, 'roleAlias');
-    _s.validateStringLength(
-      'roleAlias',
-      roleAlias,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4492,14 +3554,6 @@ class IoT {
   Future<DescribeScheduledAuditResponse> describeScheduledAudit({
     required String scheduledAuditName,
   }) async {
-    ArgumentError.checkNotNull(scheduledAuditName, 'scheduledAuditName');
-    _s.validateStringLength(
-      'scheduledAuditName',
-      scheduledAuditName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4522,14 +3576,6 @@ class IoT {
   Future<DescribeSecurityProfileResponse> describeSecurityProfile({
     required String securityProfileName,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4554,14 +3600,6 @@ class IoT {
   Future<DescribeStreamResponse> describeStream({
     required String streamId,
   }) async {
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4585,14 +3623,6 @@ class IoT {
   Future<DescribeThingResponse> describeThing({
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4614,14 +3644,6 @@ class IoT {
   Future<DescribeThingGroupResponse> describeThingGroup({
     required String thingGroupName,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4644,14 +3666,6 @@ class IoT {
   Future<DescribeThingRegistrationTaskResponse> describeThingRegistrationTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      0,
-      40,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4675,14 +3689,6 @@ class IoT {
   Future<DescribeThingTypeResponse> describeThingType({
     required String thingTypeName,
   }) async {
-    ArgumentError.checkNotNull(thingTypeName, 'thingTypeName');
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4710,15 +3716,6 @@ class IoT {
     required String policyName,
     required String target,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(target, 'target');
     final $payload = <String, dynamic>{
       'target': target,
     };
@@ -4758,15 +3755,6 @@ class IoT {
     required String policyName,
     required String principal,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
     final headers = <String, String>{
       'x-amzn-iot-principal': principal.toString(),
     };
@@ -4796,16 +3784,6 @@ class IoT {
     required String securityProfileName,
     required String securityProfileTargetArn,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        securityProfileTargetArn, 'securityProfileTargetArn');
     final $query = <String, List<String>>{
       'securityProfileTargetArn': [securityProfileTargetArn],
     };
@@ -4845,15 +3823,6 @@ class IoT {
     required String principal,
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amzn-principal': principal.toString(),
     };
@@ -4879,14 +3848,6 @@ class IoT {
   Future<void> disableTopicRule({
     required String ruleName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'POST',
@@ -4908,14 +3869,6 @@ class IoT {
   Future<void> enableTopicRule({
     required String ruleName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'POST',
@@ -4951,12 +3904,6 @@ class IoT {
       maxResults,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -5003,26 +3950,6 @@ class IoT {
     String? indexName,
     String? queryVersion,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aggregationField',
-      aggregationField,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'queryString': queryString,
       if (aggregationField != null) 'aggregationField': aggregationField,
@@ -5067,12 +3994,6 @@ class IoT {
     String? principal,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (thingName != null) 'thingName': [thingName],
     };
@@ -5120,14 +4041,6 @@ class IoT {
   Future<GetJobDocumentResponse> getJobDocument({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5169,14 +4082,6 @@ class IoT {
   Future<GetOTAUpdateResponse> getOTAUpdate({
     required String otaUpdateId,
   }) async {
-    ArgumentError.checkNotNull(otaUpdateId, 'otaUpdateId');
-    _s.validateStringLength(
-      'otaUpdateId',
-      otaUpdateId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5229,26 +4134,6 @@ class IoT {
     List<double>? percents,
     String? queryVersion,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aggregationField',
-      aggregationField,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'queryString': queryString,
       if (aggregationField != null) 'aggregationField': aggregationField,
@@ -5280,14 +4165,6 @@ class IoT {
   Future<GetPolicyResponse> getPolicy({
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5315,15 +4192,6 @@ class IoT {
     required String policyName,
     required String policyVersionId,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyVersionId, 'policyVersionId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5385,26 +4253,6 @@ class IoT {
     String? indexName,
     String? queryVersion,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aggregationField',
-      aggregationField,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'queryString': queryString,
       if (aggregationField != null) 'aggregationField': aggregationField,
@@ -5432,14 +4280,6 @@ class IoT {
   Future<GetTopicRuleResponse> getTopicRule({
     required String ruleName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5461,7 +4301,6 @@ class IoT {
   Future<GetTopicRuleDestinationResponse> getTopicRuleDestination({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -5526,18 +4365,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (behaviorCriteriaType != null)
         'behaviorCriteriaType': [behaviorCriteriaType.toValue()],
@@ -5591,13 +4418,6 @@ class IoT {
     int? pageSize,
     bool? recursive,
   }) async {
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -5671,12 +4491,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       if (checkName != null) 'checkName': checkName,
       if (endTime != null) 'endTime': unixTimestampToJson(endTime),
@@ -5727,22 +4541,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(findingId, 'findingId');
-    _s.validateStringLength(
-      'findingId',
-      findingId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5808,20 +4606,6 @@ class IoT {
     String? nextToken,
     AuditMitigationActionsTaskStatus? taskStatus,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'auditTaskId',
-      auditTaskId,
-      1,
-      40,
-    );
-    _s.validateStringLength(
-      'findingId',
-      findingId,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5928,8 +4712,6 @@ class IoT {
     AuditTaskStatus? taskStatus,
     AuditTaskType? taskType,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5979,12 +4761,6 @@ class IoT {
     int? pageSize,
     AuthorizerStatus? status,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6036,12 +4812,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'namePrefixFilter',
-      namePrefixFilter,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (namePrefixFilter != null) 'namePrefixFilter': [namePrefixFilter],
@@ -6081,12 +4851,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6134,12 +4898,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6189,20 +4947,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(caCertificateId, 'caCertificateId');
-    _s.validateStringLength(
-      'caCertificateId',
-      caCertificateId,
-      64,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6305,24 +5049,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'violationId',
-      violationId,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (endTime != null) 'endTime': [_s.iso8601ToJson(endTime).toString()],
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -6369,8 +5095,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6454,12 +5178,6 @@ class IoT {
     int? pageSize,
     ServiceType? serviceType,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6543,14 +5261,6 @@ class IoT {
     String? nextToken,
     JobExecutionStatus? status,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6610,25 +5320,11 @@ class IoT {
     String? nextToken,
     JobExecutionStatus? status,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -6702,24 +5398,6 @@ class IoT {
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'thingGroupId',
-      thingGroupId,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -6848,12 +5526,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6898,12 +5570,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -6957,20 +5623,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -7012,14 +5664,6 @@ class IoT {
   Future<ListPolicyVersionsResponse> listPolicyVersions({
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -7067,13 +5711,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(principal, 'principal');
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -7126,7 +5763,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(principal, 'principal');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7173,14 +5809,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7259,12 +5887,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -7353,23 +5975,11 @@ class IoT {
     String? metricName,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'dimensionName',
-      dimensionName,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (dimensionName != null) 'dimensionName': [dimensionName],
@@ -7413,8 +6023,6 @@ class IoT {
     String? nextToken,
     bool? recursive,
   }) async {
-    ArgumentError.checkNotNull(
-        securityProfileTargetArn, 'securityProfileTargetArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7498,7 +6106,6 @@ class IoT {
     required String resourceArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -7536,20 +6143,6 @@ class IoT {
     String? marker,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -7591,14 +6184,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7656,18 +6241,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'namePrefixFilter',
-      namePrefixFilter,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'parentGroup',
-      parentGroup,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (namePrefixFilter != null) 'namePrefixFilter': [namePrefixFilter],
@@ -7707,14 +6280,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7761,14 +6326,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7816,15 +6373,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(reportType, 'reportType');
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      0,
-      40,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -7919,12 +6467,6 @@ class IoT {
       1,
       250,
     );
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -7981,29 +6523,11 @@ class IoT {
     String? nextToken,
     String? thingTypeName,
   }) async {
-    _s.validateStringLength(
-      'attributeName',
-      attributeName,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'attributeValue',
-      attributeValue,
-      0,
-      800,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (attributeName != null) 'attributeName': [attributeName],
@@ -8044,14 +6568,6 @@ class IoT {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(billingGroupName, 'billingGroupName');
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -8100,14 +6616,6 @@ class IoT {
     String? nextToken,
     bool? recursive,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -8301,25 +6809,11 @@ class IoT {
     String? securityProfileName,
     String? thingName,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       'endTime': [_s.iso8601ToJson(endTime).toString()],
@@ -8397,23 +6891,6 @@ class IoT {
     bool? setAsActive,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(caCertificate, 'caCertificate');
-    _s.validateStringLength(
-      'caCertificate',
-      caCertificate,
-      1,
-      65536,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        verificationCertificate, 'verificationCertificate');
-    _s.validateStringLength(
-      'verificationCertificate',
-      verificationCertificate,
-      1,
-      65536,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (allowAutoRegistration != null)
         'allowAutoRegistration': [allowAutoRegistration.toString()],
@@ -8466,20 +6943,6 @@ class IoT {
     bool? setAsActive,
     CertificateStatus? status,
   }) async {
-    ArgumentError.checkNotNull(certificatePem, 'certificatePem');
-    _s.validateStringLength(
-      'certificatePem',
-      certificatePem,
-      1,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'caCertificatePem',
-      caCertificatePem,
-      1,
-      65536,
-    );
     final $query = <String, List<String>>{
       if (setAsActive != null) 'setAsActive': [setAsActive.toString()],
     };
@@ -8518,14 +6981,6 @@ class IoT {
     required String certificatePem,
     CertificateStatus? status,
   }) async {
-    ArgumentError.checkNotNull(certificatePem, 'certificatePem');
-    _s.validateStringLength(
-      'certificatePem',
-      certificatePem,
-      1,
-      65536,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'certificatePem': certificatePem,
       if (status != null) 'status': status.toValue(),
@@ -8567,7 +7022,6 @@ class IoT {
     required String templateBody,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(templateBody, 'templateBody');
     final $payload = <String, dynamic>{
       'templateBody': templateBody,
       if (parameters != null) 'parameters': parameters,
@@ -8610,20 +7064,6 @@ class IoT {
     required String certificateId,
     String? rejectReason,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'rejectReason',
-      rejectReason,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (rejectReason != null) 'rejectReason': rejectReason,
     };
@@ -8660,18 +7100,6 @@ class IoT {
     String? thingArn,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (billingGroupArn != null) 'billingGroupArn': billingGroupArn,
       if (billingGroupName != null) 'billingGroupName': billingGroupName,
@@ -8715,18 +7143,6 @@ class IoT {
     String? thingGroupName,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (thingArn != null) 'thingArn': thingArn,
       if (thingGroupArn != null) 'thingGroupArn': thingGroupArn,
@@ -8762,15 +7178,6 @@ class IoT {
     required String ruleName,
     required TopicRulePayload topicRulePayload,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(topicRulePayload, 'topicRulePayload');
     await _protocol.send(
       payload: topicRulePayload,
       method: 'PATCH',
@@ -8812,20 +7219,6 @@ class IoT {
     String? nextToken,
     String? queryVersion,
   }) async {
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -8864,14 +7257,6 @@ class IoT {
   Future<SetDefaultAuthorizerResponse> setDefaultAuthorizer({
     required String authorizerName,
   }) async {
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'authorizerName': authorizerName,
     };
@@ -8905,15 +7290,6 @@ class IoT {
     required String policyName,
     required String policyVersionId,
   }) async {
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyVersionId, 'policyVersionId');
     await _protocol.send(
       payload: null,
       method: 'PATCH',
@@ -8937,7 +7313,6 @@ class IoT {
   Future<void> setLoggingOptions({
     required LoggingOptionsPayload loggingOptionsPayload,
   }) async {
-    ArgumentError.checkNotNull(loggingOptionsPayload, 'loggingOptionsPayload');
     await _protocol.send(
       payload: loggingOptionsPayload,
       method: 'POST',
@@ -8963,8 +7338,6 @@ class IoT {
     required LogLevel logLevel,
     required LogTarget logTarget,
   }) async {
-    ArgumentError.checkNotNull(logLevel, 'logLevel');
-    ArgumentError.checkNotNull(logTarget, 'logTarget');
     final $payload = <String, dynamic>{
       'logLevel': logLevel.toValue(),
       'logTarget': logTarget,
@@ -9043,23 +7416,6 @@ class IoT {
     required String taskId,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(
-        auditCheckToActionsMapping, 'auditCheckToActionsMapping');
-    ArgumentError.checkNotNull(target, 'target');
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'auditCheckToActionsMapping': auditCheckToActionsMapping,
       'target': target,
@@ -9117,22 +7473,6 @@ class IoT {
     bool? includeSuppressedAlerts,
     ViolationEventOccurrenceRange? violationEventOccurrenceRange,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(target, 'target');
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'actions': actions,
       'target': target,
@@ -9171,7 +7511,6 @@ class IoT {
   Future<StartOnDemandAuditTaskResponse> startOnDemandAuditTask({
     required List<String> targetCheckNames,
   }) async {
-    ArgumentError.checkNotNull(targetCheckNames, 'targetCheckNames');
     final $payload = <String, dynamic>{
       'targetCheckNames': targetCheckNames,
     };
@@ -9210,31 +7549,6 @@ class IoT {
     required String roleArn,
     required String templateBody,
   }) async {
-    ArgumentError.checkNotNull(inputFileBucket, 'inputFileBucket');
-    _s.validateStringLength(
-      'inputFileBucket',
-      inputFileBucket,
-      3,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputFileKey, 'inputFileKey');
-    _s.validateStringLength(
-      'inputFileKey',
-      inputFileKey,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateBody, 'templateBody');
     final $payload = <String, dynamic>{
       'inputFileBucket': inputFileBucket,
       'inputFileKey': inputFileKey,
@@ -9263,14 +7577,6 @@ class IoT {
   Future<void> stopThingRegistrationTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      0,
-      40,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -9298,8 +7604,6 @@ class IoT {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'tags': tags,
@@ -9356,7 +7660,6 @@ class IoT {
     List<String>? policyNamesToSkip,
     String? principal,
   }) async {
-    ArgumentError.checkNotNull(authInfos, 'authInfos');
     final $query = <String, List<String>>{
       if (clientId != null) 'clientId': [clientId],
     };
@@ -9416,26 +7719,6 @@ class IoT {
     String? token,
     String? tokenSignature,
   }) async {
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'token',
-      token,
-      1,
-      6144,
-    );
-    _s.validateStringLength(
-      'tokenSignature',
-      tokenSignature,
-      1,
-      2560,
-    );
     final $payload = <String, dynamic>{
       if (httpContext != null) 'httpContext': httpContext,
       if (mqttContext != null) 'mqttContext': mqttContext,
@@ -9488,28 +7771,6 @@ class IoT {
     required String targetAwsAccount,
     String? transferMessage,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetAwsAccount, 'targetAwsAccount');
-    _s.validateStringLength(
-      'targetAwsAccount',
-      targetAwsAccount,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'transferMessage',
-      transferMessage,
-      0,
-      128,
-    );
     final $query = <String, List<String>>{
       'targetAwsAccount': [targetAwsAccount],
     };
@@ -9542,8 +7803,6 @@ class IoT {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'tagKeys': tagKeys,
@@ -9593,12 +7852,6 @@ class IoT {
         auditNotificationTargetConfigurations,
     String? roleArn,
   }) async {
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (auditCheckConfigurations != null)
         'auditCheckConfigurations': auditCheckConfigurations,
@@ -9639,14 +7892,6 @@ class IoT {
     DateTime? expirationDate,
     bool? suppressIndefinitely,
   }) async {
-    ArgumentError.checkNotNull(checkName, 'checkName');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'checkName': checkName,
       'resourceIdentifier': resourceIdentifier,
@@ -9695,26 +7940,6 @@ class IoT {
     String? tokenKeyName,
     Map<String, String>? tokenSigningPublicKeys,
   }) async {
-    ArgumentError.checkNotNull(authorizerName, 'authorizerName');
-    _s.validateStringLength(
-      'authorizerName',
-      authorizerName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authorizerFunctionArn',
-      authorizerFunctionArn,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'tokenKeyName',
-      tokenKeyName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (authorizerFunctionArn != null)
         'authorizerFunctionArn': authorizerFunctionArn,
@@ -9756,16 +7981,6 @@ class IoT {
     required BillingGroupProperties billingGroupProperties,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(billingGroupName, 'billingGroupName');
-    _s.validateStringLength(
-      'billingGroupName',
-      billingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        billingGroupProperties, 'billingGroupProperties');
     final $payload = <String, dynamic>{
       'billingGroupProperties': billingGroupProperties,
       if (expectedVersion != null) 'expectedVersion': expectedVersion,
@@ -9813,14 +8028,6 @@ class IoT {
     RegistrationConfig? registrationConfig,
     bool? removeAutoRegistration,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (newAutoRegistrationStatus != null)
         'newAutoRegistrationStatus': [newAutoRegistrationStatus.toValue()],
@@ -9877,15 +8084,6 @@ class IoT {
     required String certificateId,
     required CertificateStatus newStatus,
   }) async {
-    ArgumentError.checkNotNull(certificateId, 'certificateId');
-    _s.validateStringLength(
-      'certificateId',
-      certificateId,
-      64,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newStatus, 'newStatus');
     final $query = <String, List<String>>{
       'newStatus': [newStatus.toValue()],
     };
@@ -9916,22 +8114,6 @@ class IoT {
     required String displayName,
     required String metricName,
   }) async {
-    ArgumentError.checkNotNull(displayName, 'displayName');
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'displayName': displayName,
     };
@@ -9964,15 +8146,6 @@ class IoT {
     required String name,
     required List<String> stringValues,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stringValues, 'stringValues');
     final $payload = <String, dynamic>{
       'stringValues': stringValues,
     };
@@ -10017,15 +8190,6 @@ class IoT {
     DomainConfigurationStatus? domainConfigurationStatus,
     bool? removeAuthorizerConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        domainConfigurationName, 'domainConfigurationName');
-    _s.validateStringLength(
-      'domainConfigurationName',
-      domainConfigurationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (authorizerConfig != null) 'authorizerConfig': authorizerConfig,
       if (domainConfigurationStatus != null)
@@ -10084,27 +8248,6 @@ class IoT {
     String? queryString,
     String? queryVersion,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingGroupProperties, 'thingGroupProperties');
-    _s.validateStringLength(
-      'indexName',
-      indexName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      1152921504606846976,
-    );
     final $payload = <String, dynamic>{
       'thingGroupProperties': thingGroupProperties,
       if (expectedVersion != null) 'expectedVersion': expectedVersion,
@@ -10226,26 +8369,6 @@ class IoT {
     PresignedUrlConfig? presignedUrlConfig,
     TimeoutConfig? timeoutConfig,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2028,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespaceId != null) 'namespaceId': [namespaceId],
     };
@@ -10288,20 +8411,6 @@ class IoT {
     MitigationActionParams? actionParams,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      0,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (actionParams != null) 'actionParams': actionParams,
       if (roleArn != null) 'roleArn': roleArn,
@@ -10354,26 +8463,6 @@ class IoT {
     String? provisioningRoleArn,
     bool? removePreProvisioningHook,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'provisioningRoleArn',
-      provisioningRoleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (defaultVersionId != null) 'defaultVersionId': defaultVersionId,
       if (description != null) 'description': description,
@@ -10416,25 +8505,11 @@ class IoT {
     int? credentialDurationSeconds,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(roleAlias, 'roleAlias');
-    _s.validateStringLength(
-      'roleAlias',
-      roleAlias,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'credentialDurationSeconds',
       credentialDurationSeconds,
       900,
       3600,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
     );
     final $payload = <String, dynamic>{
       if (credentialDurationSeconds != null)
@@ -10494,14 +8569,6 @@ class IoT {
     AuditFrequency? frequency,
     List<String>? targetCheckNames,
   }) async {
-    ArgumentError.checkNotNull(scheduledAuditName, 'scheduledAuditName');
-    _s.validateStringLength(
-      'scheduledAuditName',
-      scheduledAuditName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (dayOfMonth != null) 'dayOfMonth': dayOfMonth,
       if (dayOfWeek != null) 'dayOfWeek': dayOfWeek.toValue(),
@@ -10587,20 +8654,6 @@ class IoT {
     int? expectedVersion,
     String? securityProfileDescription,
   }) async {
-    ArgumentError.checkNotNull(securityProfileName, 'securityProfileName');
-    _s.validateStringLength(
-      'securityProfileName',
-      securityProfileName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'securityProfileDescription',
-      securityProfileDescription,
-      0,
-      1000,
-    );
     final $query = <String, List<String>>{
       if (expectedVersion != null)
         'expectedVersion': [expectedVersion.toString()],
@@ -10658,26 +8711,6 @@ class IoT {
     List<StreamFile>? files,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2028,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (files != null) 'files': files,
@@ -10735,20 +8768,6 @@ class IoT {
     bool? removeThingType,
     String? thingTypeName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'thingTypeName',
-      thingTypeName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (attributePayload != null) 'attributePayload': attributePayload,
       if (expectedVersion != null) 'expectedVersion': expectedVersion,
@@ -10785,15 +8804,6 @@ class IoT {
     required ThingGroupProperties thingGroupProperties,
     int? expectedVersion,
   }) async {
-    ArgumentError.checkNotNull(thingGroupName, 'thingGroupName');
-    _s.validateStringLength(
-      'thingGroupName',
-      thingGroupName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingGroupProperties, 'thingGroupProperties');
     final $payload = <String, dynamic>{
       'thingGroupProperties': thingGroupProperties,
       if (expectedVersion != null) 'expectedVersion': expectedVersion,
@@ -10834,12 +8844,6 @@ class IoT {
     List<String>? thingGroupsToRemove,
     String? thingName,
   }) async {
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (overrideDynamicGroups != null)
         'overrideDynamicGroups': overrideDynamicGroups,
@@ -10896,8 +8900,6 @@ class IoT {
     required String arn,
     required TopicRuleDestinationStatus status,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(status, 'status');
     final $payload = <String, dynamic>{
       'arn': arn,
       'status': status.toValue(),
@@ -10923,7 +8925,6 @@ class IoT {
       validateSecurityProfileBehaviors({
     required List<Behavior> behaviors,
   }) async {
-    ArgumentError.checkNotNull(behaviors, 'behaviors');
     final $payload = <String, dynamic>{
       'behaviors': behaviors,
     };

--- a/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
+++ b/generated/aws_iot_data_api/lib/iot-data-2015-05-28.dart
@@ -77,20 +77,6 @@ class IoTDataPlane {
     required String thingName,
     String? shadowName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'shadowName',
-      shadowName,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (shadowName != null) 'name': [shadowName],
     };
@@ -130,20 +116,6 @@ class IoTDataPlane {
     required String thingName,
     String? shadowName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'shadowName',
-      shadowName,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (shadowName != null) 'name': [shadowName],
     };
@@ -182,14 +154,6 @@ class IoTDataPlane {
     String? nextToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
@@ -235,7 +199,6 @@ class IoTDataPlane {
     Uint8List? payload,
     int? qos,
   }) async {
-    ArgumentError.checkNotNull(topic, 'topic');
     _s.validateNumRange(
       'qos',
       qos,
@@ -283,21 +246,6 @@ class IoTDataPlane {
     required String thingName,
     String? shadowName,
   }) async {
-    ArgumentError.checkNotNull(payload, 'payload');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'shadowName',
-      shadowName,
-      1,
-      64,
-    );
     final $query = <String, List<String>>{
       if (shadowName != null) 'name': [shadowName],
     };

--- a/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
+++ b/generated/aws_iot_jobs_data_api/lib/iot-jobs-data-2017-09-29.dart
@@ -91,15 +91,6 @@ class IoTJobsDataPlane {
     int? executionNumber,
     bool? includeJobDocument,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (executionNumber != null)
         'executionNumber': [executionNumber.toString()],
@@ -130,14 +121,6 @@ class IoTJobsDataPlane {
   Future<GetPendingJobExecutionsResponse> getPendingJobExecutions({
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -179,14 +162,6 @@ class IoTJobsDataPlane {
     Map<String, String>? statusDetails,
     int? stepTimeoutInMinutes,
   }) async {
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (statusDetails != null) 'statusDetails': statusDetails,
       if (stepTimeoutInMinutes != null)
@@ -267,23 +242,6 @@ class IoTJobsDataPlane {
     Map<String, String>? statusDetails,
     int? stepTimeoutInMinutes,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'status': status.toValue(),
       if (executionNumber != null) 'executionNumber': executionNumber,

--- a/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
+++ b/generated/aws_iotanalytics_api/lib/iotanalytics-2017-11-27.dart
@@ -119,15 +119,6 @@ class IoTAnalytics {
     required String channelName,
     required List<Message> messages,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messages, 'messages');
     final $payload = <String, dynamic>{
       'channelName': channelName,
       'messages': messages,
@@ -159,15 +150,6 @@ class IoTAnalytics {
     required String pipelineName,
     required String reprocessingId,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reprocessingId, 'reprocessingId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -209,14 +191,6 @@ class IoTAnalytics {
     RetentionPeriod? retentionPeriod,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'channelName': channelName,
       if (channelStorage != null) 'channelStorage': channelStorage,
@@ -301,15 +275,6 @@ class IoTAnalytics {
     List<DatasetTrigger>? triggers,
     VersioningConfiguration? versioningConfiguration,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'actions': actions,
       'datasetName': datasetName,
@@ -353,20 +318,6 @@ class IoTAnalytics {
     required String datasetName,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      7,
-      36,
-    );
     final $payload = <String, dynamic>{
       if (versionId != null) 'versionId': versionId,
     };
@@ -420,14 +371,6 @@ class IoTAnalytics {
     RetentionPeriod? retentionPeriod,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(datastoreName, 'datastoreName');
-    _s.validateStringLength(
-      'datastoreName',
-      datastoreName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'datastoreName': datastoreName,
       if (datastoreStorage != null) 'datastoreStorage': datastoreStorage,
@@ -482,15 +425,6 @@ class IoTAnalytics {
     required String pipelineName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(pipelineActivities, 'pipelineActivities');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'pipelineActivities': pipelineActivities,
       'pipelineName': pipelineName,
@@ -518,14 +452,6 @@ class IoTAnalytics {
   Future<void> deleteChannel({
     required String channelName,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -550,14 +476,6 @@ class IoTAnalytics {
   Future<void> deleteDataset({
     required String datasetName,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -586,20 +504,6 @@ class IoTAnalytics {
     required String datasetName,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      7,
-      36,
-    );
     final $query = <String, List<String>>{
       if (versionId != null) 'versionId': [versionId],
     };
@@ -625,14 +529,6 @@ class IoTAnalytics {
   Future<void> deleteDatastore({
     required String datastoreName,
   }) async {
-    ArgumentError.checkNotNull(datastoreName, 'datastoreName');
-    _s.validateStringLength(
-      'datastoreName',
-      datastoreName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -654,14 +550,6 @@ class IoTAnalytics {
   Future<void> deletePipeline({
     required String pipelineName,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -689,14 +577,6 @@ class IoTAnalytics {
     required String channelName,
     bool? includeStatistics,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (includeStatistics != null)
         'includeStatistics': [includeStatistics.toString()],
@@ -724,14 +604,6 @@ class IoTAnalytics {
   Future<DescribeDatasetResponse> describeDataset({
     required String datasetName,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -760,14 +632,6 @@ class IoTAnalytics {
     required String datastoreName,
     bool? includeStatistics,
   }) async {
-    ArgumentError.checkNotNull(datastoreName, 'datastoreName');
-    _s.validateStringLength(
-      'datastoreName',
-      datastoreName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (includeStatistics != null)
         'includeStatistics': [includeStatistics.toString()],
@@ -812,14 +676,6 @@ class IoTAnalytics {
   Future<DescribePipelineResponse> describePipeline({
     required String pipelineName,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -849,20 +705,6 @@ class IoTAnalytics {
     required String datasetName,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      7,
-      36,
-    );
     final $query = <String, List<String>>{
       if (versionId != null) 'versionId': [versionId],
     };
@@ -949,14 +791,6 @@ class IoTAnalytics {
     DateTime? scheduledBefore,
     DateTime? scheduledOnOrAfter,
   }) async {
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1109,14 +943,6 @@ class IoTAnalytics {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -1148,7 +974,6 @@ class IoTAnalytics {
   Future<void> putLoggingOptions({
     required LoggingOptions loggingOptions,
   }) async {
-    ArgumentError.checkNotNull(loggingOptions, 'loggingOptions');
     final $payload = <String, dynamic>{
       'loggingOptions': loggingOptions,
     };
@@ -1181,8 +1006,6 @@ class IoTAnalytics {
     required List<Uint8List> payloads,
     required PipelineActivity pipelineActivity,
   }) async {
-    ArgumentError.checkNotNull(payloads, 'payloads');
-    ArgumentError.checkNotNull(pipelineActivity, 'pipelineActivity');
     final $payload = <String, dynamic>{
       'payloads': payloads.map(base64Encode).toList(),
       'pipelineActivity': pipelineActivity,
@@ -1223,14 +1046,6 @@ class IoTAnalytics {
     int? maxMessages,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxMessages',
       maxMessages,
@@ -1288,14 +1103,6 @@ class IoTAnalytics {
     DateTime? endTime,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (channelMessages != null) 'channelMessages': channelMessages,
       if (endTime != null) 'endTime': unixTimestampToJson(endTime),
@@ -1330,15 +1137,6 @@ class IoTAnalytics {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -1372,15 +1170,6 @@ class IoTAnalytics {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
       'tagKeys': tagKeys,
@@ -1419,14 +1208,6 @@ class IoTAnalytics {
     ChannelStorage? channelStorage,
     RetentionPeriod? retentionPeriod,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (channelStorage != null) 'channelStorage': channelStorage,
       if (retentionPeriod != null) 'retentionPeriod': retentionPeriod,
@@ -1488,15 +1269,6 @@ class IoTAnalytics {
     List<DatasetTrigger>? triggers,
     VersioningConfiguration? versioningConfiguration,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(datasetName, 'datasetName');
-    _s.validateStringLength(
-      'datasetName',
-      datasetName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'actions': actions,
       if (contentDeliveryRules != null)
@@ -1551,14 +1323,6 @@ class IoTAnalytics {
     FileFormatConfiguration? fileFormatConfiguration,
     RetentionPeriod? retentionPeriod,
   }) async {
-    ArgumentError.checkNotNull(datastoreName, 'datastoreName');
-    _s.validateStringLength(
-      'datastoreName',
-      datastoreName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (datastoreStorage != null) 'datastoreStorage': datastoreStorage,
       if (fileFormatConfiguration != null)
@@ -1605,15 +1369,6 @@ class IoTAnalytics {
     required List<PipelineActivity> pipelineActivities,
     required String pipelineName,
   }) async {
-    ArgumentError.checkNotNull(pipelineActivities, 'pipelineActivities');
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'pipelineActivities': pipelineActivities,
     };

--- a/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
+++ b/generated/aws_iotevents_api/lib/iotevents-2018-07-27.dart
@@ -97,36 +97,6 @@ class IoTEvents {
     String? key,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        detectorModelDefinition, 'detectorModelDefinition');
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'detectorModelDescription',
-      detectorModelDescription,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'detectorModelDefinition': detectorModelDefinition,
       'detectorModelName': detectorModelName,
@@ -172,21 +142,6 @@ class IoTEvents {
     String? inputDescription,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(inputDefinition, 'inputDefinition');
-    ArgumentError.checkNotNull(inputName, 'inputName');
-    _s.validateStringLength(
-      'inputName',
-      inputName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'inputDescription',
-      inputDescription,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'inputDefinition': inputDefinition,
       'inputName': inputName,
@@ -217,14 +172,6 @@ class IoTEvents {
   Future<void> deleteDetectorModel({
     required String detectorModelName,
   }) async {
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -247,14 +194,6 @@ class IoTEvents {
   Future<void> deleteInput({
     required String inputName,
   }) async {
-    ArgumentError.checkNotNull(inputName, 'inputName');
-    _s.validateStringLength(
-      'inputName',
-      inputName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -281,20 +220,6 @@ class IoTEvents {
     required String detectorModelName,
     String? detectorModelVersion,
   }) async {
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'detectorModelVersion',
-      detectorModelVersion,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (detectorModelVersion != null) 'version': [detectorModelVersion],
     };
@@ -321,14 +246,6 @@ class IoTEvents {
   Future<DescribeInputResponse> describeInput({
     required String inputName,
   }) async {
-    ArgumentError.checkNotNull(inputName, 'inputName');
-    _s.validateStringLength(
-      'inputName',
-      inputName,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -378,14 +295,6 @@ class IoTEvents {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -493,14 +402,6 @@ class IoTEvents {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -534,7 +435,6 @@ class IoTEvents {
   Future<void> putLoggingOptions({
     required LoggingOptions loggingOptions,
   }) async {
-    ArgumentError.checkNotNull(loggingOptions, 'loggingOptions');
     final $payload = <String, dynamic>{
       'loggingOptions': loggingOptions,
     };
@@ -565,15 +465,6 @@ class IoTEvents {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
     };
@@ -606,15 +497,6 @@ class IoTEvents {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'resourceArn': [resourceArn],
       'tagKeys': tagKeys,
@@ -661,30 +543,6 @@ class IoTEvents {
     String? detectorModelDescription,
     EvaluationMethod? evaluationMethod,
   }) async {
-    ArgumentError.checkNotNull(
-        detectorModelDefinition, 'detectorModelDefinition');
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'detectorModelDescription',
-      detectorModelDescription,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'detectorModelDefinition': detectorModelDefinition,
       'roleArn': roleArn,
@@ -724,21 +582,6 @@ class IoTEvents {
     required String inputName,
     String? inputDescription,
   }) async {
-    ArgumentError.checkNotNull(inputDefinition, 'inputDefinition');
-    ArgumentError.checkNotNull(inputName, 'inputName');
-    _s.validateStringLength(
-      'inputName',
-      inputName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'inputDescription',
-      inputDescription,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'inputDefinition': inputDefinition,
       if (inputDescription != null) 'inputDescription': inputDescription,

--- a/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
+++ b/generated/aws_iotevents_data_api/lib/iotevents-data-2018-10-23.dart
@@ -70,7 +70,6 @@ class IoTEventsData {
   Future<BatchPutMessageResponse> batchPutMessage({
     required List<Message> messages,
   }) async {
-    ArgumentError.checkNotNull(messages, 'messages');
     final $payload = <String, dynamic>{
       'messages': messages,
     };
@@ -97,7 +96,6 @@ class IoTEventsData {
   Future<BatchUpdateDetectorResponse> batchUpdateDetector({
     required List<UpdateDetectorRequest> detectors,
   }) async {
-    ArgumentError.checkNotNull(detectors, 'detectors');
     final $payload = <String, dynamic>{
       'detectors': detectors,
     };
@@ -129,20 +127,6 @@ class IoTEventsData {
     required String detectorModelName,
     String? keyValue,
   }) async {
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'keyValue',
-      keyValue,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (keyValue != null) 'keyValue': [keyValue],
     };
@@ -183,25 +167,11 @@ class IoTEventsData {
     String? nextToken,
     String? stateName,
   }) async {
-    ArgumentError.checkNotNull(detectorModelName, 'detectorModelName');
-    _s.validateStringLength(
-      'detectorModelName',
-      detectorModelName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       250,
-    );
-    _s.validateStringLength(
-      'stateName',
-      stateName,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],

--- a/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
+++ b/generated/aws_iotsecuretunneling_api/lib/iotsecuretunneling-2018-10-05.dart
@@ -66,7 +66,6 @@ class IoTSecureTunneling {
     required String tunnelId,
     bool? delete,
   }) async {
-    ArgumentError.checkNotNull(tunnelId, 'tunnelId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IoTSecuredTunneling.CloseTunnel'
@@ -93,7 +92,6 @@ class IoTSecureTunneling {
   Future<DescribeTunnelResponse> describeTunnel({
     required String tunnelId,
   }) async {
-    ArgumentError.checkNotNull(tunnelId, 'tunnelId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IoTSecuredTunneling.DescribeTunnel'
@@ -121,14 +119,6 @@ class IoTSecureTunneling {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IoTSecuredTunneling.ListTagsForResource'
@@ -168,12 +158,6 @@ class IoTSecureTunneling {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -251,15 +235,6 @@ class IoTSecureTunneling {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IoTSecuredTunneling.TagResource'
@@ -290,15 +265,6 @@ class IoTSecureTunneling {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IoTSecuredTunneling.UntagResource'

--- a/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
+++ b/generated/aws_iotthingsgraph_api/lib/iotthingsgraph-2018-09-06.dart
@@ -81,22 +81,6 @@ class IoTThingsGraph {
     required String thingName,
     int? namespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      0,
-      160,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.AssociateEntityToThing'
@@ -138,7 +122,6 @@ class IoTThingsGraph {
     required DefinitionDocument definition,
     int? compatibleNamespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.CreateFlowTemplate'
@@ -222,14 +205,6 @@ class IoTThingsGraph {
     String? s3BucketName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'flowActionsRoleArn',
-      flowActionsRoleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.CreateSystemInstance'
@@ -277,7 +252,6 @@ class IoTThingsGraph {
     required DefinitionDocument definition,
     int? compatibleNamespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.CreateSystemTemplate'
@@ -317,14 +291,6 @@ class IoTThingsGraph {
   Future<void> deleteFlowTemplate({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeleteFlowTemplate'
@@ -379,12 +345,6 @@ class IoTThingsGraph {
   Future<void> deleteSystemInstance({
     String? id,
   }) async {
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeleteSystemInstance'
@@ -420,14 +380,6 @@ class IoTThingsGraph {
   Future<void> deleteSystemTemplate({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeleteSystemTemplate'
@@ -481,12 +433,6 @@ class IoTThingsGraph {
   Future<DeploySystemInstanceResponse> deploySystemInstance({
     String? id,
   }) async {
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeploySystemInstance'
@@ -523,14 +469,6 @@ class IoTThingsGraph {
   Future<void> deprecateFlowTemplate({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeprecateFlowTemplate'
@@ -563,14 +501,6 @@ class IoTThingsGraph {
   Future<void> deprecateSystemTemplate({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DeprecateSystemTemplate'
@@ -601,12 +531,6 @@ class IoTThingsGraph {
   Future<DescribeNamespaceResponse> describeNamespace({
     String? namespaceName,
   }) async {
-    _s.validateStringLength(
-      'namespaceName',
-      namespaceName,
-      0,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DescribeNamespace'
@@ -643,15 +567,6 @@ class IoTThingsGraph {
     required EntityType entityType,
     required String thingName,
   }) async {
-    ArgumentError.checkNotNull(entityType, 'entityType');
-    ArgumentError.checkNotNull(thingName, 'thingName');
-    _s.validateStringLength(
-      'thingName',
-      thingName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.DissociateEntityFromThing'
@@ -723,7 +638,6 @@ class IoTThingsGraph {
     required List<String> ids,
     int? namespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(ids, 'ids');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.GetEntities'
@@ -764,14 +678,6 @@ class IoTThingsGraph {
     required String id,
     int? revisionNumber,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.GetFlowTemplate'
@@ -819,14 +725,6 @@ class IoTThingsGraph {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -892,14 +790,6 @@ class IoTThingsGraph {
   Future<GetSystemInstanceResponse> getSystemInstance({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.GetSystemInstance'
@@ -938,14 +828,6 @@ class IoTThingsGraph {
     required String id,
     int? revisionNumber,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.GetSystemTemplate'
@@ -993,14 +875,6 @@ class IoTThingsGraph {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1040,14 +914,6 @@ class IoTThingsGraph {
   Future<GetUploadStatusResponse> getUploadStatus({
     required String uploadId,
   }) async {
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
-    _s.validateStringLength(
-      'uploadId',
-      uploadId,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.GetUploadStatus'
@@ -1088,7 +954,6 @@ class IoTThingsGraph {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(flowExecutionId, 'flowExecutionId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1136,14 +1001,6 @@ class IoTThingsGraph {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1207,7 +1064,6 @@ class IoTThingsGraph {
     int? namespaceVersion,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(entityTypes, 'entityTypes');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1269,14 +1125,6 @@ class IoTThingsGraph {
     String? nextToken,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(systemInstanceId, 'systemInstanceId');
-    _s.validateStringLength(
-      'systemInstanceId',
-      systemInstanceId,
-      0,
-      160,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1492,14 +1340,6 @@ class IoTThingsGraph {
     int? namespaceVersion,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      0,
-      160,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1543,15 +1383,6 @@ class IoTThingsGraph {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.TagResource'
@@ -1582,12 +1413,6 @@ class IoTThingsGraph {
   Future<UndeploySystemInstanceResponse> undeploySystemInstance({
     String? id,
   }) async {
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.UndeploySystemInstance'
@@ -1630,15 +1455,6 @@ class IoTThingsGraph {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.UntagResource'
@@ -1689,15 +1505,6 @@ class IoTThingsGraph {
     required String id,
     int? compatibleNamespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.UpdateFlowTemplate'
@@ -1749,15 +1556,6 @@ class IoTThingsGraph {
     required String id,
     int? compatibleNamespaceVersion,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      160,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'IotThingsGraphFrontEndService.UpdateSystemTemplate'

--- a/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
+++ b/generated/aws_kafka_api/lib/kafka-2018-11-14.dart
@@ -75,8 +75,6 @@ class Kafka {
     required String clusterArn,
     required List<String> secretArnList,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(secretArnList, 'secretArnList');
     final $payload = <String, dynamic>{
       'secretArnList': secretArnList,
     };
@@ -167,24 +165,6 @@ class Kafka {
     OpenMonitoringInfo? openMonitoring,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(brokerNodeGroupInfo, 'brokerNodeGroupInfo');
-    ArgumentError.checkNotNull(clusterName, 'clusterName');
-    _s.validateStringLength(
-      'clusterName',
-      clusterName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(kafkaVersion, 'kafkaVersion');
-    _s.validateStringLength(
-      'kafkaVersion',
-      kafkaVersion,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(numberOfBrokerNodes, 'numberOfBrokerNodes');
     _s.validateNumRange(
       'numberOfBrokerNodes',
       numberOfBrokerNodes,
@@ -257,8 +237,6 @@ class Kafka {
     String? description,
     List<String>? kafkaVersions,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(serverProperties, 'serverProperties');
     final $payload = <String, dynamic>{
       'name': name,
       'serverProperties': base64Encode(serverProperties),
@@ -297,7 +275,6 @@ class Kafka {
     required String clusterArn,
     String? currentVersion,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     final $query = <String, List<String>>{
       if (currentVersion != null) 'currentVersion': [currentVersion],
     };
@@ -328,7 +305,6 @@ class Kafka {
   Future<DeleteConfigurationResponse> deleteConfiguration({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -356,7 +332,6 @@ class Kafka {
   Future<DescribeClusterResponse> describeCluster({
     required String clusterArn,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -384,7 +359,6 @@ class Kafka {
   Future<DescribeClusterOperationResponse> describeClusterOperation({
     required String clusterOperationArn,
   }) async {
-    ArgumentError.checkNotNull(clusterOperationArn, 'clusterOperationArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -413,7 +387,6 @@ class Kafka {
   Future<DescribeConfigurationResponse> describeConfiguration({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -448,8 +421,6 @@ class Kafka {
     required String arn,
     required int revision,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(revision, 'revision');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -485,8 +456,6 @@ class Kafka {
     required String clusterArn,
     required List<String> secretArnList,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(secretArnList, 'secretArnList');
     final $payload = <String, dynamic>{
       'secretArnList': secretArnList,
     };
@@ -517,7 +486,6 @@ class Kafka {
   Future<GetBootstrapBrokersResponse> getBootstrapBrokers({
     required String clusterArn,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -592,7 +560,6 @@ class Kafka {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -700,7 +667,6 @@ class Kafka {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -841,7 +807,6 @@ class Kafka {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -893,7 +858,6 @@ class Kafka {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -931,7 +895,6 @@ class Kafka {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -965,8 +928,6 @@ class Kafka {
     required List<String> brokerIds,
     required String clusterArn,
   }) async {
-    ArgumentError.checkNotNull(brokerIds, 'brokerIds');
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
     final $payload = <String, dynamic>{
       'brokerIds': brokerIds,
     };
@@ -1002,8 +963,6 @@ class Kafka {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1073,8 +1032,6 @@ class Kafka {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1118,10 +1075,6 @@ class Kafka {
     required String currentVersion,
     required int targetNumberOfBrokerNodes,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    ArgumentError.checkNotNull(
-        targetNumberOfBrokerNodes, 'targetNumberOfBrokerNodes');
     _s.validateNumRange(
       'targetNumberOfBrokerNodes',
       targetNumberOfBrokerNodes,
@@ -1173,10 +1126,6 @@ class Kafka {
     required String currentVersion,
     required List<BrokerEBSVolumeInfo> targetBrokerEBSVolumeInfo,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    ArgumentError.checkNotNull(
-        targetBrokerEBSVolumeInfo, 'targetBrokerEBSVolumeInfo');
     final $payload = <String, dynamic>{
       'currentVersion': currentVersion,
       'targetBrokerEBSVolumeInfo': targetBrokerEBSVolumeInfo,
@@ -1224,8 +1173,6 @@ class Kafka {
     required Uint8List serverProperties,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(serverProperties, 'serverProperties');
     final $payload = <String, dynamic>{
       'serverProperties': base64Encode(serverProperties),
       if (description != null) 'description': description,
@@ -1271,9 +1218,6 @@ class Kafka {
     required ConfigurationInfo configurationInfo,
     required String currentVersion,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(configurationInfo, 'configurationInfo');
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
     final $payload = <String, dynamic>{
       'configurationInfo': configurationInfo,
       'currentVersion': currentVersion,
@@ -1326,9 +1270,6 @@ class Kafka {
     required String targetKafkaVersion,
     ConfigurationInfo? configurationInfo,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    ArgumentError.checkNotNull(targetKafkaVersion, 'targetKafkaVersion');
     final $payload = <String, dynamic>{
       'currentVersion': currentVersion,
       'targetKafkaVersion': targetKafkaVersion,
@@ -1385,8 +1326,6 @@ class Kafka {
     LoggingInfo? loggingInfo,
     OpenMonitoringInfo? openMonitoring,
   }) async {
-    ArgumentError.checkNotNull(clusterArn, 'clusterArn');
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
     final $payload = <String, dynamic>{
       'currentVersion': currentVersion,
       if (enhancedMonitoring != null)

--- a/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
+++ b/generated/aws_kendra_api/lib/kendra-2019-02-03.dart
@@ -72,15 +72,6 @@ class Kendra {
     required String indexId,
     DataSourceSyncJobMetricTarget? dataSourceSyncJobMetricTarget,
   }) async {
-    ArgumentError.checkNotNull(documentIdList, 'documentIdList');
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.BatchDeleteDocument'
@@ -156,21 +147,6 @@ class Kendra {
     required String indexId,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(documents, 'documents');
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.BatchPutDocument'
@@ -277,41 +253,6 @@ class Kendra {
     String? schedule,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.CreateDataSource'
@@ -397,43 +338,6 @@ class Kendra {
     FaqFileFormat? fileFormat,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3Path, 's3Path');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.CreateFaq'
@@ -537,34 +441,6 @@ class Kendra {
     UserContextPolicy? userContextPolicy,
     List<UserTokenConfiguration>? userTokenConfigurations,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.CreateIndex'
@@ -641,43 +517,6 @@ class Kendra {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceS3Path, 'sourceS3Path');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.CreateThesaurus'
@@ -725,22 +564,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DeleteDataSource'
@@ -776,22 +599,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DeleteFaq'
@@ -826,14 +633,6 @@ class Kendra {
   Future<void> deleteIndex({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DeleteIndex'
@@ -868,22 +667,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DeleteThesaurus'
@@ -918,22 +701,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DescribeDataSource'
@@ -970,22 +737,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DescribeFaq'
@@ -1018,14 +769,6 @@ class Kendra {
   Future<DescribeIndexResponse> describeIndex({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DescribeIndex'
@@ -1061,22 +804,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.DescribeThesaurus'
@@ -1136,33 +863,11 @@ class Kendra {
     TimeRange? startTimeFilter,
     DataSourceSyncJobStatus? statusFilter,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      800,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1211,25 +916,11 @@ class Kendra {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      800,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1275,25 +966,11 @@ class Kendra {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      800,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1340,12 +1017,6 @@ class Kendra {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      800,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.ListIndices'
@@ -1380,14 +1051,6 @@ class Kendra {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.ListTagsForResource'
@@ -1430,25 +1093,11 @@ class Kendra {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      800,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1576,28 +1225,6 @@ class Kendra {
     UserContext? userContext,
     String? visitorId,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queryText, 'queryText');
-    _s.validateStringLength(
-      'queryText',
-      queryText,
-      1,
-      1000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'visitorId',
-      visitorId,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.Query'
@@ -1650,22 +1277,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.StartDataSourceSyncJob'
@@ -1704,22 +1315,6 @@ class Kendra {
     required String id,
     required String indexId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.StopDataSourceSyncJob'
@@ -1767,22 +1362,6 @@ class Kendra {
     List<ClickFeedback>? clickFeedbackItems,
     List<RelevanceFeedback>? relevanceFeedbackItems,
   }) async {
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queryId, 'queryId');
-    _s.validateStringLength(
-      'queryId',
-      queryId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.SubmitFeedback'
@@ -1824,15 +1403,6 @@ class Kendra {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.TagResource'
@@ -1869,15 +1439,6 @@ class Kendra {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.UntagResource'
@@ -1933,40 +1494,6 @@ class Kendra {
     String? roleArn,
     String? schedule,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.UpdateDataSource'
@@ -2038,32 +1565,6 @@ class Kendra {
     UserContextPolicy? userContextPolicy,
     List<UserTokenConfiguration>? userTokenConfigurations,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.UpdateIndex'
@@ -2122,40 +1623,6 @@ class Kendra {
     String? roleArn,
     S3Path? sourceS3Path,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(indexId, 'indexId');
-    _s.validateStringLength(
-      'indexId',
-      indexId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1284,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSKendraFrontendService.UpdateThesaurus'

--- a/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
+++ b/generated/aws_kinesis_api/lib/kinesis-2013-12-02.dart
@@ -74,15 +74,6 @@ class Kinesis {
     required String streamName,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.AddTagsToStream'
@@ -170,20 +161,11 @@ class Kinesis {
     required int shardCount,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(shardCount, 'shardCount');
     _s.validateNumRange(
       'shardCount',
       shardCount,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -226,15 +208,6 @@ class Kinesis {
     required int retentionPeriodHours,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(retentionPeriodHours, 'retentionPeriodHours');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DecreaseStreamRetentionPeriod'
@@ -292,14 +265,6 @@ class Kinesis {
     required String streamName,
     bool? enforceConsumerDeletion,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DeleteStream'
@@ -353,24 +318,6 @@ class Kinesis {
     String? consumerName,
     String? streamARN,
   }) async {
-    _s.validateStringLength(
-      'consumerARN',
-      consumerARN,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'consumerName',
-      consumerName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DeregisterStreamConsumer'
@@ -453,20 +400,6 @@ class Kinesis {
     String? exclusiveStartShardId,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'exclusiveStartShardId',
-      exclusiveStartShardId,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -525,24 +458,6 @@ class Kinesis {
     String? consumerName,
     String? streamARN,
   }) async {
-    _s.validateStringLength(
-      'consumerARN',
-      consumerARN,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'consumerName',
-      consumerName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DescribeStreamConsumer'
@@ -581,14 +496,6 @@ class Kinesis {
   Future<DescribeStreamSummaryOutput> describeStreamSummary({
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DescribeStreamSummary'
@@ -658,15 +565,6 @@ class Kinesis {
     required List<MetricsName> shardLevelMetrics,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(shardLevelMetrics, 'shardLevelMetrics');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.DisableEnhancedMonitoring'
@@ -736,15 +634,6 @@ class Kinesis {
     required List<MetricsName> shardLevelMetrics,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(shardLevelMetrics, 'shardLevelMetrics');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.EnableEnhancedMonitoring'
@@ -853,14 +742,6 @@ class Kinesis {
     required String shardIterator,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(shardIterator, 'shardIterator');
-    _s.validateStringLength(
-      'shardIterator',
-      shardIterator,
-      1,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -994,23 +875,6 @@ class Kinesis {
     String? startingSequenceNumber,
     DateTime? timestamp,
   }) async {
-    ArgumentError.checkNotNull(shardId, 'shardId');
-    _s.validateStringLength(
-      'shardId',
-      shardId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(shardIteratorType, 'shardIteratorType');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.GetShardIterator'
@@ -1061,15 +925,6 @@ class Kinesis {
     required int retentionPeriodHours,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(retentionPeriodHours, 'retentionPeriodHours');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.IncreaseStreamRetentionPeriod'
@@ -1176,29 +1031,11 @@ class Kinesis {
     DateTime? streamCreationTimestamp,
     String? streamName,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartShardId',
-      exclusiveStartShardId,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1048576,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1292,25 +1129,11 @@ class Kinesis {
     String? nextToken,
     DateTime? streamCreationTimestamp,
   }) async {
-    ArgumentError.checkNotNull(streamARN, 'streamARN');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1048576,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1366,12 +1189,6 @@ class Kinesis {
     String? exclusiveStartStreamName,
     int? limit,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartStreamName',
-      exclusiveStartStreamName,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1423,20 +1240,6 @@ class Kinesis {
     String? exclusiveStartTagKey,
     int? limit,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'exclusiveStartTagKey',
-      exclusiveStartTagKey,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1528,30 +1331,6 @@ class Kinesis {
     required String shardToMerge,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(adjacentShardToMerge, 'adjacentShardToMerge');
-    _s.validateStringLength(
-      'adjacentShardToMerge',
-      adjacentShardToMerge,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(shardToMerge, 'shardToMerge');
-    _s.validateStringLength(
-      'shardToMerge',
-      shardToMerge,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.MergeShards'
@@ -1671,23 +1450,6 @@ class Kinesis {
     String? explicitHashKey,
     String? sequenceNumberForOrdering,
   }) async {
-    ArgumentError.checkNotNull(data, 'data');
-    ArgumentError.checkNotNull(partitionKey, 'partitionKey');
-    _s.validateStringLength(
-      'partitionKey',
-      partitionKey,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.PutRecord'
@@ -1812,15 +1574,6 @@ class Kinesis {
     required List<PutRecordsRequestEntry> records,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(records, 'records');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.PutRecords'
@@ -1878,22 +1631,6 @@ class Kinesis {
     required String consumerName,
     required String streamARN,
   }) async {
-    ArgumentError.checkNotNull(consumerName, 'consumerName');
-    _s.validateStringLength(
-      'consumerName',
-      consumerName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamARN, 'streamARN');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.RegisterStreamConsumer'
@@ -1936,15 +1673,6 @@ class Kinesis {
     required String streamName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.RemoveTagsFromStream'
@@ -2046,23 +1774,6 @@ class Kinesis {
     required String shardToSplit,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(newStartingHashKey, 'newStartingHashKey');
-    ArgumentError.checkNotNull(shardToSplit, 'shardToSplit');
-    _s.validateStringLength(
-      'shardToSplit',
-      shardToSplit,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.SplitShard'
@@ -2152,23 +1863,6 @@ class Kinesis {
     required String keyId,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(encryptionType, 'encryptionType');
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.StartStreamEncryption'
@@ -2251,23 +1945,6 @@ class Kinesis {
     required String keyId,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(encryptionType, 'encryptionType');
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Kinesis_20131202.StopStreamEncryption'
@@ -2377,16 +2054,6 @@ class Kinesis {
     required String streamName,
     required int targetShardCount,
   }) async {
-    ArgumentError.checkNotNull(scalingType, 'scalingType');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetShardCount, 'targetShardCount');
     _s.validateNumRange(
       'targetShardCount',
       targetShardCount,

--- a/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_archived_media_api/lib/kinesis-video-archived-media-2017-09-30.dart
@@ -130,19 +130,6 @@ class KinesisVideoArchivedMedia {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(clipFragmentSelector, 'clipFragmentSelector');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'ClipFragmentSelector': clipFragmentSelector,
       if (streamARN != null) 'StreamARN': streamARN,
@@ -516,18 +503,6 @@ class KinesisVideoArchivedMedia {
       maxManifestFragmentResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
     );
     final $payload = <String, dynamic>{
       if (dASHFragmentSelector != null)
@@ -981,18 +956,6 @@ class KinesisVideoArchivedMedia {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (containerFormat != null) 'ContainerFormat': containerFormat.toValue(),
       if (discontinuityMode != null)
@@ -1081,15 +1044,6 @@ class KinesisVideoArchivedMedia {
     required List<String> fragments,
     required String streamName,
   }) async {
-    ArgumentError.checkNotNull(fragments, 'fragments');
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Fragments': fragments,
       'StreamName': streamName,
@@ -1175,25 +1129,11 @@ class KinesisVideoArchivedMedia {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final $payload = <String, dynamic>{
       'StreamName': streamName,

--- a/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
+++ b/generated/aws_kinesis_video_media_api/lib/kinesis-video-media-2017-09-30.dart
@@ -128,19 +128,6 @@ class KinesisVideoMedia {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(startSelector, 'startSelector');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'StartSelector': startSelector,
       if (streamARN != null) 'StreamARN': streamARN,

--- a/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
+++ b/generated/aws_kinesis_video_signaling_api/lib/kinesis-video-signaling-2019-12-04.dart
@@ -96,26 +96,6 @@ class KinesisVideoSignalingChannels {
     Service? service,
     String? username,
   }) async {
-    ArgumentError.checkNotNull(channelARN, 'channelARN');
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientId',
-      clientId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'ChannelARN': channelARN,
       if (clientId != null) 'ClientId': clientId,
@@ -158,30 +138,6 @@ class KinesisVideoSignalingChannels {
     required String messagePayload,
     required String senderClientId,
   }) async {
-    ArgumentError.checkNotNull(channelARN, 'channelARN');
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(messagePayload, 'messagePayload');
-    _s.validateStringLength(
-      'messagePayload',
-      messagePayload,
-      1,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(senderClientId, 'senderClientId');
-    _s.validateStringLength(
-      'senderClientId',
-      senderClientId,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ChannelARN': channelARN,
       'MessagePayload': messagePayload,

--- a/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
+++ b/generated/aws_kinesisanalytics_api/lib/kinesisanalytics-2015-08-14.dart
@@ -90,18 +90,6 @@ class KinesisAnalytics {
     required CloudWatchLoggingOption cloudWatchLoggingOption,
     required int currentApplicationVersionId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        cloudWatchLoggingOption, 'cloudWatchLoggingOption');
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -179,16 +167,6 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required Input input,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -196,7 +174,6 @@ class KinesisAnalytics {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(input, 'input');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.AddApplicationInput'
@@ -264,16 +241,6 @@ class KinesisAnalytics {
     required String inputId,
     required InputProcessingConfiguration inputProcessingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -281,16 +248,6 @@ class KinesisAnalytics {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(inputId, 'inputId');
-    _s.validateStringLength(
-      'inputId',
-      inputId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        inputProcessingConfiguration, 'inputProcessingConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -374,16 +331,6 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required Output output,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -391,7 +338,6 @@ class KinesisAnalytics {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(output, 'output');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.AddApplicationOutput'
@@ -465,16 +411,6 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required ReferenceDataSource referenceDataSource,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -482,7 +418,6 @@ class KinesisAnalytics {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(referenceDataSource, 'referenceDataSource');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -636,26 +571,6 @@ class KinesisAnalytics {
     List<Output>? outputs,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationCode',
-      applicationCode,
-      0,
-      102400,
-    );
-    _s.validateStringLength(
-      'applicationDescription',
-      applicationDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.CreateApplication'
@@ -712,15 +627,6 @@ class KinesisAnalytics {
     required String applicationName,
     required DateTime createTimestamp,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(createTimestamp, 'createTimestamp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.DeleteApplication'
@@ -774,25 +680,6 @@ class KinesisAnalytics {
     required String cloudWatchLoggingOptionId,
     required int currentApplicationVersionId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        cloudWatchLoggingOptionId, 'cloudWatchLoggingOptionId');
-    _s.validateStringLength(
-      'cloudWatchLoggingOptionId',
-      cloudWatchLoggingOptionId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -853,29 +740,11 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required String inputId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputId, 'inputId');
-    _s.validateStringLength(
-      'inputId',
-      inputId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -942,29 +811,11 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required String outputId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputId, 'outputId');
-    _s.validateStringLength(
-      'outputId',
-      outputId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1031,29 +882,11 @@ class KinesisAnalytics {
     required int currentApplicationVersionId,
     required String referenceId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(referenceId, 'referenceId');
-    _s.validateStringLength(
-      'referenceId',
-      referenceId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1102,14 +935,6 @@ class KinesisAnalytics {
   Future<DescribeApplicationResponse> describeApplication({
     required String applicationName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.DescribeApplication'
@@ -1182,18 +1007,6 @@ class KinesisAnalytics {
     String? roleARN,
     S3Configuration? s3Configuration,
   }) async {
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.DiscoverInputSchema'
@@ -1252,12 +1065,6 @@ class KinesisAnalytics {
     String? exclusiveStartApplicationName,
     int? limit,
   }) async {
-    _s.validateStringLength(
-      'exclusiveStartApplicationName',
-      exclusiveStartApplicationName,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'limit',
       limit,
@@ -1298,14 +1105,6 @@ class KinesisAnalytics {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.ListTagsForResource'
@@ -1370,15 +1169,6 @@ class KinesisAnalytics {
     required String applicationName,
     required List<InputConfiguration> inputConfigurations,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputConfigurations, 'inputConfigurations');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.StartApplication'
@@ -1423,14 +1213,6 @@ class KinesisAnalytics {
   Future<void> stopApplication({
     required String applicationName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.StopApplication'
@@ -1469,15 +1251,6 @@ class KinesisAnalytics {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.TagResource'
@@ -1516,15 +1289,6 @@ class KinesisAnalytics {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20150814.UntagResource'
@@ -1582,17 +1346,6 @@ class KinesisAnalytics {
     required ApplicationUpdate applicationUpdate,
     required int currentApplicationVersionId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(applicationUpdate, 'applicationUpdate');
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,

--- a/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
+++ b/generated/aws_kinesisanalyticsv2_api/lib/kinesisanalyticsv2-2018-05-23.dart
@@ -77,18 +77,6 @@ class KinesisAnalyticsV2 {
     required CloudWatchLoggingOption cloudWatchLoggingOption,
     required int currentApplicationVersionId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        cloudWatchLoggingOption, 'cloudWatchLoggingOption');
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -153,16 +141,6 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required Input input,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -170,7 +148,6 @@ class KinesisAnalyticsV2 {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(input, 'input');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.AddApplicationInput'
@@ -228,16 +205,6 @@ class KinesisAnalyticsV2 {
     required String inputId,
     required InputProcessingConfiguration inputProcessingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -245,16 +212,6 @@ class KinesisAnalyticsV2 {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(inputId, 'inputId');
-    _s.validateStringLength(
-      'inputId',
-      inputId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        inputProcessingConfiguration, 'inputProcessingConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -326,16 +283,6 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required Output output,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -343,7 +290,6 @@ class KinesisAnalyticsV2 {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(output, 'output');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.AddApplicationOutput'
@@ -400,16 +346,6 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required ReferenceDataSource referenceDataSource,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -417,7 +353,6 @@ class KinesisAnalyticsV2 {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(referenceDataSource, 'referenceDataSource');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -482,16 +417,6 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required VpcConfiguration vpcConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -499,7 +424,6 @@ class KinesisAnalyticsV2 {
       999999999,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(vpcConfiguration, 'vpcConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.AddApplicationVpcConfiguration'
@@ -571,29 +495,6 @@ class KinesisAnalyticsV2 {
     List<CloudWatchLoggingOption>? cloudWatchLoggingOptions,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runtimeEnvironment, 'runtimeEnvironment');
-    ArgumentError.checkNotNull(serviceExecutionRole, 'serviceExecutionRole');
-    _s.validateStringLength(
-      'serviceExecutionRole',
-      serviceExecutionRole,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationDescription',
-      applicationDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.CreateApplication'
@@ -655,15 +556,6 @@ class KinesisAnalyticsV2 {
     required UrlType urlType,
     int? sessionExpirationDurationInSeconds,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(urlType, 'urlType');
     _s.validateNumRange(
       'sessionExpirationDurationInSeconds',
       sessionExpirationDurationInSeconds,
@@ -711,22 +603,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     required String snapshotName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotName, 'snapshotName');
-    _s.validateStringLength(
-      'snapshotName',
-      snapshotName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.CreateApplicationSnapshot'
@@ -763,15 +639,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     required DateTime createTimestamp,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(createTimestamp, 'createTimestamp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.DeleteApplication'
@@ -817,25 +684,6 @@ class KinesisAnalyticsV2 {
     required String cloudWatchLoggingOptionId,
     required int currentApplicationVersionId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        cloudWatchLoggingOptionId, 'cloudWatchLoggingOptionId');
-    _s.validateStringLength(
-      'cloudWatchLoggingOptionId',
-      cloudWatchLoggingOptionId,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
@@ -892,29 +740,11 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required String inputId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputId, 'inputId');
-    _s.validateStringLength(
-      'inputId',
-      inputId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -972,29 +802,11 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required String outputId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputId, 'outputId');
-    _s.validateStringLength(
-      'outputId',
-      outputId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1050,29 +862,11 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required String referenceId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(referenceId, 'referenceId');
-    _s.validateStringLength(
-      'referenceId',
-      referenceId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1119,24 +913,6 @@ class KinesisAnalyticsV2 {
     required DateTime snapshotCreationTimestamp,
     required String snapshotName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        snapshotCreationTimestamp, 'snapshotCreationTimestamp');
-    ArgumentError.checkNotNull(snapshotName, 'snapshotName');
-    _s.validateStringLength(
-      'snapshotName',
-      snapshotName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.DeleteApplicationSnapshot'
@@ -1179,29 +955,11 @@ class KinesisAnalyticsV2 {
     required int currentApplicationVersionId,
     required String vpcConfigurationId,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpcConfigurationId, 'vpcConfigurationId');
-    _s.validateStringLength(
-      'vpcConfigurationId',
-      vpcConfigurationId,
-      1,
-      50,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1245,14 +1003,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     bool? includeAdditionalDetails,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.DescribeApplication'
@@ -1289,22 +1039,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     required String snapshotName,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotName, 'snapshotName');
-    _s.validateStringLength(
-      'snapshotName',
-      snapshotName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.DescribeApplicationSnapshot'
@@ -1365,20 +1099,6 @@ class KinesisAnalyticsV2 {
     String? resourceARN,
     S3Configuration? s3Configuration,
   }) async {
-    ArgumentError.checkNotNull(serviceExecutionRole, 'serviceExecutionRole');
-    _s.validateStringLength(
-      'serviceExecutionRole',
-      serviceExecutionRole,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.DiscoverInputSchema'
@@ -1425,25 +1145,11 @@ class KinesisAnalyticsV2 {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1493,12 +1199,6 @@ class KinesisAnalyticsV2 {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.ListApplications'
@@ -1532,14 +1232,6 @@ class KinesisAnalyticsV2 {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.ListTagsForResource'
@@ -1578,15 +1270,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     required RunConfiguration runConfiguration,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(runConfiguration, 'runConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.StartApplication'
@@ -1643,14 +1326,6 @@ class KinesisAnalyticsV2 {
     required String applicationName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.StopApplication'
@@ -1690,15 +1365,6 @@ class KinesisAnalyticsV2 {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.TagResource'
@@ -1737,15 +1403,6 @@ class KinesisAnalyticsV2 {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'KinesisAnalytics_20180523.UntagResource'
@@ -1813,28 +1470,12 @@ class KinesisAnalyticsV2 {
     RunConfigurationUpdate? runConfigurationUpdate,
     String? serviceExecutionRoleUpdate,
   }) async {
-    ArgumentError.checkNotNull(applicationName, 'applicationName');
-    _s.validateStringLength(
-      'applicationName',
-      applicationName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        currentApplicationVersionId, 'currentApplicationVersionId');
     _s.validateNumRange(
       'currentApplicationVersionId',
       currentApplicationVersionId,
       1,
       999999999,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'serviceExecutionRoleUpdate',
-      serviceExecutionRoleUpdate,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',

--- a/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
+++ b/generated/aws_kinesisvideo_api/lib/kinesisvideo-2017-09-30.dart
@@ -79,14 +79,6 @@ class KinesisVideo {
     SingleMasterConfiguration? singleMasterConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(channelName, 'channelName');
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ChannelName': channelName,
       if (channelType != null) 'ChannelType': channelType.toValue(),
@@ -186,37 +178,11 @@ class KinesisVideo {
     String? mediaType,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'dataRetentionInHours',
       dataRetentionInHours,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'deviceName',
-      deviceName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'mediaType',
-      mediaType,
-      1,
-      128,
     );
     final $payload = <String, dynamic>{
       'StreamName': streamName,
@@ -260,20 +226,6 @@ class KinesisVideo {
     required String channelARN,
     String? currentVersion,
   }) async {
-    ArgumentError.checkNotNull(channelARN, 'channelARN');
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'currentVersion',
-      currentVersion,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'ChannelARN': channelARN,
       if (currentVersion != null) 'CurrentVersion': currentVersion,
@@ -325,20 +277,6 @@ class KinesisVideo {
     required String streamARN,
     String? currentVersion,
   }) async {
-    ArgumentError.checkNotNull(streamARN, 'streamARN');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'currentVersion',
-      currentVersion,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'StreamARN': streamARN,
       if (currentVersion != null) 'CurrentVersion': currentVersion,
@@ -369,18 +307,6 @@ class KinesisVideo {
     String? channelARN,
     String? channelName,
   }) async {
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'channelName',
-      channelName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (channelARN != null) 'ChannelARN': channelARN,
       if (channelName != null) 'ChannelName': channelName,
@@ -411,18 +337,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (streamARN != null) 'StreamARN': streamARN,
       if (streamName != null) 'StreamName': streamName,
@@ -468,19 +382,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(aPIName, 'aPIName');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'APIName': aPIName.toValue(),
       if (streamARN != null) 'StreamARN': streamARN,
@@ -530,14 +431,6 @@ class KinesisVideo {
     SingleMasterChannelEndpointConfiguration?
         singleMasterChannelEndpointConfiguration,
   }) async {
-    ArgumentError.checkNotNull(channelARN, 'channelARN');
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ChannelARN': channelARN,
       if (singleMasterChannelEndpointConfiguration != null)
@@ -584,12 +477,6 @@ class KinesisVideo {
       maxResults,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      512,
     );
     final $payload = <String, dynamic>{
       if (channelNameCondition != null)
@@ -638,12 +525,6 @@ class KinesisVideo {
       1,
       10000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      512,
-    );
     final $payload = <String, dynamic>{
       if (maxResults != null) 'MaxResults': maxResults,
       if (nextToken != null) 'NextToken': nextToken,
@@ -679,20 +560,6 @@ class KinesisVideo {
     required String resourceARN,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      512,
-    );
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       if (nextToken != null) 'NextToken': nextToken,
@@ -734,24 +601,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      512,
-    );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (nextToken != null) 'NextToken': nextToken,
       if (streamARN != null) 'StreamARN': streamARN,
@@ -792,15 +641,6 @@ class KinesisVideo {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'Tags': tags,
@@ -851,19 +691,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(tags, 'tags');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'Tags': tags,
       if (streamARN != null) 'StreamARN': streamARN,
@@ -896,15 +723,6 @@ class KinesisVideo {
     required String resourceARN,
     required List<String> tagKeyList,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeyList, 'tagKeyList');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'TagKeyList': tagKeyList,
@@ -944,19 +762,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(tagKeyList, 'tagKeyList');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'TagKeyList': tagKeyList,
       if (streamARN != null) 'StreamARN': streamARN,
@@ -1031,35 +836,12 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    _s.validateStringLength(
-      'currentVersion',
-      currentVersion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        dataRetentionChangeInHours, 'dataRetentionChangeInHours');
     _s.validateNumRange(
       'dataRetentionChangeInHours',
       dataRetentionChangeInHours,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(operation, 'operation');
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
     );
     final $payload = <String, dynamic>{
       'CurrentVersion': currentVersion,
@@ -1107,22 +889,6 @@ class KinesisVideo {
     required String currentVersion,
     SingleMasterConfiguration? singleMasterConfiguration,
   }) async {
-    ArgumentError.checkNotNull(channelARN, 'channelARN');
-    _s.validateStringLength(
-      'channelARN',
-      channelARN,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    _s.validateStringLength(
-      'currentVersion',
-      currentVersion,
-      1,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ChannelARN': channelARN,
       'CurrentVersion': currentVersion,
@@ -1196,38 +962,6 @@ class KinesisVideo {
     String? streamARN,
     String? streamName,
   }) async {
-    ArgumentError.checkNotNull(currentVersion, 'currentVersion');
-    _s.validateStringLength(
-      'currentVersion',
-      currentVersion,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deviceName',
-      deviceName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'mediaType',
-      mediaType,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'streamARN',
-      streamARN,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'CurrentVersion': currentVersion,
       if (deviceName != null) 'DeviceName': deviceName,

--- a/generated/aws_kms_api/lib/kms-2014-11-01.dart
+++ b/generated/aws_kms_api/lib/kms-2014-11-01.dart
@@ -116,14 +116,6 @@ class KMS {
   Future<CancelKeyDeletionResponse> cancelKeyDeletion({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.CancelKeyDeletion'
@@ -231,14 +223,6 @@ class KMS {
   Future<void> connectCustomKeyStore({
     required String customKeyStoreId,
   }) async {
-    ArgumentError.checkNotNull(customKeyStoreId, 'customKeyStoreId');
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.ConnectCustomKeyStore'
@@ -373,22 +357,6 @@ class KMS {
     required String aliasName,
     required String targetKeyId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetKeyId, 'targetKeyId');
-    _s.validateStringLength(
-      'targetKeyId',
-      targetKeyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.CreateAlias'
@@ -509,39 +477,6 @@ class KMS {
     required String keyStorePassword,
     required String trustAnchorCertificate,
   }) async {
-    ArgumentError.checkNotNull(cloudHsmClusterId, 'cloudHsmClusterId');
-    _s.validateStringLength(
-      'cloudHsmClusterId',
-      cloudHsmClusterId,
-      19,
-      24,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(customKeyStoreName, 'customKeyStoreName');
-    _s.validateStringLength(
-      'customKeyStoreName',
-      customKeyStoreName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyStorePassword, 'keyStorePassword');
-    _s.validateStringLength(
-      'keyStorePassword',
-      keyStorePassword,
-      7,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        trustAnchorCertificate, 'trustAnchorCertificate');
-    _s.validateStringLength(
-      'trustAnchorCertificate',
-      trustAnchorCertificate,
-      1,
-      5000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.CreateCustomKeyStore'
@@ -757,35 +692,6 @@ class KMS {
     String? name,
     String? retiringPrincipal,
   }) async {
-    ArgumentError.checkNotNull(granteePrincipal, 'granteePrincipal');
-    _s.validateStringLength(
-      'granteePrincipal',
-      granteePrincipal,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(operations, 'operations');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'retiringPrincipal',
-      retiringPrincipal,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.CreateGrant'
@@ -1167,24 +1073,6 @@ class KMS {
     String? policy,
     List<Tag>? tags,
   }) async {
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      131072,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.CreateKey'
@@ -1396,13 +1284,6 @@ class KMS {
     List<String>? grantTokens,
     String? keyId,
   }) async {
-    ArgumentError.checkNotNull(ciphertextBlob, 'ciphertextBlob');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.Decrypt'
@@ -1486,14 +1367,6 @@ class KMS {
   Future<void> deleteAlias({
     required String aliasName,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DeleteAlias'
@@ -1585,14 +1458,6 @@ class KMS {
   Future<void> deleteCustomKeyStore({
     required String customKeyStoreId,
   }) async {
-    ArgumentError.checkNotNull(customKeyStoreId, 'customKeyStoreId');
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DeleteCustomKeyStore'
@@ -1675,14 +1540,6 @@ class KMS {
   Future<void> deleteImportedKeyMaterial({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DeleteImportedKeyMaterial'
@@ -1797,29 +1654,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'customKeyStoreName',
-      customKeyStoreName,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1975,14 +1814,6 @@ class KMS {
     required String keyId,
     List<String>? grantTokens,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DescribeKey'
@@ -2054,14 +1885,6 @@ class KMS {
   Future<void> disableKey({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DisableKey'
@@ -2148,14 +1971,6 @@ class KMS {
   Future<void> disableKeyRotation({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DisableKeyRotation'
@@ -2235,14 +2050,6 @@ class KMS {
   Future<void> disconnectCustomKeyStore({
     required String customKeyStoreId,
   }) async {
-    ArgumentError.checkNotNull(customKeyStoreId, 'customKeyStoreId');
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.DisconnectCustomKeyStore'
@@ -2307,14 +2114,6 @@ class KMS {
   Future<void> enableKey({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.EnableKey'
@@ -2398,14 +2197,6 @@ class KMS {
   Future<void> enableKeyRotation({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.EnableKeyRotation'
@@ -2629,15 +2420,6 @@ class KMS {
     Map<String, String>? encryptionContext,
     List<String>? grantTokens,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(plaintext, 'plaintext');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.Encrypt'
@@ -2849,14 +2631,6 @@ class KMS {
     DataKeySpec? keySpec,
     int? numberOfBytes,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'numberOfBytes',
       numberOfBytes,
@@ -3037,15 +2811,6 @@ class KMS {
     Map<String, String>? encryptionContext,
     List<String>? grantTokens,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyPairSpec, 'keyPairSpec');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GenerateDataKeyPair'
@@ -3212,15 +2977,6 @@ class KMS {
     Map<String, String>? encryptionContext,
     List<String>? grantTokens,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyPairSpec, 'keyPairSpec');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GenerateDataKeyPairWithoutPlaintext'
@@ -3399,14 +3155,6 @@ class KMS {
     DataKeySpec? keySpec,
     int? numberOfBytes,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'numberOfBytes',
       numberOfBytes,
@@ -3469,12 +3217,6 @@ class KMS {
     String? customKeyStoreId,
     int? numberOfBytes,
   }) async {
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'numberOfBytes',
       numberOfBytes,
@@ -3544,22 +3286,6 @@ class KMS {
     required String keyId,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GetKeyPolicy'
@@ -3656,14 +3382,6 @@ class KMS {
   Future<GetKeyRotationStatusResponse> getKeyRotationStatus({
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GetKeyRotationStatus'
@@ -3773,16 +3491,6 @@ class KMS {
     required AlgorithmSpec wrappingAlgorithm,
     required WrappingKeySpec wrappingKeySpec,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(wrappingAlgorithm, 'wrappingAlgorithm');
-    ArgumentError.checkNotNull(wrappingKeySpec, 'wrappingKeySpec');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GetParametersForImport'
@@ -3923,14 +3631,6 @@ class KMS {
     required String keyId,
     List<String>? grantTokens,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.GetPublicKey'
@@ -4096,16 +3796,6 @@ class KMS {
     ExpirationModelType? expirationModel,
     DateTime? validTo,
   }) async {
-    ArgumentError.checkNotNull(encryptedKeyMaterial, 'encryptedKeyMaterial');
-    ArgumentError.checkNotNull(importToken, 'importToken');
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.ImportKeyMaterial'
@@ -4220,23 +3910,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4336,25 +4014,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4443,25 +4107,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4535,12 +4185,6 @@ class KMS {
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4633,25 +4277,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4745,25 +4375,11 @@ class KMS {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(retiringPrincipal, 'retiringPrincipal');
-    _s.validateStringLength(
-      'retiringPrincipal',
-      retiringPrincipal,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4893,30 +4509,6 @@ class KMS {
     required String policyName,
     bool? bypassPolicyLockoutSafetyCheck,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      131072,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.PutKeyPolicy'
@@ -5208,21 +4800,6 @@ class KMS {
     Map<String, String>? sourceEncryptionContext,
     String? sourceKeyId,
   }) async {
-    ArgumentError.checkNotNull(ciphertextBlob, 'ciphertextBlob');
-    ArgumentError.checkNotNull(destinationKeyId, 'destinationKeyId');
-    _s.validateStringLength(
-      'destinationKeyId',
-      destinationKeyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceKeyId',
-      sourceKeyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.ReEncrypt'
@@ -5334,24 +4911,6 @@ class KMS {
     String? grantToken,
     String? keyId,
   }) async {
-    _s.validateStringLength(
-      'grantId',
-      grantId,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'grantToken',
-      grantToken,
-      1,
-      8192,
-    );
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.RetireGrant'
@@ -5431,22 +4990,6 @@ class KMS {
     required String grantId,
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(grantId, 'grantId');
-    _s.validateStringLength(
-      'grantId',
-      grantId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.RevokeGrant'
@@ -5551,14 +5094,6 @@ class KMS {
     required String keyId,
     int? pendingWindowInDays,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'pendingWindowInDays',
       pendingWindowInDays,
@@ -5721,16 +5256,6 @@ class KMS {
     List<String>? grantTokens,
     MessageType? messageType,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(message, 'message');
-    ArgumentError.checkNotNull(signingAlgorithm, 'signingAlgorithm');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.Sign'
@@ -5842,15 +5367,6 @@ class KMS {
     required String keyId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.TagResource'
@@ -5940,15 +5456,6 @@ class KMS {
     required String keyId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.UntagResource'
@@ -6081,22 +5588,6 @@ class KMS {
     required String aliasName,
     required String targetKeyId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetKeyId, 'targetKeyId');
-    _s.validateStringLength(
-      'targetKeyId',
-      targetKeyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.UpdateAlias'
@@ -6236,32 +5727,6 @@ class KMS {
     String? keyStorePassword,
     String? newCustomKeyStoreName,
   }) async {
-    ArgumentError.checkNotNull(customKeyStoreId, 'customKeyStoreId');
-    _s.validateStringLength(
-      'customKeyStoreId',
-      customKeyStoreId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cloudHsmClusterId',
-      cloudHsmClusterId,
-      19,
-      24,
-    );
-    _s.validateStringLength(
-      'keyStorePassword',
-      keyStorePassword,
-      7,
-      32,
-    );
-    _s.validateStringLength(
-      'newCustomKeyStoreName',
-      newCustomKeyStoreName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.UpdateCustomKeyStore'
@@ -6340,22 +5805,6 @@ class KMS {
     required String description,
     required String keyId,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      8192,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.UpdateKeyDescription'
@@ -6505,17 +5954,6 @@ class KMS {
     List<String>? grantTokens,
     MessageType? messageType,
   }) async {
-    ArgumentError.checkNotNull(keyId, 'keyId');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(message, 'message');
-    ArgumentError.checkNotNull(signature, 'signature');
-    ArgumentError.checkNotNull(signingAlgorithm, 'signingAlgorithm');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TrentService.Verify'

--- a/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
+++ b/generated/aws_lakeformation_api/lib/lakeformation-2017-03-31.dart
@@ -66,13 +66,6 @@ class LakeFormation {
     required List<BatchPermissionsRequestEntry> entries,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.BatchGrantPermissions'
@@ -110,13 +103,6 @@ class LakeFormation {
     required List<BatchPermissionsRequestEntry> entries,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.BatchRevokePermissions'
@@ -152,7 +138,6 @@ class LakeFormation {
   Future<void> deregisterResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.DeregisterResource'
@@ -182,7 +167,6 @@ class LakeFormation {
   Future<DescribeResourceResponse> describeResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.DescribeResource'
@@ -216,12 +200,6 @@ class LakeFormation {
   Future<GetDataLakeSettingsResponse> getDataLakeSettings({
     String? catalogId,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.GetDataLakeSettings'
@@ -272,13 +250,6 @@ class LakeFormation {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -354,15 +325,6 @@ class LakeFormation {
     String? catalogId,
     List<Permission>? permissionsWithGrantOption,
   }) async {
-    ArgumentError.checkNotNull(permissions, 'permissions');
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(resource, 'resource');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.GrantPermissions'
@@ -432,12 +394,6 @@ class LakeFormation {
     Resource? resource,
     DataLakeResourceType? resourceType,
   }) async {
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -541,13 +497,6 @@ class LakeFormation {
     required DataLakeSettings dataLakeSettings,
     String? catalogId,
   }) async {
-    ArgumentError.checkNotNull(dataLakeSettings, 'dataLakeSettings');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.PutDataLakeSettings'
@@ -612,7 +561,6 @@ class LakeFormation {
     String? roleArn,
     bool? useServiceLinkedRole,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.RegisterResource'
@@ -667,15 +615,6 @@ class LakeFormation {
     String? catalogId,
     List<Permission>? permissionsWithGrantOption,
   }) async {
-    ArgumentError.checkNotNull(permissions, 'permissions');
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(resource, 'resource');
-    _s.validateStringLength(
-      'catalogId',
-      catalogId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.RevokePermissions'
@@ -716,8 +655,6 @@ class LakeFormation {
     required String resourceArn,
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLakeFormation.UpdateResource'

--- a/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
+++ b/generated/aws_lambda_api/lib/lambda-2014-11-11.dart
@@ -111,16 +111,6 @@ class Lambda {
     int? batchSize,
     Map<String, String>? parameters,
   }) async {
-    ArgumentError.checkNotNull(eventSource, 'eventSource');
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
     final $payload = <String, dynamic>{
       'EventSource': eventSource,
       'FunctionName': functionName,
@@ -150,14 +140,6 @@ class Lambda {
   Future<void> deleteFunction({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -181,7 +163,6 @@ class Lambda {
   Future<EventSourceConfiguration> getEventSource({
     required String uuid,
   }) async {
-    ArgumentError.checkNotNull(uuid, 'uuid');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -209,14 +190,6 @@ class Lambda {
   Future<GetFunctionResponse> getFunction({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -242,14 +215,6 @@ class Lambda {
   Future<FunctionConfiguration> getFunctionConfiguration({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -281,15 +246,6 @@ class Lambda {
     required String functionName,
     required Uint8List invokeArgs,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(invokeArgs, 'invokeArgs');
     final response = await _protocol.send(
       payload: invokeArgs,
       method: 'POST',
@@ -335,12 +291,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -419,7 +369,6 @@ class Lambda {
   Future<void> removeEventSource({
     required String uuid,
   }) async {
-    ArgumentError.checkNotNull(uuid, 'uuid');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -477,20 +426,6 @@ class Lambda {
     String? role,
     int? timeout,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'memorySize',
       memorySize,
@@ -591,25 +526,6 @@ class Lambda {
     int? memorySize,
     int? timeout,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionZip, 'functionZip');
-    ArgumentError.checkNotNull(handler, 'handler');
-    ArgumentError.checkNotNull(mode, 'mode');
-    ArgumentError.checkNotNull(role, 'role');
-    ArgumentError.checkNotNull(runtime, 'runtime');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'memorySize',
       memorySize,

--- a/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
+++ b/generated/aws_lambda_api/lib/lambda-2015-03-31.dart
@@ -103,25 +103,6 @@ class Lambda {
     String? organizationId,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(action, 'action');
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(statementId, 'statementId');
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     final $query = <String, List<String>>{
       if (revisionId != null) 'RevisionId': [revisionId],
     };
@@ -237,36 +218,6 @@ class Lambda {
     String? sourceAccount,
     String? sourceArn,
   }) async {
-    ArgumentError.checkNotNull(action, 'action');
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(statementId, 'statementId');
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventSourceToken',
-      eventSourceToken,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -344,36 +295,6 @@ class Lambda {
     String? description,
     AliasRoutingConfiguration? routingConfig,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionVersion, 'functionVersion');
-    _s.validateStringLength(
-      'functionVersion',
-      functionVersion,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'FunctionVersion': functionVersion,
       'Name': name,
@@ -413,13 +334,6 @@ class Lambda {
     CodeSigningPolicies? codeSigningPolicies,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(allowedPublishers, 'allowedPublishers');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'AllowedPublishers': allowedPublishers,
       if (codeSigningPolicies != null)
@@ -643,14 +557,6 @@ class Lambda {
     List<String>? topics,
     int? tumblingWindowInSeconds,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'batchSize',
       batchSize,
@@ -920,34 +826,6 @@ class Lambda {
     TracingConfig? tracingConfig,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(code, 'code');
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'handler',
-      handler,
-      0,
-      128,
-    );
     _s.validateNumRange(
       'memorySize',
       memorySize,
@@ -1025,22 +903,6 @@ class Lambda {
     required String functionName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1063,14 +925,6 @@ class Lambda {
   Future<void> deleteCodeSigningConfig({
     required String codeSigningConfigArn,
   }) async {
-    ArgumentError.checkNotNull(codeSigningConfigArn, 'codeSigningConfigArn');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1099,7 +953,6 @@ class Lambda {
   Future<EventSourceMappingConfiguration> deleteEventSourceMapping({
     required String uuid,
   }) async {
-    ArgumentError.checkNotNull(uuid, 'uuid');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1153,20 +1006,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -1209,14 +1048,6 @@ class Lambda {
   Future<void> deleteFunctionCodeSigningConfig({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1255,14 +1086,6 @@ class Lambda {
   Future<void> deleteFunctionConcurrency({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1310,20 +1133,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -1355,15 +1164,6 @@ class Lambda {
     required String layerName,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1406,22 +1206,6 @@ class Lambda {
     required String functionName,
     required String qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(qualifier, 'qualifier');
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'Qualifier': [qualifier],
     };
@@ -1484,22 +1268,6 @@ class Lambda {
     required String functionName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1521,14 +1289,6 @@ class Lambda {
   Future<GetCodeSigningConfigResponse> getCodeSigningConfig({
     required String codeSigningConfigArn,
   }) async {
-    ArgumentError.checkNotNull(codeSigningConfigArn, 'codeSigningConfigArn');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1552,7 +1312,6 @@ class Lambda {
   Future<EventSourceMappingConfiguration> getEventSourceMapping({
     required String uuid,
   }) async {
-    ArgumentError.checkNotNull(uuid, 'uuid');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1601,20 +1360,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -1656,14 +1401,6 @@ class Lambda {
   Future<GetFunctionCodeSigningConfigResponse> getFunctionCodeSigningConfig({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1704,14 +1441,6 @@ class Lambda {
   Future<GetFunctionConcurrencyResponse> getFunctionConcurrency({
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1762,20 +1491,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -1828,20 +1543,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -1875,15 +1576,6 @@ class Lambda {
     required String layerName,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1909,14 +1601,6 @@ class Lambda {
   Future<GetLayerVersionResponse> getLayerVersionByArn({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      140,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'Arn': [arn],
     };
@@ -1949,15 +1633,6 @@ class Lambda {
     required String layerName,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2004,20 +1679,6 @@ class Lambda {
     required String functionName,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
     };
@@ -2067,22 +1728,6 @@ class Lambda {
     required String functionName,
     required String qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(qualifier, 'qualifier');
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'Qualifier': [qualifier],
     };
@@ -2236,20 +1881,6 @@ class Lambda {
     Uint8List? payload,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (clientContext != null)
         'X-Amz-Client-Context': clientContext.toString(),
@@ -2318,15 +1949,6 @@ class Lambda {
     required String functionName,
     required Uint8List invokeArgs,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(invokeArgs, 'invokeArgs');
     final response = await _protocol.send(
       payload: invokeArgs,
       method: 'POST',
@@ -2380,20 +2002,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'functionVersion',
-      functionVersion,
-      1,
-      1024,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2515,12 +2123,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2585,14 +2187,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2695,14 +2289,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(codeSigningConfigArn, 'codeSigningConfigArn');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2754,14 +2340,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2870,14 +2448,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -2913,7 +2483,6 @@ class Lambda {
   Future<ListTagsResponse> listTags({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2963,14 +2532,6 @@ class Lambda {
     String? marker,
     int? maxItems,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      170,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -3045,27 +2606,6 @@ class Lambda {
     String? description,
     String? licenseInfo,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'licenseInfo',
-      licenseInfo,
-      0,
-      512,
-    );
     final $payload = <String, dynamic>{
       'Content': content,
       if (compatibleRuntimes != null)
@@ -3145,20 +2685,6 @@ class Lambda {
     String? description,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (codeSha256 != null) 'CodeSha256': codeSha256,
       if (description != null) 'Description': description,
@@ -3210,22 +2736,6 @@ class Lambda {
     required String codeSigningConfigArn,
     required String functionName,
   }) async {
-    ArgumentError.checkNotNull(codeSigningConfigArn, 'codeSigningConfigArn');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'CodeSigningConfigArn': codeSigningConfigArn,
     };
@@ -3286,16 +2796,6 @@ class Lambda {
     required String functionName,
     required int reservedConcurrentExecutions,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        reservedConcurrentExecutions, 'reservedConcurrentExecutions');
     _s.validateNumRange(
       'reservedConcurrentExecutions',
       reservedConcurrentExecutions,
@@ -3401,14 +2901,6 @@ class Lambda {
     int? maximumRetryAttempts,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maximumEventAgeInSeconds',
       maximumEventAgeInSeconds,
@@ -3420,12 +2912,6 @@ class Lambda {
       maximumRetryAttempts,
       0,
       2,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
@@ -3488,29 +2974,11 @@ class Lambda {
     required int provisionedConcurrentExecutions,
     required String qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisionedConcurrentExecutions, 'provisionedConcurrentExecutions');
     _s.validateNumRange(
       'provisionedConcurrentExecutions',
       provisionedConcurrentExecutions,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(qualifier, 'qualifier');
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
       isRequired: true,
     );
     final $query = <String, List<String>>{
@@ -3560,23 +3028,6 @@ class Lambda {
     required int versionNumber,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(layerName, 'layerName');
-    _s.validateStringLength(
-      'layerName',
-      layerName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(statementId, 'statementId');
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     final $query = <String, List<String>>{
       if (revisionId != null) 'RevisionId': [revisionId],
     };
@@ -3637,28 +3088,6 @@ class Lambda {
     String? qualifier,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(statementId, 'statementId');
-    _s.validateStringLength(
-      'statementId',
-      statementId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
-    );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],
       if (revisionId != null) 'RevisionId': [revisionId],
@@ -3692,8 +3121,6 @@ class Lambda {
     required String resource,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -3724,8 +3151,6 @@ class Lambda {
     required String resource,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -3793,34 +3218,6 @@ class Lambda {
     String? revisionId,
     AliasRoutingConfiguration? routingConfig,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'functionVersion',
-      functionVersion,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (functionVersion != null) 'FunctionVersion': functionVersion,
@@ -3862,20 +3259,6 @@ class Lambda {
     CodeSigningPolicies? codeSigningPolicies,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(codeSigningConfigArn, 'codeSigningConfigArn');
-    _s.validateStringLength(
-      'codeSigningConfigArn',
-      codeSigningConfigArn,
-      0,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (allowedPublishers != null) 'AllowedPublishers': allowedPublishers,
       if (codeSigningPolicies != null)
@@ -4034,18 +3417,11 @@ class Lambda {
     List<SourceAccessConfiguration>? sourceAccessConfigurations,
     int? tumblingWindowInSeconds,
   }) async {
-    ArgumentError.checkNotNull(uuid, 'uuid');
     _s.validateNumRange(
       'batchSize',
       batchSize,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
     );
     _s.validateNumRange(
       'maximumBatchingWindowInSeconds',
@@ -4196,32 +3572,6 @@ class Lambda {
     String? s3ObjectVersion,
     Uint8List? zipFile,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      's3Bucket',
-      s3Bucket,
-      3,
-      63,
-    );
-    _s.validateStringLength(
-      's3Key',
-      s3Key,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      's3ObjectVersion',
-      s3ObjectVersion,
-      1,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (dryRun != null) 'DryRun': dryRun,
       if (imageUri != null) 'ImageUri': imageUri,
@@ -4382,26 +3732,6 @@ class Lambda {
     TracingConfig? tracingConfig,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'handler',
-      handler,
-      0,
-      128,
-    );
     _s.validateNumRange(
       'memorySize',
       memorySize,
@@ -4509,14 +3839,6 @@ class Lambda {
     int? maximumRetryAttempts,
     String? qualifier,
   }) async {
-    ArgumentError.checkNotNull(functionName, 'functionName');
-    _s.validateStringLength(
-      'functionName',
-      functionName,
-      1,
-      140,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maximumEventAgeInSeconds',
       maximumEventAgeInSeconds,
@@ -4528,12 +3850,6 @@ class Lambda {
       maximumRetryAttempts,
       0,
       2,
-    );
-    _s.validateStringLength(
-      'qualifier',
-      qualifier,
-      1,
-      128,
     );
     final $query = <String, List<String>>{
       if (qualifier != null) 'Qualifier': [qualifier],

--- a/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
+++ b/generated/aws_lex_models_api/lib/lex-models-2017-04-19.dart
@@ -88,14 +88,6 @@ class LexModelBuildingService {
     required String name,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (checksum != null) 'checksum': checksum,
     };
@@ -146,14 +138,6 @@ class LexModelBuildingService {
     required String name,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (checksum != null) 'checksum': checksum,
     };
@@ -205,14 +189,6 @@ class LexModelBuildingService {
     required String name,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (checksum != null) 'checksum': checksum,
     };
@@ -258,14 +234,6 @@ class LexModelBuildingService {
   Future<void> deleteBot({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -301,22 +269,6 @@ class LexModelBuildingService {
     required String botName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -352,30 +304,6 @@ class LexModelBuildingService {
     required String botName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    _s.validateStringLength(
-      'botAlias',
-      botAlias,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -409,22 +337,6 @@ class LexModelBuildingService {
     required String name,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -464,14 +376,6 @@ class LexModelBuildingService {
   Future<void> deleteIntent({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -504,22 +408,6 @@ class LexModelBuildingService {
     required String name,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -559,14 +447,6 @@ class LexModelBuildingService {
   Future<void> deleteSlotType({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -599,22 +479,6 @@ class LexModelBuildingService {
     required String name,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -660,22 +524,6 @@ class LexModelBuildingService {
     required String botName,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -705,15 +553,6 @@ class LexModelBuildingService {
     required String name,
     required String versionOrAlias,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionOrAlias, 'versionOrAlias');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -744,22 +583,6 @@ class LexModelBuildingService {
     required String botName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -802,25 +625,11 @@ class LexModelBuildingService {
     String? nameContains,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      100,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -863,30 +672,6 @@ class LexModelBuildingService {
     required String botName,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    _s.validateStringLength(
-      'botAlias',
-      botAlias,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -936,33 +721,11 @@ class LexModelBuildingService {
     String? nameContains,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    _s.validateStringLength(
-      'botAlias',
-      botAlias,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      100,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1017,14 +780,6 @@ class LexModelBuildingService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1092,12 +847,6 @@ class LexModelBuildingService {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      2,
-      50,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nameContains != null) 'nameContains': [nameContains],
@@ -1131,7 +880,6 @@ class LexModelBuildingService {
   Future<GetBuiltinIntentResponse> getBuiltinIntent({
     required String signature,
   }) async {
-    ArgumentError.checkNotNull(signature, 'signature');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1280,24 +1028,6 @@ class LexModelBuildingService {
     required ResourceType resourceType,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(exportType, 'exportType');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'exportType': [exportType.toValue()],
       'name': [name],
@@ -1327,7 +1057,6 @@ class LexModelBuildingService {
   Future<GetImportResponse> getImport({
     required String importId,
   }) async {
-    ArgumentError.checkNotNull(importId, 'importId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1357,22 +1086,6 @@ class LexModelBuildingService {
     required String name,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1420,14 +1133,6 @@ class LexModelBuildingService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1494,12 +1199,6 @@ class LexModelBuildingService {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      100,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nameContains != null) 'nameContains': [nameContains],
@@ -1535,22 +1234,6 @@ class LexModelBuildingService {
     required String name,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1598,14 +1281,6 @@ class LexModelBuildingService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1672,12 +1347,6 @@ class LexModelBuildingService {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      100,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nameContains != null) 'nameContains': [nameContains],
@@ -1742,16 +1411,6 @@ class LexModelBuildingService {
     required List<String> botVersions,
     required StatusType statusType,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(botVersions, 'botVersions');
-    ArgumentError.checkNotNull(statusType, 'statusType');
     final $query = <String, List<String>>{
       'bot_versions': botVersions,
       'status_type': [statusType.toValue()],
@@ -1780,14 +1439,6 @@ class LexModelBuildingService {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2105,22 +1756,6 @@ class LexModelBuildingService {
     List<Tag>? tags,
     String? voiceId,
   }) async {
-    ArgumentError.checkNotNull(childDirected, 'childDirected');
-    ArgumentError.checkNotNull(locale, 'locale');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      50,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     _s.validateNumRange(
       'idleSessionTTLInSeconds',
       idleSessionTTLInSeconds,
@@ -2219,36 +1854,6 @@ class LexModelBuildingService {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(botName, 'botName');
-    _s.validateStringLength(
-      'botName',
-      botName,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(botVersion, 'botVersion');
-    _s.validateStringLength(
-      'botVersion',
-      botVersion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $payload = <String, dynamic>{
       'botVersion': botVersion,
       if (checksum != null) 'checksum': checksum,
@@ -2506,20 +2111,6 @@ class LexModelBuildingService {
     List<String>? sampleUtterances,
     List<Slot>? slots,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
     final $payload = <String, dynamic>{
       if (checksum != null) 'checksum': checksum,
       if (conclusionStatement != null)
@@ -2663,26 +2254,6 @@ class LexModelBuildingService {
     List<SlotTypeConfiguration>? slotTypeConfigurations,
     SlotValueSelectionStrategy? valueSelectionStrategy,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      200,
-    );
-    _s.validateStringLength(
-      'parentSlotTypeSignature',
-      parentSlotTypeSignature,
-      1,
-      100,
-    );
     final $payload = <String, dynamic>{
       if (checksum != null) 'checksum': checksum,
       if (createVersion != null) 'createVersion': createVersion,
@@ -2754,9 +2325,6 @@ class LexModelBuildingService {
     required ResourceType resourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(mergeStrategy, 'mergeStrategy');
-    ArgumentError.checkNotNull(payload, 'payload');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final $payload = <String, dynamic>{
       'mergeStrategy': mergeStrategy.toValue(),
       'payload': base64Encode(payload),
@@ -2792,15 +2360,6 @@ class LexModelBuildingService {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -2830,15 +2389,6 @@ class LexModelBuildingService {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
+++ b/generated/aws_lex_runtime_api/lib/runtime.lex-2016-11-28.dart
@@ -79,16 +79,6 @@ class LexRuntimeService {
     required String botName,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    ArgumentError.checkNotNull(botName, 'botName');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -128,22 +118,6 @@ class LexRuntimeService {
     required String userId,
     String? checkpointLabelFilter,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    ArgumentError.checkNotNull(botName, 'botName');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'checkpointLabelFilter',
-      checkpointLabelFilter,
-      1,
-      255,
-    );
     final $query = <String, List<String>>{
       if (checkpointLabelFilter != null)
         'checkpointLabelFilter': [checkpointLabelFilter],
@@ -430,18 +404,6 @@ class LexRuntimeService {
     Object? requestAttributes,
     Object? sessionAttributes,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    ArgumentError.checkNotNull(botName, 'botName');
-    ArgumentError.checkNotNull(contentType, 'contentType');
-    ArgumentError.checkNotNull(inputStream, 'inputStream');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': contentType.toString(),
       if (accept != null) 'Accept': accept.toString(),
@@ -658,24 +620,6 @@ class LexRuntimeService {
     Map<String, String>? requestAttributes,
     Map<String, String>? sessionAttributes,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    ArgumentError.checkNotNull(botName, 'botName');
-    ArgumentError.checkNotNull(inputText, 'inputText');
-    _s.validateStringLength(
-      'inputText',
-      inputText,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'inputText': inputText,
       if (activeContexts != null) 'activeContexts': activeContexts,
@@ -815,16 +759,6 @@ class LexRuntimeService {
     List<IntentSummary>? recentIntentSummaryView,
     Map<String, String>? sessionAttributes,
   }) async {
-    ArgumentError.checkNotNull(botAlias, 'botAlias');
-    ArgumentError.checkNotNull(botName, 'botName');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      2,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (accept != null) 'Accept': accept.toString(),
     };

--- a/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
+++ b/generated/aws_license_manager_api/lib/license-manager-2018-08-01.dart
@@ -63,14 +63,6 @@ class LicenseManager {
   Future<AcceptGrantResponse> acceptGrant({
     required String grantArn,
   }) async {
-    ArgumentError.checkNotNull(grantArn, 'grantArn');
-    _s.validateStringLength(
-      'grantArn',
-      grantArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.AcceptGrant'
@@ -109,8 +101,6 @@ class LicenseManager {
     required String licenseConsumptionToken,
     String? beneficiary,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConsumptionToken, 'licenseConsumptionToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CheckInLicense'
@@ -171,25 +161,6 @@ class LicenseManager {
     List<Metadata>? checkoutMetadata,
     String? nodeId,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        digitalSignatureMethod, 'digitalSignatureMethod');
-    ArgumentError.checkNotNull(entitlements, 'entitlements');
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CheckoutBorrowLicense'
@@ -255,18 +226,6 @@ class LicenseManager {
     String? beneficiary,
     String? nodeId,
   }) async {
-    ArgumentError.checkNotNull(checkoutType, 'checkoutType');
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entitlements, 'entitlements');
-    ArgumentError.checkNotNull(keyFingerprint, 'keyFingerprint');
-    ArgumentError.checkNotNull(productSKU, 'productSKU');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CheckoutLicense'
@@ -328,19 +287,6 @@ class LicenseManager {
     required String licenseArn,
     required List<String> principals,
   }) async {
-    ArgumentError.checkNotNull(allowedOperations, 'allowedOperations');
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    ArgumentError.checkNotNull(grantName, 'grantName');
-    ArgumentError.checkNotNull(homeRegion, 'homeRegion');
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principals, 'principals');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateGrant'
@@ -400,15 +346,6 @@ class LicenseManager {
     String? sourceVersion,
     GrantStatus? status,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    ArgumentError.checkNotNull(grantArn, 'grantArn');
-    _s.validateStringLength(
-      'grantArn',
-      grantArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateGrantVersion'
@@ -493,17 +430,6 @@ class LicenseManager {
     required DatetimeRange validity,
     List<Metadata>? licenseMetadata,
   }) async {
-    ArgumentError.checkNotNull(beneficiary, 'beneficiary');
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    ArgumentError.checkNotNull(
-        consumptionConfiguration, 'consumptionConfiguration');
-    ArgumentError.checkNotNull(entitlements, 'entitlements');
-    ArgumentError.checkNotNull(homeRegion, 'homeRegion');
-    ArgumentError.checkNotNull(issuer, 'issuer');
-    ArgumentError.checkNotNull(licenseName, 'licenseName');
-    ArgumentError.checkNotNull(productName, 'productName');
-    ArgumentError.checkNotNull(productSKU, 'productSKU');
-    ArgumentError.checkNotNull(validity, 'validity');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateLicense'
@@ -618,8 +544,6 @@ class LicenseManager {
     List<ProductInformation>? productInformationList,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(licenseCountingType, 'licenseCountingType');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateLicenseConfiguration'
@@ -713,24 +637,6 @@ class LicenseManager {
     List<Metadata>? licenseMetadata,
     String? sourceVersion,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    ArgumentError.checkNotNull(
-        consumptionConfiguration, 'consumptionConfiguration');
-    ArgumentError.checkNotNull(entitlements, 'entitlements');
-    ArgumentError.checkNotNull(homeRegion, 'homeRegion');
-    ArgumentError.checkNotNull(issuer, 'issuer');
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(licenseName, 'licenseName');
-    ArgumentError.checkNotNull(productName, 'productName');
-    ArgumentError.checkNotNull(status, 'status');
-    ArgumentError.checkNotNull(validity, 'validity');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateLicenseVersion'
@@ -800,22 +706,6 @@ class LicenseManager {
     List<String>? roleArns,
     List<String>? tokenProperties,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      0,
-      60,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.CreateToken'
@@ -857,15 +747,6 @@ class LicenseManager {
     required String grantArn,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(grantArn, 'grantArn');
-    _s.validateStringLength(
-      'grantArn',
-      grantArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.DeleteGrant'
@@ -905,15 +786,6 @@ class LicenseManager {
     required String licenseArn,
     required String sourceVersion,
   }) async {
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceVersion, 'sourceVersion');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.DeleteLicense'
@@ -948,8 +820,6 @@ class LicenseManager {
   Future<void> deleteLicenseConfiguration({
     required String licenseConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.DeleteLicenseConfiguration'
@@ -981,7 +851,6 @@ class LicenseManager {
   Future<void> deleteToken({
     required String tokenId,
   }) async {
-    ArgumentError.checkNotNull(tokenId, 'tokenId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.DeleteToken'
@@ -1019,8 +888,6 @@ class LicenseManager {
     required String licenseConsumptionToken,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConsumptionToken, 'licenseConsumptionToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.ExtendLicenseConsumption'
@@ -1058,14 +925,6 @@ class LicenseManager {
     required String token,
     List<String>? tokenProperties,
   }) async {
-    ArgumentError.checkNotNull(token, 'token');
-    _s.validateStringLength(
-      'token',
-      token,
-      0,
-      4096,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.GetAccessToken'
@@ -1104,14 +963,6 @@ class LicenseManager {
     required String grantArn,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(grantArn, 'grantArn');
-    _s.validateStringLength(
-      'grantArn',
-      grantArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.GetGrant'
@@ -1149,14 +1000,6 @@ class LicenseManager {
     required String licenseArn,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.GetLicense'
@@ -1189,8 +1032,6 @@ class LicenseManager {
   Future<GetLicenseConfigurationResponse> getLicenseConfiguration({
     required String licenseConfigurationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.GetLicenseConfiguration'
@@ -1223,14 +1064,6 @@ class LicenseManager {
   Future<GetLicenseUsageResponse> getLicenseUsage({
     required String licenseArn,
   }) async {
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.GetLicenseUsage'
@@ -1298,8 +1131,6 @@ class LicenseManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1413,8 +1244,6 @@ class LicenseManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1528,7 +1357,6 @@ class LicenseManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.ListLicenseSpecificationsForResource'
@@ -1571,14 +1399,6 @@ class LicenseManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(licenseArn, 'licenseArn');
-    _s.validateStringLength(
-      'licenseArn',
-      licenseArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1894,7 +1714,6 @@ class LicenseManager {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.ListTagsForResource'
@@ -2020,8 +1839,6 @@ class LicenseManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.ListUsageForLicenseConfiguration'
@@ -2058,14 +1875,6 @@ class LicenseManager {
   Future<RejectGrantResponse> rejectGrant({
     required String grantArn,
   }) async {
-    ArgumentError.checkNotNull(grantArn, 'grantArn');
-    _s.validateStringLength(
-      'grantArn',
-      grantArn,
-      0,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.RejectGrant'
@@ -2101,8 +1910,6 @@ class LicenseManager {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.TagResource'
@@ -2137,8 +1944,6 @@ class LicenseManager {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.UntagResource'
@@ -2203,8 +2008,6 @@ class LicenseManager {
     String? name,
     List<ProductInformation>? productInformationList,
   }) async {
-    ArgumentError.checkNotNull(
-        licenseConfigurationArn, 'licenseConfigurationArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.UpdateLicenseConfiguration'
@@ -2262,7 +2065,6 @@ class LicenseManager {
     List<LicenseSpecification>? addLicenseSpecifications,
     List<LicenseSpecification>? removeLicenseSpecifications,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSLicenseManager.UpdateLicenseSpecificationsForResource'

--- a/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
+++ b/generated/aws_lightsail_api/lib/lightsail-2016-11-28.dart
@@ -81,7 +81,6 @@ class Lightsail {
   Future<AllocateStaticIpResult> allocateStaticIp({
     required String staticIpName,
   }) async {
-    ArgumentError.checkNotNull(staticIpName, 'staticIpName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AllocateStaticIp'
@@ -149,8 +148,6 @@ class Lightsail {
     required String certificateName,
     required String distributionName,
   }) async {
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
-    ArgumentError.checkNotNull(distributionName, 'distributionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AttachCertificateToDistribution'
@@ -201,9 +198,6 @@ class Lightsail {
     required String diskPath,
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(diskName, 'diskName');
-    ArgumentError.checkNotNull(diskPath, 'diskPath');
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AttachDisk'
@@ -261,8 +255,6 @@ class Lightsail {
     required List<String> instanceNames,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AttachInstancesToLoadBalancer'
@@ -318,8 +310,6 @@ class Lightsail {
     required String certificateName,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AttachLoadBalancerTlsCertificate'
@@ -358,8 +348,6 @@ class Lightsail {
     required String instanceName,
     required String staticIpName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(staticIpName, 'staticIpName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.AttachStaticIp'
@@ -404,8 +392,6 @@ class Lightsail {
     required String instanceName,
     required PortInfo portInfo,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(portInfo, 'portInfo');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CloseInstancePublicPorts'
@@ -535,8 +521,6 @@ class Lightsail {
     String? sourceSnapshotName,
     bool? useLatestRestorableAutoSnapshot,
   }) async {
-    ArgumentError.checkNotNull(sourceRegion, 'sourceRegion');
-    ArgumentError.checkNotNull(targetSnapshotName, 'targetSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CopySnapshot'
@@ -611,8 +595,6 @@ class Lightsail {
     List<String>? subjectAlternativeNames,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateCertificate'
@@ -663,7 +645,6 @@ class Lightsail {
   Future<CreateCloudFormationStackResult> createCloudFormationStack({
     required List<InstanceEntry> instances,
   }) async {
-    ArgumentError.checkNotNull(instances, 'instances');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateCloudFormationStack'
@@ -750,15 +731,6 @@ class Lightsail {
     required String contactEndpoint,
     required ContactProtocol protocol,
   }) async {
-    ArgumentError.checkNotNull(contactEndpoint, 'contactEndpoint');
-    _s.validateStringLength(
-      'contactEndpoint',
-      contactEndpoint,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(protocol, 'protocol');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateContactMethod'
@@ -888,21 +860,11 @@ class Lightsail {
     Map<String, List<String>>? publicDomainNames,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(power, 'power');
-    ArgumentError.checkNotNull(scale, 'scale');
     _s.validateNumRange(
       'scale',
       scale,
       1,
       20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -966,14 +928,6 @@ class Lightsail {
     Map<String, Container>? containers,
     EndpointRequest? publicEndpoint,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateContainerServiceDeployment'
@@ -1087,9 +1041,6 @@ class Lightsail {
     List<AddOnRequest>? addOns,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(diskName, 'diskName');
-    ArgumentError.checkNotNull(sizeInGb, 'sizeInGb');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDisk'
@@ -1244,9 +1195,6 @@ class Lightsail {
     List<Tag>? tags,
     bool? useLatestRestorableAutoSnapshot,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(diskName, 'diskName');
-    ArgumentError.checkNotNull(sizeInGb, 'sizeInGb');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDiskFromSnapshot'
@@ -1345,7 +1293,6 @@ class Lightsail {
     String? instanceName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(diskSnapshotName, 'diskSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDiskSnapshot'
@@ -1424,10 +1371,6 @@ class Lightsail {
     List<CacheBehaviorPerPath>? cacheBehaviors,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
-    ArgumentError.checkNotNull(defaultCacheBehavior, 'defaultCacheBehavior');
-    ArgumentError.checkNotNull(distributionName, 'distributionName');
-    ArgumentError.checkNotNull(origin, 'origin');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDistribution'
@@ -1486,7 +1429,6 @@ class Lightsail {
     required String domainName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDomain'
@@ -1536,8 +1478,6 @@ class Lightsail {
     required DomainEntry domainEntry,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainEntry, 'domainEntry');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateDomainEntry'
@@ -1590,8 +1530,6 @@ class Lightsail {
     required String instanceSnapshotName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(instanceSnapshotName, 'instanceSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateInstanceSnapshot'
@@ -1701,10 +1639,6 @@ class Lightsail {
     List<Tag>? tags,
     String? userData,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(blueprintId, 'blueprintId');
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateInstances'
@@ -1887,9 +1821,6 @@ class Lightsail {
     bool? useLatestRestorableAutoSnapshot,
     String? userData,
   }) async {
-    ArgumentError.checkNotNull(availabilityZone, 'availabilityZone');
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateInstancesFromSnapshot'
@@ -1950,7 +1881,6 @@ class Lightsail {
     required String keyPairName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(keyPairName, 'keyPairName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateKeyPair'
@@ -2040,7 +1970,6 @@ class Lightsail {
     String? healthCheckPath,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(instancePort, 'instancePort');
     _s.validateNumRange(
       'instancePort',
       instancePort,
@@ -2048,7 +1977,6 @@ class Lightsail {
       65535,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateLoadBalancer'
@@ -2129,9 +2057,6 @@ class Lightsail {
     List<String>? certificateAlternativeNames,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(certificateDomainName, 'certificateDomainName');
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateLoadBalancerTlsCertificate'
@@ -2335,14 +2260,6 @@ class Lightsail {
     bool? publiclyAccessible,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(masterDatabaseName, 'masterDatabaseName');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
-    ArgumentError.checkNotNull(
-        relationalDatabaseBlueprintId, 'relationalDatabaseBlueprintId');
-    ArgumentError.checkNotNull(
-        relationalDatabaseBundleId, 'relationalDatabaseBundleId');
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateRelationalDatabase'
@@ -2492,8 +2409,6 @@ class Lightsail {
     List<Tag>? tags,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateRelationalDatabaseFromSnapshot'
@@ -2573,10 +2488,6 @@ class Lightsail {
     required String relationalDatabaseSnapshotName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
-    ArgumentError.checkNotNull(
-        relationalDatabaseSnapshotName, 'relationalDatabaseSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.CreateRelationalDatabaseSnapshot'
@@ -2618,7 +2529,6 @@ class Lightsail {
   Future<DeleteAlarmResult> deleteAlarm({
     required String alarmName,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteAlarm'
@@ -2661,8 +2571,6 @@ class Lightsail {
     required String date,
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(date, 'date');
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteAutoSnapshot'
@@ -2703,7 +2611,6 @@ class Lightsail {
   Future<DeleteCertificateResult> deleteCertificate({
     required String certificateName,
   }) async {
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteCertificate'
@@ -2750,7 +2657,6 @@ class Lightsail {
   Future<DeleteContactMethodResult> deleteContactMethod({
     required ContactProtocol protocol,
   }) async {
-    ArgumentError.checkNotNull(protocol, 'protocol');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteContactMethod'
@@ -2799,15 +2705,6 @@ class Lightsail {
     required String image,
     required String serviceName,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteContainerImage'
@@ -2838,14 +2735,6 @@ class Lightsail {
   Future<void> deleteContainerService({
     required String serviceName,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteContainerService'
@@ -2893,7 +2782,6 @@ class Lightsail {
     required String diskName,
     bool? forceDeleteAddOns,
   }) async {
-    ArgumentError.checkNotNull(diskName, 'diskName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteDisk'
@@ -2942,7 +2830,6 @@ class Lightsail {
   Future<DeleteDiskSnapshotResult> deleteDiskSnapshot({
     required String diskSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(diskSnapshotName, 'diskSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteDiskSnapshot'
@@ -3017,7 +2904,6 @@ class Lightsail {
   Future<DeleteDomainResult> deleteDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteDomain'
@@ -3062,8 +2948,6 @@ class Lightsail {
     required DomainEntry domainEntry,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainEntry, 'domainEntry');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteDomainEntry'
@@ -3109,7 +2993,6 @@ class Lightsail {
     required String instanceName,
     bool? forceDeleteAddOns,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteInstance'
@@ -3151,7 +3034,6 @@ class Lightsail {
   Future<DeleteInstanceSnapshotResult> deleteInstanceSnapshot({
     required String instanceSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(instanceSnapshotName, 'instanceSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteInstanceSnapshot'
@@ -3191,7 +3073,6 @@ class Lightsail {
   Future<DeleteKeyPairResult> deleteKeyPair({
     required String keyPairName,
   }) async {
-    ArgumentError.checkNotNull(keyPairName, 'keyPairName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteKeyPair'
@@ -3237,7 +3118,6 @@ class Lightsail {
   Future<DeleteKnownHostKeysResult> deleteKnownHostKeys({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteKnownHostKeys'
@@ -3280,7 +3160,6 @@ class Lightsail {
   Future<DeleteLoadBalancerResult> deleteLoadBalancer({
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteLoadBalancer'
@@ -3335,8 +3214,6 @@ class Lightsail {
     required String loadBalancerName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(certificateName, 'certificateName');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteLoadBalancerTlsCertificate'
@@ -3411,8 +3288,6 @@ class Lightsail {
     String? finalRelationalDatabaseSnapshotName,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteRelationalDatabase'
@@ -3457,8 +3332,6 @@ class Lightsail {
       deleteRelationalDatabaseSnapshot({
     required String relationalDatabaseSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseSnapshotName, 'relationalDatabaseSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DeleteRelationalDatabaseSnapshot'
@@ -3499,7 +3372,6 @@ class Lightsail {
       detachCertificateFromDistribution({
     required String distributionName,
   }) async {
-    ArgumentError.checkNotNull(distributionName, 'distributionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DetachCertificateFromDistribution'
@@ -3542,7 +3414,6 @@ class Lightsail {
   Future<DetachDiskResult> detachDisk({
     required String diskName,
   }) async {
-    ArgumentError.checkNotNull(diskName, 'diskName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DetachDisk'
@@ -3592,8 +3463,6 @@ class Lightsail {
     required List<String> instanceNames,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(instanceNames, 'instanceNames');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DetachInstancesFromLoadBalancer'
@@ -3629,7 +3498,6 @@ class Lightsail {
   Future<DetachStaticIpResult> detachStaticIp({
     required String staticIpName,
   }) async {
-    ArgumentError.checkNotNull(staticIpName, 'staticIpName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DetachStaticIp'
@@ -3669,8 +3537,6 @@ class Lightsail {
     required AddOnType addOnType,
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(addOnType, 'addOnType');
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.DisableAddOn'
@@ -3736,8 +3602,6 @@ class Lightsail {
     required AddOnRequest addOnRequest,
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(addOnRequest, 'addOnRequest');
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.EnableAddOn'
@@ -3792,7 +3656,6 @@ class Lightsail {
   Future<ExportSnapshotResult> exportSnapshot({
     required String sourceSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(sourceSnapshotName, 'sourceSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.ExportSnapshot'
@@ -3928,7 +3791,6 @@ class Lightsail {
   Future<GetAutoSnapshotsResult> getAutoSnapshots({
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetAutoSnapshots'
@@ -4241,14 +4103,6 @@ class Lightsail {
   Future<GetContainerImagesResult> getContainerImages({
     required String serviceName,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetContainerImages'
@@ -4376,15 +4230,6 @@ class Lightsail {
     String? pageToken,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetContainerLog'
@@ -4433,14 +4278,6 @@ class Lightsail {
   Future<GetContainerServiceDeploymentsResult> getContainerServiceDeployments({
     required String serviceName,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetContainerServiceDeployments'
@@ -4561,9 +4398,6 @@ class Lightsail {
     required DateTime startTime,
     required List<MetricStatistic> statistics,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -4571,16 +4405,6 @@ class Lightsail {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statistics, 'statistics');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetContainerServiceMetricData'
@@ -4648,12 +4472,6 @@ class Lightsail {
   Future<ContainerServicesListResult> getContainerServices({
     String? serviceName,
   }) async {
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetContainerServices'
@@ -4687,7 +4505,6 @@ class Lightsail {
   Future<GetDiskResult> getDisk({
     required String diskName,
   }) async {
-    ArgumentError.checkNotNull(diskName, 'diskName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetDisk'
@@ -4721,7 +4538,6 @@ class Lightsail {
   Future<GetDiskSnapshotResult> getDiskSnapshot({
     required String diskSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(diskSnapshotName, 'diskSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetDiskSnapshot'
@@ -5065,10 +4881,6 @@ class Lightsail {
     required List<MetricStatistic> statistics,
     required MetricUnit unit,
   }) async {
-    ArgumentError.checkNotNull(distributionName, 'distributionName');
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -5076,9 +4888,6 @@ class Lightsail {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statistics, 'statistics');
-    ArgumentError.checkNotNull(unit, 'unit');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetDistributionMetricData'
@@ -5166,7 +4975,6 @@ class Lightsail {
   Future<GetDomainResult> getDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetDomain'
@@ -5281,7 +5089,6 @@ class Lightsail {
   Future<GetInstanceResult> getInstance({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstance'
@@ -5327,7 +5134,6 @@ class Lightsail {
     required String instanceName,
     InstanceAccessProtocol? protocol,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstanceAccessDetails'
@@ -5538,10 +5344,6 @@ class Lightsail {
     required List<MetricStatistic> statistics,
     required MetricUnit unit,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -5549,9 +5351,6 @@ class Lightsail {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statistics, 'statistics');
-    ArgumentError.checkNotNull(unit, 'unit');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstanceMetricData'
@@ -5593,7 +5392,6 @@ class Lightsail {
   Future<GetInstancePortStatesResult> getInstancePortStates({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstancePortStates'
@@ -5627,7 +5425,6 @@ class Lightsail {
   Future<GetInstanceSnapshotResult> getInstanceSnapshot({
     required String instanceSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(instanceSnapshotName, 'instanceSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstanceSnapshot'
@@ -5698,7 +5495,6 @@ class Lightsail {
   Future<GetInstanceStateResult> getInstanceState({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetInstanceState'
@@ -5770,7 +5566,6 @@ class Lightsail {
   Future<GetKeyPairResult> getKeyPair({
     required String keyPairName,
   }) async {
-    ArgumentError.checkNotNull(keyPairName, 'keyPairName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetKeyPair'
@@ -5841,7 +5636,6 @@ class Lightsail {
   Future<GetLoadBalancerResult> getLoadBalancer({
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetLoadBalancer'
@@ -6072,10 +5866,6 @@ class Lightsail {
     required List<MetricStatistic> statistics,
     required MetricUnit unit,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -6083,9 +5873,6 @@ class Lightsail {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statistics, 'statistics');
-    ArgumentError.checkNotNull(unit, 'unit');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetLoadBalancerMetricData'
@@ -6132,7 +5919,6 @@ class Lightsail {
   Future<GetLoadBalancerTlsCertificatesResult> getLoadBalancerTlsCertificates({
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetLoadBalancerTlsCertificates'
@@ -6205,7 +5991,6 @@ class Lightsail {
   Future<GetOperationResult> getOperation({
     required String operationId,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetOperation'
@@ -6291,7 +6076,6 @@ class Lightsail {
     required String resourceName,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetOperationsForResource'
@@ -6373,8 +6157,6 @@ class Lightsail {
   Future<GetRelationalDatabaseResult> getRelationalDatabase({
     required String relationalDatabaseName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabase'
@@ -6511,8 +6293,6 @@ class Lightsail {
     int? durationInMinutes,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseEvents'
@@ -6613,9 +6393,6 @@ class Lightsail {
     bool? startFromHead,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(logStreamName, 'logStreamName');
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseLogEvents'
@@ -6656,8 +6433,6 @@ class Lightsail {
       getRelationalDatabaseLogStreams({
     required String relationalDatabaseName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseLogStreams'
@@ -6710,8 +6485,6 @@ class Lightsail {
     required String relationalDatabaseName,
     RelationalDatabasePasswordVersion? passwordVersion,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -6905,9 +6678,6 @@ class Lightsail {
     required List<MetricStatistic> statistics,
     required MetricUnit unit,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(period, 'period');
     _s.validateNumRange(
       'period',
       period,
@@ -6915,11 +6685,6 @@ class Lightsail {
       86400,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    ArgumentError.checkNotNull(statistics, 'statistics');
-    ArgumentError.checkNotNull(unit, 'unit');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseMetricData'
@@ -6975,8 +6740,6 @@ class Lightsail {
     required String relationalDatabaseName,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseParameters'
@@ -7012,8 +6775,6 @@ class Lightsail {
   Future<GetRelationalDatabaseSnapshotResult> getRelationalDatabaseSnapshot({
     required String relationalDatabaseSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseSnapshotName, 'relationalDatabaseSnapshotName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetRelationalDatabaseSnapshot'
@@ -7124,7 +6885,6 @@ class Lightsail {
   Future<GetStaticIpResult> getStaticIp({
     required String staticIpName,
   }) async {
-    ArgumentError.checkNotNull(staticIpName, 'staticIpName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.GetStaticIp'
@@ -7199,8 +6959,6 @@ class Lightsail {
     required String keyPairName,
     required String publicKeyBase64,
   }) async {
-    ArgumentError.checkNotNull(keyPairName, 'keyPairName');
-    ArgumentError.checkNotNull(publicKeyBase64, 'publicKeyBase64');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.ImportKeyPair'
@@ -7272,8 +7030,6 @@ class Lightsail {
     required String instanceName,
     required PortInfo portInfo,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(portInfo, 'portInfo');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.OpenInstancePublicPorts'
@@ -7515,12 +7271,6 @@ class Lightsail {
     List<AlarmState>? notificationTriggers,
     TreatMissingData? treatMissingData,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
-    ArgumentError.checkNotNull(comparisonOperator, 'comparisonOperator');
-    ArgumentError.checkNotNull(evaluationPeriods, 'evaluationPeriods');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    ArgumentError.checkNotNull(monitoredResourceName, 'monitoredResourceName');
-    ArgumentError.checkNotNull(threshold, 'threshold');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.PutAlarm'
@@ -7586,8 +7336,6 @@ class Lightsail {
     required String instanceName,
     required List<PortInfo> portInfos,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
-    ArgumentError.checkNotNull(portInfos, 'portInfos');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.PutInstancePublicPorts'
@@ -7628,7 +7376,6 @@ class Lightsail {
   Future<RebootInstanceResult> rebootInstance({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.RebootInstance'
@@ -7668,8 +7415,6 @@ class Lightsail {
   Future<RebootRelationalDatabaseResult> rebootRelationalDatabase({
     required String relationalDatabaseName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.RebootRelationalDatabase'
@@ -7743,23 +7488,6 @@ class Lightsail {
     required String label,
     required String serviceName,
   }) async {
-    ArgumentError.checkNotNull(digest, 'digest');
-    ArgumentError.checkNotNull(label, 'label');
-    _s.validateStringLength(
-      'label',
-      label,
-      1,
-      53,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.RegisterContainerImage'
@@ -7795,7 +7523,6 @@ class Lightsail {
   Future<ReleaseStaticIpResult> releaseStaticIp({
     required String staticIpName,
   }) async {
-    ArgumentError.checkNotNull(staticIpName, 'staticIpName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.ReleaseStaticIp'
@@ -7885,7 +7612,6 @@ class Lightsail {
   Future<SendContactMethodVerificationResult> sendContactMethodVerification({
     required ContactMethodVerificationProtocol protocol,
   }) async {
-    ArgumentError.checkNotNull(protocol, 'protocol');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.SendContactMethodVerification'
@@ -7933,7 +7659,6 @@ class Lightsail {
   Future<StartInstanceResult> startInstance({
     required String instanceName,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.StartInstance'
@@ -7975,8 +7700,6 @@ class Lightsail {
   Future<StartRelationalDatabaseResult> startRelationalDatabase({
     required String relationalDatabaseName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.StartRelationalDatabase'
@@ -8033,7 +7756,6 @@ class Lightsail {
     required String instanceName,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(instanceName, 'instanceName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.StopInstance'
@@ -8079,8 +7801,6 @@ class Lightsail {
     required String relationalDatabaseName,
     String? relationalDatabaseSnapshotName,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.StopRelationalDatabase'
@@ -8136,8 +7856,6 @@ class Lightsail {
     required List<Tag> tags,
     String? resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.TagResource'
@@ -8202,8 +7920,6 @@ class Lightsail {
     required String alarmName,
     required AlarmState state,
   }) async {
-    ArgumentError.checkNotNull(alarmName, 'alarmName');
-    ArgumentError.checkNotNull(state, 'state');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.TestAlarm'
@@ -8279,8 +7995,6 @@ class Lightsail {
     required List<String> tagKeys,
     String? resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UntagResource'
@@ -8364,14 +8078,6 @@ class Lightsail {
     Map<String, List<String>>? publicDomainNames,
     int? scale,
   }) async {
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
-    _s.validateStringLength(
-      'serviceName',
-      serviceName,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'scale',
       scale,
@@ -8449,7 +8155,6 @@ class Lightsail {
     bool? isEnabled,
     InputOrigin? origin,
   }) async {
-    ArgumentError.checkNotNull(distributionName, 'distributionName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UpdateDistribution'
@@ -8556,8 +8261,6 @@ class Lightsail {
     required DomainEntry domainEntry,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainEntry, 'domainEntry');
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UpdateDomainEntry'
@@ -8609,16 +8312,6 @@ class Lightsail {
     required String attributeValue,
     required String loadBalancerName,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(attributeValue, 'attributeValue');
-    _s.validateStringLength(
-      'attributeValue',
-      attributeValue,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(loadBalancerName, 'loadBalancerName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UpdateLoadBalancerAttribute'
@@ -8772,8 +8465,6 @@ class Lightsail {
     bool? publiclyAccessible,
     bool? rotateMasterUserPassword,
   }) async {
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UpdateRelationalDatabase'
@@ -8844,9 +8535,6 @@ class Lightsail {
     required List<RelationalDatabaseParameter> parameters,
     required String relationalDatabaseName,
   }) async {
-    ArgumentError.checkNotNull(parameters, 'parameters');
-    ArgumentError.checkNotNull(
-        relationalDatabaseName, 'relationalDatabaseName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Lightsail_20161128.UpdateRelationalDatabaseParameters'

--- a/generated/aws_logs_api/lib/logs-2014-03-28.dart
+++ b/generated/aws_logs_api/lib/logs-2014-03-28.dart
@@ -122,22 +122,6 @@ class CloudWatchLogs {
     required String kmsKeyId,
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(kmsKeyId, 'kmsKeyId');
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.AssociateKmsKey'
@@ -170,14 +154,6 @@ class CloudWatchLogs {
   Future<void> cancelExportTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.CancelExportTask'
@@ -260,15 +236,6 @@ class CloudWatchLogs {
     String? logStreamNamePrefix,
     String? taskName,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    _s.validateStringLength(
-      'destination',
-      destination,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(from, 'from');
     _s.validateNumRange(
       'from',
       from,
@@ -276,33 +243,12 @@ class CloudWatchLogs {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(to, 'to');
     _s.validateNumRange(
       'to',
       to,
       0,
       1152921504606846976,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'logStreamNamePrefix',
-      logStreamNamePrefix,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'taskName',
-      taskName,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -390,20 +336,6 @@ class CloudWatchLogs {
     String? kmsKeyId,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.CreateLogGroup'
@@ -458,22 +390,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required String logStreamName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logStreamName, 'logStreamName');
-    _s.validateStringLength(
-      'logStreamName',
-      logStreamName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.CreateLogStream'
@@ -505,14 +421,6 @@ class CloudWatchLogs {
   Future<void> deleteDestination({
     required String destinationName,
   }) async {
-    ArgumentError.checkNotNull(destinationName, 'destinationName');
-    _s.validateStringLength(
-      'destinationName',
-      destinationName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteDestination'
@@ -542,14 +450,6 @@ class CloudWatchLogs {
   Future<void> deleteLogGroup({
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteLogGroup'
@@ -583,22 +483,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required String logStreamName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logStreamName, 'logStreamName');
-    _s.validateStringLength(
-      'logStreamName',
-      logStreamName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteLogStream'
@@ -632,22 +516,6 @@ class CloudWatchLogs {
     required String filterName,
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(filterName, 'filterName');
-    _s.validateStringLength(
-      'filterName',
-      filterName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteMetricFilter'
@@ -685,14 +553,6 @@ class CloudWatchLogs {
   Future<DeleteQueryDefinitionResponse> deleteQueryDefinition({
     required String queryDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(queryDefinitionId, 'queryDefinitionId');
-    _s.validateStringLength(
-      'queryDefinitionId',
-      queryDefinitionId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteQueryDefinition'
@@ -754,14 +614,6 @@ class CloudWatchLogs {
   Future<void> deleteRetentionPolicy({
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteRetentionPolicy'
@@ -794,22 +646,6 @@ class CloudWatchLogs {
     required String filterName,
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(filterName, 'filterName');
-    _s.validateStringLength(
-      'filterName',
-      filterName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DeleteSubscriptionFilter'
@@ -849,23 +685,11 @@ class CloudWatchLogs {
     int? limit,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'destinationNamePrefix',
-      destinationNamePrefix,
-      1,
-      512,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -921,18 +745,6 @@ class CloudWatchLogs {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      1,
-      512,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DescribeExportTasks'
@@ -980,18 +792,6 @@ class CloudWatchLogs {
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'logGroupNamePrefix',
-      logGroupNamePrefix,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1070,31 +870,11 @@ class CloudWatchLogs {
     String? nextToken,
     OrderBy? orderBy,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'logStreamNamePrefix',
-      logStreamNamePrefix,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1160,41 +940,11 @@ class CloudWatchLogs {
     String? metricNamespace,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'filterNamePrefix',
-      filterNamePrefix,
-      1,
-      512,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'metricNamespace',
-      metricNamespace,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1244,23 +994,11 @@ class CloudWatchLogs {
     String? nextToken,
     QueryStatus? status,
   }) async {
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1310,18 +1048,6 @@ class CloudWatchLogs {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'queryDefinitionNamePrefix',
-      queryDefinitionNamePrefix,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DescribeQueryDefinitions'
@@ -1360,12 +1086,6 @@ class CloudWatchLogs {
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1414,31 +1134,11 @@ class CloudWatchLogs {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'filterNamePrefix',
-      filterNamePrefix,
-      1,
-      512,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1481,14 +1181,6 @@ class CloudWatchLogs {
   Future<void> disassociateKmsKey({
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.DisassociateKmsKey'
@@ -1592,43 +1284,17 @@ class CloudWatchLogs {
     String? nextToken,
     int? startTime,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'endTime',
       endTime,
       0,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'filterPattern',
-      filterPattern,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'logStreamNamePrefix',
-      logStreamNamePrefix,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     _s.validateNumRange(
       'startTime',
@@ -1721,22 +1387,6 @@ class CloudWatchLogs {
     bool? startFromHead,
     int? startTime,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logStreamName, 'logStreamName');
-    _s.validateStringLength(
-      'logStreamName',
-      logStreamName,
-      1,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'endTime',
       endTime,
@@ -1748,12 +1398,6 @@ class CloudWatchLogs {
       limit,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     _s.validateNumRange(
       'startTime',
@@ -1818,14 +1462,6 @@ class CloudWatchLogs {
     required String logGroupName,
     int? time,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'time',
       time,
@@ -1872,7 +1508,6 @@ class CloudWatchLogs {
   Future<GetLogRecordResponse> getLogRecord({
     required String logRecordPointer,
   }) async {
-    ArgumentError.checkNotNull(logRecordPointer, 'logRecordPointer');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.GetLogRecord'
@@ -1917,14 +1552,6 @@ class CloudWatchLogs {
   Future<GetQueryResultsResponse> getQueryResults({
     required String queryId,
   }) async {
-    ArgumentError.checkNotNull(queryId, 'queryId');
-    _s.validateStringLength(
-      'queryId',
-      queryId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.GetQueryResults'
@@ -1953,14 +1580,6 @@ class CloudWatchLogs {
   Future<ListTagsLogGroupResponse> listTagsLogGroup({
     required String logGroupName,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.ListTagsLogGroup'
@@ -2018,30 +1637,6 @@ class CloudWatchLogs {
     required String roleArn,
     required String targetArn,
   }) async {
-    ArgumentError.checkNotNull(destinationName, 'destinationName');
-    _s.validateStringLength(
-      'destinationName',
-      destinationName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetArn, 'targetArn');
-    _s.validateStringLength(
-      'targetArn',
-      targetArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutDestination'
@@ -2083,22 +1678,6 @@ class CloudWatchLogs {
     required String accessPolicy,
     required String destinationName,
   }) async {
-    ArgumentError.checkNotNull(accessPolicy, 'accessPolicy');
-    _s.validateStringLength(
-      'accessPolicy',
-      accessPolicy,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(destinationName, 'destinationName');
-    _s.validateStringLength(
-      'destinationName',
-      destinationName,
-      1,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutDestinationPolicy'
@@ -2196,29 +1775,6 @@ class CloudWatchLogs {
     required String logStreamName,
     String? sequenceToken,
   }) async {
-    ArgumentError.checkNotNull(logEvents, 'logEvents');
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logStreamName, 'logStreamName');
-    _s.validateStringLength(
-      'logStreamName',
-      logStreamName,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sequenceToken',
-      sequenceToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutLogEvents'
@@ -2271,31 +1827,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required List<MetricTransformation> metricTransformations,
   }) async {
-    ArgumentError.checkNotNull(filterName, 'filterName');
-    _s.validateStringLength(
-      'filterName',
-      filterName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterPattern, 'filterPattern');
-    _s.validateStringLength(
-      'filterPattern',
-      filterPattern,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricTransformations, 'metricTransformations');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutMetricFilter'
@@ -2370,28 +1901,6 @@ class CloudWatchLogs {
     List<String>? logGroupNames,
     String? queryDefinitionId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      1,
-      10000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'queryDefinitionId',
-      queryDefinitionId,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutQueryDefinition'
@@ -2442,12 +1951,6 @@ class CloudWatchLogs {
     String? policyDocument,
     String? policyName,
   }) async {
-    _s.validateStringLength(
-      'policyDocument',
-      policyDocument,
-      1,
-      5120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutResourcePolicy'
@@ -2482,15 +1985,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required int retentionInDays,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(retentionInDays, 'retentionInDays');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutRetentionPolicy'
@@ -2606,44 +2100,6 @@ class CloudWatchLogs {
     Distribution? distribution,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(destinationArn, 'destinationArn');
-    _s.validateStringLength(
-      'destinationArn',
-      destinationArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterName, 'filterName');
-    _s.validateStringLength(
-      'filterName',
-      filterName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterPattern, 'filterPattern');
-    _s.validateStringLength(
-      'filterPattern',
-      filterPattern,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.PutSubscriptionFilter'
@@ -2723,7 +2179,6 @@ class CloudWatchLogs {
     String? logGroupName,
     List<String>? logGroupNames,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
     _s.validateNumRange(
       'endTime',
       endTime,
@@ -2731,15 +2186,6 @@ class CloudWatchLogs {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(queryString, 'queryString');
-    _s.validateStringLength(
-      'queryString',
-      queryString,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'startTime',
       startTime,
@@ -2752,12 +2198,6 @@ class CloudWatchLogs {
       limit,
       1,
       10000,
-    );
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2796,14 +2236,6 @@ class CloudWatchLogs {
   Future<StopQueryResponse> stopQuery({
     required String queryId,
   }) async {
-    ArgumentError.checkNotNull(queryId, 'queryId');
-    _s.validateStringLength(
-      'queryId',
-      queryId,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.StopQuery'
@@ -2846,15 +2278,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.TagLogGroup'
@@ -2885,15 +2308,6 @@ class CloudWatchLogs {
     required String filterPattern,
     required List<String> logEventMessages,
   }) async {
-    ArgumentError.checkNotNull(filterPattern, 'filterPattern');
-    _s.validateStringLength(
-      'filterPattern',
-      filterPattern,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(logEventMessages, 'logEventMessages');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.TestMetricFilter'
@@ -2931,15 +2345,6 @@ class CloudWatchLogs {
     required String logGroupName,
     required List<String> tags,
   }) async {
-    ArgumentError.checkNotNull(logGroupName, 'logGroupName');
-    _s.validateStringLength(
-      'logGroupName',
-      logGroupName,
-      1,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Logs_20140328.UntagLogGroup'

--- a/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
+++ b/generated/aws_machinelearning_api/lib/machinelearning-2014-12-12.dart
@@ -73,16 +73,6 @@ class MachineLearning {
     required TaggableResourceType resourceType,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.AddTags'
@@ -158,45 +148,6 @@ class MachineLearning {
     required String outputUri,
     String? batchPredictionName,
   }) async {
-    ArgumentError.checkNotNull(
-        batchPredictionDataSourceId, 'batchPredictionDataSourceId');
-    _s.validateStringLength(
-      'batchPredictionDataSourceId',
-      batchPredictionDataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(batchPredictionId, 'batchPredictionId');
-    _s.validateStringLength(
-      'batchPredictionId',
-      batchPredictionId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputUri, 'outputUri');
-    _s.validateStringLength(
-      'outputUri',
-      outputUri,
-      0,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'batchPredictionName',
-      batchPredictionName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateBatchPrediction'
@@ -336,29 +287,6 @@ class MachineLearning {
     bool? computeStatistics,
     String? dataSourceName,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rDSData, 'rDSData');
-    ArgumentError.checkNotNull(roleARN, 'roleARN');
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      1,
-      110,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateDataSourceFromRDS'
@@ -509,29 +437,6 @@ class MachineLearning {
     bool? computeStatistics,
     String? dataSourceName,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSpec, 'dataSpec');
-    ArgumentError.checkNotNull(roleARN, 'roleARN');
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      1,
-      110,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateDataSourceFromRedshift'
@@ -640,21 +545,6 @@ class MachineLearning {
     bool? computeStatistics,
     String? dataSourceName,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSpec, 'dataSpec');
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateDataSourceFromS3'
@@ -724,37 +614,6 @@ class MachineLearning {
     required String mLModelId,
     String? evaluationName,
   }) async {
-    ArgumentError.checkNotNull(
-        evaluationDataSourceId, 'evaluationDataSourceId');
-    _s.validateStringLength(
-      'evaluationDataSourceId',
-      evaluationDataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(evaluationId, 'evaluationId');
-    _s.validateStringLength(
-      'evaluationId',
-      evaluationId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'evaluationName',
-      evaluationName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateEvaluation'
@@ -902,41 +761,6 @@ class MachineLearning {
     String? recipe,
     String? recipeUri,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(mLModelType, 'mLModelType');
-    ArgumentError.checkNotNull(trainingDataSourceId, 'trainingDataSourceId');
-    _s.validateStringLength(
-      'trainingDataSourceId',
-      trainingDataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'mLModelName',
-      mLModelName,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'recipe',
-      recipe,
-      0,
-      131071,
-    );
-    _s.validateStringLength(
-      'recipeUri',
-      recipeUri,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateMLModel'
@@ -974,14 +798,6 @@ class MachineLearning {
   Future<CreateRealtimeEndpointOutput> createRealtimeEndpoint({
     required String mLModelId,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.CreateRealtimeEndpoint'
@@ -1020,14 +836,6 @@ class MachineLearning {
   Future<DeleteBatchPredictionOutput> deleteBatchPrediction({
     required String batchPredictionId,
   }) async {
-    ArgumentError.checkNotNull(batchPredictionId, 'batchPredictionId');
-    _s.validateStringLength(
-      'batchPredictionId',
-      batchPredictionId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteBatchPrediction'
@@ -1065,14 +873,6 @@ class MachineLearning {
   Future<DeleteDataSourceOutput> deleteDataSource({
     required String dataSourceId,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteDataSource'
@@ -1112,14 +912,6 @@ class MachineLearning {
   Future<DeleteEvaluationOutput> deleteEvaluation({
     required String evaluationId,
   }) async {
-    ArgumentError.checkNotNull(evaluationId, 'evaluationId');
-    _s.validateStringLength(
-      'evaluationId',
-      evaluationId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteEvaluation'
@@ -1157,14 +949,6 @@ class MachineLearning {
   Future<DeleteMLModelOutput> deleteMLModel({
     required String mLModelId,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteMLModel'
@@ -1194,14 +978,6 @@ class MachineLearning {
   Future<DeleteRealtimeEndpointOutput> deleteRealtimeEndpoint({
     required String mLModelId,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteRealtimeEndpoint'
@@ -1243,16 +1019,6 @@ class MachineLearning {
     required TaggableResourceType resourceType,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DeleteTags'
@@ -1386,53 +1152,11 @@ class MachineLearning {
     String? prefix,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'eq',
-      eq,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'ge',
-      ge,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'gt',
-      gt,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'le',
-      le,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'lt',
-      lt,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'ne',
-      ne,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'prefix',
-      prefix,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1569,53 +1293,11 @@ class MachineLearning {
     String? prefix,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'eq',
-      eq,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'ge',
-      ge,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'gt',
-      gt,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'le',
-      le,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'lt',
-      lt,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'ne',
-      ne,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'prefix',
-      prefix,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1755,53 +1437,11 @@ class MachineLearning {
     String? prefix,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'eq',
-      eq,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'ge',
-      ge,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'gt',
-      gt,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'le',
-      le,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'lt',
-      lt,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'ne',
-      ne,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'prefix',
-      prefix,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1949,53 +1589,11 @@ class MachineLearning {
     String? prefix,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'eq',
-      eq,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'ge',
-      ge,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'gt',
-      gt,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'le',
-      le,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'lt',
-      lt,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'ne',
-      ne,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'prefix',
-      prefix,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2040,15 +1638,6 @@ class MachineLearning {
     required String resourceId,
     required TaggableResourceType resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.DescribeTags'
@@ -2081,14 +1670,6 @@ class MachineLearning {
   Future<GetBatchPredictionOutput> getBatchPrediction({
     required String batchPredictionId,
   }) async {
-    ArgumentError.checkNotNull(batchPredictionId, 'batchPredictionId');
-    _s.validateStringLength(
-      'batchPredictionId',
-      batchPredictionId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.GetBatchPrediction'
@@ -2132,14 +1713,6 @@ class MachineLearning {
     required String dataSourceId,
     bool? verbose,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.GetDataSource'
@@ -2173,14 +1746,6 @@ class MachineLearning {
   Future<GetEvaluationOutput> getEvaluation({
     required String evaluationId,
   }) async {
-    ArgumentError.checkNotNull(evaluationId, 'evaluationId');
-    _s.validateStringLength(
-      'evaluationId',
-      evaluationId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.GetEvaluation'
@@ -2222,14 +1787,6 @@ class MachineLearning {
     required String mLModelId,
     bool? verbose,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.GetMLModel'
@@ -2269,23 +1826,6 @@ class MachineLearning {
     required String predictEndpoint,
     required Map<String, String> record,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(predictEndpoint, 'predictEndpoint');
-    _s.validateStringLength(
-      'predictEndpoint',
-      predictEndpoint,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(record, 'record');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.Predict'
@@ -2326,22 +1866,6 @@ class MachineLearning {
     required String batchPredictionId,
     required String batchPredictionName,
   }) async {
-    ArgumentError.checkNotNull(batchPredictionId, 'batchPredictionId');
-    _s.validateStringLength(
-      'batchPredictionId',
-      batchPredictionId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(batchPredictionName, 'batchPredictionName');
-    _s.validateStringLength(
-      'batchPredictionName',
-      batchPredictionName,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.UpdateBatchPrediction'
@@ -2380,22 +1904,6 @@ class MachineLearning {
     required String dataSourceId,
     required String dataSourceName,
   }) async {
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    _s.validateStringLength(
-      'dataSourceId',
-      dataSourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceName, 'dataSourceName');
-    _s.validateStringLength(
-      'dataSourceName',
-      dataSourceName,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.UpdateDataSource'
@@ -2434,22 +1942,6 @@ class MachineLearning {
     required String evaluationId,
     required String evaluationName,
   }) async {
-    ArgumentError.checkNotNull(evaluationId, 'evaluationId');
-    _s.validateStringLength(
-      'evaluationId',
-      evaluationId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(evaluationName, 'evaluationName');
-    _s.validateStringLength(
-      'evaluationName',
-      evaluationName,
-      0,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.UpdateEvaluation'
@@ -2500,20 +1992,6 @@ class MachineLearning {
     String? mLModelName,
     double? scoreThreshold,
   }) async {
-    ArgumentError.checkNotNull(mLModelId, 'mLModelId');
-    _s.validateStringLength(
-      'mLModelId',
-      mLModelId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'mLModelName',
-      mLModelName,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonML_20141212.UpdateMLModel'

--- a/generated/aws_macie_api/lib/macie-2017-12-19.dart
+++ b/generated/aws_macie_api/lib/macie-2017-12-19.dart
@@ -67,7 +67,6 @@ class Macie {
   Future<void> associateMemberAccount({
     required String memberAccountId,
   }) async {
-    ArgumentError.checkNotNull(memberAccountId, 'memberAccountId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.AssociateMemberAccount'
@@ -107,7 +106,6 @@ class Macie {
     required List<S3ResourceClassification> s3Resources,
     String? memberAccountId,
   }) async {
-    ArgumentError.checkNotNull(s3Resources, 's3Resources');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.AssociateS3Resources'
@@ -138,7 +136,6 @@ class Macie {
   Future<void> disassociateMemberAccount({
     required String memberAccountId,
   }) async {
-    ArgumentError.checkNotNull(memberAccountId, 'memberAccountId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.DisassociateMemberAccount'
@@ -176,7 +173,6 @@ class Macie {
     required List<S3Resource> associatedS3Resources,
     String? memberAccountId,
   }) async {
-    ArgumentError.checkNotNull(associatedS3Resources, 'associatedS3Resources');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.DisassociateS3Resources'
@@ -220,12 +216,6 @@ class Macie {
       maxResults,
       0,
       250,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      500,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -280,12 +270,6 @@ class Macie {
       0,
       250,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      500,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.ListS3Resources'
@@ -327,7 +311,6 @@ class Macie {
     required List<S3ResourceClassificationUpdate> s3ResourcesUpdate,
     String? memberAccountId,
   }) async {
-    ArgumentError.checkNotNull(s3ResourcesUpdate, 's3ResourcesUpdate');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MacieService.UpdateS3Resources'

--- a/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
+++ b/generated/aws_managedblockchain_api/lib/managedblockchain-2018-09-24.dart
@@ -99,29 +99,6 @@ class ManagedBlockchain {
     required String networkId,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(invitationId, 'invitationId');
-    _s.validateStringLength(
-      'invitationId',
-      invitationId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberConfiguration, 'memberConfiguration');
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'InvitationId': invitationId,
       'MemberConfiguration': memberConfiguration,
@@ -186,37 +163,6 @@ class ManagedBlockchain {
     String? description,
     NetworkFrameworkConfiguration? frameworkConfiguration,
   }) async {
-    ArgumentError.checkNotNull(framework, 'framework');
-    ArgumentError.checkNotNull(frameworkVersion, 'frameworkVersion');
-    _s.validateStringLength(
-      'frameworkVersion',
-      frameworkVersion,
-      1,
-      8,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberConfiguration, 'memberConfiguration');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(votingPolicy, 'votingPolicy');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'Framework': framework.toValue(),
       'FrameworkVersion': frameworkVersion,
@@ -287,27 +233,6 @@ class ManagedBlockchain {
     String? clientRequestToken,
     String? memberId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeConfiguration, 'nodeConfiguration');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       'NodeConfiguration': nodeConfiguration,
       'ClientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -366,35 +291,6 @@ class ManagedBlockchain {
     String? clientRequestToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
     final $payload = <String, dynamic>{
       'Actions': actions,
       'MemberId': memberId,
@@ -437,22 +333,6 @@ class ManagedBlockchain {
     required String memberId,
     required String networkId,
   }) async {
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -503,28 +383,6 @@ class ManagedBlockchain {
     required String nodeId,
     String? memberId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeId, 'nodeId');
-    _s.validateStringLength(
-      'nodeId',
-      nodeId,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-    );
     final $query = <String, List<String>>{
       if (memberId != null) 'memberId': [memberId],
     };
@@ -557,22 +415,6 @@ class ManagedBlockchain {
     required String memberId,
     required String networkId,
   }) async {
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -598,14 +440,6 @@ class ManagedBlockchain {
   Future<GetNetworkOutput> getNetwork({
     required String networkId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -640,28 +474,6 @@ class ManagedBlockchain {
     required String nodeId,
     String? memberId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeId, 'nodeId');
-    _s.validateStringLength(
-      'nodeId',
-      nodeId,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-    );
     final $query = <String, List<String>>{
       if (memberId != null) 'memberId': [memberId],
     };
@@ -695,22 +507,6 @@ class ManagedBlockchain {
     required String networkId,
     required String proposalId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(proposalId, 'proposalId');
-    _s.validateStringLength(
-      'proposalId',
-      proposalId,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -746,12 +542,6 @@ class ManagedBlockchain {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -806,25 +596,11 @@ class ManagedBlockchain {
     String? nextToken,
     MemberStatus? status,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
     );
     final $query = <String, List<String>>{
       if (isOwned != null) 'isOwned': [isOwned.toString()],
@@ -884,12 +660,6 @@ class ManagedBlockchain {
       1,
       10,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
-    );
     final $query = <String, List<String>>{
       if (framework != null) 'framework': [framework.toValue()],
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -940,31 +710,11 @@ class ManagedBlockchain {
     String? nextToken,
     NodeStatus? status,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1009,33 +759,11 @@ class ManagedBlockchain {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(proposalId, 'proposalId');
-    _s.validateStringLength(
-      'proposalId',
-      proposalId,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1075,25 +803,11 @@ class ManagedBlockchain {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      128,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
@@ -1127,14 +841,6 @@ class ManagedBlockchain {
   Future<void> rejectInvitation({
     required String invitationId,
   }) async {
-    ArgumentError.checkNotNull(invitationId, 'invitationId');
-    _s.validateStringLength(
-      'invitationId',
-      invitationId,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1167,22 +873,6 @@ class ManagedBlockchain {
     required String networkId,
     MemberLogPublishingConfiguration? logPublishingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (logPublishingConfiguration != null)
         'LogPublishingConfiguration': logPublishingConfiguration,
@@ -1225,28 +915,6 @@ class ManagedBlockchain {
     NodeLogPublishingConfiguration? logPublishingConfiguration,
     String? memberId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeId, 'nodeId');
-    _s.validateStringLength(
-      'nodeId',
-      nodeId,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       if (logPublishingConfiguration != null)
         'LogPublishingConfiguration': logPublishingConfiguration,
@@ -1291,31 +959,6 @@ class ManagedBlockchain {
     required VoteValue vote,
     required String voterMemberId,
   }) async {
-    ArgumentError.checkNotNull(networkId, 'networkId');
-    _s.validateStringLength(
-      'networkId',
-      networkId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(proposalId, 'proposalId');
-    _s.validateStringLength(
-      'proposalId',
-      proposalId,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vote, 'vote');
-    ArgumentError.checkNotNull(voterMemberId, 'voterMemberId');
-    _s.validateStringLength(
-      'voterMemberId',
-      voterMemberId,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Vote': vote.toValue(),
       'VoterMemberId': voterMemberId,

--- a/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
+++ b/generated/aws_marketplace_catalog_api/lib/marketplace-catalog-2018-09-17.dart
@@ -78,22 +78,6 @@ class MarketplaceCatalog {
     required String catalog,
     required String changeSetId,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeSetId, 'changeSetId');
-    _s.validateStringLength(
-      'changeSetId',
-      changeSetId,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'catalog': [catalog],
       'changeSetId': [changeSetId],
@@ -127,22 +111,6 @@ class MarketplaceCatalog {
     required String catalog,
     required String changeSetId,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeSetId, 'changeSetId');
-    _s.validateStringLength(
-      'changeSetId',
-      changeSetId,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'catalog': [catalog],
       'changeSetId': [changeSetId],
@@ -176,22 +144,6 @@ class MarketplaceCatalog {
     required String catalog,
     required String entityId,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      1,
-      255,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       'catalog': [catalog],
       'entityId': [entityId],
@@ -246,25 +198,11 @@ class MarketplaceCatalog {
     String? nextToken,
     Sort? sort,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $payload = <String, dynamic>{
       'Catalog': catalog,
@@ -320,33 +258,11 @@ class MarketplaceCatalog {
     String? nextToken,
     Sort? sort,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityType, 'entityType');
-    _s.validateStringLength(
-      'entityType',
-      entityType,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final $payload = <String, dynamic>{
       'Catalog': catalog,
@@ -406,27 +322,6 @@ class MarketplaceCatalog {
     String? changeSetName,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(catalog, 'catalog');
-    _s.validateStringLength(
-      'catalog',
-      catalog,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeSet, 'changeSet');
-    _s.validateStringLength(
-      'changeSetName',
-      changeSetName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      36,
-    );
     final $payload = <String, dynamic>{
       'Catalog': catalog,
       'ChangeSet': changeSet,

--- a/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
+++ b/generated/aws_marketplace_entitlement_api/lib/entitlement.marketplace-2017-01-11.dart
@@ -82,14 +82,6 @@ class MarketplaceEntitlementService {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(productCode, 'productCode');
-    _s.validateStringLength(
-      'productCode',
-      productCode,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMPEntitlementService.GetEntitlements'

--- a/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
+++ b/generated/aws_marketplacecommerceanalytics_api/lib/marketplacecommerceanalytics-2015-07-01.dart
@@ -199,34 +199,6 @@ class MarketplaceCommerceAnalytics {
     Map<String, String>? customerDefinedValues,
     String? destinationS3Prefix,
   }) async {
-    ArgumentError.checkNotNull(
-        dataSetPublicationDate, 'dataSetPublicationDate');
-    ArgumentError.checkNotNull(dataSetType, 'dataSetType');
-    ArgumentError.checkNotNull(
-        destinationS3BucketName, 'destinationS3BucketName');
-    _s.validateStringLength(
-      'destinationS3BucketName',
-      destinationS3BucketName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleNameArn, 'roleNameArn');
-    _s.validateStringLength(
-      'roleNameArn',
-      roleNameArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    _s.validateStringLength(
-      'snsTopicArn',
-      snsTopicArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MarketplaceCommerceAnalytics20150701.GenerateDataSet'
@@ -324,33 +296,6 @@ class MarketplaceCommerceAnalytics {
     Map<String, String>? customerDefinedValues,
     String? destinationS3Prefix,
   }) async {
-    ArgumentError.checkNotNull(dataSetType, 'dataSetType');
-    ArgumentError.checkNotNull(
-        destinationS3BucketName, 'destinationS3BucketName');
-    _s.validateStringLength(
-      'destinationS3BucketName',
-      destinationS3BucketName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fromDate, 'fromDate');
-    ArgumentError.checkNotNull(roleNameArn, 'roleNameArn');
-    _s.validateStringLength(
-      'roleNameArn',
-      roleNameArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    _s.validateStringLength(
-      'snsTopicArn',
-      snsTopicArn,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':

--- a/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
+++ b/generated/aws_mediaconnect_api/lib/mediaconnect-2018-11-14.dart
@@ -68,8 +68,6 @@ class MediaConnect {
     required String flowArn,
     required List<AddOutputRequest> outputs,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(outputs, 'outputs');
     final $payload = <String, dynamic>{
       'outputs': outputs,
     };
@@ -100,8 +98,6 @@ class MediaConnect {
     required String flowArn,
     required List<SetSourceRequest> sources,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(sources, 'sources');
     final $payload = <String, dynamic>{
       'sources': sources,
     };
@@ -132,8 +128,6 @@ class MediaConnect {
     required String flowArn,
     required List<VpcInterfaceRequest> vpcInterfaces,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(vpcInterfaces, 'vpcInterfaces');
     final $payload = <String, dynamic>{
       'vpcInterfaces': vpcInterfaces,
     };
@@ -181,7 +175,6 @@ class MediaConnect {
     List<SetSourceRequest>? sources,
     List<VpcInterfaceRequest>? vpcInterfaces,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (availabilityZone != null) 'availabilityZone': availabilityZone,
@@ -216,7 +209,6 @@ class MediaConnect {
   Future<DeleteFlowResponse> deleteFlow({
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -242,7 +234,6 @@ class MediaConnect {
   Future<DescribeFlowResponse> describeFlow({
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -267,7 +258,6 @@ class MediaConnect {
   Future<DescribeOfferingResponse> describeOffering({
     required String offeringArn,
   }) async {
-    ArgumentError.checkNotNull(offeringArn, 'offeringArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -293,7 +283,6 @@ class MediaConnect {
   Future<DescribeReservationResponse> describeReservation({
     required String reservationArn,
   }) async {
-    ArgumentError.checkNotNull(reservationArn, 'reservationArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -322,8 +311,6 @@ class MediaConnect {
     required List<GrantEntitlementRequest> entitlements,
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(entitlements, 'entitlements');
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final $payload = <String, dynamic>{
       'entitlements': entitlements,
     };
@@ -539,7 +526,6 @@ class MediaConnect {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -577,9 +563,6 @@ class MediaConnect {
     required String reservationName,
     required String start,
   }) async {
-    ArgumentError.checkNotNull(offeringArn, 'offeringArn');
-    ArgumentError.checkNotNull(reservationName, 'reservationName');
-    ArgumentError.checkNotNull(start, 'start');
     final $payload = <String, dynamic>{
       'reservationName': reservationName,
       'start': start,
@@ -615,8 +598,6 @@ class MediaConnect {
     required String flowArn,
     required String outputArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(outputArn, 'outputArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -646,8 +627,6 @@ class MediaConnect {
     required String flowArn,
     required String sourceArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -680,8 +659,6 @@ class MediaConnect {
     required String flowArn,
     required String vpcInterfaceName,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(vpcInterfaceName, 'vpcInterfaceName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -712,8 +689,6 @@ class MediaConnect {
     required String entitlementArn,
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(entitlementArn, 'entitlementArn');
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -738,7 +713,6 @@ class MediaConnect {
   Future<StartFlowResponse> startFlow({
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -762,7 +736,6 @@ class MediaConnect {
   Future<StopFlowResponse> stopFlow({
     required String flowArn,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -793,8 +766,6 @@ class MediaConnect {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -822,8 +793,6 @@ class MediaConnect {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -851,7 +820,6 @@ class MediaConnect {
     required String flowArn,
     UpdateFailoverConfig? sourceFailoverConfig,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final $payload = <String, dynamic>{
       if (sourceFailoverConfig != null)
         'sourceFailoverConfig': sourceFailoverConfig,
@@ -909,8 +877,6 @@ class MediaConnect {
     EntitlementStatus? entitlementStatus,
     List<String>? subscribers,
   }) async {
-    ArgumentError.checkNotNull(entitlementArn, 'entitlementArn');
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (encryption != null) 'encryption': encryption,
@@ -995,8 +961,6 @@ class MediaConnect {
     String? streamId,
     VpcInterfaceAttachment? vpcInterfaceAttachment,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(outputArn, 'outputArn');
     final $payload = <String, dynamic>{
       if (cidrAllowList != null) 'cidrAllowList': cidrAllowList,
       if (description != null) 'description': description,
@@ -1086,8 +1050,6 @@ class MediaConnect {
     String? vpcInterfaceName,
     String? whitelistCidr,
   }) async {
-    ArgumentError.checkNotNull(flowArn, 'flowArn');
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
     final $payload = <String, dynamic>{
       if (decryption != null) 'decryption': decryption,
       if (description != null) 'description': description,

--- a/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
+++ b/generated/aws_mediaconvert_api/lib/mediaconvert-2017-08-29.dart
@@ -64,7 +64,6 @@ class MediaConvert {
   Future<void> associateCertificate({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $payload = <String, dynamic>{
       'arn': arn,
     };
@@ -91,7 +90,6 @@ class MediaConvert {
   Future<void> cancelJob({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -200,8 +198,6 @@ class MediaConvert {
     Map<String, String>? tags,
     Map<String, String>? userMetadata,
   }) async {
-    ArgumentError.checkNotNull(role, 'role');
-    ArgumentError.checkNotNull(settings, 'settings');
     _s.validateNumRange(
       'priority',
       priority,
@@ -306,8 +302,6 @@ class MediaConvert {
     StatusUpdateInterval? statusUpdateInterval,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(settings, 'settings');
     _s.validateNumRange(
       'priority',
       priority,
@@ -369,8 +363,6 @@ class MediaConvert {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(settings, 'settings');
     final $payload = <String, dynamic>{
       'name': name,
       'settings': settings,
@@ -431,7 +423,6 @@ class MediaConvert {
     QueueStatus? status,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (description != null) 'description': description,
@@ -464,7 +455,6 @@ class MediaConvert {
   Future<void> deleteJobTemplate({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -487,7 +477,6 @@ class MediaConvert {
   Future<void> deletePreset({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -510,7 +499,6 @@ class MediaConvert {
   Future<void> deleteQueue({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -578,7 +566,6 @@ class MediaConvert {
   Future<void> disassociateCertificate({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -601,7 +588,6 @@ class MediaConvert {
   Future<GetJobResponse> getJob({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -625,7 +611,6 @@ class MediaConvert {
   Future<GetJobTemplateResponse> getJobTemplate({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -649,7 +634,6 @@ class MediaConvert {
   Future<GetPresetResponse> getPreset({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -673,7 +657,6 @@ class MediaConvert {
   Future<GetQueueResponse> getQueue({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -939,7 +922,6 @@ class MediaConvert {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -971,8 +953,6 @@ class MediaConvert {
     required String arn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'arn': arn,
       'tags': tags,
@@ -1006,7 +986,6 @@ class MediaConvert {
     required String arn,
     List<String>? tagKeys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
     final $payload = <String, dynamic>{
       if (tagKeys != null) 'tagKeys': tagKeys,
     };
@@ -1076,7 +1055,6 @@ class MediaConvert {
     JobTemplateSettings? settings,
     StatusUpdateInterval? statusUpdateInterval,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'priority',
       priority,
@@ -1130,7 +1108,6 @@ class MediaConvert {
     String? description,
     PresetSettings? settings,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       if (category != null) 'category': category,
       if (description != null) 'description': description,
@@ -1179,7 +1156,6 @@ class MediaConvert {
     ReservationPlanSettings? reservationPlanSettings,
     QueueStatus? status,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
       if (reservationPlanSettings != null)

--- a/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
+++ b/generated/aws_medialive_api/lib/medialive-2017-10-14.dart
@@ -67,7 +67,6 @@ class MediaLive {
   Future<void> acceptInputDeviceTransfer({
     required String inputDeviceId,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -211,7 +210,6 @@ class MediaLive {
     BatchScheduleActionCreateRequest? creates,
     BatchScheduleActionDeleteRequest? deletes,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final $payload = <String, dynamic>{
       if (creates != null) 'creates': creates,
       if (deletes != null) 'deletes': deletes,
@@ -243,7 +241,6 @@ class MediaLive {
   Future<void> cancelInputDeviceTransfer({
     required String inputDeviceId,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -479,9 +476,6 @@ class MediaLive {
     String? requestId,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(availabilityZones, 'availabilityZones');
-    ArgumentError.checkNotNull(multiplexSettings, 'multiplexSettings');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'availabilityZones': availabilityZones,
       'multiplexSettings': multiplexSettings,
@@ -527,10 +521,6 @@ class MediaLive {
     required String programName,
     String? requestId,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
-    ArgumentError.checkNotNull(
-        multiplexProgramSettings, 'multiplexProgramSettings');
-    ArgumentError.checkNotNull(programName, 'programName');
     final $payload = <String, dynamic>{
       'multiplexProgramSettings': multiplexProgramSettings,
       'programName': programName,
@@ -556,7 +546,6 @@ class MediaLive {
     required String resourceArn,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
     };
@@ -584,7 +573,6 @@ class MediaLive {
   Future<DeleteChannelResponse> deleteChannel({
     required String channelId,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -610,7 +598,6 @@ class MediaLive {
   Future<void> deleteInput({
     required String inputId,
   }) async {
-    ArgumentError.checkNotNull(inputId, 'inputId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -634,7 +621,6 @@ class MediaLive {
   Future<void> deleteInputSecurityGroup({
     required String inputSecurityGroupId,
   }) async {
-    ArgumentError.checkNotNull(inputSecurityGroupId, 'inputSecurityGroupId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -660,7 +646,6 @@ class MediaLive {
   Future<DeleteMultiplexResponse> deleteMultiplex({
     required String multiplexId,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -690,8 +675,6 @@ class MediaLive {
     required String multiplexId,
     required String programName,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
-    ArgumentError.checkNotNull(programName, 'programName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -718,7 +701,6 @@ class MediaLive {
   Future<DeleteReservationResponse> deleteReservation({
     required String reservationId,
   }) async {
-    ArgumentError.checkNotNull(reservationId, 'reservationId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -743,7 +725,6 @@ class MediaLive {
   Future<void> deleteSchedule({
     required String channelId,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -765,8 +746,6 @@ class MediaLive {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -794,7 +773,6 @@ class MediaLive {
   Future<DescribeChannelResponse> describeChannel({
     required String channelId,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -819,7 +797,6 @@ class MediaLive {
   Future<DescribeInputResponse> describeInput({
     required String inputId,
   }) async {
-    ArgumentError.checkNotNull(inputId, 'inputId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -844,7 +821,6 @@ class MediaLive {
   Future<DescribeInputDeviceResponse> describeInputDevice({
     required String inputDeviceId,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -873,8 +849,6 @@ class MediaLive {
     required AcceptHeader accept,
     required String inputDeviceId,
   }) async {
-    ArgumentError.checkNotNull(accept, 'accept');
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final headers = <String, String>{
       'accept': accept.toValue(),
     };
@@ -914,7 +888,6 @@ class MediaLive {
   Future<DescribeInputSecurityGroupResponse> describeInputSecurityGroup({
     required String inputSecurityGroupId,
   }) async {
-    ArgumentError.checkNotNull(inputSecurityGroupId, 'inputSecurityGroupId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -940,7 +913,6 @@ class MediaLive {
   Future<DescribeMultiplexResponse> describeMultiplex({
     required String multiplexId,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -969,8 +941,6 @@ class MediaLive {
     required String multiplexId,
     required String programName,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
-    ArgumentError.checkNotNull(programName, 'programName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -996,7 +966,6 @@ class MediaLive {
   Future<DescribeOfferingResponse> describeOffering({
     required String offeringId,
   }) async {
-    ArgumentError.checkNotNull(offeringId, 'offeringId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1021,7 +990,6 @@ class MediaLive {
   Future<DescribeReservationResponse> describeReservation({
     required String reservationId,
   }) async {
-    ArgumentError.checkNotNull(reservationId, 'reservationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1048,7 +1016,6 @@ class MediaLive {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1117,7 +1084,6 @@ class MediaLive {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(transferType, 'transferType');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1258,7 +1224,6 @@ class MediaLive {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1483,7 +1448,6 @@ class MediaLive {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1532,7 +1496,6 @@ class MediaLive {
     String? start,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(count, 'count');
     _s.validateNumRange(
       'count',
       count,
@@ -1540,7 +1503,6 @@ class MediaLive {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(offeringId, 'offeringId');
     final $payload = <String, dynamic>{
       'count': count,
       if (name != null) 'name': name,
@@ -1575,7 +1537,6 @@ class MediaLive {
   Future<void> rejectInputDeviceTransfer({
     required String inputDeviceId,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1601,7 +1562,6 @@ class MediaLive {
   Future<StartChannelResponse> startChannel({
     required String channelId,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1628,7 +1588,6 @@ class MediaLive {
   Future<StartMultiplexResponse> startMultiplex({
     required String multiplexId,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1654,7 +1613,6 @@ class MediaLive {
   Future<StopChannelResponse> stopChannel({
     required String channelId,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1681,7 +1639,6 @@ class MediaLive {
   Future<StopMultiplexResponse> stopMultiplex({
     required String multiplexId,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1717,7 +1674,6 @@ class MediaLive {
     String? targetCustomerId,
     String? transferMessage,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final $payload = <String, dynamic>{
       if (targetCustomerId != null) 'targetCustomerId': targetCustomerId,
       if (transferMessage != null) 'transferMessage': transferMessage,
@@ -1777,7 +1733,6 @@ class MediaLive {
     String? name,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final $payload = <String, dynamic>{
       if (cdiInputSpecification != null)
         'cdiInputSpecification': cdiInputSpecification,
@@ -1823,8 +1778,6 @@ class MediaLive {
     required String channelId,
     List<OutputDestination>? destinations,
   }) async {
-    ArgumentError.checkNotNull(channelClass, 'channelClass');
-    ArgumentError.checkNotNull(channelId, 'channelId');
     final $payload = <String, dynamic>{
       'channelClass': channelClass.toValue(),
       if (destinations != null) 'destinations': destinations,
@@ -1890,7 +1843,6 @@ class MediaLive {
     String? roleArn,
     List<InputSourceRequest>? sources,
   }) async {
-    ArgumentError.checkNotNull(inputId, 'inputId');
     final $payload = <String, dynamic>{
       if (destinations != null) 'destinations': destinations,
       if (inputDevices != null) 'inputDevices': inputDevices,
@@ -1938,7 +1890,6 @@ class MediaLive {
     String? name,
     InputDeviceConfigurableSettings? uhdDeviceSettings,
   }) async {
-    ArgumentError.checkNotNull(inputDeviceId, 'inputDeviceId');
     final $payload = <String, dynamic>{
       if (hdDeviceSettings != null) 'hdDeviceSettings': hdDeviceSettings,
       if (name != null) 'name': name,
@@ -1976,7 +1927,6 @@ class MediaLive {
     Map<String, String>? tags,
     List<InputWhitelistRuleCidr>? whitelistRules,
   }) async {
-    ArgumentError.checkNotNull(inputSecurityGroupId, 'inputSecurityGroupId');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
       if (whitelistRules != null) 'whitelistRules': whitelistRules,
@@ -2015,7 +1965,6 @@ class MediaLive {
     MultiplexSettings? multiplexSettings,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
     final $payload = <String, dynamic>{
       if (multiplexSettings != null) 'multiplexSettings': multiplexSettings,
       if (name != null) 'name': name,
@@ -2053,8 +2002,6 @@ class MediaLive {
     required String programName,
     MultiplexProgramSettings? multiplexProgramSettings,
   }) async {
-    ArgumentError.checkNotNull(multiplexId, 'multiplexId');
-    ArgumentError.checkNotNull(programName, 'programName');
     final $payload = <String, dynamic>{
       if (multiplexProgramSettings != null)
         'multiplexProgramSettings': multiplexProgramSettings,
@@ -2089,7 +2036,6 @@ class MediaLive {
     required String reservationId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(reservationId, 'reservationId');
     final $payload = <String, dynamic>{
       if (name != null) 'name': name,
     };

--- a/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
+++ b/generated/aws_mediapackage_api/lib/mediapackage-2017-10-12.dart
@@ -64,7 +64,6 @@ class MediaPackage {
     EgressAccessLogs? egressAccessLogs,
     IngressAccessLogs? ingressAccessLogs,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       if (egressAccessLogs != null) 'egressAccessLogs': egressAccessLogs,
       if (ingressAccessLogs != null) 'ingressAccessLogs': ingressAccessLogs,
@@ -98,7 +97,6 @@ class MediaPackage {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       'id': id,
       if (description != null) 'description': description,
@@ -142,11 +140,6 @@ class MediaPackage {
     required S3Destination s3Destination,
     required String startTime,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(originEndpointId, 'originEndpointId');
-    ArgumentError.checkNotNull(s3Destination, 's3Destination');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $payload = <String, dynamic>{
       'endTime': endTime,
       'id': id,
@@ -224,8 +217,6 @@ class MediaPackage {
     int? timeDelaySeconds,
     List<String>? whitelist,
   }) async {
-    ArgumentError.checkNotNull(channelId, 'channelId');
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       'channelId': channelId,
       'id': id,
@@ -266,7 +257,6 @@ class MediaPackage {
   Future<void> deleteChannel({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -289,7 +279,6 @@ class MediaPackage {
   Future<void> deleteOriginEndpoint({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -312,7 +301,6 @@ class MediaPackage {
   Future<DescribeChannelResponse> describeChannel({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -336,7 +324,6 @@ class MediaPackage {
   Future<DescribeHarvestJobResponse> describeHarvestJob({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -360,7 +347,6 @@ class MediaPackage {
   Future<DescribeOriginEndpointResponse> describeOriginEndpoint({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -505,7 +491,6 @@ class MediaPackage {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -532,7 +517,6 @@ class MediaPackage {
   Future<RotateChannelCredentialsResponse> rotateChannelCredentials({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -562,8 +546,6 @@ class MediaPackage {
     required String id,
     required String ingestEndpointId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(ingestEndpointId, 'ingestEndpointId');
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -578,8 +560,6 @@ class MediaPackage {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -598,8 +578,6 @@ class MediaPackage {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -630,7 +608,6 @@ class MediaPackage {
     required String id,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       if (description != null) 'description': description,
     };
@@ -696,7 +673,6 @@ class MediaPackage {
     int? timeDelaySeconds,
     List<String>? whitelist,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       if (authorization != null) 'authorization': authorization,
       if (cmafPackage != null) 'cmafPackage': cmafPackage,

--- a/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
+++ b/generated/aws_mediapackage_vod_api/lib/mediapackage-vod-2018-11-07.dart
@@ -79,10 +79,6 @@ class MediaPackageVod {
     String? resourceId,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(packagingGroupId, 'packagingGroupId');
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
-    ArgumentError.checkNotNull(sourceRoleArn, 'sourceRoleArn');
     final $payload = <String, dynamic>{
       'id': id,
       'packagingGroupId': packagingGroupId,
@@ -123,8 +119,6 @@ class MediaPackageVod {
     MssPackage? mssPackage,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(packagingGroupId, 'packagingGroupId');
     final $payload = <String, dynamic>{
       'id': id,
       'packagingGroupId': packagingGroupId,
@@ -159,7 +153,6 @@ class MediaPackageVod {
     Authorization? authorization,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       'id': id,
       if (authorization != null) 'authorization': authorization,
@@ -188,7 +181,6 @@ class MediaPackageVod {
   Future<void> deleteAsset({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -211,7 +203,6 @@ class MediaPackageVod {
   Future<void> deletePackagingConfiguration({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -234,7 +225,6 @@ class MediaPackageVod {
   Future<void> deletePackagingGroup({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -257,7 +247,6 @@ class MediaPackageVod {
   Future<DescribeAssetResponse> describeAsset({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -283,7 +272,6 @@ class MediaPackageVod {
       describePackagingConfiguration({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -307,7 +295,6 @@ class MediaPackageVod {
   Future<DescribePackagingGroupResponse> describePackagingGroup({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -450,7 +437,6 @@ class MediaPackageVod {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -473,8 +459,6 @@ class MediaPackageVod {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -499,8 +483,6 @@ class MediaPackageVod {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -529,7 +511,6 @@ class MediaPackageVod {
     required String id,
     Authorization? authorization,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final $payload = <String, dynamic>{
       if (authorization != null) 'authorization': authorization,
     };

--- a/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
+++ b/generated/aws_mediastore_api/lib/mediastore-2017-09-01.dart
@@ -76,14 +76,6 @@ class MediaStore {
     required String containerName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.CreateContainer'
@@ -116,14 +108,6 @@ class MediaStore {
   Future<void> deleteContainer({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DeleteContainer'
@@ -152,14 +136,6 @@ class MediaStore {
   Future<void> deleteContainerPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DeleteContainerPolicy'
@@ -193,14 +169,6 @@ class MediaStore {
   Future<void> deleteCorsPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DeleteCorsPolicy'
@@ -230,14 +198,6 @@ class MediaStore {
   Future<void> deleteLifecyclePolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DeleteLifecyclePolicy'
@@ -269,14 +229,6 @@ class MediaStore {
   Future<void> deleteMetricPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DeleteMetricPolicy'
@@ -310,12 +262,6 @@ class MediaStore {
   Future<DescribeContainerOutput> describeContainer({
     String? containerName,
   }) async {
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.DescribeContainer'
@@ -349,14 +295,6 @@ class MediaStore {
   Future<GetContainerPolicyOutput> getContainerPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.GetContainerPolicy'
@@ -392,14 +330,6 @@ class MediaStore {
   Future<GetCorsPolicyOutput> getCorsPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.GetCorsPolicy'
@@ -430,14 +360,6 @@ class MediaStore {
   Future<GetLifecyclePolicyOutput> getLifecyclePolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.GetLifecyclePolicy'
@@ -468,14 +390,6 @@ class MediaStore {
   Future<GetMetricPolicyOutput> getMetricPolicy({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.GetMetricPolicy'
@@ -528,12 +442,6 @@ class MediaStore {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.ListContainers'
@@ -564,14 +472,6 @@ class MediaStore {
   Future<ListTagsForResourceOutput> listTagsForResource({
     required String resource,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    _s.validateStringLength(
-      'resource',
-      resource,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.ListTagsForResource'
@@ -623,22 +523,6 @@ class MediaStore {
     required String containerName,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      8192,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.PutContainerPolicy'
@@ -686,15 +570,6 @@ class MediaStore {
     required String containerName,
     required List<CorsRule> corsPolicy,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(corsPolicy, 'corsPolicy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.PutCorsPolicy'
@@ -735,22 +610,6 @@ class MediaStore {
     required String containerName,
     required String lifecyclePolicy,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifecyclePolicy, 'lifecyclePolicy');
-    _s.validateStringLength(
-      'lifecyclePolicy',
-      lifecyclePolicy,
-      0,
-      8192,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.PutLifecyclePolicy'
@@ -805,15 +664,6 @@ class MediaStore {
     required String containerName,
     required MetricPolicy metricPolicy,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricPolicy, 'metricPolicy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.PutMetricPolicy'
@@ -844,14 +694,6 @@ class MediaStore {
   Future<void> startAccessLogging({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.StartAccessLogging'
@@ -881,14 +723,6 @@ class MediaStore {
   Future<void> stopAccessLogging({
     required String containerName,
   }) async {
-    ArgumentError.checkNotNull(containerName, 'containerName');
-    _s.validateStringLength(
-      'containerName',
-      containerName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.StopAccessLogging'
@@ -933,15 +767,6 @@ class MediaStore {
     required String resource,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    _s.validateStringLength(
-      'resource',
-      resource,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.TagResource'
@@ -978,15 +803,6 @@ class MediaStore {
     required String resource,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
-    _s.validateStringLength(
-      'resource',
-      resource,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MediaStore_20170901.UntagResource'

--- a/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
+++ b/generated/aws_mediastore_data_api/lib/mediastore-data-2017-09-01.dart
@@ -63,14 +63,6 @@ class MediaStoreData {
   Future<void> deleteObject({
     required String path,
   }) async {
-    ArgumentError.checkNotNull(path, 'path');
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      900,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -92,14 +84,6 @@ class MediaStoreData {
   Future<DescribeObjectResponse> describeObject({
     required String path,
   }) async {
-    ArgumentError.checkNotNull(path, 'path');
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      900,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'HEAD',
@@ -169,14 +153,6 @@ class MediaStoreData {
     required String path,
     String? range,
   }) async {
-    ArgumentError.checkNotNull(path, 'path');
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      900,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (range != null) 'Range': range.toString(),
     };
@@ -245,12 +221,6 @@ class MediaStoreData {
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'path',
-      path,
-      0,
-      900,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
@@ -341,15 +311,6 @@ class MediaStoreData {
     StorageClass? storageClass,
     UploadAvailability? uploadAvailability,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
-    ArgumentError.checkNotNull(path, 'path');
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      900,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (cacheControl != null) 'Cache-Control': cacheControl.toString(),
       if (contentType != null) 'Content-Type': contentType.toString(),

--- a/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
+++ b/generated/aws_mediatailor_api/lib/mediatailor-2018-04-23.dart
@@ -64,7 +64,6 @@ class MediaTailor {
   Future<void> deletePlaybackConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -80,7 +79,6 @@ class MediaTailor {
   Future<GetPlaybackConfigurationResponse> getPlaybackConfiguration({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -138,7 +136,6 @@ class MediaTailor {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -279,8 +276,6 @@ class MediaTailor {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -308,8 +303,6 @@ class MediaTailor {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
+++ b/generated/aws_meteringmarketplace_api/lib/meteringmarketplace-2016-01-14.dart
@@ -89,15 +89,6 @@ class MarketplaceMetering {
     required String productCode,
     required List<UsageRecord> usageRecords,
   }) async {
-    ArgumentError.checkNotNull(productCode, 'productCode');
-    _s.validateStringLength(
-      'productCode',
-      productCode,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(usageRecords, 'usageRecords');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMPMeteringService.BatchMeterUsage'
@@ -176,23 +167,6 @@ class MarketplaceMetering {
     List<UsageAllocation>? usageAllocations,
     int? usageQuantity,
   }) async {
-    ArgumentError.checkNotNull(productCode, 'productCode');
-    _s.validateStringLength(
-      'productCode',
-      productCode,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(timestamp, 'timestamp');
-    ArgumentError.checkNotNull(usageDimension, 'usageDimension');
-    _s.validateStringLength(
-      'usageDimension',
-      usageDimension,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'usageQuantity',
       usageQuantity,
@@ -287,27 +261,12 @@ class MarketplaceMetering {
     required int publicKeyVersion,
     String? nonce,
   }) async {
-    ArgumentError.checkNotNull(productCode, 'productCode');
-    _s.validateStringLength(
-      'productCode',
-      productCode,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(publicKeyVersion, 'publicKeyVersion');
     _s.validateNumRange(
       'publicKeyVersion',
       publicKeyVersion,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'nonce',
-      nonce,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -348,7 +307,6 @@ class MarketplaceMetering {
   Future<ResolveCustomerResult> resolveCustomer({
     required String registrationToken,
   }) async {
-    ArgumentError.checkNotNull(registrationToken, 'registrationToken');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMPMeteringService.ResolveCustomer'

--- a/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
+++ b/generated/aws_mgh_api/lib/AWSMigrationHub-2017-05-31.dart
@@ -105,23 +105,6 @@ class MigrationHub {
     required String progressUpdateStream,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(createdArtifact, 'createdArtifact');
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.AssociateCreatedArtifact'
@@ -174,23 +157,6 @@ class MigrationHub {
     required String progressUpdateStream,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(discoveredResource, 'discoveredResource');
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.AssociateDiscoveredResource'
@@ -236,15 +202,6 @@ class MigrationHub {
     required String progressUpdateStreamName,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        progressUpdateStreamName, 'progressUpdateStreamName');
-    _s.validateStringLength(
-      'progressUpdateStreamName',
-      progressUpdateStreamName,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.CreateProgressUpdateStream'
@@ -315,15 +272,6 @@ class MigrationHub {
     required String progressUpdateStreamName,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(
-        progressUpdateStreamName, 'progressUpdateStreamName');
-    _s.validateStringLength(
-      'progressUpdateStreamName',
-      progressUpdateStreamName,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.DeleteProgressUpdateStream'
@@ -358,14 +306,6 @@ class MigrationHub {
   Future<DescribeApplicationStateResult> describeApplicationState({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    _s.validateStringLength(
-      'applicationId',
-      applicationId,
-      1,
-      1600,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.DescribeApplicationState'
@@ -405,22 +345,6 @@ class MigrationHub {
     required String migrationTaskName,
     required String progressUpdateStream,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.DescribeMigrationTask'
@@ -490,30 +414,6 @@ class MigrationHub {
     required String progressUpdateStream,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(createdArtifactName, 'createdArtifactName');
-    _s.validateStringLength(
-      'createdArtifactName',
-      createdArtifactName,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.DisassociateCreatedArtifact'
@@ -566,30 +466,6 @@ class MigrationHub {
     required String progressUpdateStream,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
-    _s.validateStringLength(
-      'configurationId',
-      configurationId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.DisassociateDiscoveredResource'
@@ -641,22 +517,6 @@ class MigrationHub {
     required String progressUpdateStream,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.ImportMigrationTask'
@@ -707,12 +567,6 @@ class MigrationHub {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -778,33 +632,11 @@ class MigrationHub {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -858,33 +690,11 @@ class MigrationHub {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -953,18 +763,6 @@ class MigrationHub {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'resourceName',
-      resourceName,
-      1,
-      1600,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.ListMigrationTasks'
@@ -1011,12 +809,6 @@ class MigrationHub {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1072,15 +864,6 @@ class MigrationHub {
     bool? dryRun,
     DateTime? updateDateTime,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    _s.validateStringLength(
-      'applicationId',
-      applicationId,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.NotifyApplicationState'
@@ -1158,15 +941,6 @@ class MigrationHub {
     required DateTime updateDateTime,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nextUpdateSeconds, 'nextUpdateSeconds');
     _s.validateNumRange(
       'nextUpdateSeconds',
       nextUpdateSeconds,
@@ -1174,16 +948,6 @@ class MigrationHub {
       1152921504606846976,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(task, 'task');
-    ArgumentError.checkNotNull(updateDateTime, 'updateDateTime');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.NotifyMigrationTaskState'
@@ -1287,23 +1051,6 @@ class MigrationHub {
     required List<ResourceAttribute> resourceAttributeList,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(migrationTaskName, 'migrationTaskName');
-    _s.validateStringLength(
-      'migrationTaskName',
-      migrationTaskName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(progressUpdateStream, 'progressUpdateStream');
-    _s.validateStringLength(
-      'progressUpdateStream',
-      progressUpdateStream,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceAttributeList, 'resourceAttributeList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSMigrationHub.PutResourceAttributes'

--- a/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
+++ b/generated/aws_migrationhub_config_api/lib/migrationhub-config-2019-06-30.dart
@@ -97,15 +97,6 @@ class MigrationHubConfig {
     required Target target,
     bool? dryRun,
   }) async {
-    ArgumentError.checkNotNull(homeRegion, 'homeRegion');
-    _s.validateStringLength(
-      'homeRegion',
-      homeRegion,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(target, 'target');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -162,29 +153,11 @@ class MigrationHubConfig {
     String? nextToken,
     Target? target,
   }) async {
-    _s.validateStringLength(
-      'controlId',
-      controlId,
-      1,
-      50,
-    );
-    _s.validateStringLength(
-      'homeRegion',
-      homeRegion,
-      1,
-      50,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',

--- a/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
+++ b/generated/aws_mobile_api/lib/mobile-2017-07-01.dart
@@ -110,7 +110,6 @@ class Mobile {
   Future<DeleteProjectResult> deleteProject({
     required String projectId,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -134,7 +133,6 @@ class Mobile {
   Future<DescribeBundleResult> describeBundle({
     required String bundleId,
   }) async {
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -164,7 +162,6 @@ class Mobile {
     required String projectId,
     bool? syncFromResources,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
     final $query = <String, List<String>>{
       'projectId': [projectId],
       if (syncFromResources != null)
@@ -204,7 +201,6 @@ class Mobile {
     Platform? platform,
     String? projectId,
   }) async {
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
     final $query = <String, List<String>>{
       if (platform != null) 'platform': [platform.toValue()],
       if (projectId != null) 'projectId': [projectId],
@@ -236,7 +232,6 @@ class Mobile {
   Future<ExportProjectResult> exportProject({
     required String projectId,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -334,7 +329,6 @@ class Mobile {
     required String projectId,
     Uint8List? contents,
   }) async {
-    ArgumentError.checkNotNull(projectId, 'projectId');
     final $query = <String, List<String>>{
       'projectId': [projectId],
     };

--- a/generated/aws_mq_api/lib/mq-2017-11-27.dart
+++ b/generated/aws_mq_api/lib/mq-2017-11-27.dart
@@ -263,7 +263,6 @@ class MQ {
     required String resourceArn,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       if (tags != null) 'tags': tags,
     };
@@ -311,8 +310,6 @@ class MQ {
     List<String>? groups,
     String? password,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
-    ArgumentError.checkNotNull(username, 'username');
     final $payload = <String, dynamic>{
       if (consoleAccess != null) 'consoleAccess': consoleAccess,
       if (groups != null) 'groups': groups,
@@ -339,7 +336,6 @@ class MQ {
   Future<DeleteBrokerResponse> deleteBroker({
     required String brokerId,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -365,8 +361,6 @@ class MQ {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -397,8 +391,6 @@ class MQ {
     required String brokerId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
-    ArgumentError.checkNotNull(username, 'username');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -423,7 +415,6 @@ class MQ {
   Future<DescribeBrokerResponse> describeBroker({
     required String brokerId,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -539,7 +530,6 @@ class MQ {
   Future<DescribeConfigurationResponse> describeConfiguration({
     required String configurationId,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -566,8 +556,6 @@ class MQ {
     required String configurationId,
     required String configurationRevision,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
-    ArgumentError.checkNotNull(configurationRevision, 'configurationRevision');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -596,8 +584,6 @@ class MQ {
     required String brokerId,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
-    ArgumentError.checkNotNull(username, 'username');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -667,7 +653,6 @@ class MQ {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -738,7 +723,6 @@ class MQ {
   Future<ListTagsResponse> listTags({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -770,7 +754,6 @@ class MQ {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -803,7 +786,6 @@ class MQ {
   Future<void> rebootBroker({
     required String brokerId,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -865,7 +847,6 @@ class MQ {
     Logs? logs,
     List<String>? securityGroups,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
     final $payload = <String, dynamic>{
       if (authenticationStrategy != null)
         'authenticationStrategy': authenticationStrategy.toValue(),
@@ -908,7 +889,6 @@ class MQ {
     String? data,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(configurationId, 'configurationId');
     final $payload = <String, dynamic>{
       if (data != null) 'data': data,
       if (description != null) 'description': description,
@@ -957,8 +937,6 @@ class MQ {
     List<String>? groups,
     String? password,
   }) async {
-    ArgumentError.checkNotNull(brokerId, 'brokerId');
-    ArgumentError.checkNotNull(username, 'username');
     final $payload = <String, dynamic>{
       if (consoleAccess != null) 'consoleAccess': consoleAccess,
       if (groups != null) 'groups': groups,

--- a/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
+++ b/generated/aws_mturk_api/lib/mturk-requester-2017-01-17.dart
@@ -70,8 +70,6 @@ class MTurk {
     required String qualificationRequestId,
     int? integerValue,
   }) async {
-    ArgumentError.checkNotNull(
-        qualificationRequestId, 'qualificationRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -136,14 +134,6 @@ class MTurk {
     bool? overrideRejection,
     String? requesterFeedback,
   }) async {
-    ArgumentError.checkNotNull(assignmentId, 'assignmentId');
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.ApproveAssignment'
@@ -203,22 +193,6 @@ class MTurk {
     int? integerValue,
     bool? sendNotification,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -283,22 +257,6 @@ class MTurk {
     required int numberOfAdditionalAssignments,
     String? uniqueRequestToken,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        numberOfAdditionalAssignments, 'numberOfAdditionalAssignments');
-    _s.validateStringLength(
-      'uniqueRequestToken',
-      uniqueRequestToken,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -478,24 +436,6 @@ class MTurk {
     String? requesterAnnotation,
     String? uniqueRequestToken,
   }) async {
-    ArgumentError.checkNotNull(
-        assignmentDurationInSeconds, 'assignmentDurationInSeconds');
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(lifetimeInSeconds, 'lifetimeInSeconds');
-    ArgumentError.checkNotNull(reward, 'reward');
-    ArgumentError.checkNotNull(title, 'title');
-    _s.validateStringLength(
-      'hITLayoutId',
-      hITLayoutId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'uniqueRequestToken',
-      uniqueRequestToken,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.CreateHIT'
@@ -592,11 +532,6 @@ class MTurk {
     String? keywords,
     List<QualificationRequirement>? qualificationRequirements,
   }) async {
-    ArgumentError.checkNotNull(
-        assignmentDurationInSeconds, 'assignmentDurationInSeconds');
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(reward, 'reward');
-    ArgumentError.checkNotNull(title, 'title');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.CreateHITType'
@@ -729,27 +664,6 @@ class MTurk {
     String? requesterAnnotation,
     String? uniqueRequestToken,
   }) async {
-    ArgumentError.checkNotNull(hITTypeId, 'hITTypeId');
-    _s.validateStringLength(
-      'hITTypeId',
-      hITTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lifetimeInSeconds, 'lifetimeInSeconds');
-    _s.validateStringLength(
-      'hITLayoutId',
-      hITLayoutId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'uniqueRequestToken',
-      uniqueRequestToken,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.CreateHITWithHITType'
@@ -868,10 +782,6 @@ class MTurk {
     String? test,
     int? testDurationInSeconds,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(
-        qualificationTypeStatus, 'qualificationTypeStatus');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.CreateQualificationType'
@@ -919,15 +829,6 @@ class MTurk {
     required String reason,
     required String workerId,
   }) async {
-    ArgumentError.checkNotNull(reason, 'reason');
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.CreateWorkerBlock'
@@ -981,14 +882,6 @@ class MTurk {
   Future<void> deleteHIT({
     required String hITId,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.DeleteHIT'
@@ -1028,14 +921,6 @@ class MTurk {
   Future<void> deleteQualificationType({
     required String qualificationTypeId,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.DeleteQualificationType'
@@ -1072,14 +957,6 @@ class MTurk {
     required String workerId,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.DeleteWorkerBlock'
@@ -1120,22 +997,6 @@ class MTurk {
     required String workerId,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1187,14 +1048,6 @@ class MTurk {
   Future<GetAssignmentResponse> getAssignment({
     required String assignmentId,
   }) async {
-    ArgumentError.checkNotNull(assignmentId, 'assignmentId');
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.GetAssignment'
@@ -1239,15 +1092,6 @@ class MTurk {
     required String assignmentId,
     required String questionIdentifier,
   }) async {
-    ArgumentError.checkNotNull(assignmentId, 'assignmentId');
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(questionIdentifier, 'questionIdentifier');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.GetFileUploadURL'
@@ -1278,14 +1122,6 @@ class MTurk {
   Future<GetHITResponse> getHIT({
     required String hITId,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.GetHIT'
@@ -1326,22 +1162,6 @@ class MTurk {
     required String qualificationTypeId,
     required String workerId,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.GetQualificationScore'
@@ -1372,14 +1192,6 @@ class MTurk {
   Future<GetQualificationTypeResponse> getQualificationType({
     required String qualificationTypeId,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.GetQualificationType'
@@ -1438,25 +1250,11 @@ class MTurk {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1506,29 +1304,11 @@ class MTurk {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1569,12 +1349,6 @@ class MTurk {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1617,25 +1391,11 @@ class MTurk {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1681,18 +1441,6 @@ class MTurk {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1746,18 +1494,11 @@ class MTurk {
     String? nextToken,
     String? query,
   }) async {
-    ArgumentError.checkNotNull(mustBeRequestable, 'mustBeRequestable');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1821,25 +1562,11 @@ class MTurk {
     bool? retrieveActions,
     bool? retrieveResults,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1892,23 +1619,11 @@ class MTurk {
     String? nextToken,
     ReviewableHITStatus? status,
   }) async {
-    _s.validateStringLength(
-      'hITTypeId',
-      hITTypeId,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1948,12 +1663,6 @@ class MTurk {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1999,25 +1708,11 @@ class MTurk {
     String? nextToken,
     QualificationStatus? status,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2066,9 +1761,6 @@ class MTurk {
     required String subject,
     required List<String> workerIds,
   }) async {
-    ArgumentError.checkNotNull(messageText, 'messageText');
-    ArgumentError.checkNotNull(subject, 'subject');
-    ArgumentError.checkNotNull(workerIds, 'workerIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.NotifyWorkers'
@@ -2115,15 +1807,6 @@ class MTurk {
     required String assignmentId,
     required String requesterFeedback,
   }) async {
-    ArgumentError.checkNotNull(assignmentId, 'assignmentId');
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(requesterFeedback, 'requesterFeedback');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.RejectAssignment'
@@ -2161,8 +1844,6 @@ class MTurk {
     required String qualificationRequestId,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(
-        qualificationRequestId, 'qualificationRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2223,30 +1904,6 @@ class MTurk {
     required String workerId,
     String? uniqueRequestToken,
   }) async {
-    ArgumentError.checkNotNull(assignmentId, 'assignmentId');
-    _s.validateStringLength(
-      'assignmentId',
-      assignmentId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bonusAmount, 'bonusAmount');
-    ArgumentError.checkNotNull(reason, 'reason');
-    ArgumentError.checkNotNull(workerId, 'workerId');
-    _s.validateStringLength(
-      'workerId',
-      workerId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'uniqueRequestToken',
-      uniqueRequestToken,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.SendBonus'
@@ -2292,8 +1949,6 @@ class MTurk {
     required NotificationSpecification notification,
     required EventType testEventType,
   }) async {
-    ArgumentError.checkNotNull(notification, 'notification');
-    ArgumentError.checkNotNull(testEventType, 'testEventType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.SendTestEventNotification'
@@ -2327,15 +1982,6 @@ class MTurk {
     required DateTime expireAt,
     required String hITId,
   }) async {
-    ArgumentError.checkNotNull(expireAt, 'expireAt');
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.UpdateExpirationForHIT'
@@ -2380,14 +2026,6 @@ class MTurk {
     required String hITId,
     bool? revert,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.UpdateHITReviewStatus'
@@ -2423,22 +2061,6 @@ class MTurk {
     required String hITId,
     required String hITTypeId,
   }) async {
-    ArgumentError.checkNotNull(hITId, 'hITId');
-    _s.validateStringLength(
-      'hITId',
-      hITId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hITTypeId, 'hITTypeId');
-    _s.validateStringLength(
-      'hITTypeId',
-      hITTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.UpdateHITTypeOfHIT'
@@ -2487,14 +2109,6 @@ class MTurk {
     bool? active,
     NotificationSpecification? notification,
   }) async {
-    ArgumentError.checkNotNull(hITTypeId, 'hITTypeId');
-    _s.validateStringLength(
-      'hITTypeId',
-      hITTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2611,14 +2225,6 @@ class MTurk {
     String? test,
     int? testDurationInSeconds,
   }) async {
-    ArgumentError.checkNotNull(qualificationTypeId, 'qualificationTypeId');
-    _s.validateStringLength(
-      'qualificationTypeId',
-      qualificationTypeId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'MTurkRequesterServiceV20170117.UpdateQualificationType'

--- a/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
+++ b/generated/aws_neptune_api/lib/neptune-2014-10-31.dart
@@ -88,8 +88,6 @@ class Neptune {
     required String roleArn,
     String? featureName,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['RoleArn'] = roleArn;
@@ -143,8 +141,6 @@ class Neptune {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -183,8 +179,6 @@ class Neptune {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -241,9 +235,6 @@ class Neptune {
     required String optInType,
     required String resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(applyAction, 'applyAction');
-    ArgumentError.checkNotNull(optInType, 'optInType');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final $request = <String, dynamic>{};
     $request['ApplyAction'] = applyAction;
     $request['OptInType'] = optInType;
@@ -324,12 +315,6 @@ class Neptune {
     required String targetDBClusterParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(sourceDBClusterParameterGroupIdentifier,
-        'sourceDBClusterParameterGroupIdentifier');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupDescription,
-        'targetDBClusterParameterGroupDescription');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupIdentifier,
-        'targetDBClusterParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterParameterGroupIdentifier'] =
         sourceDBClusterParameterGroupIdentifier;
@@ -441,10 +426,6 @@ class Neptune {
     String? preSignedUrl,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBClusterSnapshotIdentifier, 'sourceDBClusterSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBClusterSnapshotIdentifier, 'targetDBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterSnapshotIdentifier'] =
         sourceDBClusterSnapshotIdentifier;
@@ -524,12 +505,6 @@ class Neptune {
     required String targetDBParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBParameterGroupIdentifier, 'sourceDBParameterGroupIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupDescription, 'targetDBParameterGroupDescription');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupIdentifier, 'targetDBParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBParameterGroupIdentifier'] =
         sourceDBParameterGroupIdentifier;
@@ -816,8 +791,6 @@ class Neptune {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -905,10 +878,6 @@ class Neptune {
     List<String>? staticMembers,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(endpointType, 'endpointType');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
@@ -992,11 +961,6 @@ class Neptune {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
@@ -1063,9 +1027,6 @@ class Neptune {
     required String dBClusterSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -1445,9 +1406,6 @@ class Neptune {
     String? timezone,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['DBInstanceClass'] = dBInstanceClass;
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
@@ -1578,10 +1536,6 @@ class Neptune {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -1633,10 +1587,6 @@ class Neptune {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -1757,8 +1707,6 @@ class Neptune {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -1844,7 +1792,6 @@ class Neptune {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     finalDBSnapshotIdentifier
@@ -1877,8 +1824,6 @@ class Neptune {
   Future<DeleteDBClusterEndpointOutput> deleteDBClusterEndpoint({
     required String dBClusterEndpointIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     final $result = await _protocol.send(
@@ -1920,8 +1865,6 @@ class Neptune {
   Future<void> deleteDBClusterParameterGroup({
     required String dBClusterParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     await _protocol.send(
@@ -1954,8 +1897,6 @@ class Neptune {
   Future<DeleteDBClusterSnapshotResult> deleteDBClusterSnapshot({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -2054,7 +1995,6 @@ class Neptune {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     finalDBSnapshotIdentifier
@@ -2099,7 +2039,6 @@ class Neptune {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -2138,7 +2077,6 @@ class Neptune {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -2163,7 +2101,6 @@ class Neptune {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -2364,8 +2301,6 @@ class Neptune {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -2409,8 +2344,6 @@ class Neptune {
       describeDBClusterSnapshotAttributes({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -2930,7 +2863,6 @@ class Neptune {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -3039,8 +2971,6 @@ class Neptune {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -3091,8 +3021,6 @@ class Neptune {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -3365,7 +3293,6 @@ class Neptune {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -3469,7 +3396,6 @@ class Neptune {
       describeValidDBInstanceModifications({
     required String dBInstanceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     final $result = await _protocol.send(
@@ -3560,7 +3486,6 @@ class Neptune {
     required String resourceName,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -3758,7 +3683,6 @@ class Neptune {
     String? preferredMaintenanceWindow,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -3826,8 +3750,6 @@ class Neptune {
     List<String>? excludedMembers,
     List<String>? staticMembers,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     endpointType?.also((arg) => $request['EndpointType'] = arg);
@@ -3882,9 +3804,6 @@ class Neptune {
     required String dBClusterParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['Parameters'] = parameters;
@@ -3964,9 +3883,6 @@ class Neptune {
     List<String>? valuesToAdd,
     List<String>? valuesToRemove,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -4354,7 +4270,6 @@ class Neptune {
     String? tdeCredentialPassword,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -4472,8 +4387,6 @@ class Neptune {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -4519,8 +4432,6 @@ class Neptune {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -4587,7 +4498,6 @@ class Neptune {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -4618,7 +4528,6 @@ class Neptune {
   Future<PromoteReadReplicaDBClusterResult> promoteReadReplicaDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -4669,7 +4578,6 @@ class Neptune {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -4711,8 +4619,6 @@ class Neptune {
     required String roleArn,
     String? featureName,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['RoleArn'] = roleArn;
@@ -4748,8 +4654,6 @@ class Neptune {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -4786,8 +4690,6 @@ class Neptune {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -4837,8 +4739,6 @@ class Neptune {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -4900,7 +4800,6 @@ class Neptune {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -5095,9 +4994,6 @@ class Neptune {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -5344,9 +5240,6 @@ class Neptune {
     bool? useLatestRestorableTime,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBClusterIdentifier, 'sourceDBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['SourceDBClusterIdentifier'] = sourceDBClusterIdentifier;
@@ -5395,7 +5288,6 @@ class Neptune {
   Future<StartDBClusterResult> startDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -5429,7 +5321,6 @@ class Neptune {
   Future<StopDBClusterResult> stopDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(

--- a/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
+++ b/generated/aws_networkmanager_api/lib/networkmanager-2019-07-05.dart
@@ -97,9 +97,6 @@ class NetworkManager {
     required String globalNetworkId,
     String? linkId,
   }) async {
-    ArgumentError.checkNotNull(customerGatewayArn, 'customerGatewayArn');
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       'CustomerGatewayArn': customerGatewayArn,
       'DeviceId': deviceId,
@@ -140,9 +137,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String linkId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(linkId, 'linkId');
     final $payload = <String, dynamic>{
       'DeviceId': deviceId,
       'LinkId': linkId,
@@ -193,10 +187,6 @@ class NetworkManager {
     required String transitGatewayConnectPeerArn,
     String? linkId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(
-        transitGatewayConnectPeerArn, 'transitGatewayConnectPeerArn');
     final $payload = <String, dynamic>{
       'DeviceId': deviceId,
       'TransitGatewayConnectPeerArn': transitGatewayConnectPeerArn,
@@ -255,9 +245,6 @@ class NetworkManager {
     String? linkId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(connectedDeviceId, 'connectedDeviceId');
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       'ConnectedDeviceId': connectedDeviceId,
       'DeviceId': deviceId,
@@ -337,7 +324,6 @@ class NetworkManager {
     String? type,
     String? vendor,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       if (awsLocation != null) 'AWSLocation': awsLocation,
       if (description != null) 'Description': description,
@@ -441,9 +427,6 @@ class NetworkManager {
     List<Tag>? tags,
     String? type,
   }) async {
-    ArgumentError.checkNotNull(bandwidth, 'bandwidth');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(siteId, 'siteId');
     final $payload = <String, dynamic>{
       'Bandwidth': bandwidth,
       'SiteId': siteId,
@@ -505,7 +488,6 @@ class NetworkManager {
     Location? location,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (location != null) 'Location': location,
@@ -539,8 +521,6 @@ class NetworkManager {
     required String connectionId,
     required String globalNetworkId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -570,8 +550,6 @@ class NetworkManager {
     required String deviceId,
     required String globalNetworkId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -598,7 +576,6 @@ class NetworkManager {
   Future<DeleteGlobalNetworkResponse> deleteGlobalNetwork({
     required String globalNetworkId,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -627,8 +604,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String linkId,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(linkId, 'linkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -658,8 +633,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String siteId,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(siteId, 'siteId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -690,8 +663,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String transitGatewayArn,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(transitGatewayArn, 'transitGatewayArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -769,8 +740,6 @@ class NetworkManager {
     required String customerGatewayArn,
     required String globalNetworkId,
   }) async {
-    ArgumentError.checkNotNull(customerGatewayArn, 'customerGatewayArn');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -804,9 +773,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String linkId,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(linkId, 'linkId');
     final $query = <String, List<String>>{
       'deviceId': [deviceId],
       'linkId': [linkId],
@@ -841,9 +807,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String transitGatewayConnectPeerArn,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(
-        transitGatewayConnectPeerArn, 'transitGatewayConnectPeerArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -884,7 +847,6 @@ class NetworkManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -939,7 +901,6 @@ class NetworkManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -992,7 +953,6 @@ class NetworkManager {
     String? nextToken,
     String? siteId,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1046,7 +1006,6 @@ class NetworkManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1110,7 +1069,6 @@ class NetworkManager {
     String? siteId,
     String? type,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1161,7 +1119,6 @@ class NetworkManager {
     String? nextToken,
     List<String>? siteIds,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1212,7 +1169,6 @@ class NetworkManager {
     String? nextToken,
     List<String>? transitGatewayConnectPeerArns,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1264,7 +1220,6 @@ class NetworkManager {
     String? nextToken,
     List<String>? transitGatewayArns,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1300,7 +1255,6 @@ class NetworkManager {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1334,8 +1288,6 @@ class NetworkManager {
     required String globalNetworkId,
     required String transitGatewayArn,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(transitGatewayArn, 'transitGatewayArn');
     final $payload = <String, dynamic>{
       'TransitGatewayArn': transitGatewayArn,
     };
@@ -1368,8 +1320,6 @@ class NetworkManager {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1399,8 +1349,6 @@ class NetworkManager {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1446,8 +1394,6 @@ class NetworkManager {
     String? description,
     String? linkId,
   }) async {
-    ArgumentError.checkNotNull(connectionId, 'connectionId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       if (connectedLinkId != null) 'ConnectedLinkId': connectedLinkId,
       if (description != null) 'Description': description,
@@ -1519,8 +1465,6 @@ class NetworkManager {
     String? type,
     String? vendor,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       if (awsLocation != null) 'AWSLocation': awsLocation,
       if (description != null) 'Description': description,
@@ -1562,7 +1506,6 @@ class NetworkManager {
     required String globalNetworkId,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
     };
@@ -1617,8 +1560,6 @@ class NetworkManager {
     String? provider,
     String? type,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(linkId, 'linkId');
     final $payload = <String, dynamic>{
       if (bandwidth != null) 'Bandwidth': bandwidth,
       if (description != null) 'Description': description,
@@ -1676,8 +1617,6 @@ class NetworkManager {
     String? description,
     Location? location,
   }) async {
-    ArgumentError.checkNotNull(globalNetworkId, 'globalNetworkId');
-    ArgumentError.checkNotNull(siteId, 'siteId');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (location != null) 'Location': location,

--- a/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
+++ b/generated/aws_opsworks_api/lib/opsworks-2013-02-18.dart
@@ -83,8 +83,6 @@ class OpsWorks {
     required String instanceId,
     required List<String> layerIds,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(layerIds, 'layerIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.AssignInstance'
@@ -129,7 +127,6 @@ class OpsWorks {
     required String volumeId,
     String? instanceId,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.AssignVolume'
@@ -172,7 +169,6 @@ class OpsWorks {
     required String elasticIp,
     String? instanceId,
   }) async {
-    ArgumentError.checkNotNull(elasticIp, 'elasticIp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.AssociateElasticIp'
@@ -223,9 +219,6 @@ class OpsWorks {
     required String elasticLoadBalancerName,
     required String layerId,
   }) async {
-    ArgumentError.checkNotNull(
-        elasticLoadBalancerName, 'elasticLoadBalancerName');
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.AttachElasticLoadBalancer'
@@ -583,8 +576,6 @@ class OpsWorks {
     bool? useOpsworksSecurityGroups,
     String? vpcId,
   }) async {
-    ArgumentError.checkNotNull(serviceRoleArn, 'serviceRoleArn');
-    ArgumentError.checkNotNull(sourceStackId, 'sourceStackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CloneStack'
@@ -718,9 +709,6 @@ class OpsWorks {
     String? shortname,
     SslConfiguration? sslConfiguration,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(stackId, 'stackId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateApp'
@@ -808,8 +796,6 @@ class OpsWorks {
     List<String>? instanceIds,
     List<String>? layerIds,
   }) async {
-    ArgumentError.checkNotNull(command, 'command');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateDeployment'
@@ -1040,9 +1026,6 @@ class OpsWorks {
     String? tenancy,
     String? virtualizationType,
   }) async {
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    ArgumentError.checkNotNull(layerIds, 'layerIds');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateInstance'
@@ -1222,10 +1205,6 @@ class OpsWorks {
     bool? useEbsOptimizedInstances,
     List<VolumeConfiguration>? volumeConfigurations,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(shortname, 'shortname');
-    ArgumentError.checkNotNull(stackId, 'stackId');
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateLayer'
@@ -1610,11 +1589,6 @@ class OpsWorks {
     bool? useOpsworksSecurityGroups,
     String? vpcId,
   }) async {
-    ArgumentError.checkNotNull(
-        defaultInstanceProfileArn, 'defaultInstanceProfileArn');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(region, 'region');
-    ArgumentError.checkNotNull(serviceRoleArn, 'serviceRoleArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateStack'
@@ -1692,7 +1666,6 @@ class OpsWorks {
     String? sshPublicKey,
     String? sshUsername,
   }) async {
-    ArgumentError.checkNotNull(iamUserArn, 'iamUserArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.CreateUserProfile'
@@ -1732,7 +1705,6 @@ class OpsWorks {
   Future<void> deleteApp({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeleteApp'
@@ -1779,7 +1751,6 @@ class OpsWorks {
     bool? deleteElasticIp,
     bool? deleteVolumes,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeleteInstance'
@@ -1819,7 +1790,6 @@ class OpsWorks {
   Future<void> deleteLayer({
     required String layerId,
   }) async {
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeleteLayer'
@@ -1856,7 +1826,6 @@ class OpsWorks {
   Future<void> deleteStack({
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeleteStack'
@@ -1889,7 +1858,6 @@ class OpsWorks {
   Future<void> deleteUserProfile({
     required String iamUserArn,
   }) async {
-    ArgumentError.checkNotNull(iamUserArn, 'iamUserArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeleteUserProfile'
@@ -1925,7 +1893,6 @@ class OpsWorks {
   Future<void> deregisterEcsCluster({
     required String ecsClusterArn,
   }) async {
-    ArgumentError.checkNotNull(ecsClusterArn, 'ecsClusterArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeregisterEcsCluster'
@@ -1962,7 +1929,6 @@ class OpsWorks {
   Future<void> deregisterElasticIp({
     required String elasticIp,
   }) async {
-    ArgumentError.checkNotNull(elasticIp, 'elasticIp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeregisterElasticIp'
@@ -1999,7 +1965,6 @@ class OpsWorks {
   Future<void> deregisterInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeregisterInstance'
@@ -2033,7 +1998,6 @@ class OpsWorks {
   Future<void> deregisterRdsDbInstance({
     required String rdsDbInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(rdsDbInstanceArn, 'rdsDbInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeregisterRdsDbInstance'
@@ -2072,7 +2036,6 @@ class OpsWorks {
   Future<void> deregisterVolume({
     required String volumeId,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DeregisterVolume'
@@ -2556,7 +2519,6 @@ class OpsWorks {
   Future<DescribeLoadBasedAutoScalingResult> describeLoadBasedAutoScaling({
     required List<String> layerIds,
   }) async {
-    ArgumentError.checkNotNull(layerIds, 'layerIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DescribeLoadBasedAutoScaling'
@@ -2733,7 +2695,6 @@ class OpsWorks {
     required String stackId,
     List<String>? rdsDbInstanceArns,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DescribeRdsDbInstances'
@@ -2824,7 +2785,6 @@ class OpsWorks {
       describeStackProvisioningParameters({
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DescribeStackProvisioningParameters'
@@ -2863,7 +2823,6 @@ class OpsWorks {
   Future<DescribeStackSummaryResult> describeStackSummary({
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DescribeStackSummary'
@@ -2938,7 +2897,6 @@ class OpsWorks {
   Future<DescribeTimeBasedAutoScalingResult> describeTimeBasedAutoScaling({
     required List<String> instanceIds,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DescribeTimeBasedAutoScaling'
@@ -3072,9 +3030,6 @@ class OpsWorks {
     required String elasticLoadBalancerName,
     required String layerId,
   }) async {
-    ArgumentError.checkNotNull(
-        elasticLoadBalancerName, 'elasticLoadBalancerName');
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DetachElasticLoadBalancer'
@@ -3112,7 +3067,6 @@ class OpsWorks {
   Future<void> disassociateElasticIp({
     required String elasticIp,
   }) async {
-    ArgumentError.checkNotNull(elasticIp, 'elasticIp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.DisassociateElasticIp'
@@ -3147,7 +3101,6 @@ class OpsWorks {
   Future<GetHostnameSuggestionResult> getHostnameSuggestion({
     required String layerId,
   }) async {
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.GetHostnameSuggestion'
@@ -3186,7 +3139,6 @@ class OpsWorks {
     required String instanceId,
     int? validForInMinutes,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     _s.validateNumRange(
       'validForInMinutes',
       validForInMinutes,
@@ -3232,7 +3184,6 @@ class OpsWorks {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.ListTags'
@@ -3272,7 +3223,6 @@ class OpsWorks {
   Future<void> rebootInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RebootInstance'
@@ -3314,8 +3264,6 @@ class OpsWorks {
     required String ecsClusterArn,
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(ecsClusterArn, 'ecsClusterArn');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RegisterEcsCluster'
@@ -3361,8 +3309,6 @@ class OpsWorks {
     required String elasticIp,
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(elasticIp, 'elasticIp');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RegisterElasticIp'
@@ -3442,7 +3388,6 @@ class OpsWorks {
     String? rsaPublicKey,
     String? rsaPublicKeyFingerprint,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RegisterInstance'
@@ -3497,10 +3442,6 @@ class OpsWorks {
     required String rdsDbInstanceArn,
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(dbPassword, 'dbPassword');
-    ArgumentError.checkNotNull(dbUser, 'dbUser');
-    ArgumentError.checkNotNull(rdsDbInstanceArn, 'rdsDbInstanceArn');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RegisterRdsDbInstance'
@@ -3546,7 +3487,6 @@ class OpsWorks {
     required String stackId,
     String? ec2VolumeId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.RegisterVolume'
@@ -3608,7 +3548,6 @@ class OpsWorks {
     bool? enable,
     AutoScalingThresholds? upScaling,
   }) async {
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.SetLoadBasedAutoScaling'
@@ -3686,8 +3625,6 @@ class OpsWorks {
     bool? allowSudo,
     String? level,
   }) async {
-    ArgumentError.checkNotNull(iamUserArn, 'iamUserArn');
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.SetPermission'
@@ -3732,7 +3669,6 @@ class OpsWorks {
     required String instanceId,
     WeeklyAutoScalingSchedule? autoScalingSchedule,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.SetTimeBasedAutoScaling'
@@ -3770,7 +3706,6 @@ class OpsWorks {
   Future<void> startInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.StartInstance'
@@ -3804,7 +3739,6 @@ class OpsWorks {
   Future<void> startStack({
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.StartStack'
@@ -3853,7 +3787,6 @@ class OpsWorks {
     required String instanceId,
     bool? force,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.StopInstance'
@@ -3888,7 +3821,6 @@ class OpsWorks {
   Future<void> stopStack({
     required String stackId,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.StopStack'
@@ -3945,8 +3877,6 @@ class OpsWorks {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.TagResource'
@@ -3984,7 +3914,6 @@ class OpsWorks {
   Future<void> unassignInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UnassignInstance'
@@ -4021,7 +3950,6 @@ class OpsWorks {
   Future<void> unassignVolume({
     required String volumeId,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UnassignVolume'
@@ -4052,8 +3980,6 @@ class OpsWorks {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UntagResource'
@@ -4146,7 +4072,6 @@ class OpsWorks {
     SslConfiguration? sslConfiguration,
     AppType? type,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateApp'
@@ -4198,7 +4123,6 @@ class OpsWorks {
     required String elasticIp,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(elasticIp, 'elasticIp');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateElasticIp'
@@ -4367,7 +4291,6 @@ class OpsWorks {
     String? os,
     String? sshKeyName,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateInstance'
@@ -4516,7 +4439,6 @@ class OpsWorks {
     bool? useEbsOptimizedInstances,
     List<VolumeConfiguration>? volumeConfigurations,
   }) async {
-    ArgumentError.checkNotNull(layerId, 'layerId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateLayer'
@@ -4615,7 +4537,6 @@ class OpsWorks {
     String? dbPassword,
     String? dbUser,
   }) async {
-    ArgumentError.checkNotNull(rdsDbInstanceArn, 'rdsDbInstanceArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateRdsDbInstance'
@@ -4899,7 +4820,6 @@ class OpsWorks {
     bool? useCustomCookbooks,
     bool? useOpsworksSecurityGroups,
   }) async {
-    ArgumentError.checkNotNull(stackId, 'stackId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateStack'
@@ -4976,7 +4896,6 @@ class OpsWorks {
     String? sshPublicKey,
     String? sshUsername,
   }) async {
-    ArgumentError.checkNotNull(iamUserArn, 'iamUserArn');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateUserProfile'
@@ -5025,7 +4944,6 @@ class OpsWorks {
     String? mountPoint,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(volumeId, 'volumeId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorks_20130218.UpdateVolume'

--- a/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
+++ b/generated/aws_opsworks_cm_api/lib/opsworkscm-2016-11-01.dart
@@ -117,23 +117,6 @@ class OpsWorksCM {
     required String nodeName,
     required String serverName,
   }) async {
-    ArgumentError.checkNotNull(engineAttributes, 'engineAttributes');
-    ArgumentError.checkNotNull(nodeName, 'nodeName');
-    _s.validateStringLength(
-      'nodeName',
-      nodeName,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.AssociateNode'
@@ -213,20 +196,6 @@ class OpsWorksCM {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.CreateBackup'
@@ -553,105 +522,11 @@ class OpsWorksCM {
     List<String>? subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
-    _s.validateStringLength(
-      'engine',
-      engine,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceProfileArn, 'instanceProfileArn');
-    _s.validateStringLength(
-      'instanceProfileArn',
-      instanceProfileArn,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceRoleArn, 'serviceRoleArn');
-    _s.validateStringLength(
-      'serviceRoleArn',
-      serviceRoleArn,
-      0,
-      10000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      0,
-      79,
-    );
     _s.validateNumRange(
       'backupRetentionCount',
       backupRetentionCount,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'customCertificate',
-      customCertificate,
-      0,
-      2097152,
-    );
-    _s.validateStringLength(
-      'customDomain',
-      customDomain,
-      0,
-      253,
-    );
-    _s.validateStringLength(
-      'customPrivateKey',
-      customPrivateKey,
-      0,
-      4096,
-    );
-    _s.validateStringLength(
-      'engineModel',
-      engineModel,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'engineVersion',
-      engineVersion,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'keyPair',
-      keyPair,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'preferredBackupWindow',
-      preferredBackupWindow,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'preferredMaintenanceWindow',
-      preferredMaintenanceWindow,
-      0,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -715,14 +590,6 @@ class OpsWorksCM {
   Future<void> deleteBackup({
     required String backupId,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      0,
-      79,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.DeleteBackup'
@@ -763,14 +630,6 @@ class OpsWorksCM {
   Future<void> deleteServer({
     required String serverName,
   }) async {
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.DeleteServer'
@@ -839,29 +698,11 @@ class OpsWorksCM {
     String? nextToken,
     String? serverName,
   }) async {
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      0,
-      79,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -922,25 +763,11 @@ class OpsWorksCM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -983,23 +810,6 @@ class OpsWorksCM {
     required String nodeAssociationStatusToken,
     required String serverName,
   }) async {
-    ArgumentError.checkNotNull(
-        nodeAssociationStatusToken, 'nodeAssociationStatusToken');
-    _s.validateStringLength(
-      'nodeAssociationStatusToken',
-      nodeAssociationStatusToken,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus'
@@ -1053,18 +863,6 @@ class OpsWorksCM {
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1127,22 +925,6 @@ class OpsWorksCM {
     required String serverName,
     List<EngineAttribute>? engineAttributes,
   }) async {
-    ArgumentError.checkNotNull(nodeName, 'nodeName');
-    _s.validateStringLength(
-      'nodeName',
-      nodeName,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.DisassociateNode'
@@ -1221,22 +1003,6 @@ class OpsWorksCM {
     required String serverName,
     List<EngineAttribute>? inputAttributes,
   }) async {
-    ArgumentError.checkNotNull(exportAttributeName, 'exportAttributeName');
-    _s.validateStringLength(
-      'exportAttributeName',
-      exportAttributeName,
-      0,
-      10000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.ExportServerEngineAttribute'
@@ -1291,18 +1057,11 @@ class OpsWorksCM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      10000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1372,34 +1131,6 @@ class OpsWorksCM {
     String? instanceType,
     String? keyPair,
   }) async {
-    ArgumentError.checkNotNull(backupId, 'backupId');
-    _s.validateStringLength(
-      'backupId',
-      backupId,
-      0,
-      79,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'instanceType',
-      instanceType,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'keyPair',
-      keyPair,
-      0,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.RestoreServer'
@@ -1459,14 +1190,6 @@ class OpsWorksCM {
     required String serverName,
     List<EngineAttribute>? engineAttributes,
   }) async {
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.StartMaintenance'
@@ -1528,8 +1251,6 @@ class OpsWorksCM {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.TagResource'
@@ -1564,8 +1285,6 @@ class OpsWorksCM {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.UntagResource'
@@ -1607,26 +1326,6 @@ class OpsWorksCM {
     String? preferredBackupWindow,
     String? preferredMaintenanceWindow,
   }) async {
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'preferredBackupWindow',
-      preferredBackupWindow,
-      0,
-      10000,
-    );
-    _s.validateStringLength(
-      'preferredMaintenanceWindow',
-      preferredMaintenanceWindow,
-      0,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.UpdateServer'
@@ -1685,28 +1384,6 @@ class OpsWorksCM {
     required String serverName,
     String? attributeValue,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    _s.validateStringLength(
-      'attributeName',
-      attributeName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverName, 'serverName');
-    _s.validateStringLength(
-      'serverName',
-      serverName,
-      1,
-      40,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'attributeValue',
-      attributeValue,
-      0,
-      10000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes'

--- a/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
+++ b/generated/aws_organizations_api/lib/organizations-2016-11-28.dart
@@ -105,14 +105,6 @@ class Organizations {
   Future<AcceptHandshakeResponse> acceptHandshake({
     required String handshakeId,
   }) async {
-    ArgumentError.checkNotNull(handshakeId, 'handshakeId');
-    _s.validateStringLength(
-      'handshakeId',
-      handshakeId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.AcceptHandshake'
@@ -208,22 +200,6 @@ class Organizations {
     required String policyId,
     required String targetId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetId, 'targetId');
-    _s.validateStringLength(
-      'targetId',
-      targetId,
-      0,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.AttachPolicy'
@@ -271,14 +247,6 @@ class Organizations {
   Future<CancelHandshakeResponse> cancelHandshake({
     required String handshakeId,
   }) async {
-    ArgumentError.checkNotNull(handshakeId, 'handshakeId');
-    _s.validateStringLength(
-      'handshakeId',
-      handshakeId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.CancelHandshake'
@@ -476,28 +444,6 @@ class Organizations {
     String? roleName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountName, 'accountName');
-    _s.validateStringLength(
-      'accountName',
-      accountName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(email, 'email');
-    _s.validateStringLength(
-      'email',
-      email,
-      6,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.CreateAccount'
@@ -757,28 +703,6 @@ class Organizations {
     String? roleName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountName, 'accountName');
-    _s.validateStringLength(
-      'accountName',
-      accountName,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(email, 'email');
-    _s.validateStringLength(
-      'email',
-      email,
-      6,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleName',
-      roleName,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.CreateGovCloudAccount'
@@ -938,22 +862,6 @@ class Organizations {
     required String parentId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parentId, 'parentId');
-    _s.validateStringLength(
-      'parentId',
-      parentId,
-      0,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.CreateOrganizationalUnit'
@@ -1055,31 +963,6 @@ class Organizations {
     required PolicyType type,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1000000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.CreatePolicy'
@@ -1132,14 +1015,6 @@ class Organizations {
   Future<DeclineHandshakeResponse> declineHandshake({
     required String handshakeId,
   }) async {
-    ArgumentError.checkNotNull(handshakeId, 'handshakeId');
-    _s.validateStringLength(
-      'handshakeId',
-      handshakeId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DeclineHandshake'
@@ -1212,14 +1087,6 @@ class Organizations {
   Future<void> deleteOrganizationalUnit({
     required String organizationalUnitId,
   }) async {
-    ArgumentError.checkNotNull(organizationalUnitId, 'organizationalUnitId');
-    _s.validateStringLength(
-      'organizationalUnitId',
-      organizationalUnitId,
-      0,
-      68,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DeleteOrganizationalUnit'
@@ -1264,14 +1131,6 @@ class Organizations {
   Future<void> deletePolicy({
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DeletePolicy'
@@ -1333,22 +1192,6 @@ class Organizations {
     required String accountId,
     required String servicePrincipal,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(servicePrincipal, 'servicePrincipal');
-    _s.validateStringLength(
-      'servicePrincipal',
-      servicePrincipal,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1391,14 +1234,6 @@ class Organizations {
   Future<DescribeAccountResponse> describeAccount({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribeAccount'
@@ -1445,15 +1280,6 @@ class Organizations {
   Future<DescribeCreateAccountStatusResponse> describeCreateAccountStatus({
     required String createAccountRequestId,
   }) async {
-    ArgumentError.checkNotNull(
-        createAccountRequestId, 'createAccountRequestId');
-    _s.validateStringLength(
-      'createAccountRequestId',
-      createAccountRequestId,
-      0,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribeCreateAccountStatus'
@@ -1525,13 +1351,6 @@ class Organizations {
     required EffectivePolicyType policyType,
     String? targetId,
   }) async {
-    ArgumentError.checkNotNull(policyType, 'policyType');
-    _s.validateStringLength(
-      'targetId',
-      targetId,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribeEffectivePolicy'
@@ -1580,14 +1399,6 @@ class Organizations {
   Future<DescribeHandshakeResponse> describeHandshake({
     required String handshakeId,
   }) async {
-    ArgumentError.checkNotNull(handshakeId, 'handshakeId');
-    _s.validateStringLength(
-      'handshakeId',
-      handshakeId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribeHandshake'
@@ -1663,14 +1474,6 @@ class Organizations {
   Future<DescribeOrganizationalUnitResponse> describeOrganizationalUnit({
     required String organizationalUnitId,
   }) async {
-    ArgumentError.checkNotNull(organizationalUnitId, 'organizationalUnitId');
-    _s.validateStringLength(
-      'organizationalUnitId',
-      organizationalUnitId,
-      0,
-      68,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribeOrganizationalUnit'
@@ -1714,14 +1517,6 @@ class Organizations {
   Future<DescribePolicyResponse> describePolicy({
     required String policyId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DescribePolicy'
@@ -1814,22 +1609,6 @@ class Organizations {
     required String policyId,
     required String targetId,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetId, 'targetId');
-    _s.validateStringLength(
-      'targetId',
-      targetId,
-      0,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DetachPolicy'
@@ -1895,14 +1674,6 @@ class Organizations {
   Future<void> disableAWSServiceAccess({
     required String servicePrincipal,
   }) async {
-    ArgumentError.checkNotNull(servicePrincipal, 'servicePrincipal');
-    _s.validateStringLength(
-      'servicePrincipal',
-      servicePrincipal,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DisableAWSServiceAccess'
@@ -1986,15 +1757,6 @@ class Organizations {
     required PolicyType policyType,
     required String rootId,
   }) async {
-    ArgumentError.checkNotNull(policyType, 'policyType');
-    ArgumentError.checkNotNull(rootId, 'rootId');
-    _s.validateStringLength(
-      'rootId',
-      rootId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.DisablePolicyType'
@@ -2057,14 +1819,6 @@ class Organizations {
   Future<void> enableAWSServiceAccess({
     required String servicePrincipal,
   }) async {
-    ArgumentError.checkNotNull(servicePrincipal, 'servicePrincipal');
-    _s.validateStringLength(
-      'servicePrincipal',
-      servicePrincipal,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.EnableAWSServiceAccess'
@@ -2203,15 +1957,6 @@ class Organizations {
     required PolicyType policyType,
     required String rootId,
   }) async {
-    ArgumentError.checkNotNull(policyType, 'policyType');
-    ArgumentError.checkNotNull(rootId, 'rootId');
-    _s.validateStringLength(
-      'rootId',
-      rootId,
-      0,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.EnablePolicyType'
@@ -2323,13 +2068,6 @@ class Organizations {
     String? notes,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'notes',
-      notes,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.InviteAccountToOrganization'
@@ -2484,12 +2222,6 @@ class Organizations {
       1,
       20,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2560,12 +2292,6 @@ class Organizations {
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2639,25 +2365,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(parentId, 'parentId');
-    _s.validateStringLength(
-      'parentId',
-      parentId,
-      0,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2750,26 +2462,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(childType, 'childType');
-    ArgumentError.checkNotNull(parentId, 'parentId');
-    _s.validateStringLength(
-      'parentId',
-      parentId,
-      0,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2847,12 +2544,6 @@ class Organizations {
       1,
       20,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.ListCreateAccountStatus'
@@ -2925,18 +2616,6 @@ class Organizations {
       1,
       20,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
-    );
-    _s.validateStringLength(
-      'servicePrincipal',
-      servicePrincipal,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.ListDelegatedAdministrators'
@@ -3003,25 +2682,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3106,12 +2771,6 @@ class Organizations {
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3201,12 +2860,6 @@ class Organizations {
       1,
       20,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.ListHandshakesForOrganization'
@@ -3293,25 +2946,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(parentId, 'parentId');
-    _s.validateStringLength(
-      'parentId',
-      parentId,
-      0,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3403,25 +3042,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(childId, 'childId');
-    _s.validateStringLength(
-      'childId',
-      childId,
-      0,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3510,18 +3135,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(filter, 'filter');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3637,26 +3255,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(filter, 'filter');
-    ArgumentError.checkNotNull(targetId, 'targetId');
-    _s.validateStringLength(
-      'targetId',
-      targetId,
-      0,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3734,12 +3337,6 @@ class Organizations {
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3823,20 +3420,6 @@ class Organizations {
     required String resourceId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      0,
-      130,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.ListTagsForResource'
@@ -3910,25 +3493,11 @@ class Organizations {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       20,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      100000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4017,30 +3586,6 @@ class Organizations {
     required String destinationParentId,
     required String sourceParentId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(destinationParentId, 'destinationParentId');
-    _s.validateStringLength(
-      'destinationParentId',
-      destinationParentId,
-      0,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceParentId, 'sourceParentId');
-    _s.validateStringLength(
-      'sourceParentId',
-      sourceParentId,
-      0,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.MoveAccount'
@@ -4096,22 +3641,6 @@ class Organizations {
     required String accountId,
     required String servicePrincipal,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(servicePrincipal, 'servicePrincipal');
-    _s.validateStringLength(
-      'servicePrincipal',
-      servicePrincipal,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.RegisterDelegatedAdministrator'
@@ -4184,14 +3713,6 @@ class Organizations {
   Future<void> removeAccountFromOrganization({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      12,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.RemoveAccountFromOrganization'
@@ -4276,15 +3797,6 @@ class Organizations {
     required String resourceId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      0,
-      130,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.TagResource'
@@ -4361,15 +3873,6 @@ class Organizations {
     required String resourceId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      0,
-      130,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.UntagResource'
@@ -4423,20 +3926,6 @@ class Organizations {
     required String organizationalUnitId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(organizationalUnitId, 'organizationalUnitId');
-    _s.validateStringLength(
-      'organizationalUnitId',
-      organizationalUnitId,
-      0,
-      68,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.UpdateOrganizationalUnit'
@@ -4505,32 +3994,6 @@ class Organizations {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(policyId, 'policyId');
-    _s.validateStringLength(
-      'policyId',
-      policyId,
-      0,
-      130,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1000000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSOrganizationsV20161128.UpdatePolicy'

--- a/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
+++ b/generated/aws_outposts_api/lib/outposts-2019-12-03.dart
@@ -71,40 +71,6 @@ class Outposts {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(siteId, 'siteId');
-    _s.validateStringLength(
-      'siteId',
-      siteId,
-      1,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'availabilityZone',
-      availabilityZone,
-      1,
-      1000,
-    );
-    _s.validateStringLength(
-      'availabilityZoneId',
-      availabilityZoneId,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1000,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'SiteId': siteId,
@@ -131,14 +97,6 @@ class Outposts {
   Future<void> deleteOutpost({
     required String outpostId,
   }) async {
-    ArgumentError.checkNotNull(outpostId, 'outpostId');
-    _s.validateStringLength(
-      'outpostId',
-      outpostId,
-      1,
-      180,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -156,14 +114,6 @@ class Outposts {
   Future<void> deleteSite({
     required String siteId,
   }) async {
-    ArgumentError.checkNotNull(siteId, 'siteId');
-    _s.validateStringLength(
-      'siteId',
-      siteId,
-      1,
-      255,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -181,14 +131,6 @@ class Outposts {
   Future<GetOutpostOutput> getOutpost({
     required String outpostId,
   }) async {
-    ArgumentError.checkNotNull(outpostId, 'outpostId');
-    _s.validateStringLength(
-      'outpostId',
-      outpostId,
-      1,
-      180,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -209,25 +151,11 @@ class Outposts {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(outpostId, 'outpostId');
-    _s.validateStringLength(
-      'outpostId',
-      outpostId,
-      1,
-      180,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1005,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
@@ -258,12 +186,6 @@ class Outposts {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1005,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -293,12 +215,6 @@ class Outposts {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1005,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
       if (nextToken != null) 'NextToken': [nextToken],
@@ -324,14 +240,6 @@ class Outposts {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      1011,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -356,15 +264,6 @@ class Outposts {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -391,15 +290,6 @@ class Outposts {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
+++ b/generated/aws_personalize_api/lib/personalize-2018-05-22.dart
@@ -97,38 +97,6 @@ class Personalize {
     String? filterArn,
     int? numResults,
   }) async {
-    ArgumentError.checkNotNull(jobInput, 'jobInput');
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobOutput, 'jobOutput');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(solutionVersionArn, 'solutionVersionArn');
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'filterArn',
-      filterArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateBatchInferenceJob'
@@ -237,28 +205,11 @@ class Personalize {
     required String solutionVersionArn,
     CampaignConfig? campaignConfig,
   }) async {
-    ArgumentError.checkNotNull(minProvisionedTPS, 'minProvisionedTPS');
     _s.validateNumRange(
       'minProvisionedTPS',
       minProvisionedTPS,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(solutionVersionArn, 'solutionVersionArn');
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -368,38 +319,6 @@ class Personalize {
     required String name,
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(datasetType, 'datasetType');
-    _s.validateStringLength(
-      'datasetType',
-      datasetType,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
-    _s.validateStringLength(
-      'schemaArn',
-      schemaArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateDataset'
@@ -506,20 +425,6 @@ class Personalize {
     String? kmsKeyArn,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateDatasetGroup'
@@ -601,31 +506,6 @@ class Personalize {
     required String jobName,
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(dataSource, 'dataSource');
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobName, 'jobName');
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateDatasetImportJob'
@@ -709,22 +589,6 @@ class Personalize {
     required String datasetGroupArn,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateEventTracker'
@@ -777,30 +641,6 @@ class Personalize {
     required String filterExpression,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filterExpression, 'filterExpression');
-    _s.validateStringLength(
-      'filterExpression',
-      filterExpression,
-      1,
-      2500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateFilter'
@@ -854,22 +694,6 @@ class Personalize {
     required String name,
     required String schema,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schema, 'schema');
-    _s.validateStringLength(
-      'schema',
-      schema,
-      0,
-      10000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateSchema'
@@ -1005,34 +829,6 @@ class Personalize {
     String? recipeArn,
     SolutionConfig? solutionConfig,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'eventType',
-      eventType,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'recipeArn',
-      recipeArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateSolution'
@@ -1129,14 +925,6 @@ class Personalize {
     required String solutionArn,
     TrainingMode? trainingMode,
   }) async {
-    ArgumentError.checkNotNull(solutionArn, 'solutionArn');
-    _s.validateStringLength(
-      'solutionArn',
-      solutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.CreateSolutionVersion'
@@ -1171,14 +959,6 @@ class Personalize {
   Future<void> deleteCampaign({
     required String campaignArn,
   }) async {
-    ArgumentError.checkNotNull(campaignArn, 'campaignArn');
-    _s.validateStringLength(
-      'campaignArn',
-      campaignArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteCampaign'
@@ -1209,14 +989,6 @@ class Personalize {
   Future<void> deleteDataset({
     required String datasetArn,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteDataset'
@@ -1257,14 +1029,6 @@ class Personalize {
   Future<void> deleteDatasetGroup({
     required String datasetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteDatasetGroup'
@@ -1294,14 +1058,6 @@ class Personalize {
   Future<void> deleteEventTracker({
     required String eventTrackerArn,
   }) async {
-    ArgumentError.checkNotNull(eventTrackerArn, 'eventTrackerArn');
-    _s.validateStringLength(
-      'eventTrackerArn',
-      eventTrackerArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteEventTracker'
@@ -1329,14 +1085,6 @@ class Personalize {
   Future<void> deleteFilter({
     required String filterArn,
   }) async {
-    ArgumentError.checkNotNull(filterArn, 'filterArn');
-    _s.validateStringLength(
-      'filterArn',
-      filterArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteFilter'
@@ -1366,14 +1114,6 @@ class Personalize {
   Future<void> deleteSchema({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
-    _s.validateStringLength(
-      'schemaArn',
-      schemaArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteSchema'
@@ -1407,14 +1147,6 @@ class Personalize {
   Future<void> deleteSolution({
     required String solutionArn,
   }) async {
-    ArgumentError.checkNotNull(solutionArn, 'solutionArn');
-    _s.validateStringLength(
-      'solutionArn',
-      solutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DeleteSolution'
@@ -1441,14 +1173,6 @@ class Personalize {
   Future<DescribeAlgorithmResponse> describeAlgorithm({
     required String algorithmArn,
   }) async {
-    ArgumentError.checkNotNull(algorithmArn, 'algorithmArn');
-    _s.validateStringLength(
-      'algorithmArn',
-      algorithmArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeAlgorithm'
@@ -1479,14 +1203,6 @@ class Personalize {
   Future<DescribeBatchInferenceJobResponse> describeBatchInferenceJob({
     required String batchInferenceJobArn,
   }) async {
-    ArgumentError.checkNotNull(batchInferenceJobArn, 'batchInferenceJobArn');
-    _s.validateStringLength(
-      'batchInferenceJobArn',
-      batchInferenceJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeBatchInferenceJob'
@@ -1530,14 +1246,6 @@ class Personalize {
   Future<DescribeCampaignResponse> describeCampaign({
     required String campaignArn,
   }) async {
-    ArgumentError.checkNotNull(campaignArn, 'campaignArn');
-    _s.validateStringLength(
-      'campaignArn',
-      campaignArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeCampaign'
@@ -1567,14 +1275,6 @@ class Personalize {
   Future<DescribeDatasetResponse> describeDataset({
     required String datasetArn,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeDataset'
@@ -1604,14 +1304,6 @@ class Personalize {
   Future<DescribeDatasetGroupResponse> describeDatasetGroup({
     required String datasetGroupArn,
   }) async {
-    ArgumentError.checkNotNull(datasetGroupArn, 'datasetGroupArn');
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeDatasetGroup'
@@ -1641,14 +1333,6 @@ class Personalize {
   Future<DescribeDatasetImportJobResponse> describeDatasetImportJob({
     required String datasetImportJobArn,
   }) async {
-    ArgumentError.checkNotNull(datasetImportJobArn, 'datasetImportJobArn');
-    _s.validateStringLength(
-      'datasetImportJobArn',
-      datasetImportJobArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeDatasetImportJob'
@@ -1679,14 +1363,6 @@ class Personalize {
   Future<DescribeEventTrackerResponse> describeEventTracker({
     required String eventTrackerArn,
   }) async {
-    ArgumentError.checkNotNull(eventTrackerArn, 'eventTrackerArn');
-    _s.validateStringLength(
-      'eventTrackerArn',
-      eventTrackerArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeEventTracker'
@@ -1715,15 +1391,6 @@ class Personalize {
   Future<DescribeFeatureTransformationResponse> describeFeatureTransformation({
     required String featureTransformationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        featureTransformationArn, 'featureTransformationArn');
-    _s.validateStringLength(
-      'featureTransformationArn',
-      featureTransformationArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeFeatureTransformation'
@@ -1752,14 +1419,6 @@ class Personalize {
   Future<DescribeFilterResponse> describeFilter({
     required String filterArn,
   }) async {
-    ArgumentError.checkNotNull(filterArn, 'filterArn');
-    _s.validateStringLength(
-      'filterArn',
-      filterArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeFilter'
@@ -1810,14 +1469,6 @@ class Personalize {
   Future<DescribeRecipeResponse> describeRecipe({
     required String recipeArn,
   }) async {
-    ArgumentError.checkNotNull(recipeArn, 'recipeArn');
-    _s.validateStringLength(
-      'recipeArn',
-      recipeArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeRecipe'
@@ -1847,14 +1498,6 @@ class Personalize {
   Future<DescribeSchemaResponse> describeSchema({
     required String schemaArn,
   }) async {
-    ArgumentError.checkNotNull(schemaArn, 'schemaArn');
-    _s.validateStringLength(
-      'schemaArn',
-      schemaArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeSchema'
@@ -1884,14 +1527,6 @@ class Personalize {
   Future<DescribeSolutionResponse> describeSolution({
     required String solutionArn,
   }) async {
-    ArgumentError.checkNotNull(solutionArn, 'solutionArn');
-    _s.validateStringLength(
-      'solutionArn',
-      solutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeSolution'
@@ -1921,14 +1556,6 @@ class Personalize {
   Future<DescribeSolutionVersionResponse> describeSolutionVersion({
     required String solutionVersionArn,
   }) async {
-    ArgumentError.checkNotNull(solutionVersionArn, 'solutionVersionArn');
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.DescribeSolutionVersion'
@@ -1959,14 +1586,6 @@ class Personalize {
   Future<GetSolutionMetricsResponse> getSolutionMetrics({
     required String solutionVersionArn,
   }) async {
-    ArgumentError.checkNotNull(solutionVersionArn, 'solutionVersionArn');
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.GetSolutionMetrics'
@@ -2011,18 +1630,6 @@ class Personalize {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
-    );
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2076,18 +1683,6 @@ class Personalize {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
-    );
-    _s.validateStringLength(
-      'solutionArn',
-      solutionArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.ListCampaigns'
@@ -2129,12 +1724,6 @@ class Personalize {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2181,23 +1770,11 @@ class Personalize {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2243,23 +1820,11 @@ class Personalize {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2303,23 +1868,11 @@ class Personalize {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2360,23 +1913,11 @@ class Personalize {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2423,12 +1964,6 @@ class Personalize {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.ListRecipes'
@@ -2470,12 +2005,6 @@ class Personalize {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2527,18 +2056,6 @@ class Personalize {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
-    );
-    _s.validateStringLength(
-      'solutionArn',
-      solutionArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonPersonalize.ListSolutionVersions'
@@ -2582,23 +2099,11 @@ class Personalize {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'datasetGroupArn',
-      datasetGroupArn,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1300,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2653,25 +2158,11 @@ class Personalize {
     int? minProvisionedTPS,
     String? solutionVersionArn,
   }) async {
-    ArgumentError.checkNotNull(campaignArn, 'campaignArn');
-    _s.validateStringLength(
-      'campaignArn',
-      campaignArn,
-      0,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'minProvisionedTPS',
       minProvisionedTPS,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'solutionVersionArn',
-      solutionVersionArn,
-      0,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',

--- a/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
+++ b/generated/aws_personalize_events_api/lib/personalize-events-2018-03-22.dart
@@ -79,29 +79,6 @@ class PersonalizeEvents {
     required String trackingId,
     String? userId,
   }) async {
-    ArgumentError.checkNotNull(eventList, 'eventList');
-    ArgumentError.checkNotNull(sessionId, 'sessionId');
-    _s.validateStringLength(
-      'sessionId',
-      sessionId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trackingId, 'trackingId');
-    _s.validateStringLength(
-      'trackingId',
-      trackingId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-    );
     final $payload = <String, dynamic>{
       'eventList': eventList,
       'sessionId': sessionId,
@@ -132,15 +109,6 @@ class PersonalizeEvents {
     required String datasetArn,
     required List<Item> items,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(items, 'items');
     final $payload = <String, dynamic>{
       'datasetArn': datasetArn,
       'items': items,
@@ -169,15 +137,6 @@ class PersonalizeEvents {
     required String datasetArn,
     required List<User> users,
   }) async {
-    ArgumentError.checkNotNull(datasetArn, 'datasetArn');
-    _s.validateStringLength(
-      'datasetArn',
-      datasetArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(users, 'users');
     final $payload = <String, dynamic>{
       'datasetArn': datasetArn,
       'users': users,

--- a/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
+++ b/generated/aws_personalize_runtime_api/lib/personalize-runtime-2018-05-22.dart
@@ -108,29 +108,6 @@ class PersonalizeRuntime {
     String? filterArn,
     Map<String, String>? filterValues,
   }) async {
-    ArgumentError.checkNotNull(campaignArn, 'campaignArn');
-    _s.validateStringLength(
-      'campaignArn',
-      campaignArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputList, 'inputList');
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'filterArn',
-      filterArn,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'campaignArn': campaignArn,
       'inputList': inputList,
@@ -224,37 +201,11 @@ class PersonalizeRuntime {
     int? numResults,
     String? userId,
   }) async {
-    ArgumentError.checkNotNull(campaignArn, 'campaignArn');
-    _s.validateStringLength(
-      'campaignArn',
-      campaignArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'filterArn',
-      filterArn,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'itemId',
-      itemId,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'numResults',
       numResults,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      0,
-      256,
     );
     final $payload = <String, dynamic>{
       'campaignArn': campaignArn,

--- a/generated/aws_pi_api/lib/pi-2018-02-27.dart
+++ b/generated/aws_pi_api/lib/pi-2018-02-27.dart
@@ -188,12 +188,6 @@ class PI {
     DimensionGroup? partitionBy,
     int? periodInSeconds,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(groupBy, 'groupBy');
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    ArgumentError.checkNotNull(metric, 'metric');
-    ArgumentError.checkNotNull(serviceType, 'serviceType');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -319,11 +313,6 @@ class PI {
     String? nextToken,
     int? periodInSeconds,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(identifier, 'identifier');
-    ArgumentError.checkNotNull(metricQueries, 'metricQueries');
-    ArgumentError.checkNotNull(serviceType, 'serviceType');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     _s.validateNumRange(
       'maxResults',
       maxResults,

--- a/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
+++ b/generated/aws_pinpoint_api/lib/pinpoint-2016-12-01.dart
@@ -60,8 +60,6 @@ class Pinpoint {
   Future<CreateAppResponse> createApp({
     required CreateApplicationRequest createApplicationRequest,
   }) async {
-    ArgumentError.checkNotNull(
-        createApplicationRequest, 'createApplicationRequest');
     final response = await _protocol.sendRaw(
       payload: createApplicationRequest,
       method: 'POST',
@@ -92,8 +90,6 @@ class Pinpoint {
     required String applicationId,
     required WriteCampaignRequest writeCampaignRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(writeCampaignRequest, 'writeCampaignRequest');
     final response = await _protocol.sendRaw(
       payload: writeCampaignRequest,
       method: 'POST',
@@ -124,8 +120,6 @@ class Pinpoint {
     required EmailTemplateRequest emailTemplateRequest,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(emailTemplateRequest, 'emailTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final response = await _protocol.sendRaw(
       payload: emailTemplateRequest,
       method: 'POST',
@@ -155,8 +149,6 @@ class Pinpoint {
     required String applicationId,
     required ExportJobRequest exportJobRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(exportJobRequest, 'exportJobRequest');
     final response = await _protocol.sendRaw(
       payload: exportJobRequest,
       method: 'POST',
@@ -186,8 +178,6 @@ class Pinpoint {
     required String applicationId,
     required ImportJobRequest importJobRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(importJobRequest, 'importJobRequest');
     final response = await _protocol.sendRaw(
       payload: importJobRequest,
       method: 'POST',
@@ -217,8 +207,6 @@ class Pinpoint {
     required String applicationId,
     required WriteJourneyRequest writeJourneyRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(writeJourneyRequest, 'writeJourneyRequest');
     final response = await _protocol.sendRaw(
       payload: writeJourneyRequest,
       method: 'POST',
@@ -249,9 +237,6 @@ class Pinpoint {
     required PushNotificationTemplateRequest pushNotificationTemplateRequest,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(
-        pushNotificationTemplateRequest, 'pushNotificationTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final response = await _protocol.sendRaw(
       payload: pushNotificationTemplateRequest,
       method: 'POST',
@@ -277,8 +262,6 @@ class Pinpoint {
       createRecommenderConfiguration({
     required CreateRecommenderConfiguration createRecommenderConfiguration,
   }) async {
-    ArgumentError.checkNotNull(
-        createRecommenderConfiguration, 'createRecommenderConfiguration');
     final response = await _protocol.sendRaw(
       payload: createRecommenderConfiguration,
       method: 'POST',
@@ -311,8 +294,6 @@ class Pinpoint {
     required String applicationId,
     required WriteSegmentRequest writeSegmentRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(writeSegmentRequest, 'writeSegmentRequest');
     final response = await _protocol.sendRaw(
       payload: writeSegmentRequest,
       method: 'POST',
@@ -343,8 +324,6 @@ class Pinpoint {
     required SMSTemplateRequest sMSTemplateRequest,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(sMSTemplateRequest, 'sMSTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final response = await _protocol.sendRaw(
       payload: sMSTemplateRequest,
       method: 'POST',
@@ -375,8 +354,6 @@ class Pinpoint {
     required String templateName,
     required VoiceTemplateRequest voiceTemplateRequest,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    ArgumentError.checkNotNull(voiceTemplateRequest, 'voiceTemplateRequest');
     final response = await _protocol.sendRaw(
       payload: voiceTemplateRequest,
       method: 'POST',
@@ -406,7 +383,6 @@ class Pinpoint {
   Future<DeleteAdmChannelResponse> deleteAdmChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -436,7 +412,6 @@ class Pinpoint {
   Future<DeleteApnsChannelResponse> deleteApnsChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -467,7 +442,6 @@ class Pinpoint {
   Future<DeleteApnsSandboxChannelResponse> deleteApnsSandboxChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -498,7 +472,6 @@ class Pinpoint {
   Future<DeleteApnsVoipChannelResponse> deleteApnsVoipChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -529,7 +502,6 @@ class Pinpoint {
   Future<DeleteApnsVoipSandboxChannelResponse> deleteApnsVoipSandboxChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -560,7 +532,6 @@ class Pinpoint {
   Future<DeleteAppResponse> deleteApp({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -590,7 +561,6 @@ class Pinpoint {
   Future<DeleteBaiduChannelResponse> deleteBaiduChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -624,8 +594,6 @@ class Pinpoint {
     required String applicationId,
     required String campaignId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -656,7 +624,6 @@ class Pinpoint {
   Future<DeleteEmailChannelResponse> deleteEmailChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -721,7 +688,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -758,8 +724,6 @@ class Pinpoint {
     required String applicationId,
     required String endpointId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -789,7 +753,6 @@ class Pinpoint {
   Future<DeleteEventStreamResponse> deleteEventStream({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -819,7 +782,6 @@ class Pinpoint {
   Future<DeleteGcmChannelResponse> deleteGcmChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -852,8 +814,6 @@ class Pinpoint {
     required String applicationId,
     required String journeyId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -918,7 +878,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -953,7 +912,6 @@ class Pinpoint {
       deleteRecommenderConfiguration({
     required String recommenderId,
   }) async {
-    ArgumentError.checkNotNull(recommenderId, 'recommenderId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -987,8 +945,6 @@ class Pinpoint {
     required String applicationId,
     required String segmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -1019,7 +975,6 @@ class Pinpoint {
   Future<DeleteSmsChannelResponse> deleteSmsChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -1083,7 +1038,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -1120,8 +1074,6 @@ class Pinpoint {
     required String applicationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -1152,7 +1104,6 @@ class Pinpoint {
   Future<DeleteVoiceChannelResponse> deleteVoiceChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'DELETE',
@@ -1217,7 +1168,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -1251,7 +1201,6 @@ class Pinpoint {
   Future<GetAdmChannelResponse> getAdmChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1281,7 +1230,6 @@ class Pinpoint {
   Future<GetApnsChannelResponse> getApnsChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1312,7 +1260,6 @@ class Pinpoint {
   Future<GetApnsSandboxChannelResponse> getApnsSandboxChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1343,7 +1290,6 @@ class Pinpoint {
   Future<GetApnsVoipChannelResponse> getApnsVoipChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1374,7 +1320,6 @@ class Pinpoint {
   Future<GetApnsVoipSandboxChannelResponse> getApnsVoipSandboxChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1405,7 +1350,6 @@ class Pinpoint {
   Future<GetAppResponse> getApp({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1473,8 +1417,6 @@ class Pinpoint {
     String? pageSize,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(kpiName, 'kpiName');
     final $query = <String, List<String>>{
       if (endTime != null) 'end-time': [_s.iso8601ToJson(endTime).toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -1513,7 +1455,6 @@ class Pinpoint {
   Future<GetApplicationSettingsResponse> getApplicationSettings({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1583,7 +1524,6 @@ class Pinpoint {
   Future<GetBaiduChannelResponse> getBaiduChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1618,8 +1558,6 @@ class Pinpoint {
     required String applicationId,
     required String campaignId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1664,8 +1602,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -1743,9 +1679,6 @@ class Pinpoint {
     String? pageSize,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
-    ArgumentError.checkNotNull(kpiName, 'kpiName');
     final $query = <String, List<String>>{
       if (endTime != null) 'end-time': [_s.iso8601ToJson(endTime).toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -1793,9 +1726,6 @@ class Pinpoint {
     required String campaignId,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
-    ArgumentError.checkNotNull(version, 'version');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1841,8 +1771,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -1889,7 +1817,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -1924,7 +1851,6 @@ class Pinpoint {
   Future<GetChannelsResponse> getChannels({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -1954,7 +1880,6 @@ class Pinpoint {
   Future<GetEmailChannelResponse> getEmailChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2019,7 +1944,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -2057,8 +1981,6 @@ class Pinpoint {
     required String applicationId,
     required String endpointId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2088,7 +2010,6 @@ class Pinpoint {
   Future<GetEventStreamResponse> getEventStream({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2122,8 +2043,6 @@ class Pinpoint {
     required String applicationId,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2165,7 +2084,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2200,7 +2118,6 @@ class Pinpoint {
   Future<GetGcmChannelResponse> getGcmChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2234,8 +2151,6 @@ class Pinpoint {
     required String applicationId,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2277,7 +2192,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2316,8 +2230,6 @@ class Pinpoint {
     required String applicationId,
     required String journeyId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2390,9 +2302,6 @@ class Pinpoint {
     String? pageSize,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
-    ArgumentError.checkNotNull(kpiName, 'kpiName');
     final $query = <String, List<String>>{
       if (endTime != null) 'end-time': [_s.iso8601ToJson(endTime).toString()],
       if (nextToken != null) 'next-token': [nextToken],
@@ -2452,9 +2361,6 @@ class Pinpoint {
     String? nextToken,
     String? pageSize,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyActivityId, 'journeyActivityId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'next-token': [nextToken],
       if (pageSize != null) 'page-size': [pageSize],
@@ -2507,8 +2413,6 @@ class Pinpoint {
     String? nextToken,
     String? pageSize,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
     final $query = <String, List<String>>{
       if (nextToken != null) 'next-token': [nextToken],
       if (pageSize != null) 'page-size': [pageSize],
@@ -2579,7 +2483,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -2615,7 +2518,6 @@ class Pinpoint {
   Future<GetRecommenderConfigurationResponse> getRecommenderConfiguration({
     required String recommenderId,
   }) async {
-    ArgumentError.checkNotNull(recommenderId, 'recommenderId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2691,8 +2593,6 @@ class Pinpoint {
     required String applicationId,
     required String segmentId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2738,8 +2638,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2790,8 +2688,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2836,9 +2732,6 @@ class Pinpoint {
     required String segmentId,
     required String version,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
-    ArgumentError.checkNotNull(version, 'version');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -2885,8 +2778,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2933,7 +2824,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -2968,7 +2858,6 @@ class Pinpoint {
   Future<GetSmsChannelResponse> getSmsChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -3032,7 +2921,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -3070,8 +2958,6 @@ class Pinpoint {
     required String applicationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(userId, 'userId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -3102,7 +2988,6 @@ class Pinpoint {
   Future<GetVoiceChannelResponse> getVoiceChannel({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -3167,7 +3052,6 @@ class Pinpoint {
     required String templateName,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (version != null) 'version': [version],
     };
@@ -3212,7 +3096,6 @@ class Pinpoint {
     String? pageSize,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (pageSize != null) 'page-size': [pageSize],
       if (token != null) 'token': [token],
@@ -3238,7 +3121,6 @@ class Pinpoint {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',
@@ -3287,8 +3169,6 @@ class Pinpoint {
     String? nextToken,
     String? pageSize,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    ArgumentError.checkNotNull(templateType, 'templateType');
     final $query = <String, List<String>>{
       if (nextToken != null) 'next-token': [nextToken],
       if (pageSize != null) 'page-size': [pageSize],
@@ -3372,7 +3252,6 @@ class Pinpoint {
   Future<PhoneNumberValidateResponse> phoneNumberValidate({
     required NumberValidateRequest numberValidateRequest,
   }) async {
-    ArgumentError.checkNotNull(numberValidateRequest, 'numberValidateRequest');
     final response = await _protocol.sendRaw(
       payload: numberValidateRequest,
       method: 'POST',
@@ -3403,8 +3282,6 @@ class Pinpoint {
     required String applicationId,
     required WriteEventStream writeEventStream,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(writeEventStream, 'writeEventStream');
     final response = await _protocol.sendRaw(
       payload: writeEventStream,
       method: 'POST',
@@ -3435,8 +3312,6 @@ class Pinpoint {
     required String applicationId,
     required EventsRequest eventsRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(eventsRequest, 'eventsRequest');
     final response = await _protocol.sendRaw(
       payload: eventsRequest,
       method: 'POST',
@@ -3488,10 +3363,6 @@ class Pinpoint {
     required String attributeType,
     required UpdateAttributesRequest updateAttributesRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(attributeType, 'attributeType');
-    ArgumentError.checkNotNull(
-        updateAttributesRequest, 'updateAttributesRequest');
     final response = await _protocol.sendRaw(
       payload: updateAttributesRequest,
       method: 'PUT',
@@ -3522,8 +3393,6 @@ class Pinpoint {
     required String applicationId,
     required MessageRequest messageRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(messageRequest, 'messageRequest');
     final response = await _protocol.sendRaw(
       payload: messageRequest,
       method: 'POST',
@@ -3553,9 +3422,6 @@ class Pinpoint {
     required String applicationId,
     required SendUsersMessageRequest sendUsersMessageRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        sendUsersMessageRequest, 'sendUsersMessageRequest');
     final response = await _protocol.sendRaw(
       payload: sendUsersMessageRequest,
       method: 'POST',
@@ -3578,8 +3444,6 @@ class Pinpoint {
     required String resourceArn,
     required TagsModel tagsModel,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagsModel, 'tagsModel');
     await _protocol.send(
       payload: tagsModel,
       method: 'POST',
@@ -3602,8 +3466,6 @@ class Pinpoint {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -3634,8 +3496,6 @@ class Pinpoint {
     required ADMChannelRequest aDMChannelRequest,
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(aDMChannelRequest, 'aDMChannelRequest');
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: aDMChannelRequest,
       method: 'PUT',
@@ -3666,8 +3526,6 @@ class Pinpoint {
     required APNSChannelRequest aPNSChannelRequest,
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(aPNSChannelRequest, 'aPNSChannelRequest');
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: aPNSChannelRequest,
       method: 'PUT',
@@ -3699,9 +3557,6 @@ class Pinpoint {
     required APNSSandboxChannelRequest aPNSSandboxChannelRequest,
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(
-        aPNSSandboxChannelRequest, 'aPNSSandboxChannelRequest');
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: aPNSSandboxChannelRequest,
       method: 'PUT',
@@ -3733,9 +3588,6 @@ class Pinpoint {
     required APNSVoipChannelRequest aPNSVoipChannelRequest,
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(
-        aPNSVoipChannelRequest, 'aPNSVoipChannelRequest');
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: aPNSVoipChannelRequest,
       method: 'PUT',
@@ -3767,9 +3619,6 @@ class Pinpoint {
     required APNSVoipSandboxChannelRequest aPNSVoipSandboxChannelRequest,
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(
-        aPNSVoipSandboxChannelRequest, 'aPNSVoipSandboxChannelRequest');
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.sendRaw(
       payload: aPNSVoipSandboxChannelRequest,
       method: 'PUT',
@@ -3801,9 +3650,6 @@ class Pinpoint {
     required String applicationId,
     required WriteApplicationSettingsRequest writeApplicationSettingsRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(
-        writeApplicationSettingsRequest, 'writeApplicationSettingsRequest');
     final response = await _protocol.sendRaw(
       payload: writeApplicationSettingsRequest,
       method: 'PUT',
@@ -3834,8 +3680,6 @@ class Pinpoint {
     required String applicationId,
     required BaiduChannelRequest baiduChannelRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(baiduChannelRequest, 'baiduChannelRequest');
     final response = await _protocol.sendRaw(
       payload: baiduChannelRequest,
       method: 'PUT',
@@ -3870,9 +3714,6 @@ class Pinpoint {
     required String campaignId,
     required WriteCampaignRequest writeCampaignRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
-    ArgumentError.checkNotNull(writeCampaignRequest, 'writeCampaignRequest');
     final response = await _protocol.sendRaw(
       payload: writeCampaignRequest,
       method: 'PUT',
@@ -3904,8 +3745,6 @@ class Pinpoint {
     required String applicationId,
     required EmailChannelRequest emailChannelRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(emailChannelRequest, 'emailChannelRequest');
     final response = await _protocol.sendRaw(
       payload: emailChannelRequest,
       method: 'PUT',
@@ -3983,8 +3822,6 @@ class Pinpoint {
     bool? createNewVersion,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(emailTemplateRequest, 'emailTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (createNewVersion != null)
         'create-new-version': [createNewVersion.toString()],
@@ -4028,9 +3865,6 @@ class Pinpoint {
     required String endpointId,
     required EndpointRequest endpointRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(endpointId, 'endpointId');
-    ArgumentError.checkNotNull(endpointRequest, 'endpointRequest');
     final response = await _protocol.sendRaw(
       payload: endpointRequest,
       method: 'PUT',
@@ -4066,8 +3900,6 @@ class Pinpoint {
     required String applicationId,
     required EndpointBatchRequest endpointBatchRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(endpointBatchRequest, 'endpointBatchRequest');
     final response = await _protocol.sendRaw(
       payload: endpointBatchRequest,
       method: 'PUT',
@@ -4098,8 +3930,6 @@ class Pinpoint {
     required String applicationId,
     required GCMChannelRequest gCMChannelRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(gCMChannelRequest, 'gCMChannelRequest');
     final response = await _protocol.sendRaw(
       payload: gCMChannelRequest,
       method: 'PUT',
@@ -4134,9 +3964,6 @@ class Pinpoint {
     required String journeyId,
     required WriteJourneyRequest writeJourneyRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
-    ArgumentError.checkNotNull(writeJourneyRequest, 'writeJourneyRequest');
     final response = await _protocol.sendRaw(
       payload: writeJourneyRequest,
       method: 'PUT',
@@ -4171,9 +3998,6 @@ class Pinpoint {
     required String journeyId,
     required JourneyStateRequest journeyStateRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(journeyId, 'journeyId');
-    ArgumentError.checkNotNull(journeyStateRequest, 'journeyStateRequest');
     final response = await _protocol.sendRaw(
       payload: journeyStateRequest,
       method: 'PUT',
@@ -4251,9 +4075,6 @@ class Pinpoint {
     bool? createNewVersion,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(
-        pushNotificationTemplateRequest, 'pushNotificationTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (createNewVersion != null)
         'create-new-version': [createNewVersion.toString()],
@@ -4291,9 +4112,6 @@ class Pinpoint {
     required String recommenderId,
     required UpdateRecommenderConfiguration updateRecommenderConfiguration,
   }) async {
-    ArgumentError.checkNotNull(recommenderId, 'recommenderId');
-    ArgumentError.checkNotNull(
-        updateRecommenderConfiguration, 'updateRecommenderConfiguration');
     final response = await _protocol.sendRaw(
       payload: updateRecommenderConfiguration,
       method: 'PUT',
@@ -4330,9 +4148,6 @@ class Pinpoint {
     required String segmentId,
     required WriteSegmentRequest writeSegmentRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(segmentId, 'segmentId');
-    ArgumentError.checkNotNull(writeSegmentRequest, 'writeSegmentRequest');
     final response = await _protocol.sendRaw(
       payload: writeSegmentRequest,
       method: 'PUT',
@@ -4364,8 +4179,6 @@ class Pinpoint {
     required String applicationId,
     required SMSChannelRequest sMSChannelRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(sMSChannelRequest, 'sMSChannelRequest');
     final response = await _protocol.sendRaw(
       payload: sMSChannelRequest,
       method: 'PUT',
@@ -4442,8 +4255,6 @@ class Pinpoint {
     bool? createNewVersion,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(sMSTemplateRequest, 'sMSTemplateRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $query = <String, List<String>>{
       if (createNewVersion != null)
         'create-new-version': [createNewVersion.toString()],
@@ -4487,10 +4298,6 @@ class Pinpoint {
     required String templateName,
     required String templateType,
   }) async {
-    ArgumentError.checkNotNull(
-        templateActiveVersionRequest, 'templateActiveVersionRequest');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    ArgumentError.checkNotNull(templateType, 'templateType');
     final response = await _protocol.sendRaw(
       payload: templateActiveVersionRequest,
       method: 'PUT',
@@ -4522,8 +4329,6 @@ class Pinpoint {
     required String applicationId,
     required VoiceChannelRequest voiceChannelRequest,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(voiceChannelRequest, 'voiceChannelRequest');
     final response = await _protocol.sendRaw(
       payload: voiceChannelRequest,
       method: 'PUT',
@@ -4601,8 +4406,6 @@ class Pinpoint {
     bool? createNewVersion,
     String? version,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    ArgumentError.checkNotNull(voiceTemplateRequest, 'voiceTemplateRequest');
     final $query = <String, List<String>>{
       if (createNewVersion != null)
         'create-new-version': [createNewVersion.toString()],

--- a/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
+++ b/generated/aws_pinpoint_email_api/lib/pinpoint-email-2018-07-26.dart
@@ -94,7 +94,6 @@ class PinpointEmail {
     List<Tag>? tags,
     TrackingOptions? trackingOptions,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       'ConfigurationSetName': configurationSetName,
       if (deliveryOptions != null) 'DeliveryOptions': deliveryOptions,
@@ -141,9 +140,6 @@ class PinpointEmail {
     required EventDestinationDefinition eventDestination,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $payload = <String, dynamic>{
       'EventDestination': eventDestination,
       'EventDestinationName': eventDestinationName,
@@ -179,7 +175,6 @@ class PinpointEmail {
     required String poolName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
     final $payload = <String, dynamic>{
       'PoolName': poolName,
       if (tags != null) 'Tags': tags,
@@ -234,8 +229,6 @@ class PinpointEmail {
     String? reportName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(fromEmailAddress, 'fromEmailAddress');
     final $payload = <String, dynamic>{
       'Content': content,
       'FromEmailAddress': fromEmailAddress,
@@ -284,7 +277,6 @@ class PinpointEmail {
     required String emailIdentity,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final $payload = <String, dynamic>{
       'EmailIdentity': emailIdentity,
       if (tags != null) 'Tags': tags,
@@ -316,7 +308,6 @@ class PinpointEmail {
   Future<void> deleteConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -349,8 +340,6 @@ class PinpointEmail {
     required String configurationSetName,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -372,7 +361,6 @@ class PinpointEmail {
   Future<void> deleteDedicatedIpPool({
     required String poolName,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -396,7 +384,6 @@ class PinpointEmail {
   Future<void> deleteEmailIdentity({
     required String emailIdentity,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -434,7 +421,6 @@ class PinpointEmail {
   Future<GetBlacklistReportsResponse> getBlacklistReports({
     required List<String> blacklistItemNames,
   }) async {
-    ArgumentError.checkNotNull(blacklistItemNames, 'blacklistItemNames');
     final $query = <String, List<String>>{
       'BlacklistItemNames': blacklistItemNames,
     };
@@ -468,7 +454,6 @@ class PinpointEmail {
   Future<GetConfigurationSetResponse> getConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -499,7 +484,6 @@ class PinpointEmail {
       getConfigurationSetEventDestinations({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -525,7 +509,6 @@ class PinpointEmail {
   Future<GetDedicatedIpResponse> getDedicatedIp({
     required String ip,
   }) async {
-    ArgumentError.checkNotNull(ip, 'ip');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -613,7 +596,6 @@ class PinpointEmail {
   Future<GetDeliverabilityTestReportResponse> getDeliverabilityTestReport({
     required String reportId,
   }) async {
-    ArgumentError.checkNotNull(reportId, 'reportId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -643,7 +625,6 @@ class PinpointEmail {
       getDomainDeliverabilityCampaign({
     required String campaignId,
   }) async {
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -677,9 +658,6 @@ class PinpointEmail {
     required DateTime endDate,
     required DateTime startDate,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    ArgumentError.checkNotNull(endDate, 'endDate');
-    ArgumentError.checkNotNull(startDate, 'startDate');
     final $query = <String, List<String>>{
       'EndDate': [_s.iso8601ToJson(endDate).toString()],
       'StartDate': [_s.iso8601ToJson(startDate).toString()],
@@ -708,7 +686,6 @@ class PinpointEmail {
   Future<GetEmailIdentityResponse> getEmailIdentity({
     required String emailIdentity,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -873,9 +850,6 @@ class PinpointEmail {
     String? nextToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(endDate, 'endDate');
-    ArgumentError.checkNotNull(startDate, 'startDate');
-    ArgumentError.checkNotNull(subscribedDomain, 'subscribedDomain');
     final $query = <String, List<String>>{
       'EndDate': [_s.iso8601ToJson(endDate).toString()],
       'StartDate': [_s.iso8601ToJson(startDate).toString()],
@@ -948,7 +922,6 @@ class PinpointEmail {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $query = <String, List<String>>{
       'ResourceArn': [resourceArn],
     };
@@ -1041,7 +1014,6 @@ class PinpointEmail {
     String? sendingPoolName,
     TlsPolicy? tlsPolicy,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (sendingPoolName != null) 'SendingPoolName': sendingPoolName,
       if (tlsPolicy != null) 'TlsPolicy': tlsPolicy.toValue(),
@@ -1074,7 +1046,6 @@ class PinpointEmail {
     required String configurationSetName,
     bool? reputationMetricsEnabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (reputationMetricsEnabled != null)
         'ReputationMetricsEnabled': reputationMetricsEnabled,
@@ -1107,7 +1078,6 @@ class PinpointEmail {
     required String configurationSetName,
     bool? sendingEnabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (sendingEnabled != null) 'SendingEnabled': sendingEnabled,
     };
@@ -1137,7 +1107,6 @@ class PinpointEmail {
     required String configurationSetName,
     String? customRedirectDomain,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (customRedirectDomain != null)
         'CustomRedirectDomain': customRedirectDomain,
@@ -1176,8 +1145,6 @@ class PinpointEmail {
     required String destinationPoolName,
     required String ip,
   }) async {
-    ArgumentError.checkNotNull(destinationPoolName, 'destinationPoolName');
-    ArgumentError.checkNotNull(ip, 'ip');
     final $payload = <String, dynamic>{
       'DestinationPoolName': destinationPoolName,
     };
@@ -1206,8 +1173,6 @@ class PinpointEmail {
     required String ip,
     required int warmupPercentage,
   }) async {
-    ArgumentError.checkNotNull(ip, 'ip');
-    ArgumentError.checkNotNull(warmupPercentage, 'warmupPercentage');
     final $payload = <String, dynamic>{
       'WarmupPercentage': warmupPercentage,
     };
@@ -1250,7 +1215,6 @@ class PinpointEmail {
     required bool dashboardEnabled,
     List<DomainDeliverabilityTrackingOption>? subscribedDomains,
   }) async {
-    ArgumentError.checkNotNull(dashboardEnabled, 'dashboardEnabled');
     final $payload = <String, dynamic>{
       'DashboardEnabled': dashboardEnabled,
       if (subscribedDomains != null) 'SubscribedDomains': subscribedDomains,
@@ -1283,7 +1247,6 @@ class PinpointEmail {
     required String emailIdentity,
     bool? signingEnabled,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final $payload = <String, dynamic>{
       if (signingEnabled != null) 'SigningEnabled': signingEnabled,
     };
@@ -1339,7 +1302,6 @@ class PinpointEmail {
     required String emailIdentity,
     bool? emailForwardingEnabled,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final $payload = <String, dynamic>{
       if (emailForwardingEnabled != null)
         'EmailForwardingEnabled': emailForwardingEnabled,
@@ -1398,7 +1360,6 @@ class PinpointEmail {
     BehaviorOnMxFailure? behaviorOnMxFailure,
     String? mailFromDomain,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
     final $payload = <String, dynamic>{
       if (behaviorOnMxFailure != null)
         'BehaviorOnMxFailure': behaviorOnMxFailure.toValue(),
@@ -1476,8 +1437,6 @@ class PinpointEmail {
     String? fromEmailAddress,
     List<String>? replyToAddresses,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(destination, 'destination');
     final $payload = <String, dynamic>{
       'Content': content,
       'Destination': destination,
@@ -1527,8 +1486,6 @@ class PinpointEmail {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'Tags': tags,
@@ -1565,8 +1522,6 @@ class PinpointEmail {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'ResourceArn': [resourceArn],
       'TagKeys': tagKeys,
@@ -1607,9 +1562,6 @@ class PinpointEmail {
     required EventDestinationDefinition eventDestination,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $payload = <String, dynamic>{
       'EventDestination': eventDestination,
     };

--- a/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
+++ b/generated/aws_pinpoint_sms_voice_api/lib/pinpoint-sms-voice-2018-09-05.dart
@@ -93,7 +93,6 @@ class PinpointSMSVoice {
     EventDestinationDefinition? eventDestination,
     String? eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (eventDestination != null) 'EventDestination': eventDestination,
       if (eventDestinationName != null)
@@ -120,7 +119,6 @@ class PinpointSMSVoice {
   Future<void> deleteConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -146,8 +144,6 @@ class PinpointSMSVoice {
     required String configurationSetName,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -172,7 +168,6 @@ class PinpointSMSVoice {
       getConfigurationSetEventDestinations({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -283,8 +278,6 @@ class PinpointSMSVoice {
     required String eventDestinationName,
     EventDestinationDefinition? eventDestination,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $payload = <String, dynamic>{
       if (eventDestination != null) 'EventDestination': eventDestination,
     };

--- a/generated/aws_polly_api/lib/polly-2016-06-10.dart
+++ b/generated/aws_polly_api/lib/polly-2016-06-10.dart
@@ -71,7 +71,6 @@ class Polly {
   Future<void> deleteLexicon({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -131,12 +130,6 @@ class Polly {
     LanguageCode? languageCode,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
-    );
     final $query = <String, List<String>>{
       if (engine != null) 'Engine': [engine.toValue()],
       if (includeAdditionalLanguageCodes != null)
@@ -169,7 +162,6 @@ class Polly {
   Future<GetLexiconOutput> getLexicon({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -193,7 +185,6 @@ class Polly {
   Future<GetSpeechSynthesisTaskOutput> getSpeechSynthesisTask({
     required String taskId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -218,12 +209,6 @@ class Polly {
   Future<ListLexiconsOutput> listLexicons({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
-    );
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
     };
@@ -263,12 +248,6 @@ class Polly {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'MaxResults': [maxResults.toString()],
@@ -314,8 +293,6 @@ class Polly {
     required String content,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'Content': content,
     };
@@ -423,10 +400,6 @@ class Polly {
     List<SpeechMarkType>? speechMarkTypes,
     TextType? textType,
   }) async {
-    ArgumentError.checkNotNull(outputFormat, 'outputFormat');
-    ArgumentError.checkNotNull(outputS3BucketName, 'outputS3BucketName');
-    ArgumentError.checkNotNull(text, 'text');
-    ArgumentError.checkNotNull(voiceId, 'voiceId');
     final $payload = <String, dynamic>{
       'OutputFormat': outputFormat.toValue(),
       'OutputS3BucketName': outputS3BucketName,
@@ -562,9 +535,6 @@ class Polly {
     List<SpeechMarkType>? speechMarkTypes,
     TextType? textType,
   }) async {
-    ArgumentError.checkNotNull(outputFormat, 'outputFormat');
-    ArgumentError.checkNotNull(text, 'text');
-    ArgumentError.checkNotNull(voiceId, 'voiceId');
     final $payload = <String, dynamic>{
       'OutputFormat': outputFormat.toValue(),
       'Text': text,

--- a/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
+++ b/generated/aws_pricing_api/lib/pricing-2017-10-15.dart
@@ -178,8 +178,6 @@ class Pricing {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
     _s.validateNumRange(
       'maxResults',
       maxResults,

--- a/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
+++ b/generated/aws_qldb_api/lib/qldb-2019-01-02.dart
@@ -68,22 +68,6 @@ class QLDB {
     required String ledgerName,
     required String streamId,
   }) async {
-    ArgumentError.checkNotNull(ledgerName, 'ledgerName');
-    _s.validateStringLength(
-      'ledgerName',
-      ledgerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      22,
-      22,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -133,15 +117,6 @@ class QLDB {
     bool? deletionProtection,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionsMode, 'permissionsMode');
     final $payload = <String, dynamic>{
       'Name': name,
       'PermissionsMode': permissionsMode.toValue(),
@@ -175,14 +150,6 @@ class QLDB {
   Future<void> deleteLedger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -209,22 +176,6 @@ class QLDB {
     required String ledgerName,
     required String streamId,
   }) async {
-    ArgumentError.checkNotNull(ledgerName, 'ledgerName');
-    _s.validateStringLength(
-      'ledgerName',
-      ledgerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamId, 'streamId');
-    _s.validateStringLength(
-      'streamId',
-      streamId,
-      22,
-      22,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -261,22 +212,6 @@ class QLDB {
     required String exportId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(exportId, 'exportId');
-    _s.validateStringLength(
-      'exportId',
-      exportId,
-      22,
-      22,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -298,14 +233,6 @@ class QLDB {
   Future<DescribeLedgerResponse> describeLedger({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -385,25 +312,6 @@ class QLDB {
     required String roleArn,
     required S3ExportConfiguration s3ExportConfiguration,
   }) async {
-    ArgumentError.checkNotNull(exclusiveEndTime, 'exclusiveEndTime');
-    ArgumentError.checkNotNull(inclusiveStartTime, 'inclusiveStartTime');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3ExportConfiguration, 's3ExportConfiguration');
     final $payload = <String, dynamic>{
       'ExclusiveEndTime': unixTimestampToJson(exclusiveEndTime),
       'InclusiveStartTime': unixTimestampToJson(inclusiveStartTime),
@@ -463,15 +371,6 @@ class QLDB {
     required String name,
     ValueHolder? digestTipAddress,
   }) async {
-    ArgumentError.checkNotNull(blockAddress, 'blockAddress');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'BlockAddress': blockAddress,
       if (digestTipAddress != null) 'DigestTipAddress': digestTipAddress,
@@ -497,14 +396,6 @@ class QLDB {
   Future<GetDigestResponse> getDigest({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -549,23 +440,6 @@ class QLDB {
     required String name,
     ValueHolder? digestTipAddress,
   }) async {
-    ArgumentError.checkNotNull(blockAddress, 'blockAddress');
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      22,
-      22,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'BlockAddress': blockAddress,
       'DocumentId': documentId,
@@ -611,25 +485,11 @@ class QLDB {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(ledgerName, 'ledgerName');
-    _s.validateStringLength(
-      'ledgerName',
-      ledgerName,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -678,12 +538,6 @@ class QLDB {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
       if (nextToken != null) 'next_token': [nextToken],
@@ -728,25 +582,11 @@ class QLDB {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
     );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
@@ -789,12 +629,6 @@ class QLDB {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      4,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'max_results': [maxResults.toString()],
       if (nextToken != null) 'next_token': [nextToken],
@@ -822,14 +656,6 @@ class QLDB {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -904,32 +730,6 @@ class QLDB {
     DateTime? exclusiveEndTime,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(inclusiveStartTime, 'inclusiveStartTime');
-    ArgumentError.checkNotNull(kinesisConfiguration, 'kinesisConfiguration');
-    ArgumentError.checkNotNull(ledgerName, 'ledgerName');
-    _s.validateStringLength(
-      'ledgerName',
-      ledgerName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(streamName, 'streamName');
-    _s.validateStringLength(
-      'streamName',
-      streamName,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'InclusiveStartTime': unixTimestampToJson(inclusiveStartTime),
       'KinesisConfiguration': kinesisConfiguration,
@@ -972,15 +772,6 @@ class QLDB {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1010,15 +801,6 @@ class QLDB {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1053,14 +835,6 @@ class QLDB {
     required String name,
     bool? deletionProtection,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (deletionProtection != null) 'DeletionProtection': deletionProtection,
     };

--- a/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
+++ b/generated/aws_qldb_session_api/lib/qldb-session-2019-07-11.dart
@@ -137,12 +137,6 @@ class QLDBSession {
     StartSessionRequest? startSession,
     StartTransactionRequest? startTransaction,
   }) async {
-    _s.validateStringLength(
-      'sessionToken',
-      sessionToken,
-      4,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'QLDBSession.SendCommand'

--- a/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
+++ b/generated/aws_quicksight_api/lib/quicksight-2018-04-01.dart
@@ -72,23 +72,6 @@ class QuickSight {
     required String dataSetId,
     required String ingestionId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(ingestionId, 'ingestionId');
-    _s.validateStringLength(
-      'ingestionId',
-      ingestionId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -157,21 +140,6 @@ class QuickSight {
     String? namespace,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountCustomization, 'accountCustomization');
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespace != null) 'namespace': [namespace],
     };
@@ -248,31 +216,6 @@ class QuickSight {
     List<Tag>? tags,
     String? themeArn,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
     final $payload = <String, dynamic>{
       'Name': name,
       'SourceEntity': sourceEntity,
@@ -393,37 +336,6 @@ class QuickSight {
     String? themeArn,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'SourceEntity': sourceEntity,
@@ -508,25 +420,6 @@ class QuickSight {
     RowLevelPermissionDataSet? rowLevelPermissionDataSet,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(importMode, 'importMode');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(physicalTableMap, 'physicalTableMap');
     final $payload = <String, dynamic>{
       'DataSetId': dataSetId,
       'ImportMode': importMode.toValue(),
@@ -611,24 +504,6 @@ class QuickSight {
     List<Tag>? tags,
     VpcConnectionProperties? vpcConnectionProperties,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'DataSourceId': dataSourceId,
       'Name': name,
@@ -687,36 +562,6 @@ class QuickSight {
     required String namespace,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'GroupName': groupName,
       if (description != null) 'Description': description,
@@ -759,38 +604,6 @@ class QuickSight {
     required String memberName,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberName, 'memberName');
-    _s.validateStringLength(
-      'memberName',
-      memberName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -859,31 +672,6 @@ class QuickSight {
     Map<String, List<String>>? identities,
     String? policyArn,
   }) async {
-    ArgumentError.checkNotNull(assignmentName, 'assignmentName');
-    _s.validateStringLength(
-      'assignmentName',
-      assignmentName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(assignmentStatus, 'assignmentStatus');
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'AssignmentName': assignmentName,
       'AssignmentStatus': assignmentStatus.toValue(),
@@ -930,23 +718,6 @@ class QuickSight {
     required String dataSetId,
     required String ingestionId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(ingestionId, 'ingestionId');
-    _s.validateStringLength(
-      'ingestionId',
-      ingestionId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'PUT',
@@ -999,23 +770,6 @@ class QuickSight {
     required String namespace,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityStore, 'identityStore');
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'IdentityStore': identityStore.toValue(),
       'Namespace': namespace,
@@ -1099,35 +853,6 @@ class QuickSight {
     List<Tag>? tags,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'SourceEntity': sourceEntity,
       if (name != null) 'Name': name,
@@ -1176,31 +901,6 @@ class QuickSight {
     required String templateId,
     required int templateVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateVersionNumber, 'templateVersionNumber');
     _s.validateNumRange(
       'templateVersionNumber',
       templateVersionNumber,
@@ -1279,45 +979,6 @@ class QuickSight {
     List<Tag>? tags,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(baseThemeId, 'baseThemeId');
-    _s.validateStringLength(
-      'baseThemeId',
-      baseThemeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configuration, 'configuration');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'BaseThemeId': baseThemeId,
       'Configuration': configuration,
@@ -1366,31 +1027,6 @@ class QuickSight {
     required String themeId,
     required int themeVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeVersionNumber, 'themeVersionNumber');
     _s.validateNumRange(
       'themeVersionNumber',
       themeVersionNumber,
@@ -1431,20 +1067,6 @@ class QuickSight {
     required String awsAccountId,
     String? namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespace != null) 'namespace': [namespace],
     };
@@ -1506,22 +1128,6 @@ class QuickSight {
     bool? forceDeleteWithoutRecovery,
     int? recoveryWindowInDays,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'recoveryWindowInDays',
       recoveryWindowInDays,
@@ -1571,22 +1177,6 @@ class QuickSight {
     required String dashboardId,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -1625,15 +1215,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSetId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1663,15 +1244,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSourceId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1706,30 +1278,6 @@ class QuickSight {
     required String groupName,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1769,38 +1317,6 @@ class QuickSight {
     required String memberName,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberName, 'memberName');
-    _s.validateStringLength(
-      'memberName',
-      memberName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1834,30 +1350,6 @@ class QuickSight {
     required String awsAccountId,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(assignmentName, 'assignmentName');
-    _s.validateStringLength(
-      'assignmentName',
-      assignmentName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1891,22 +1383,6 @@ class QuickSight {
     required String awsAccountId,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1942,22 +1418,6 @@ class QuickSight {
     required String templateId,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -2004,30 +1464,6 @@ class QuickSight {
     required String awsAccountId,
     required String templateId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2064,22 +1500,6 @@ class QuickSight {
     required String themeId,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -2124,30 +1544,6 @@ class QuickSight {
     required String awsAccountId,
     required String themeId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2184,30 +1580,6 @@ class QuickSight {
     required String namespace,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2242,23 +1614,6 @@ class QuickSight {
     required String namespace,
     required String principalId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalId, 'principalId');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -2361,20 +1716,6 @@ class QuickSight {
     String? namespace,
     bool? resolved,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespace != null) 'namespace': [namespace],
       if (resolved != null) 'resolved': [resolved.toString()],
@@ -2406,14 +1747,6 @@ class QuickSight {
   Future<DescribeAccountSettingsResponse> describeAccountSettings({
     required String awsAccountId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2443,22 +1776,6 @@ class QuickSight {
     required String analysisId,
     required String awsAccountId,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2489,22 +1806,6 @@ class QuickSight {
     required String analysisId,
     required String awsAccountId,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2543,28 +1844,6 @@ class QuickSight {
     String? aliasName,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -2604,22 +1883,6 @@ class QuickSight {
     required String awsAccountId,
     required String dashboardId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2648,15 +1911,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSetId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2688,15 +1942,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSetId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2725,15 +1970,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSourceId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2762,15 +1998,6 @@ class QuickSight {
     required String awsAccountId,
     required String dataSourceId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2806,30 +2033,6 @@ class QuickSight {
     required String groupName,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2864,30 +2067,6 @@ class QuickSight {
     required String awsAccountId,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(assignmentName, 'assignmentName');
-    _s.validateStringLength(
-      'assignmentName',
-      assignmentName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2920,23 +2099,6 @@ class QuickSight {
     required String dataSetId,
     required String ingestionId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(ingestionId, 'ingestionId');
-    _s.validateStringLength(
-      'ingestionId',
-      ingestionId,
-      1,
-      128,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2966,22 +2128,6 @@ class QuickSight {
     required String awsAccountId,
     required String namespace,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3027,28 +2173,6 @@ class QuickSight {
     String? aliasName,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -3095,30 +2219,6 @@ class QuickSight {
     required String awsAccountId,
     required String templateId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3148,22 +2248,6 @@ class QuickSight {
     required String awsAccountId,
     required String templateId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3207,21 +2291,6 @@ class QuickSight {
     String? aliasName,
     int? versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-    );
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -3266,30 +2335,6 @@ class QuickSight {
     required String awsAccountId,
     required String themeId,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3318,22 +2363,6 @@ class QuickSight {
     required String awsAccountId,
     required String themeId,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3368,30 +2397,6 @@ class QuickSight {
     required String namespace,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -3521,29 +2526,6 @@ class QuickSight {
     bool? undoRedoDisabled,
     String? userArn,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-    );
     _s.validateNumRange(
       'sessionLifetimeInMinutes',
       sessionLifetimeInMinutes,
@@ -3670,20 +2652,6 @@ class QuickSight {
     int? sessionLifetimeInMinutes,
     String? userArn,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'entryPoint',
-      entryPoint,
-      1,
-      1000,
-    );
     _s.validateNumRange(
       'sessionLifetimeInMinutes',
       sessionLifetimeInMinutes,
@@ -3727,14 +2695,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3783,22 +2743,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3842,14 +2786,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3896,14 +2832,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3946,14 +2874,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4007,30 +2927,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4081,22 +2977,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4149,22 +3029,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4221,30 +3085,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4294,15 +3134,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4349,14 +3180,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4391,7 +3214,6 @@ class QuickSight {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -4428,22 +3250,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4493,22 +3299,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4553,14 +3343,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4610,22 +3392,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4675,22 +3441,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4755,14 +3505,6 @@ class QuickSight {
     String? nextToken,
     ThemeType? type,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4818,30 +3560,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4893,22 +3611,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5059,43 +3761,6 @@ class QuickSight {
     String? sessionName,
     String? userName,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(email, 'email');
-    ArgumentError.checkNotNull(identityType, 'identityType');
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userRole, 'userRole');
-    _s.validateStringLength(
-      'customPermissionsName',
-      customPermissionsName,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'sessionName',
-      sessionName,
-      2,
-      64,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-    );
     final $payload = <String, dynamic>{
       'Email': email,
       'IdentityType': identityType.toValue(),
@@ -5134,22 +3799,6 @@ class QuickSight {
     required String analysisId,
     required String awsAccountId,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -5188,15 +3837,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filters, 'filters');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5249,15 +3889,6 @@ class QuickSight {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(filters, 'filters');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5326,8 +3957,6 @@ class QuickSight {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -5358,8 +3987,6 @@ class QuickSight {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'keys': tagKeys,
     };
@@ -5403,21 +4030,6 @@ class QuickSight {
     required String awsAccountId,
     String? namespace,
   }) async {
-    ArgumentError.checkNotNull(accountCustomization, 'accountCustomization');
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (namespace != null) 'namespace': [namespace],
     };
@@ -5462,22 +4074,6 @@ class QuickSight {
     required String defaultNamespace,
     String? notificationEmail,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(defaultNamespace, 'defaultNamespace');
-    _s.validateStringLength(
-      'defaultNamespace',
-      defaultNamespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DefaultNamespace': defaultNamespace,
       if (notificationEmail != null) 'NotificationEmail': notificationEmail,
@@ -5534,31 +4130,6 @@ class QuickSight {
     Parameters? parameters,
     String? themeArn,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
     final $payload = <String, dynamic>{
       'Name': name,
       'SourceEntity': sourceEntity,
@@ -5606,22 +4177,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(analysisId, 'analysisId');
-    _s.validateStringLength(
-      'analysisId',
-      analysisId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -5719,37 +4274,6 @@ class QuickSight {
     String? themeArn,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       'SourceEntity': sourceEntity,
@@ -5796,22 +4320,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -5850,23 +4358,6 @@ class QuickSight {
     required String dashboardId,
     required int versionNumber,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dashboardId, 'dashboardId');
-    _s.validateStringLength(
-      'dashboardId',
-      dashboardId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionNumber, 'versionNumber');
     _s.validateNumRange(
       'versionNumber',
       versionNumber,
@@ -5937,25 +4428,6 @@ class QuickSight {
     Map<String, LogicalTable>? logicalTableMap,
     RowLevelPermissionDataSet? rowLevelPermissionDataSet,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
-    ArgumentError.checkNotNull(importMode, 'importMode');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(physicalTableMap, 'physicalTableMap');
     final $payload = <String, dynamic>{
       'ImportMode': importMode.toValue(),
       'Name': name,
@@ -6007,15 +4479,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSetId, 'dataSetId');
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -6073,23 +4536,6 @@ class QuickSight {
     SslProperties? sslProperties,
     VpcConnectionProperties? vpcConnectionProperties,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (credentials != null) 'Credentials': credentials,
@@ -6136,15 +4582,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dataSourceId, 'dataSourceId');
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -6187,36 +4624,6 @@ class QuickSight {
     required String namespace,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
     };
@@ -6285,30 +4692,6 @@ class QuickSight {
     Map<String, List<String>>? identities,
     String? policyArn,
   }) async {
-    ArgumentError.checkNotNull(assignmentName, 'assignmentName');
-    _s.validateStringLength(
-      'assignmentName',
-      assignmentName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (assignmentStatus != null)
         'AssignmentStatus': assignmentStatus.toValue(),
@@ -6373,35 +4756,6 @@ class QuickSight {
     String? name,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceEntity, 'sourceEntity');
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'SourceEntity': sourceEntity,
       if (name != null) 'Name': name,
@@ -6448,31 +4802,6 @@ class QuickSight {
     required String templateId,
     required int templateVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateVersionNumber, 'templateVersionNumber');
     _s.validateNumRange(
       'templateVersionNumber',
       templateVersionNumber,
@@ -6519,22 +4848,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateId, 'templateId');
-    _s.validateStringLength(
-      'templateId',
-      templateId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -6589,42 +4902,6 @@ class QuickSight {
     String? name,
     String? versionDescription,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(baseThemeId, 'baseThemeId');
-    _s.validateStringLength(
-      'baseThemeId',
-      baseThemeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'versionDescription',
-      versionDescription,
-      1,
-      512,
-    );
     final $payload = <String, dynamic>{
       'BaseThemeId': baseThemeId,
       if (configuration != null) 'Configuration': configuration,
@@ -6669,31 +4946,6 @@ class QuickSight {
     required String themeId,
     required int themeVersionNumber,
   }) async {
-    ArgumentError.checkNotNull(aliasName, 'aliasName');
-    _s.validateStringLength(
-      'aliasName',
-      aliasName,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeVersionNumber, 'themeVersionNumber');
     _s.validateNumRange(
       'themeVersionNumber',
       themeVersionNumber,
@@ -6807,22 +5059,6 @@ class QuickSight {
     List<ResourcePermission>? grantPermissions,
     List<ResourcePermission>? revokePermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(themeId, 'themeId');
-    _s.validateStringLength(
-      'themeId',
-      themeId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (grantPermissions != null) 'GrantPermissions': grantPermissions,
       if (revokePermissions != null) 'RevokePermissions': revokePermissions,
@@ -6927,38 +5163,6 @@ class QuickSight {
     String? customPermissionsName,
     bool? unapplyCustomPermissions,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    _s.validateStringLength(
-      'awsAccountId',
-      awsAccountId,
-      12,
-      12,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(email, 'email');
-    ArgumentError.checkNotNull(namespace, 'namespace');
-    _s.validateStringLength(
-      'namespace',
-      namespace,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'customPermissionsName',
-      customPermissionsName,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'Email': email,
       'Role': role.toValue(),

--- a/generated/aws_ram_api/lib/ram-2018-01-04.dart
+++ b/generated/aws_ram_api/lib/ram-2018-01-04.dart
@@ -79,8 +79,6 @@ class RAM {
     required String resourceShareInvitationArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(
-        resourceShareInvitationArn, 'resourceShareInvitationArn');
     final $payload = <String, dynamic>{
       'resourceShareInvitationArn': resourceShareInvitationArn,
       if (clientToken != null) 'clientToken': clientToken,
@@ -128,7 +126,6 @@ class RAM {
     List<String>? principals,
     List<String>? resourceArns,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $payload = <String, dynamic>{
       'resourceShareArn': resourceShareArn,
       if (clientToken != null) 'clientToken': clientToken,
@@ -176,8 +173,6 @@ class RAM {
     String? clientToken,
     bool? replace,
   }) async {
-    ArgumentError.checkNotNull(permissionArn, 'permissionArn');
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $payload = <String, dynamic>{
       'permissionArn': permissionArn,
       'resourceShareArn': resourceShareArn,
@@ -243,7 +238,6 @@ class RAM {
     List<String>? resourceArns,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'name': name,
       if (allowExternalPrincipals != null)
@@ -285,7 +279,6 @@ class RAM {
     required String resourceShareArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $query = <String, List<String>>{
       'resourceShareArn': [resourceShareArn],
       if (clientToken != null) 'clientToken': [clientToken],
@@ -332,7 +325,6 @@ class RAM {
     List<String>? principals,
     List<String>? resourceArns,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $payload = <String, dynamic>{
       'resourceShareArn': resourceShareArn,
       if (clientToken != null) 'clientToken': clientToken,
@@ -373,8 +365,6 @@ class RAM {
     required String resourceShareArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(permissionArn, 'permissionArn');
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $payload = <String, dynamic>{
       'permissionArn': permissionArn,
       'resourceShareArn': resourceShareArn,
@@ -425,7 +415,6 @@ class RAM {
     required String permissionArn,
     int? permissionVersion,
   }) async {
-    ArgumentError.checkNotNull(permissionArn, 'permissionArn');
     final $payload = <String, dynamic>{
       'permissionArn': permissionArn,
       if (permissionVersion != null) 'permissionVersion': permissionVersion,
@@ -468,7 +457,6 @@ class RAM {
     String? nextToken,
     String? principal,
   }) async {
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -536,7 +524,6 @@ class RAM {
     String? resourceArn,
     List<String>? resourceShareArns,
   }) async {
-    ArgumentError.checkNotNull(associationType, 'associationType');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -655,7 +642,6 @@ class RAM {
     ResourceShareStatus? resourceShareStatus,
     List<TagFilter>? tagFilters,
   }) async {
-    ArgumentError.checkNotNull(resourceOwner, 'resourceOwner');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -710,8 +696,6 @@ class RAM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        resourceShareInvitationArn, 'resourceShareInvitationArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -828,7 +812,6 @@ class RAM {
     List<String>? resourceShareArns,
     String? resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceOwner, 'resourceOwner');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -878,7 +861,6 @@ class RAM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -988,7 +970,6 @@ class RAM {
     List<String>? resourceShareArns,
     String? resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceOwner, 'resourceOwner');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1043,7 +1024,6 @@ class RAM {
       promoteResourceShareCreatedFromPolicy({
     required String resourceShareArn,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $query = <String, List<String>>{
       'resourceShareArn': [resourceShareArn],
     };
@@ -1080,8 +1060,6 @@ class RAM {
     required String resourceShareInvitationArn,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(
-        resourceShareInvitationArn, 'resourceShareInvitationArn');
     final $payload = <String, dynamic>{
       'resourceShareInvitationArn': resourceShareInvitationArn,
       if (clientToken != null) 'clientToken': clientToken,
@@ -1114,8 +1092,6 @@ class RAM {
     required String resourceShareArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'resourceShareArn': resourceShareArn,
       'tags': tags,
@@ -1143,8 +1119,6 @@ class RAM {
     required String resourceShareArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'resourceShareArn': resourceShareArn,
       'tagKeys': tagKeys,
@@ -1188,7 +1162,6 @@ class RAM {
     String? clientToken,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(resourceShareArn, 'resourceShareArn');
     final $payload = <String, dynamic>{
       'resourceShareArn': resourceShareArn,
       if (allowExternalPrincipals != null)

--- a/generated/aws_rds_api/lib/rds-2013-01-10.dart
+++ b/generated/aws_rds_api/lib/rds-2013-01-10.dart
@@ -59,8 +59,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -85,8 +83,6 @@ class RDS {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -115,7 +111,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -146,10 +141,6 @@ class RDS {
     required String sourceDBSnapshotIdentifier,
     required String targetDBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBSnapshotIdentifier, 'sourceDBSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBSnapshotIdentifier, 'targetDBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBSnapshotIdentifier'] = sourceDBSnapshotIdentifier;
     $request['TargetDBSnapshotIdentifier'] = targetDBSnapshotIdentifier;
@@ -206,12 +197,6 @@ class RDS {
     bool? publiclyAccessible,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(allocatedStorage, 'allocatedStorage');
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
     final $request = <String, dynamic>{};
     $request['AllocatedStorage'] = allocatedStorage;
     $request['DBInstanceClass'] = dBInstanceClass;
@@ -281,9 +266,6 @@ class RDS {
     int? port,
     bool? publiclyAccessible,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
@@ -317,10 +299,6 @@ class RDS {
     required String dBParameterGroupName,
     required String description,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -347,9 +325,6 @@ class RDS {
     required String dBSecurityGroupDescription,
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSecurityGroupDescription, 'dBSecurityGroupDescription');
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupDescription'] = dBSecurityGroupDescription;
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
@@ -376,8 +351,6 @@ class RDS {
     required String dBInstanceIdentifier,
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -406,10 +379,6 @@ class RDS {
     required String dBSubnetGroupName,
     required List<String> subnetIds,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -444,8 +413,6 @@ class RDS {
     List<String>? sourceIds,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -476,11 +443,6 @@ class RDS {
     required String optionGroupDescription,
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
-    ArgumentError.checkNotNull(majorEngineVersion, 'majorEngineVersion');
-    ArgumentError.checkNotNull(
-        optionGroupDescription, 'optionGroupDescription');
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     $request['MajorEngineVersion'] = majorEngineVersion;
@@ -510,7 +472,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     finalDBSnapshotIdentifier
@@ -536,7 +497,6 @@ class RDS {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -557,7 +517,6 @@ class RDS {
   Future<void> deleteDBSecurityGroup({
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     await _protocol.send(
@@ -578,7 +537,6 @@ class RDS {
   Future<DeleteDBSnapshotResult> deleteDBSnapshot({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -602,7 +560,6 @@ class RDS {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -623,7 +580,6 @@ class RDS {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -646,7 +602,6 @@ class RDS {
   Future<void> deleteOptionGroup({
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     await _protocol.send(
@@ -752,7 +707,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -857,8 +811,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -960,7 +912,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     majorEngineVersion?.also((arg) => $request['MajorEngineVersion'] = arg);
@@ -1018,7 +969,6 @@ class RDS {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -1122,7 +1072,6 @@ class RDS {
   Future<TagListMessage> listTagsForResource({
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     final $result = await _protocol.send(
@@ -1172,7 +1121,6 @@ class RDS {
     String? preferredMaintenanceWindow,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -1219,8 +1167,6 @@ class RDS {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -1249,8 +1195,6 @@ class RDS {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -1284,7 +1228,6 @@ class RDS {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -1314,7 +1257,6 @@ class RDS {
     List<OptionConfiguration>? optionsToInclude,
     List<String>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -1342,7 +1284,6 @@ class RDS {
     int? backupRetentionPeriod,
     String? preferredBackupWindow,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     backupRetentionPeriod
@@ -1373,8 +1314,6 @@ class RDS {
     int? dBInstanceCount,
     String? reservedDBInstanceId,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedDBInstancesOfferingId, 'reservedDBInstancesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedDBInstancesOfferingId'] = reservedDBInstancesOfferingId;
     dBInstanceCount?.also((arg) => $request['DBInstanceCount'] = arg);
@@ -1400,7 +1339,6 @@ class RDS {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -1426,8 +1364,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -1452,8 +1388,6 @@ class RDS {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -1477,7 +1411,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -1527,8 +1460,6 @@ class RDS {
     int? port,
     bool? publiclyAccessible,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -1592,10 +1523,6 @@ class RDS {
     DateTime? restoreTime,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBInstanceIdentifier, 'targetDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
     $request['TargetDBInstanceIdentifier'] = targetDBInstanceIdentifier;
@@ -1640,7 +1567,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);

--- a/generated/aws_rds_api/lib/rds-2013-02-12.dart
+++ b/generated/aws_rds_api/lib/rds-2013-02-12.dart
@@ -59,8 +59,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -85,8 +83,6 @@ class RDS {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -115,7 +111,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -146,10 +141,6 @@ class RDS {
     required String sourceDBSnapshotIdentifier,
     required String targetDBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBSnapshotIdentifier, 'sourceDBSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBSnapshotIdentifier, 'targetDBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBSnapshotIdentifier'] = sourceDBSnapshotIdentifier;
     $request['TargetDBSnapshotIdentifier'] = targetDBSnapshotIdentifier;
@@ -206,12 +197,6 @@ class RDS {
     bool? publiclyAccessible,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(allocatedStorage, 'allocatedStorage');
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
     final $request = <String, dynamic>{};
     $request['AllocatedStorage'] = allocatedStorage;
     $request['DBInstanceClass'] = dBInstanceClass;
@@ -281,9 +266,6 @@ class RDS {
     int? port,
     bool? publiclyAccessible,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
@@ -317,10 +299,6 @@ class RDS {
     required String dBParameterGroupName,
     required String description,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -347,9 +325,6 @@ class RDS {
     required String dBSecurityGroupDescription,
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSecurityGroupDescription, 'dBSecurityGroupDescription');
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupDescription'] = dBSecurityGroupDescription;
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
@@ -376,8 +351,6 @@ class RDS {
     required String dBInstanceIdentifier,
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -406,10 +379,6 @@ class RDS {
     required String dBSubnetGroupName,
     required List<String> subnetIds,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -444,8 +413,6 @@ class RDS {
     List<String>? sourceIds,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -476,11 +443,6 @@ class RDS {
     required String optionGroupDescription,
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
-    ArgumentError.checkNotNull(majorEngineVersion, 'majorEngineVersion');
-    ArgumentError.checkNotNull(
-        optionGroupDescription, 'optionGroupDescription');
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     $request['MajorEngineVersion'] = majorEngineVersion;
@@ -510,7 +472,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     finalDBSnapshotIdentifier
@@ -536,7 +497,6 @@ class RDS {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -557,7 +517,6 @@ class RDS {
   Future<void> deleteDBSecurityGroup({
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     await _protocol.send(
@@ -578,7 +537,6 @@ class RDS {
   Future<DeleteDBSnapshotResult> deleteDBSnapshot({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -602,7 +560,6 @@ class RDS {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -623,7 +580,6 @@ class RDS {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -646,7 +602,6 @@ class RDS {
   Future<void> deleteOptionGroup({
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     await _protocol.send(
@@ -729,7 +684,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     fileLastWritten?.also((arg) => $request['FileLastWritten'] = arg);
@@ -784,7 +738,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -889,8 +842,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -992,7 +943,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     majorEngineVersion?.also((arg) => $request['MajorEngineVersion'] = arg);
@@ -1050,7 +1000,6 @@ class RDS {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -1157,8 +1106,6 @@ class RDS {
     String? marker,
     int? numberOfLines,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(logFileName, 'logFileName');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['LogFileName'] = logFileName;
@@ -1184,7 +1131,6 @@ class RDS {
   Future<TagListMessage> listTagsForResource({
     required String resourceName,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     final $result = await _protocol.send(
@@ -1234,7 +1180,6 @@ class RDS {
     String? preferredMaintenanceWindow,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -1281,8 +1226,6 @@ class RDS {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -1311,8 +1254,6 @@ class RDS {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -1346,7 +1287,6 @@ class RDS {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -1376,7 +1316,6 @@ class RDS {
     List<OptionConfiguration>? optionsToInclude,
     List<String>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -1404,7 +1343,6 @@ class RDS {
     int? backupRetentionPeriod,
     String? preferredBackupWindow,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     backupRetentionPeriod
@@ -1435,8 +1373,6 @@ class RDS {
     int? dBInstanceCount,
     String? reservedDBInstanceId,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedDBInstancesOfferingId, 'reservedDBInstancesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedDBInstancesOfferingId'] = reservedDBInstancesOfferingId;
     dBInstanceCount?.also((arg) => $request['DBInstanceCount'] = arg);
@@ -1462,7 +1398,6 @@ class RDS {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -1488,8 +1423,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -1514,8 +1447,6 @@ class RDS {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -1539,7 +1470,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -1589,8 +1519,6 @@ class RDS {
     int? port,
     bool? publiclyAccessible,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -1654,10 +1582,6 @@ class RDS {
     DateTime? restoreTime,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBInstanceIdentifier, 'targetDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
     $request['TargetDBInstanceIdentifier'] = targetDBInstanceIdentifier;
@@ -1702,7 +1626,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);

--- a/generated/aws_rds_api/lib/rds-2013-09-09.dart
+++ b/generated/aws_rds_api/lib/rds-2013-09-09.dart
@@ -59,8 +59,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -85,8 +83,6 @@ class RDS {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -115,7 +111,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -147,10 +142,6 @@ class RDS {
     required String targetDBSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBSnapshotIdentifier, 'sourceDBSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBSnapshotIdentifier, 'targetDBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBSnapshotIdentifier'] = sourceDBSnapshotIdentifier;
     $request['TargetDBSnapshotIdentifier'] = targetDBSnapshotIdentifier;
@@ -209,12 +200,6 @@ class RDS {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(allocatedStorage, 'allocatedStorage');
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
     final $request = <String, dynamic>{};
     $request['AllocatedStorage'] = allocatedStorage;
     $request['DBInstanceClass'] = dBInstanceClass;
@@ -289,9 +274,6 @@ class RDS {
     bool? publiclyAccessible,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
@@ -328,10 +310,6 @@ class RDS {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -360,9 +338,6 @@ class RDS {
     required String dBSecurityGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSecurityGroupDescription, 'dBSecurityGroupDescription');
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupDescription'] = dBSecurityGroupDescription;
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
@@ -391,8 +366,6 @@ class RDS {
     required String dBSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -423,10 +396,6 @@ class RDS {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -463,8 +432,6 @@ class RDS {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -497,11 +464,6 @@ class RDS {
     required String optionGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
-    ArgumentError.checkNotNull(majorEngineVersion, 'majorEngineVersion');
-    ArgumentError.checkNotNull(
-        optionGroupDescription, 'optionGroupDescription');
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     $request['MajorEngineVersion'] = majorEngineVersion;
@@ -532,7 +494,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     finalDBSnapshotIdentifier
@@ -558,7 +519,6 @@ class RDS {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -579,7 +539,6 @@ class RDS {
   Future<void> deleteDBSecurityGroup({
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     await _protocol.send(
@@ -600,7 +559,6 @@ class RDS {
   Future<DeleteDBSnapshotResult> deleteDBSnapshot({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -624,7 +582,6 @@ class RDS {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -645,7 +602,6 @@ class RDS {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -668,7 +624,6 @@ class RDS {
   Future<void> deleteOptionGroup({
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     await _protocol.send(
@@ -756,7 +711,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     fileLastWritten?.also((arg) => $request['FileLastWritten'] = arg);
@@ -815,7 +769,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -928,8 +881,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1039,7 +990,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1101,7 +1051,6 @@ class RDS {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -1213,8 +1162,6 @@ class RDS {
     String? marker,
     int? numberOfLines,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(logFileName, 'logFileName');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['LogFileName'] = logFileName;
@@ -1241,7 +1188,6 @@ class RDS {
     required String resourceName,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1292,7 +1238,6 @@ class RDS {
     String? preferredMaintenanceWindow,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -1339,8 +1284,6 @@ class RDS {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -1369,8 +1312,6 @@ class RDS {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -1404,7 +1345,6 @@ class RDS {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -1434,7 +1374,6 @@ class RDS {
     List<OptionConfiguration>? optionsToInclude,
     List<String>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -1462,7 +1401,6 @@ class RDS {
     int? backupRetentionPeriod,
     String? preferredBackupWindow,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     backupRetentionPeriod
@@ -1494,8 +1432,6 @@ class RDS {
     String? reservedDBInstanceId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedDBInstancesOfferingId, 'reservedDBInstancesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedDBInstancesOfferingId'] = reservedDBInstancesOfferingId;
     dBInstanceCount?.also((arg) => $request['DBInstanceCount'] = arg);
@@ -1522,7 +1458,6 @@ class RDS {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -1548,8 +1483,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -1574,8 +1507,6 @@ class RDS {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -1599,7 +1530,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -1650,8 +1580,6 @@ class RDS {
     bool? publiclyAccessible,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -1717,10 +1645,6 @@ class RDS {
     List<Tag>? tags,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBInstanceIdentifier, 'targetDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
     $request['TargetDBInstanceIdentifier'] = targetDBInstanceIdentifier;
@@ -1766,7 +1690,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);

--- a/generated/aws_rds_api/lib/rds-2014-09-01.dart
+++ b/generated/aws_rds_api/lib/rds-2014-09-01.dart
@@ -59,8 +59,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -85,8 +83,6 @@ class RDS {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -115,7 +111,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -147,12 +142,6 @@ class RDS {
     required String targetDBParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBParameterGroupIdentifier, 'sourceDBParameterGroupIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupDescription, 'targetDBParameterGroupDescription');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupIdentifier, 'targetDBParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBParameterGroupIdentifier'] =
         sourceDBParameterGroupIdentifier;
@@ -185,10 +174,6 @@ class RDS {
     required String targetDBSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBSnapshotIdentifier, 'sourceDBSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBSnapshotIdentifier, 'targetDBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBSnapshotIdentifier'] = sourceDBSnapshotIdentifier;
     $request['TargetDBSnapshotIdentifier'] = targetDBSnapshotIdentifier;
@@ -217,12 +202,6 @@ class RDS {
     required String targetOptionGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceOptionGroupIdentifier, 'sourceOptionGroupIdentifier');
-    ArgumentError.checkNotNull(
-        targetOptionGroupDescription, 'targetOptionGroupDescription');
-    ArgumentError.checkNotNull(
-        targetOptionGroupIdentifier, 'targetOptionGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceOptionGroupIdentifier'] = sourceOptionGroupIdentifier;
     $request['TargetOptionGroupDescription'] = targetOptionGroupDescription;
@@ -287,12 +266,6 @@ class RDS {
     String? tdeCredentialPassword,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(allocatedStorage, 'allocatedStorage');
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
     final $request = <String, dynamic>{};
     $request['AllocatedStorage'] = allocatedStorage;
     $request['DBInstanceClass'] = dBInstanceClass;
@@ -373,9 +346,6 @@ class RDS {
     String? storageType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
@@ -413,10 +383,6 @@ class RDS {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -445,9 +411,6 @@ class RDS {
     required String dBSecurityGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSecurityGroupDescription, 'dBSecurityGroupDescription');
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupDescription'] = dBSecurityGroupDescription;
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
@@ -476,8 +439,6 @@ class RDS {
     required String dBSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -508,10 +469,6 @@ class RDS {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -548,8 +505,6 @@ class RDS {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -582,11 +537,6 @@ class RDS {
     required String optionGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
-    ArgumentError.checkNotNull(majorEngineVersion, 'majorEngineVersion');
-    ArgumentError.checkNotNull(
-        optionGroupDescription, 'optionGroupDescription');
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     $request['MajorEngineVersion'] = majorEngineVersion;
@@ -617,7 +567,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     finalDBSnapshotIdentifier
@@ -643,7 +592,6 @@ class RDS {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -664,7 +612,6 @@ class RDS {
   Future<void> deleteDBSecurityGroup({
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     await _protocol.send(
@@ -685,7 +632,6 @@ class RDS {
   Future<DeleteDBSnapshotResult> deleteDBSnapshot({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -709,7 +655,6 @@ class RDS {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -730,7 +675,6 @@ class RDS {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -753,7 +697,6 @@ class RDS {
   Future<void> deleteOptionGroup({
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     await _protocol.send(
@@ -841,7 +784,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     fileLastWritten?.also((arg) => $request['FileLastWritten'] = arg);
@@ -900,7 +842,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1013,8 +954,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1124,7 +1063,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1186,7 +1124,6 @@ class RDS {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     dBInstanceClass?.also((arg) => $request['DBInstanceClass'] = arg);
@@ -1298,8 +1235,6 @@ class RDS {
     String? marker,
     int? numberOfLines,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(logFileName, 'logFileName');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['LogFileName'] = logFileName;
@@ -1326,7 +1261,6 @@ class RDS {
     required String resourceName,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -1382,7 +1316,6 @@ class RDS {
     String? tdeCredentialPassword,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -1433,8 +1366,6 @@ class RDS {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -1463,8 +1394,6 @@ class RDS {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -1498,7 +1427,6 @@ class RDS {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -1528,7 +1456,6 @@ class RDS {
     List<OptionConfiguration>? optionsToInclude,
     List<String>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -1556,7 +1483,6 @@ class RDS {
     int? backupRetentionPeriod,
     String? preferredBackupWindow,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     backupRetentionPeriod
@@ -1588,8 +1514,6 @@ class RDS {
     String? reservedDBInstanceId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedDBInstancesOfferingId, 'reservedDBInstancesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedDBInstancesOfferingId'] = reservedDBInstancesOfferingId;
     dBInstanceCount?.also((arg) => $request['DBInstanceCount'] = arg);
@@ -1616,7 +1540,6 @@ class RDS {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -1642,8 +1565,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -1668,8 +1589,6 @@ class RDS {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -1693,7 +1612,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -1749,8 +1667,6 @@ class RDS {
     String? tdeCredentialArn,
     String? tdeCredentialPassword,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -1825,10 +1741,6 @@ class RDS {
     String? tdeCredentialPassword,
     bool? useLatestRestorableTime,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBInstanceIdentifier, 'targetDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
     $request['TargetDBInstanceIdentifier'] = targetDBInstanceIdentifier;
@@ -1878,7 +1790,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);

--- a/generated/aws_rds_api/lib/rds-2014-10-31.dart
+++ b/generated/aws_rds_api/lib/rds-2014-10-31.dart
@@ -88,8 +88,6 @@ class RDS {
     required String roleArn,
     String? featureName,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['RoleArn'] = roleArn;
@@ -135,9 +133,6 @@ class RDS {
     required String featureName,
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(featureName, 'featureName');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['FeatureName'] = featureName;
@@ -200,8 +195,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -246,8 +239,6 @@ class RDS {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -307,9 +298,6 @@ class RDS {
     required String optInType,
     required String resourceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(applyAction, 'applyAction');
-    ArgumentError.checkNotNull(optInType, 'optInType');
-    ArgumentError.checkNotNull(resourceIdentifier, 'resourceIdentifier');
     final $request = <String, dynamic>{};
     $request['ApplyAction'] = applyAction;
     $request['OptInType'] = optInType;
@@ -386,7 +374,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -479,8 +466,6 @@ class RDS {
     bool? force,
     bool? useEarliestTimeOnPointInTimeUnavailable,
   }) async {
-    ArgumentError.checkNotNull(backtrackTo, 'backtrackTo');
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['BacktrackTo'] = _s.iso8601ToJson(backtrackTo);
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
@@ -512,7 +497,6 @@ class RDS {
   Future<ExportTask> cancelExportTask({
     required String exportTaskIdentifier,
   }) async {
-    ArgumentError.checkNotNull(exportTaskIdentifier, 'exportTaskIdentifier');
     final $request = <String, dynamic>{};
     $request['ExportTaskIdentifier'] = exportTaskIdentifier;
     final $result = await _protocol.send(
@@ -592,12 +576,6 @@ class RDS {
     required String targetDBClusterParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(sourceDBClusterParameterGroupIdentifier,
-        'sourceDBClusterParameterGroupIdentifier');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupDescription,
-        'targetDBClusterParameterGroupDescription');
-    ArgumentError.checkNotNull(targetDBClusterParameterGroupIdentifier,
-        'targetDBClusterParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterParameterGroupIdentifier'] =
         sourceDBClusterParameterGroupIdentifier;
@@ -862,10 +840,6 @@ class RDS {
     String? sourceRegion,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBClusterSnapshotIdentifier, 'sourceDBClusterSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBClusterSnapshotIdentifier, 'targetDBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBClusterSnapshotIdentifier'] =
         sourceDBClusterSnapshotIdentifier;
@@ -944,12 +918,6 @@ class RDS {
     required String targetDBParameterGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBParameterGroupIdentifier, 'sourceDBParameterGroupIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupDescription, 'targetDBParameterGroupDescription');
-    ArgumentError.checkNotNull(
-        targetDBParameterGroupIdentifier, 'targetDBParameterGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBParameterGroupIdentifier'] =
         sourceDBParameterGroupIdentifier;
@@ -1160,10 +1128,6 @@ class RDS {
     List<Tag>? tags,
     String? targetCustomAvailabilityZone,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceDBSnapshotIdentifier, 'sourceDBSnapshotIdentifier');
-    ArgumentError.checkNotNull(
-        targetDBSnapshotIdentifier, 'targetDBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceDBSnapshotIdentifier'] = sourceDBSnapshotIdentifier;
     $request['TargetDBSnapshotIdentifier'] = targetDBSnapshotIdentifier;
@@ -1235,12 +1199,6 @@ class RDS {
     required String targetOptionGroupIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceOptionGroupIdentifier, 'sourceOptionGroupIdentifier');
-    ArgumentError.checkNotNull(
-        targetOptionGroupDescription, 'targetOptionGroupDescription');
-    ArgumentError.checkNotNull(
-        targetOptionGroupIdentifier, 'targetOptionGroupIdentifier');
     final $request = <String, dynamic>{};
     $request['SourceOptionGroupIdentifier'] = sourceOptionGroupIdentifier;
     $request['TargetOptionGroupDescription'] = targetOptionGroupDescription;
@@ -1297,8 +1255,6 @@ class RDS {
     String? newVpnTunnelName,
     String? vpnTunnelOriginatorIP,
   }) async {
-    ArgumentError.checkNotNull(
-        customAvailabilityZoneName, 'customAvailabilityZoneName');
     final $request = <String, dynamic>{};
     $request['CustomAvailabilityZoneName'] = customAvailabilityZoneName;
     existingVpnId?.also((arg) => $request['ExistingVpnId'] = arg);
@@ -1815,8 +1771,6 @@ class RDS {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -1919,10 +1873,6 @@ class RDS {
     List<String>? staticMembers,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(endpointType, 'endpointType');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
@@ -2020,11 +1970,6 @@ class RDS {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
@@ -2097,9 +2042,6 @@ class RDS {
     required String dBClusterSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -3155,9 +3097,6 @@ class RDS {
     String? timezone,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['DBInstanceClass'] = dBInstanceClass;
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
@@ -3707,9 +3646,6 @@ class RDS {
     bool? useDefaultProcessorFeatures,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBInstanceIdentifier, 'sourceDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['SourceDBInstanceIdentifier'] = sourceDBInstanceIdentifier;
@@ -3838,10 +3774,6 @@ class RDS {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(description, 'description');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     $request['DBParameterGroupName'] = dBParameterGroupName;
@@ -3926,11 +3858,6 @@ class RDS {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(auth, 'auth');
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
-    ArgumentError.checkNotNull(engineFamily, 'engineFamily');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    ArgumentError.checkNotNull(vpcSubnetIds, 'vpcSubnetIds');
     final $request = <String, dynamic>{};
     $request['Auth'] = auth;
     $request['DBProxyName'] = dBProxyName;
@@ -3999,9 +3926,6 @@ class RDS {
     required String dBSecurityGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSecurityGroupDescription, 'dBSecurityGroupDescription');
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupDescription'] = dBSecurityGroupDescription;
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
@@ -4064,8 +3988,6 @@ class RDS {
     required String dBSnapshotIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -4116,10 +4038,6 @@ class RDS {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dBSubnetGroupDescription, 'dBSubnetGroupDescription');
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupDescription'] = dBSubnetGroupDescription;
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
@@ -4260,8 +4178,6 @@ class RDS {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -4403,11 +4319,6 @@ class RDS {
     required String optionGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
-    ArgumentError.checkNotNull(majorEngineVersion, 'majorEngineVersion');
-    ArgumentError.checkNotNull(
-        optionGroupDescription, 'optionGroupDescription');
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     $request['MajorEngineVersion'] = majorEngineVersion;
@@ -4445,8 +4356,6 @@ class RDS {
   Future<DeleteCustomAvailabilityZoneResult> deleteCustomAvailabilityZone({
     required String customAvailabilityZoneId,
   }) async {
-    ArgumentError.checkNotNull(
-        customAvailabilityZoneId, 'customAvailabilityZoneId');
     final $request = <String, dynamic>{};
     $request['CustomAvailabilityZoneId'] = customAvailabilityZoneId;
     final $result = await _protocol.send(
@@ -4531,7 +4440,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     finalDBSnapshotIdentifier
@@ -4566,8 +4474,6 @@ class RDS {
   Future<DBClusterEndpoint> deleteDBClusterEndpoint({
     required String dBClusterEndpointIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     final $result = await _protocol.send(
@@ -4616,8 +4522,6 @@ class RDS {
   Future<void> deleteDBClusterParameterGroup({
     required String dBClusterParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     await _protocol.send(
@@ -4656,8 +4560,6 @@ class RDS {
   Future<DeleteDBClusterSnapshotResult> deleteDBClusterSnapshot({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -4779,7 +4681,6 @@ class RDS {
     String? finalDBSnapshotIdentifier,
     bool? skipFinalSnapshot,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     deleteAutomatedBackups
@@ -4864,7 +4765,6 @@ class RDS {
   Future<void> deleteDBParameterGroup({
     required String dBParameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     await _protocol.send(
@@ -4889,7 +4789,6 @@ class RDS {
   Future<DeleteDBProxyResponse> deleteDBProxy({
     required String dBProxyName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     final $request = <String, dynamic>{};
     $request['DBProxyName'] = dBProxyName;
     final $result = await _protocol.send(
@@ -4939,7 +4838,6 @@ class RDS {
   Future<void> deleteDBSecurityGroup({
     required String dBSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     await _protocol.send(
@@ -4971,7 +4869,6 @@ class RDS {
   Future<DeleteDBSnapshotResult> deleteDBSnapshot({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -5012,7 +4909,6 @@ class RDS {
   Future<void> deleteDBSubnetGroup({
     required String dBSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     await _protocol.send(
@@ -5037,7 +4933,6 @@ class RDS {
   Future<DeleteEventSubscriptionResult> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     final $result = await _protocol.send(
@@ -5068,8 +4963,6 @@ class RDS {
   Future<DeleteGlobalClusterResult> deleteGlobalCluster({
     required String globalClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        globalClusterIdentifier, 'globalClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['GlobalClusterIdentifier'] = globalClusterIdentifier;
     final $result = await _protocol.send(
@@ -5096,7 +4989,6 @@ class RDS {
   Future<InstallationMedia> deleteInstallationMedia({
     required String installationMediaId,
   }) async {
-    ArgumentError.checkNotNull(installationMediaId, 'installationMediaId');
     final $request = <String, dynamic>{};
     $request['InstallationMediaId'] = installationMediaId;
     final $result = await _protocol.send(
@@ -5126,7 +5018,6 @@ class RDS {
   Future<void> deleteOptionGroup({
     required String optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     await _protocol.send(
@@ -5167,7 +5058,6 @@ class RDS {
     List<String>? dBInstanceIdentifiers,
     String? targetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     final $request = <String, dynamic>{};
     $request['DBProxyName'] = dBProxyName;
     dBClusterIdentifiers?.also((arg) => $request['DBClusterIdentifiers'] = arg);
@@ -5432,7 +5322,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     backtrackIdentifier?.also((arg) => $request['BacktrackIdentifier'] = arg);
@@ -5650,8 +5539,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -5698,8 +5585,6 @@ class RDS {
       describeDBClusterSnapshotAttributes({
     required String dBClusterSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -6319,7 +6204,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     fileLastWritten?.also((arg) => $request['FileLastWritten'] = arg);
@@ -6449,7 +6333,6 @@ class RDS {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -6563,7 +6446,6 @@ class RDS {
     int? maxRecords,
     String? targetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
@@ -6628,7 +6510,6 @@ class RDS {
     int? maxRecords,
     String? targetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     _s.validateNumRange(
       'maxRecords',
       maxRecords,
@@ -6728,7 +6609,6 @@ class RDS {
   Future<DescribeDBSnapshotAttributesResult> describeDBSnapshotAttributes({
     required String dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     final $result = await _protocol.send(
@@ -7013,8 +6893,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -7065,8 +6943,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(
-        dBParameterGroupFamily, 'dBParameterGroupFamily');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupFamily'] = dBParameterGroupFamily;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -7569,7 +7445,6 @@ class RDS {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(engineName, 'engineName');
     final $request = <String, dynamic>{};
     $request['EngineName'] = engineName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -7711,7 +7586,6 @@ class RDS {
     int? maxRecords,
     bool? vpc,
   }) async {
-    ArgumentError.checkNotNull(engine, 'engine');
     final $request = <String, dynamic>{};
     $request['Engine'] = engine;
     availabilityZoneGroup
@@ -8070,7 +7944,6 @@ class RDS {
       describeValidDBInstanceModifications({
     required String dBInstanceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     final $result = await _protocol.send(
@@ -8148,8 +8021,6 @@ class RDS {
     String? marker,
     int? numberOfLines,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(logFileName, 'logFileName');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['LogFileName'] = logFileName;
@@ -8214,7 +8085,6 @@ class RDS {
     required String dBClusterIdentifier,
     String? targetDBInstanceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     targetDBInstanceIdentifier
@@ -8301,14 +8171,6 @@ class RDS {
     required String engineVersion,
     required String oSInstallationMediaPath,
   }) async {
-    ArgumentError.checkNotNull(
-        customAvailabilityZoneId, 'customAvailabilityZoneId');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(
-        engineInstallationMediaPath, 'engineInstallationMediaPath');
-    ArgumentError.checkNotNull(engineVersion, 'engineVersion');
-    ArgumentError.checkNotNull(
-        oSInstallationMediaPath, 'oSInstallationMediaPath');
     final $request = <String, dynamic>{};
     $request['CustomAvailabilityZoneId'] = customAvailabilityZoneId;
     $request['Engine'] = engine;
@@ -8354,7 +8216,6 @@ class RDS {
     required String resourceName,
     List<Filter>? filters,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     filters?.also((arg) => $request['Filters'] = arg);
@@ -8535,7 +8396,6 @@ class RDS {
     int? secondsBeforeTimeout,
     String? timeoutAction,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     capacity?.also((arg) => $request['Capacity'] = arg);
@@ -8872,7 +8732,6 @@ class RDS {
     ScalingConfiguration? scalingConfiguration,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     allowMajorVersionUpgrade
@@ -8955,8 +8814,6 @@ class RDS {
     List<String>? excludedMembers,
     List<String>? staticMembers,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterEndpointIdentifier, 'dBClusterEndpointIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterEndpointIdentifier'] = dBClusterEndpointIdentifier;
     endpointType?.also((arg) => $request['EndpointType'] = arg);
@@ -9024,9 +8881,6 @@ class RDS {
     required String dBClusterParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     $request['Parameters'] = parameters;
@@ -9118,9 +8972,6 @@ class RDS {
     List<String>? valuesToAdd,
     List<String>? valuesToRemove,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(
-        dBClusterSnapshotIdentifier, 'dBClusterSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['DBClusterSnapshotIdentifier'] = dBClusterSnapshotIdentifier;
@@ -9862,7 +9713,6 @@ class RDS {
     bool? useDefaultProcessorFeatures,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     allocatedStorage?.also((arg) => $request['AllocatedStorage'] = arg);
@@ -9993,8 +9843,6 @@ class RDS {
     required String dBParameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     $request['Parameters'] = parameters;
@@ -10065,7 +9913,6 @@ class RDS {
     String? roleArn,
     List<String>? securityGroups,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     final $request = <String, dynamic>{};
     $request['DBProxyName'] = dBProxyName;
     auth?.also((arg) => $request['Auth'] = arg);
@@ -10115,8 +9962,6 @@ class RDS {
     ConnectionPoolConfiguration? connectionPoolConfig,
     String? newName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
-    ArgumentError.checkNotNull(targetGroupName, 'targetGroupName');
     final $request = <String, dynamic>{};
     $request['DBProxyName'] = dBProxyName;
     $request['TargetGroupName'] = targetGroupName;
@@ -10193,7 +10038,6 @@ class RDS {
     String? engineVersion,
     String? optionGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
     engineVersion?.also((arg) => $request['EngineVersion'] = arg);
@@ -10279,8 +10123,6 @@ class RDS {
     List<String>? valuesToAdd,
     List<String>? valuesToRemove,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -10328,8 +10170,6 @@ class RDS {
     required List<String> subnetIds,
     String? dBSubnetGroupDescription,
   }) async {
-    ArgumentError.checkNotNull(dBSubnetGroupName, 'dBSubnetGroupName');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['DBSubnetGroupName'] = dBSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -10402,7 +10242,6 @@ class RDS {
     String? snsTopicArn,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -10525,7 +10364,6 @@ class RDS {
     List<OptionConfiguration>? optionsToInclude,
     List<String>? optionsToRemove,
   }) async {
-    ArgumentError.checkNotNull(optionGroupName, 'optionGroupName');
     final $request = <String, dynamic>{};
     $request['OptionGroupName'] = optionGroupName;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -10628,7 +10466,6 @@ class RDS {
     int? backupRetentionPeriod,
     String? preferredBackupWindow,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     backupRetentionPeriod
@@ -10672,7 +10509,6 @@ class RDS {
   Future<PromoteReadReplicaDBClusterResult> promoteReadReplicaDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -10716,8 +10552,6 @@ class RDS {
     String? reservedDBInstanceId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedDBInstancesOfferingId, 'reservedDBInstancesOfferingId');
     final $request = <String, dynamic>{};
     $request['ReservedDBInstancesOfferingId'] = reservedDBInstancesOfferingId;
     dBInstanceCount?.also((arg) => $request['DBInstanceCount'] = arg);
@@ -10775,7 +10609,6 @@ class RDS {
     required String dBInstanceIdentifier,
     bool? forceFailover,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     forceFailover?.also((arg) => $request['ForceFailover'] = arg);
@@ -10824,7 +10657,6 @@ class RDS {
     List<String>? dBInstanceIdentifiers,
     String? targetGroupName,
   }) async {
-    ArgumentError.checkNotNull(dBProxyName, 'dBProxyName');
     final $request = <String, dynamic>{};
     $request['DBProxyName'] = dBProxyName;
     dBClusterIdentifiers?.also((arg) => $request['DBClusterIdentifiers'] = arg);
@@ -10915,8 +10747,6 @@ class RDS {
     required String roleArn,
     String? featureName,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['RoleArn'] = roleArn;
@@ -10957,9 +10787,6 @@ class RDS {
     required String featureName,
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(featureName, 'featureName');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['FeatureName'] = featureName;
@@ -10995,8 +10822,6 @@ class RDS {
     required String sourceIdentifier,
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(sourceIdentifier, 'sourceIdentifier');
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
     final $request = <String, dynamic>{};
     $request['SourceIdentifier'] = sourceIdentifier;
     $request['SubscriptionName'] = subscriptionName;
@@ -11039,8 +10864,6 @@ class RDS {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -11098,8 +10921,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(
-        dBClusterParameterGroupName, 'dBClusterParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBClusterParameterGroupName'] = dBClusterParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -11180,7 +11001,6 @@ class RDS {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(dBParameterGroupName, 'dBParameterGroupName');
     final $request = <String, dynamic>{};
     $request['DBParameterGroupName'] = dBParameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -11558,14 +11378,6 @@ class RDS {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    ArgumentError.checkNotNull(s3IngestionRoleArn, 's3IngestionRoleArn');
-    ArgumentError.checkNotNull(sourceEngine, 'sourceEngine');
-    ArgumentError.checkNotNull(sourceEngineVersion, 'sourceEngineVersion');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -11907,9 +11719,6 @@ class RDS {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['Engine'] = engine;
@@ -12225,9 +12034,6 @@ class RDS {
     bool? useLatestRestorableTime,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
-    ArgumentError.checkNotNull(
-        sourceDBClusterIdentifier, 'sourceDBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     $request['SourceDBClusterIdentifier'] = sourceDBClusterIdentifier;
@@ -12639,8 +12445,6 @@ class RDS {
     bool? useDefaultProcessorFeatures,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(dBSnapshotIdentifier, 'dBSnapshotIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     $request['DBSnapshotIdentifier'] = dBSnapshotIdentifier;
@@ -13123,13 +12927,6 @@ class RDS {
     bool? useDefaultProcessorFeatures,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceClass, 'dBInstanceClass');
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
-    ArgumentError.checkNotNull(engine, 'engine');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    ArgumentError.checkNotNull(s3IngestionRoleArn, 's3IngestionRoleArn');
-    ArgumentError.checkNotNull(sourceEngine, 'sourceEngine');
-    ArgumentError.checkNotNull(sourceEngineVersion, 'sourceEngineVersion');
     final $request = <String, dynamic>{};
     $request['DBInstanceClass'] = dBInstanceClass;
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
@@ -13594,8 +13391,6 @@ class RDS {
     bool? useLatestRestorableTime,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(
-        targetDBInstanceIdentifier, 'targetDBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['TargetDBInstanceIdentifier'] = targetDBInstanceIdentifier;
     autoMinorVersionUpgrade
@@ -13700,7 +13495,6 @@ class RDS {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(dBSecurityGroupName, 'dBSecurityGroupName');
     final $request = <String, dynamic>{};
     $request['DBSecurityGroupName'] = dBSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -13757,9 +13551,6 @@ class RDS {
     required String resourceArn,
     bool? applyImmediately,
   }) async {
-    ArgumentError.checkNotNull(kmsKeyId, 'kmsKeyId');
-    ArgumentError.checkNotNull(mode, 'mode');
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $request = <String, dynamic>{};
     $request['KmsKeyId'] = kmsKeyId;
     $request['Mode'] = mode.toValue();
@@ -13800,7 +13591,6 @@ class RDS {
   Future<StartDBClusterResult> startDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -13846,7 +13636,6 @@ class RDS {
   Future<StartDBInstanceResult> startDBInstance({
     required String dBInstanceIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     final $result = await _protocol.send(
@@ -13903,7 +13692,6 @@ class RDS {
     String? kmsKeyId,
     String? preSignedUrl,
   }) async {
-    ArgumentError.checkNotNull(sourceDBInstanceArn, 'sourceDBInstanceArn');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceArn'] = sourceDBInstanceArn;
     backupRetentionPeriod
@@ -14027,11 +13815,6 @@ class RDS {
     List<String>? exportOnly,
     String? s3Prefix,
   }) async {
-    ArgumentError.checkNotNull(exportTaskIdentifier, 'exportTaskIdentifier');
-    ArgumentError.checkNotNull(iamRoleArn, 'iamRoleArn');
-    ArgumentError.checkNotNull(kmsKeyId, 'kmsKeyId');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
     final $request = <String, dynamic>{};
     $request['ExportTaskIdentifier'] = exportTaskIdentifier;
     $request['IamRoleArn'] = iamRoleArn;
@@ -14080,7 +13863,6 @@ class RDS {
     required String resourceArn,
     bool? applyImmediately,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     applyImmediately?.also((arg) => $request['ApplyImmediately'] = arg);
@@ -14121,7 +13903,6 @@ class RDS {
   Future<StopDBClusterResult> stopDBCluster({
     required String dBClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBClusterIdentifier, 'dBClusterIdentifier');
     final $request = <String, dynamic>{};
     $request['DBClusterIdentifier'] = dBClusterIdentifier;
     final $result = await _protocol.send(
@@ -14168,7 +13949,6 @@ class RDS {
     required String dBInstanceIdentifier,
     String? dBSnapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(dBInstanceIdentifier, 'dBInstanceIdentifier');
     final $request = <String, dynamic>{};
     $request['DBInstanceIdentifier'] = dBInstanceIdentifier;
     dBSnapshotIdentifier?.also((arg) => $request['DBSnapshotIdentifier'] = arg);
@@ -14204,7 +13984,6 @@ class RDS {
       stopDBInstanceAutomatedBackupsReplication({
     required String sourceDBInstanceArn,
   }) async {
-    ArgumentError.checkNotNull(sourceDBInstanceArn, 'sourceDBInstanceArn');
     final $request = <String, dynamic>{};
     $request['SourceDBInstanceArn'] = sourceDBInstanceArn;
     final $result = await _protocol.send(

--- a/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
+++ b/generated/aws_rds_data_api/lib/rds-data-2018-08-01.dart
@@ -118,48 +118,6 @@ class RDSDataService {
     String? schema,
     String? transactionId,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretArn, 'secretArn');
-    _s.validateStringLength(
-      'secretArn',
-      secretArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sql, 'sql');
-    _s.validateStringLength(
-      'sql',
-      sql,
-      0,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'database',
-      database,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'schema',
-      schema,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'transactionId',
-      transactionId,
-      0,
-      192,
-    );
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'secretArn': secretArn,
@@ -213,34 +171,6 @@ class RDSDataService {
     String? database,
     String? schema,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretArn, 'secretArn');
-    _s.validateStringLength(
-      'secretArn',
-      secretArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'database',
-      database,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'schema',
-      schema,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'secretArn': secretArn,
@@ -279,30 +209,6 @@ class RDSDataService {
     required String secretArn,
     required String transactionId,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretArn, 'secretArn');
-    _s.validateStringLength(
-      'secretArn',
-      secretArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transactionId, 'transactionId');
-    _s.validateStringLength(
-      'transactionId',
-      transactionId,
-      0,
-      192,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'secretArn': secretArn,
@@ -355,43 +261,6 @@ class RDSDataService {
     String? database,
     String? schema,
   }) async {
-    ArgumentError.checkNotNull(awsSecretStoreArn, 'awsSecretStoreArn');
-    _s.validateStringLength(
-      'awsSecretStoreArn',
-      awsSecretStoreArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        dbClusterOrInstanceArn, 'dbClusterOrInstanceArn');
-    _s.validateStringLength(
-      'dbClusterOrInstanceArn',
-      dbClusterOrInstanceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sqlStatements, 'sqlStatements');
-    _s.validateStringLength(
-      'sqlStatements',
-      sqlStatements,
-      0,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'database',
-      database,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'schema',
-      schema,
-      0,
-      64,
-    );
     final $payload = <String, dynamic>{
       'awsSecretStoreArn': awsSecretStoreArn,
       'dbClusterOrInstanceArn': dbClusterOrInstanceArn,
@@ -479,48 +348,6 @@ class RDSDataService {
     String? schema,
     String? transactionId,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretArn, 'secretArn');
-    _s.validateStringLength(
-      'secretArn',
-      secretArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sql, 'sql');
-    _s.validateStringLength(
-      'sql',
-      sql,
-      0,
-      65536,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'database',
-      database,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'schema',
-      schema,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'transactionId',
-      transactionId,
-      0,
-      192,
-    );
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'secretArn': secretArn,
@@ -567,30 +394,6 @@ class RDSDataService {
     required String secretArn,
     required String transactionId,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretArn, 'secretArn');
-    _s.validateStringLength(
-      'secretArn',
-      secretArn,
-      11,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transactionId, 'transactionId');
-    _s.validateStringLength(
-      'transactionId',
-      transactionId,
-      0,
-      192,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'secretArn': secretArn,

--- a/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
+++ b/generated/aws_redshift_api/lib/redshift-2012-12-01.dart
@@ -86,23 +86,6 @@ class Redshift {
     required String reservedNodeId,
     required String targetReservedNodeOfferingId,
   }) async {
-    ArgumentError.checkNotNull(reservedNodeId, 'reservedNodeId');
-    _s.validateStringLength(
-      'reservedNodeId',
-      reservedNodeId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        targetReservedNodeOfferingId, 'targetReservedNodeOfferingId');
-    _s.validateStringLength(
-      'targetReservedNodeOfferingId',
-      targetReservedNodeOfferingId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ReservedNodeId'] = reservedNodeId;
     $request['TargetReservedNodeOfferingId'] = targetReservedNodeOfferingId;
@@ -172,33 +155,6 @@ class Redshift {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSecurityGroupName, 'clusterSecurityGroupName');
-    _s.validateStringLength(
-      'clusterSecurityGroupName',
-      clusterSecurityGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cidrip',
-      cidrip,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'eC2SecurityGroupName',
-      eC2SecurityGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'eC2SecurityGroupOwnerId',
-      eC2SecurityGroupOwnerId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSecurityGroupName'] = clusterSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -253,29 +209,6 @@ class Redshift {
     required String snapshotIdentifier,
     String? snapshotClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        accountWithRestoreAccess, 'accountWithRestoreAccess');
-    _s.validateStringLength(
-      'accountWithRestoreAccess',
-      accountWithRestoreAccess,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'snapshotClusterIdentifier',
-      snapshotClusterIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['AccountWithRestoreAccess'] = accountWithRestoreAccess;
     $request['SnapshotIdentifier'] = snapshotIdentifier;
@@ -304,7 +237,6 @@ class Redshift {
   Future<BatchDeleteClusterSnapshotsResult> batchDeleteClusterSnapshots({
     required List<DeleteClusterSnapshotMessage> identifiers,
   }) async {
-    ArgumentError.checkNotNull(identifiers, 'identifiers');
     final $request = <String, dynamic>{};
     $request['Identifiers'] = identifiers;
     final $result = await _protocol.send(
@@ -348,8 +280,6 @@ class Redshift {
     bool? force,
     int? manualSnapshotRetentionPeriod,
   }) async {
-    ArgumentError.checkNotNull(
-        snapshotIdentifierList, 'snapshotIdentifierList');
     final $request = <String, dynamic>{};
     $request['SnapshotIdentifierList'] = snapshotIdentifierList;
     force?.also((arg) => $request['Force'] = arg);
@@ -382,14 +312,6 @@ class Redshift {
   Future<ResizeProgressMessage> cancelResize({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -489,30 +411,6 @@ class Redshift {
     int? manualSnapshotRetentionPeriod,
     String? sourceSnapshotClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        sourceSnapshotIdentifier, 'sourceSnapshotIdentifier');
-    _s.validateStringLength(
-      'sourceSnapshotIdentifier',
-      sourceSnapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        targetSnapshotIdentifier, 'targetSnapshotIdentifier');
-    _s.validateStringLength(
-      'targetSnapshotIdentifier',
-      targetSnapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceSnapshotClusterIdentifier',
-      sourceSnapshotClusterIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['SourceSnapshotIdentifier'] = sourceSnapshotIdentifier;
     $request['TargetSnapshotIdentifier'] = targetSnapshotIdentifier;
@@ -931,122 +829,6 @@ class Redshift {
     List<Tag>? tags,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(masterUserPassword, 'masterUserPassword');
-    _s.validateStringLength(
-      'masterUserPassword',
-      masterUserPassword,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(masterUsername, 'masterUsername');
-    _s.validateStringLength(
-      'masterUsername',
-      masterUsername,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nodeType, 'nodeType');
-    _s.validateStringLength(
-      'nodeType',
-      nodeType,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'additionalInfo',
-      additionalInfo,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'availabilityZone',
-      availabilityZone,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterParameterGroupName',
-      clusterParameterGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterType',
-      clusterType,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterVersion',
-      clusterVersion,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'dBName',
-      dBName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'elasticIp',
-      elasticIp,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'maintenanceTrackName',
-      maintenanceTrackName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'preferredMaintenanceWindow',
-      preferredMaintenanceWindow,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotScheduleIdentifier',
-      snapshotScheduleIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['MasterUserPassword'] = masterUserPassword;
@@ -1167,30 +949,6 @@ class Redshift {
     required String parameterGroupName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parameterGroupFamily, 'parameterGroupFamily');
-    _s.validateStringLength(
-      'parameterGroupFamily',
-      parameterGroupFamily,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Description'] = description;
     $request['ParameterGroupFamily'] = parameterGroupFamily;
@@ -1253,23 +1011,6 @@ class Redshift {
     required String description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSecurityGroupName, 'clusterSecurityGroupName');
-    _s.validateStringLength(
-      'clusterSecurityGroupName',
-      clusterSecurityGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSecurityGroupName'] = clusterSecurityGroupName;
     $request['Description'] = description;
@@ -1345,22 +1086,6 @@ class Redshift {
     int? manualSnapshotRetentionPeriod,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['SnapshotIdentifier'] = snapshotIdentifier;
@@ -1433,24 +1158,6 @@ class Redshift {
     required List<String> subnetIds,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSubnetGroupName, 'clusterSubnetGroupName');
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
     final $request = <String, dynamic>{};
     $request['ClusterSubnetGroupName'] = clusterSubnetGroupName;
     $request['Description'] = description;
@@ -1582,34 +1289,6 @@ class Redshift {
     String? sourceType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snsTopicArn, 'snsTopicArn');
-    _s.validateStringLength(
-      'snsTopicArn',
-      snsTopicArn,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
-    _s.validateStringLength(
-      'subscriptionName',
-      subscriptionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'severity',
-      severity,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'sourceType',
-      sourceType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['SnsTopicArn'] = snsTopicArn;
     $request['SubscriptionName'] = subscriptionName;
@@ -1661,15 +1340,6 @@ class Redshift {
     required String hsmClientCertificateIdentifier,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        hsmClientCertificateIdentifier, 'hsmClientCertificateIdentifier');
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['HsmClientCertificateIdentifier'] = hsmClientCertificateIdentifier;
     tags?.also((arg) => $request['Tags'] = arg);
@@ -1736,56 +1406,6 @@ class Redshift {
     required String hsmServerPublicCertificate,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        hsmConfigurationIdentifier, 'hsmConfigurationIdentifier');
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hsmIpAddress, 'hsmIpAddress');
-    _s.validateStringLength(
-      'hsmIpAddress',
-      hsmIpAddress,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hsmPartitionName, 'hsmPartitionName');
-    _s.validateStringLength(
-      'hsmPartitionName',
-      hsmPartitionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hsmPartitionPassword, 'hsmPartitionPassword');
-    _s.validateStringLength(
-      'hsmPartitionPassword',
-      hsmPartitionPassword,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        hsmServerPublicCertificate, 'hsmServerPublicCertificate');
-    _s.validateStringLength(
-      'hsmServerPublicCertificate',
-      hsmServerPublicCertificate,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Description'] = description;
     $request['HsmConfigurationIdentifier'] = hsmConfigurationIdentifier;
@@ -1864,37 +1484,6 @@ class Redshift {
     String? scheduledActionDescription,
     DateTime? startTime,
   }) async {
-    ArgumentError.checkNotNull(iamRole, 'iamRole');
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schedule, 'schedule');
-    _s.validateStringLength(
-      'schedule',
-      schedule,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetAction, 'targetAction');
-    _s.validateStringLength(
-      'scheduledActionDescription',
-      scheduledActionDescription,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['IamRole'] = iamRole;
     $request['Schedule'] = schedule;
@@ -1971,20 +1560,6 @@ class Redshift {
     String? kmsKeyId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snapshotCopyGrantName, 'snapshotCopyGrantName');
-    _s.validateStringLength(
-      'snapshotCopyGrantName',
-      snapshotCopyGrantName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['SnapshotCopyGrantName'] = snapshotCopyGrantName;
     kmsKeyId?.also((arg) => $request['KmsKeyId'] = arg);
@@ -2040,18 +1615,6 @@ class Redshift {
     String? scheduleIdentifier,
     List<Tag>? tags,
   }) async {
-    _s.validateStringLength(
-      'scheduleDescription',
-      scheduleDescription,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'scheduleIdentifier',
-      scheduleIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     dryRun?.also((arg) => $request['DryRun'] = arg);
     nextInvocations?.also((arg) => $request['NextInvocations'] = arg);
@@ -2102,15 +1665,6 @@ class Redshift {
     required String resourceName,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    _s.validateStringLength(
-      'resourceName',
-      resourceName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['Tags'] = tags;
@@ -2176,17 +1730,6 @@ class Redshift {
     UsageLimitPeriod? period,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(amount, 'amount');
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(featureType, 'featureType');
-    ArgumentError.checkNotNull(limitType, 'limitType');
     final $request = <String, dynamic>{};
     $request['Amount'] = amount;
     $request['ClusterIdentifier'] = clusterIdentifier;
@@ -2301,20 +1844,6 @@ class Redshift {
     int? finalClusterSnapshotRetentionPeriod,
     bool? skipFinalClusterSnapshot,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'finalClusterSnapshotIdentifier',
-      finalClusterSnapshotIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     finalClusterSnapshotIdentifier
@@ -2361,14 +1890,6 @@ class Redshift {
   Future<void> deleteClusterParameterGroup({
     required String parameterGroupName,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ParameterGroupName'] = parameterGroupName;
     await _protocol.send(
@@ -2401,15 +1922,6 @@ class Redshift {
   Future<void> deleteClusterSecurityGroup({
     required String clusterSecurityGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSecurityGroupName, 'clusterSecurityGroupName');
-    _s.validateStringLength(
-      'clusterSecurityGroupName',
-      clusterSecurityGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSecurityGroupName'] = clusterSecurityGroupName;
     await _protocol.send(
@@ -2455,20 +1967,6 @@ class Redshift {
     required String snapshotIdentifier,
     String? snapshotClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'snapshotClusterIdentifier',
-      snapshotClusterIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['SnapshotIdentifier'] = snapshotIdentifier;
     snapshotClusterIdentifier
@@ -2498,15 +1996,6 @@ class Redshift {
   Future<void> deleteClusterSubnetGroup({
     required String clusterSubnetGroupName,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSubnetGroupName, 'clusterSubnetGroupName');
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSubnetGroupName'] = clusterSubnetGroupName;
     await _protocol.send(
@@ -2532,14 +2021,6 @@ class Redshift {
   Future<void> deleteEventSubscription({
     required String subscriptionName,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
-    _s.validateStringLength(
-      'subscriptionName',
-      subscriptionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     await _protocol.send(
@@ -2564,15 +2045,6 @@ class Redshift {
   Future<void> deleteHsmClientCertificate({
     required String hsmClientCertificateIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        hsmClientCertificateIdentifier, 'hsmClientCertificateIdentifier');
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['HsmClientCertificateIdentifier'] = hsmClientCertificateIdentifier;
     await _protocol.send(
@@ -2597,15 +2069,6 @@ class Redshift {
   Future<void> deleteHsmConfiguration({
     required String hsmConfigurationIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        hsmConfigurationIdentifier, 'hsmConfigurationIdentifier');
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['HsmConfigurationIdentifier'] = hsmConfigurationIdentifier;
     await _protocol.send(
@@ -2630,14 +2093,6 @@ class Redshift {
   Future<void> deleteScheduledAction({
     required String scheduledActionName,
   }) async {
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ScheduledActionName'] = scheduledActionName;
     await _protocol.send(
@@ -2662,14 +2117,6 @@ class Redshift {
   Future<void> deleteSnapshotCopyGrant({
     required String snapshotCopyGrantName,
   }) async {
-    ArgumentError.checkNotNull(snapshotCopyGrantName, 'snapshotCopyGrantName');
-    _s.validateStringLength(
-      'snapshotCopyGrantName',
-      snapshotCopyGrantName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SnapshotCopyGrantName'] = snapshotCopyGrantName;
     await _protocol.send(
@@ -2694,14 +2141,6 @@ class Redshift {
   Future<void> deleteSnapshotSchedule({
     required String scheduleIdentifier,
   }) async {
-    ArgumentError.checkNotNull(scheduleIdentifier, 'scheduleIdentifier');
-    _s.validateStringLength(
-      'scheduleIdentifier',
-      scheduleIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ScheduleIdentifier'] = scheduleIdentifier;
     await _protocol.send(
@@ -2733,15 +2172,6 @@ class Redshift {
     required String resourceName,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceName, 'resourceName');
-    _s.validateStringLength(
-      'resourceName',
-      resourceName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceName'] = resourceName;
     $request['TagKeys'] = tagKeys;
@@ -2767,14 +2197,6 @@ class Redshift {
   Future<void> deleteUsageLimit({
     required String usageLimitId,
   }) async {
-    ArgumentError.checkNotNull(usageLimitId, 'usageLimitId');
-    _s.validateStringLength(
-      'usageLimitId',
-      usageLimitId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UsageLimitId'] = usageLimitId;
     await _protocol.send(
@@ -2850,18 +2272,6 @@ class Redshift {
     String? marker,
     int? maxRecords,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -2954,18 +2364,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -3040,26 +2438,6 @@ class Redshift {
     int? maxRecords,
     String? source,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'source',
-      source,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ParameterGroupName'] = parameterGroupName;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -3156,18 +2534,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'clusterSecurityGroupName',
-      clusterSecurityGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterSecurityGroupName
         ?.also((arg) => $request['ClusterSecurityGroupName'] = arg);
@@ -3326,36 +2692,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'ownerAccount',
-      ownerAccount,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotType',
-      snapshotType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterExists?.also((arg) => $request['ClusterExists'] = arg);
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
@@ -3448,18 +2784,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterSubnetGroupName
         ?.also((arg) => $request['ClusterSubnetGroupName'] = arg);
@@ -3505,18 +2829,6 @@ class Redshift {
     String? marker,
     int? maxRecords,
   }) async {
-    _s.validateStringLength(
-      'maintenanceTrackName',
-      maintenanceTrackName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     maintenanceTrackName?.also((arg) => $request['MaintenanceTrackName'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -3590,24 +2902,6 @@ class Redshift {
     String? marker,
     int? maxRecords,
   }) async {
-    _s.validateStringLength(
-      'clusterParameterGroupFamily',
-      clusterParameterGroupFamily,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterVersion',
-      clusterVersion,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterParameterGroupFamily
         ?.also((arg) => $request['ClusterParameterGroupFamily'] = arg);
@@ -3701,18 +2995,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -3769,20 +3051,6 @@ class Redshift {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupFamily, 'parameterGroupFamily');
-    _s.validateStringLength(
-      'parameterGroupFamily',
-      parameterGroupFamily,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ParameterGroupFamily'] = parameterGroupFamily;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -3816,12 +3084,6 @@ class Redshift {
   Future<EventCategoriesMessage> describeEventCategories({
     String? sourceType,
   }) async {
-    _s.validateStringLength(
-      'sourceType',
-      sourceType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     sourceType?.also((arg) => $request['SourceType'] = arg);
     final $result = await _protocol.send(
@@ -3903,18 +3165,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'subscriptionName',
-      subscriptionName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -4047,18 +3297,6 @@ class Redshift {
     SourceType? sourceType,
     DateTime? startTime,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'sourceIdentifier',
-      sourceIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     duration?.also((arg) => $request['Duration'] = arg);
     endTime?.also((arg) => $request['EndTime'] = _s.iso8601ToJson(arg));
@@ -4148,18 +3386,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     hsmClientCertificateIdentifier
         ?.also((arg) => $request['HsmClientCertificateIdentifier'] = arg);
@@ -4247,18 +3473,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     hsmConfigurationIdentifier
         ?.also((arg) => $request['HsmConfigurationIdentifier'] = arg);
@@ -4292,14 +3506,6 @@ class Redshift {
   Future<LoggingStatus> describeLoggingStatus({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -4376,31 +3582,6 @@ class Redshift {
     String? ownerAccount,
     String? snapshotIdentifier,
   }) async {
-    ArgumentError.checkNotNull(actionType, 'actionType');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'ownerAccount',
-      ownerAccount,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ActionType'] = actionType.toValue();
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
@@ -4473,24 +3654,6 @@ class Redshift {
     int? maxRecords,
     String? nodeType,
   }) async {
-    _s.validateStringLength(
-      'clusterVersion',
-      clusterVersion,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'nodeType',
-      nodeType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterVersion?.also((arg) => $request['ClusterVersion'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -4553,18 +3716,6 @@ class Redshift {
     int? maxRecords,
     String? reservedNodeOfferingId,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'reservedNodeOfferingId',
-      reservedNodeOfferingId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -4615,18 +3766,6 @@ class Redshift {
     int? maxRecords,
     String? reservedNodeId,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'reservedNodeId',
-      reservedNodeId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -4666,14 +3805,6 @@ class Redshift {
   Future<ResizeProgressMessage> describeResize({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -4744,18 +3875,6 @@ class Redshift {
     DateTime? startTime,
     ScheduledActionTypeValues? targetActionType,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     active?.also((arg) => $request['Active'] = arg);
     endTime?.also((arg) => $request['EndTime'] = _s.iso8601ToJson(arg));
@@ -4840,18 +3959,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotCopyGrantName',
-      snapshotCopyGrantName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -4911,24 +4018,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'scheduleIdentifier',
-      scheduleIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -5003,24 +4092,6 @@ class Redshift {
     int? maxRecords,
     String? tableRestoreRequestId,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'tableRestoreRequestId',
-      tableRestoreRequestId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
     marker?.also((arg) => $request['Marker'] = arg);
@@ -5162,24 +4233,6 @@ class Redshift {
     List<String>? tagKeys,
     List<String>? tagValues,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'resourceName',
-      resourceName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     marker?.also((arg) => $request['Marker'] = arg);
     maxRecords?.also((arg) => $request['MaxRecords'] = arg);
@@ -5282,24 +4335,6 @@ class Redshift {
     List<String>? tagValues,
     String? usageLimitId,
   }) async {
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'usageLimitId',
-      usageLimitId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     clusterIdentifier?.also((arg) => $request['ClusterIdentifier'] = arg);
     featureType?.also((arg) => $request['FeatureType'] = arg.toValue());
@@ -5334,14 +4369,6 @@ class Redshift {
   Future<LoggingStatus> disableLogging({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -5380,14 +4407,6 @@ class Redshift {
   Future<DisableSnapshotCopyResult> disableSnapshotCopy({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -5470,28 +4489,6 @@ class Redshift {
     required String clusterIdentifier,
     String? s3KeyPrefix,
   }) async {
-    ArgumentError.checkNotNull(bucketName, 'bucketName');
-    _s.validateStringLength(
-      'bucketName',
-      bucketName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      's3KeyPrefix',
-      s3KeyPrefix,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['BucketName'] = bucketName;
     $request['ClusterIdentifier'] = clusterIdentifier;
@@ -5564,28 +4561,6 @@ class Redshift {
     int? retentionPeriod,
     String? snapshotCopyGrantName,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(destinationRegion, 'destinationRegion');
-    _s.validateStringLength(
-      'destinationRegion',
-      destinationRegion,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'snapshotCopyGrantName',
-      snapshotCopyGrantName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['DestinationRegion'] = destinationRegion;
@@ -5762,28 +4737,6 @@ class Redshift {
     String? dbName,
     int? durationSeconds,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(dbUser, 'dbUser');
-    _s.validateStringLength(
-      'dbUser',
-      dbUser,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'dbName',
-      dbName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['DbUser'] = dbUser;
@@ -5832,20 +4785,6 @@ class Redshift {
     String? marker,
     int? maxRecords,
   }) async {
-    ArgumentError.checkNotNull(reservedNodeId, 'reservedNodeId');
-    _s.validateStringLength(
-      'reservedNodeId',
-      reservedNodeId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ReservedNodeId'] = reservedNodeId;
     marker?.also((arg) => $request['Marker'] = arg);
@@ -6189,92 +5128,6 @@ class Redshift {
     bool? publiclyAccessible,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'availabilityZone',
-      availabilityZone,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterParameterGroupName',
-      clusterParameterGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterType',
-      clusterType,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterVersion',
-      clusterVersion,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'elasticIp',
-      elasticIp,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'maintenanceTrackName',
-      maintenanceTrackName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'masterUserPassword',
-      masterUserPassword,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'newClusterIdentifier',
-      newClusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'nodeType',
-      nodeType,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'preferredMaintenanceWindow',
-      preferredMaintenanceWindow,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     allowVersionUpgrade?.also((arg) => $request['AllowVersionUpgrade'] = arg);
@@ -6343,22 +5196,6 @@ class Redshift {
     required String clusterIdentifier,
     required String revisionTarget,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revisionTarget, 'revisionTarget');
-    _s.validateStringLength(
-      'revisionTarget',
-      revisionTarget,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['RevisionTarget'] = revisionTarget;
@@ -6402,14 +5239,6 @@ class Redshift {
     List<String>? addIamRoles,
     List<String>? removeIamRoles,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     addIamRoles?.also((arg) => $request['AddIamRoles'] = arg);
@@ -6461,20 +5290,6 @@ class Redshift {
     String? deferMaintenanceIdentifier,
     DateTime? deferMaintenanceStartTime,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deferMaintenanceIdentifier',
-      deferMaintenanceIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     deferMaintenance?.also((arg) => $request['DeferMaintenance'] = arg);
@@ -6527,15 +5342,6 @@ class Redshift {
     required String parameterGroupName,
     required List<Parameter> parameters,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parameters, 'parameters');
     final $request = <String, dynamic>{};
     $request['ParameterGroupName'] = parameterGroupName;
     $request['Parameters'] = parameters;
@@ -6582,14 +5388,6 @@ class Redshift {
     bool? force,
     int? manualSnapshotRetentionPeriod,
   }) async {
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['SnapshotIdentifier'] = snapshotIdentifier;
     force?.also((arg) => $request['Force'] = arg);
@@ -6631,20 +5429,6 @@ class Redshift {
     bool? disassociateSchedule,
     String? scheduleIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'scheduleIdentifier',
-      scheduleIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     disassociateSchedule?.also((arg) => $request['DisassociateSchedule'] = arg);
@@ -6686,22 +5470,6 @@ class Redshift {
     required List<String> subnetIds,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSubnetGroupName, 'clusterSubnetGroupName');
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSubnetGroupName'] = clusterSubnetGroupName;
     $request['SubnetIds'] = subnetIds;
@@ -6784,32 +5552,6 @@ class Redshift {
     List<String>? sourceIds,
     String? sourceType,
   }) async {
-    ArgumentError.checkNotNull(subscriptionName, 'subscriptionName');
-    _s.validateStringLength(
-      'subscriptionName',
-      subscriptionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'severity',
-      severity,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snsTopicArn',
-      snsTopicArn,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'sourceType',
-      sourceType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['SubscriptionName'] = subscriptionName;
     enabled?.also((arg) => $request['Enabled'] = arg);
@@ -6880,32 +5622,6 @@ class Redshift {
     DateTime? startTime,
     ScheduledActionType? targetAction,
   }) async {
-    ArgumentError.checkNotNull(scheduledActionName, 'scheduledActionName');
-    _s.validateStringLength(
-      'scheduledActionName',
-      scheduledActionName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'schedule',
-      schedule,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'scheduledActionDescription',
-      scheduledActionDescription,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ScheduledActionName'] = scheduledActionName;
     enable?.also((arg) => $request['Enable'] = arg);
@@ -6986,15 +5702,6 @@ class Redshift {
     required int retentionPeriod,
     bool? manual,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(retentionPeriod, 'retentionPeriod');
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['RetentionPeriod'] = retentionPeriod;
@@ -7030,15 +5737,6 @@ class Redshift {
     required List<String> scheduleDefinitions,
     required String scheduleIdentifier,
   }) async {
-    ArgumentError.checkNotNull(scheduleDefinitions, 'scheduleDefinitions');
-    ArgumentError.checkNotNull(scheduleIdentifier, 'scheduleIdentifier');
-    _s.validateStringLength(
-      'scheduleIdentifier',
-      scheduleIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ScheduleDefinitions'] = scheduleDefinitions;
     $request['ScheduleIdentifier'] = scheduleIdentifier;
@@ -7078,14 +5776,6 @@ class Redshift {
     int? amount,
     UsageLimitBreachAction? breachAction,
   }) async {
-    ArgumentError.checkNotNull(usageLimitId, 'usageLimitId');
-    _s.validateStringLength(
-      'usageLimitId',
-      usageLimitId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['UsageLimitId'] = usageLimitId;
     amount?.also((arg) => $request['Amount'] = arg);
@@ -7114,14 +5804,6 @@ class Redshift {
   Future<PauseClusterResult> pauseCluster({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -7165,15 +5847,6 @@ class Redshift {
     required String reservedNodeOfferingId,
     int? nodeCount,
   }) async {
-    ArgumentError.checkNotNull(
-        reservedNodeOfferingId, 'reservedNodeOfferingId');
-    _s.validateStringLength(
-      'reservedNodeOfferingId',
-      reservedNodeOfferingId,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ReservedNodeOfferingId'] = reservedNodeOfferingId;
     nodeCount?.also((arg) => $request['NodeCount'] = arg);
@@ -7209,14 +5882,6 @@ class Redshift {
   Future<RebootClusterResult> rebootCluster({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -7261,14 +5926,6 @@ class Redshift {
     List<Parameter>? parameters,
     bool? resetAllParameters,
   }) async {
-    ArgumentError.checkNotNull(parameterGroupName, 'parameterGroupName');
-    _s.validateStringLength(
-      'parameterGroupName',
-      parameterGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ParameterGroupName'] = parameterGroupName;
     parameters?.also((arg) => $request['Parameters'] = arg);
@@ -7368,26 +6025,6 @@ class Redshift {
     String? nodeType,
     int? numberOfNodes,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clusterType',
-      clusterType,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'nodeType',
-      nodeType,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     classic?.also((arg) => $request['Classic'] = arg);
@@ -7694,106 +6331,6 @@ class Redshift {
     String? snapshotScheduleIdentifier,
     List<String>? vpcSecurityGroupIds,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'additionalInfo',
-      additionalInfo,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'availabilityZone',
-      availabilityZone,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterParameterGroupName',
-      clusterParameterGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'clusterSubnetGroupName',
-      clusterSubnetGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'elasticIp',
-      elasticIp,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmClientCertificateIdentifier',
-      hsmClientCertificateIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'hsmConfigurationIdentifier',
-      hsmConfigurationIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'maintenanceTrackName',
-      maintenanceTrackName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'nodeType',
-      nodeType,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'ownerAccount',
-      ownerAccount,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'preferredMaintenanceWindow',
-      preferredMaintenanceWindow,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotClusterIdentifier',
-      snapshotClusterIdentifier,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'snapshotScheduleIdentifier',
-      snapshotScheduleIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['SnapshotIdentifier'] = snapshotIdentifier;
@@ -7908,64 +6445,6 @@ class Redshift {
     String? targetDatabaseName,
     String? targetSchemaName,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(newTableName, 'newTableName');
-    _s.validateStringLength(
-      'newTableName',
-      newTableName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceDatabaseName, 'sourceDatabaseName');
-    _s.validateStringLength(
-      'sourceDatabaseName',
-      sourceDatabaseName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceTableName, 'sourceTableName');
-    _s.validateStringLength(
-      'sourceTableName',
-      sourceTableName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceSchemaName',
-      sourceSchemaName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'targetDatabaseName',
-      targetDatabaseName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'targetSchemaName',
-      targetSchemaName,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     $request['NewTableName'] = newTableName;
@@ -8000,14 +6479,6 @@ class Redshift {
   Future<ResumeClusterResult> resumeCluster({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(
@@ -8066,33 +6537,6 @@ class Redshift {
     String? eC2SecurityGroupName,
     String? eC2SecurityGroupOwnerId,
   }) async {
-    ArgumentError.checkNotNull(
-        clusterSecurityGroupName, 'clusterSecurityGroupName');
-    _s.validateStringLength(
-      'clusterSecurityGroupName',
-      clusterSecurityGroupName,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cidrip',
-      cidrip,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'eC2SecurityGroupName',
-      eC2SecurityGroupName,
-      0,
-      2147483647,
-    );
-    _s.validateStringLength(
-      'eC2SecurityGroupOwnerId',
-      eC2SecurityGroupOwnerId,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterSecurityGroupName'] = clusterSecurityGroupName;
     cidrip?.also((arg) => $request['CIDRIP'] = arg);
@@ -8143,29 +6587,6 @@ class Redshift {
     required String snapshotIdentifier,
     String? snapshotClusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(
-        accountWithRestoreAccess, 'accountWithRestoreAccess');
-    _s.validateStringLength(
-      'accountWithRestoreAccess',
-      accountWithRestoreAccess,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(snapshotIdentifier, 'snapshotIdentifier');
-    _s.validateStringLength(
-      'snapshotIdentifier',
-      snapshotIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'snapshotClusterIdentifier',
-      snapshotClusterIdentifier,
-      0,
-      2147483647,
-    );
     final $request = <String, dynamic>{};
     $request['AccountWithRestoreAccess'] = accountWithRestoreAccess;
     $request['SnapshotIdentifier'] = snapshotIdentifier;
@@ -8200,14 +6621,6 @@ class Redshift {
   Future<RotateEncryptionKeyResult> rotateEncryptionKey({
     required String clusterIdentifier,
   }) async {
-    ArgumentError.checkNotNull(clusterIdentifier, 'clusterIdentifier');
-    _s.validateStringLength(
-      'clusterIdentifier',
-      clusterIdentifier,
-      0,
-      2147483647,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ClusterIdentifier'] = clusterIdentifier;
     final $result = await _protocol.send(

--- a/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
+++ b/generated/aws_rekognition_api/lib/rekognition-2016-06-27.dart
@@ -153,8 +153,6 @@ class Rekognition {
     QualityFilter? qualityFilter,
     double? similarityThreshold,
   }) async {
-    ArgumentError.checkNotNull(sourceImage, 'sourceImage');
-    ArgumentError.checkNotNull(targetImage, 'targetImage');
     _s.validateNumRange(
       'similarityThreshold',
       similarityThreshold,
@@ -212,14 +210,6 @@ class Rekognition {
   Future<CreateCollectionResponse> createCollection({
     required String collectionId,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.CreateCollection'
@@ -258,14 +248,6 @@ class Rekognition {
   Future<CreateProjectResponse> createProject({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.CreateProject'
@@ -334,25 +316,6 @@ class Rekognition {
     required TrainingData trainingData,
     required String versionName,
   }) async {
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(testingData, 'testingData');
-    ArgumentError.checkNotNull(trainingData, 'trainingData');
-    ArgumentError.checkNotNull(versionName, 'versionName');
-    _s.validateStringLength(
-      'versionName',
-      versionName,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.CreateProjectVersion'
@@ -433,18 +396,6 @@ class Rekognition {
     required String roleArn,
     required StreamProcessorSettings settings,
   }) async {
-    ArgumentError.checkNotNull(input, 'input');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(output, 'output');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    ArgumentError.checkNotNull(settings, 'settings');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.CreateStreamProcessor'
@@ -486,14 +437,6 @@ class Rekognition {
   Future<DeleteCollectionResponse> deleteCollection({
     required String collectionId,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DeleteCollection'
@@ -534,15 +477,6 @@ class Rekognition {
     required String collectionId,
     required List<String> faceIds,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(faceIds, 'faceIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DeleteFaces'
@@ -582,14 +516,6 @@ class Rekognition {
   Future<DeleteProjectResponse> deleteProject({
     required String projectArn,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DeleteProject'
@@ -633,14 +559,6 @@ class Rekognition {
   Future<DeleteProjectVersionResponse> deleteProjectVersion({
     required String projectVersionArn,
   }) async {
-    ArgumentError.checkNotNull(projectVersionArn, 'projectVersionArn');
-    _s.validateStringLength(
-      'projectVersionArn',
-      projectVersionArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DeleteProjectVersion'
@@ -678,14 +596,6 @@ class Rekognition {
   Future<void> deleteStreamProcessor({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DeleteStreamProcessor'
@@ -722,14 +632,6 @@ class Rekognition {
   Future<DescribeCollectionResponse> describeCollection({
     required String collectionId,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DescribeCollection'
@@ -793,25 +695,11 @@ class Rekognition {
     String? nextToken,
     List<String>? versionNames,
   }) async {
-    ArgumentError.checkNotNull(projectArn, 'projectArn');
-    _s.validateStringLength(
-      'projectArn',
-      projectArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -867,12 +755,6 @@ class Rekognition {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DescribeProjects'
@@ -909,14 +791,6 @@ class Rekognition {
   Future<DescribeStreamProcessorResponse> describeStreamProcessor({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DescribeStreamProcessor'
@@ -1004,15 +878,6 @@ class Rekognition {
     int? maxResults,
     double? minConfidence,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
-    ArgumentError.checkNotNull(projectVersionArn, 'projectVersionArn');
-    _s.validateStringLength(
-      'projectVersionArn',
-      projectVersionArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1106,7 +971,6 @@ class Rekognition {
     required Image image,
     List<Attribute>? attributes,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DetectFaces'
@@ -1236,7 +1100,6 @@ class Rekognition {
     int? maxLabels,
     double? minConfidence,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     _s.validateNumRange(
       'maxLabels',
       maxLabels,
@@ -1322,7 +1185,6 @@ class Rekognition {
     HumanLoopConfig? humanLoopConfig,
     double? minConfidence,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     _s.validateNumRange(
       'minConfidence',
       minConfidence,
@@ -1419,7 +1281,6 @@ class Rekognition {
     required Image image,
     ProtectiveEquipmentSummarizationAttributes? summarizationAttributes,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DetectProtectiveEquipment'
@@ -1504,7 +1365,6 @@ class Rekognition {
     required Image image,
     DetectTextFilters? filters,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.DetectText'
@@ -1549,7 +1409,6 @@ class Rekognition {
   Future<GetCelebrityInfoResponse> getCelebrityInfo({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.GetCelebrityInfo'
@@ -1654,25 +1513,11 @@ class Rekognition {
     String? nextToken,
     CelebrityRecognitionSortBy? sortBy,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1774,25 +1619,11 @@ class Rekognition {
     String? nextToken,
     ContentModerationSortBy? sortBy,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1867,25 +1698,11 @@ class Rekognition {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1977,25 +1794,11 @@ class Rekognition {
     String? nextToken,
     FaceSearchSortBy? sortBy,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2089,25 +1892,11 @@ class Rekognition {
     String? nextToken,
     LabelDetectionSortBy? sortBy,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2206,25 +1995,11 @@ class Rekognition {
     String? nextToken,
     PersonTrackingSortBy? sortBy,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2313,25 +2088,11 @@ class Rekognition {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2412,25 +2173,11 @@ class Rekognition {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2655,21 +2402,6 @@ class Rekognition {
     int? maxFaces,
     QualityFilter? qualityFilter,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(image, 'image');
-    _s.validateStringLength(
-      'externalImageId',
-      externalImageId,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxFaces',
       maxFaces,
@@ -2734,12 +2466,6 @@ class Rekognition {
       0,
       4096,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.ListCollections'
@@ -2790,25 +2516,11 @@ class Rekognition {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       4096,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2858,12 +2570,6 @@ class Rekognition {
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2941,7 +2647,6 @@ class Rekognition {
   Future<RecognizeCelebritiesResponse> recognizeCelebrities({
     required Image image,
   }) async {
-    ArgumentError.checkNotNull(image, 'image');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.RecognizeCelebrities'
@@ -3008,15 +2713,6 @@ class Rekognition {
     double? faceMatchThreshold,
     int? maxFaces,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(faceId, 'faceId');
     _s.validateNumRange(
       'faceMatchThreshold',
       faceMatchThreshold,
@@ -3149,15 +2845,6 @@ class Rekognition {
     int? maxFaces,
     QualityFilter? qualityFilter,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(image, 'image');
     _s.validateNumRange(
       'faceMatchThreshold',
       faceMatchThreshold,
@@ -3247,19 +2934,6 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartCelebrityRecognition'
@@ -3348,19 +3022,6 @@ class Rekognition {
     double? minConfidence,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'minConfidence',
       minConfidence,
@@ -3452,19 +3113,6 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartFaceDetection'
@@ -3551,32 +3199,11 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(collectionId, 'collectionId');
-    _s.validateStringLength(
-      'collectionId',
-      collectionId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'faceMatchThreshold',
       faceMatchThreshold,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3674,19 +3301,6 @@ class Rekognition {
     double? minConfidence,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'minConfidence',
       minConfidence,
@@ -3768,19 +3382,6 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartPersonTracking'
@@ -3838,20 +3439,11 @@ class Rekognition {
     required int minInferenceUnits,
     required String projectVersionArn,
   }) async {
-    ArgumentError.checkNotNull(minInferenceUnits, 'minInferenceUnits');
     _s.validateNumRange(
       'minInferenceUnits',
       minInferenceUnits,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(projectVersionArn, 'projectVersionArn');
-    _s.validateStringLength(
-      'projectVersionArn',
-      projectVersionArn,
-      20,
-      2048,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -3939,20 +3531,6 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(segmentTypes, 'segmentTypes');
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartSegmentDetection'
@@ -3997,14 +3575,6 @@ class Rekognition {
   Future<void> startStreamProcessor({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartStreamProcessor'
@@ -4069,19 +3639,6 @@ class Rekognition {
     String? jobTag,
     NotificationChannel? notificationChannel,
   }) async {
-    ArgumentError.checkNotNull(video, 'video');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StartTextDetection'
@@ -4126,14 +3683,6 @@ class Rekognition {
   Future<StopProjectVersionResponse> stopProjectVersion({
     required String projectVersionArn,
   }) async {
-    ArgumentError.checkNotNull(projectVersionArn, 'projectVersionArn');
-    _s.validateStringLength(
-      'projectVersionArn',
-      projectVersionArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StopProjectVersion'
@@ -4168,14 +3717,6 @@ class Rekognition {
   Future<void> stopStreamProcessor({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'RekognitionService.StopStreamProcessor'

--- a/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
+++ b/generated/aws_resource_groups_api/lib/resource-groups-2017-11-27.dart
@@ -127,20 +127,6 @@ class ResourceGroups {
     ResourceQuery? resourceQuery,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
     final $payload = <String, dynamic>{
       'Name': name,
       if (configuration != null) 'Configuration': configuration,
@@ -187,18 +173,6 @@ class ResourceGroups {
     String? group,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (group != null) 'Group': group,
       if (groupName != null) 'GroupName': groupName,
@@ -240,18 +214,6 @@ class ResourceGroups {
     String? group,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (group != null) 'Group': group,
       if (groupName != null) 'GroupName': groupName,
@@ -292,12 +254,6 @@ class ResourceGroups {
   Future<GetGroupConfigurationOutput> getGroupConfiguration({
     String? group,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
     final $payload = <String, dynamic>{
       if (group != null) 'Group': group,
     };
@@ -341,18 +297,6 @@ class ResourceGroups {
     String? group,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (group != null) 'Group': group,
       if (groupName != null) 'GroupName': groupName,
@@ -391,14 +335,6 @@ class ResourceGroups {
   Future<GetTagsOutput> getTags({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      12,
-      1600,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -436,15 +372,6 @@ class ResourceGroups {
     required String group,
     required List<String> resourceArns,
   }) async {
-    ArgumentError.checkNotNull(group, 'group');
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
     final $payload = <String, dynamic>{
       'Group': group,
       'ResourceArns': resourceArns,
@@ -548,29 +475,11 @@ class ResourceGroups {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final $payload = <String, dynamic>{
       if (filters != null) 'Filters': filters,
@@ -662,12 +571,6 @@ class ResourceGroups {
       1,
       50,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxResults': [maxResults.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -727,12 +630,6 @@ class ResourceGroups {
     List<GroupConfigurationItem>? configuration,
     String? group,
   }) async {
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
     final $payload = <String, dynamic>{
       if (configuration != null) 'Configuration': configuration,
       if (group != null) 'Group': group,
@@ -794,18 +691,11 @@ class ResourceGroups {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceQuery, 'resourceQuery');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final $payload = <String, dynamic>{
       'ResourceQuery': resourceQuery,
@@ -857,15 +747,6 @@ class ResourceGroups {
     required String arn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      12,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -907,15 +788,6 @@ class ResourceGroups {
     required String group,
     required List<String> resourceArns,
   }) async {
-    ArgumentError.checkNotNull(group, 'group');
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArns, 'resourceArns');
     final $payload = <String, dynamic>{
       'Group': group,
       'ResourceArns': resourceArns,
@@ -958,15 +830,6 @@ class ResourceGroups {
     required String arn,
     required List<String> keys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      12,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(keys, 'keys');
     final $payload = <String, dynamic>{
       'Keys': keys,
     };
@@ -1014,24 +877,6 @@ class ResourceGroups {
     String? group,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      512,
-    );
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (group != null) 'Group': group,
@@ -1086,19 +931,6 @@ class ResourceGroups {
     String? group,
     String? groupName,
   }) async {
-    ArgumentError.checkNotNull(resourceQuery, 'resourceQuery');
-    _s.validateStringLength(
-      'group',
-      group,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      128,
-    );
     final $payload = <String, dynamic>{
       'ResourceQuery': resourceQuery,
       if (group != null) 'Group': group,

--- a/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
+++ b/generated/aws_resourcegroupstaggingapi_api/lib/resourcegroupstaggingapi-2017-01-26.dart
@@ -161,12 +161,6 @@ class ResourceGroupsTaggingAPI {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.GetComplianceSummary'
@@ -366,12 +360,6 @@ class ResourceGroupsTaggingAPI {
     List<TagFilter>? tagFilters,
     int? tagsPerPage,
   }) async {
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.GetResources'
@@ -414,12 +402,6 @@ class ResourceGroupsTaggingAPI {
   Future<GetTagKeysOutput> getTagKeys({
     String? paginationToken,
   }) async {
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.GetTagKeys'
@@ -459,20 +441,6 @@ class ResourceGroupsTaggingAPI {
     required String key,
     String? paginationToken,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'paginationToken',
-      paginationToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.GetTagValues'
@@ -520,14 +488,6 @@ class ResourceGroupsTaggingAPI {
   Future<void> startReportCreation({
     required String s3Bucket,
   }) async {
-    ArgumentError.checkNotNull(s3Bucket, 's3Bucket');
-    _s.validateStringLength(
-      's3Bucket',
-      s3Bucket,
-      3,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.StartReportCreation'
@@ -594,8 +554,6 @@ class ResourceGroupsTaggingAPI {
     required List<String> resourceARNList,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARNList, 'resourceARNList');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.TagResources'
@@ -652,8 +610,6 @@ class ResourceGroupsTaggingAPI {
     required List<String> resourceARNList,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARNList, 'resourceARNList');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ResourceGroupsTaggingAPI_20170126.UntagResources'

--- a/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
+++ b/generated/aws_robomaker_api/lib/robomaker-2018-06-29.dart
@@ -60,7 +60,6 @@ class RoboMaker {
   Future<BatchDeleteWorldsResponse> batchDeleteWorlds({
     required List<String> worlds,
   }) async {
-    ArgumentError.checkNotNull(worlds, 'worlds');
     final $payload = <String, dynamic>{
       'worlds': worlds,
     };
@@ -85,7 +84,6 @@ class RoboMaker {
   Future<BatchDescribeSimulationJobResponse> batchDescribeSimulationJob({
     required List<String> jobs,
   }) async {
-    ArgumentError.checkNotNull(jobs, 'jobs');
     final $payload = <String, dynamic>{
       'jobs': jobs,
     };
@@ -110,14 +108,6 @@ class RoboMaker {
   Future<void> cancelDeploymentJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -141,14 +131,6 @@ class RoboMaker {
   Future<void> cancelSimulationJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -174,14 +156,6 @@ class RoboMaker {
   Future<void> cancelSimulationJobBatch({
     required String batch,
   }) async {
-    ArgumentError.checkNotNull(batch, 'batch');
-    _s.validateStringLength(
-      'batch',
-      batch,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'batch': batch,
     };
@@ -205,14 +179,6 @@ class RoboMaker {
   Future<void> cancelWorldExportJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -236,14 +202,6 @@ class RoboMaker {
   Future<void> cancelWorldGenerationJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -298,22 +256,6 @@ class RoboMaker {
     DeploymentConfig? deploymentConfig,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        deploymentApplicationConfigs, 'deploymentApplicationConfigs');
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'deploymentApplicationConfigs': deploymentApplicationConfigs,
       'fleet': fleet,
@@ -348,14 +290,6 @@ class RoboMaker {
     required String name,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'name': name,
       if (tags != null) 'tags': tags,
@@ -395,23 +329,6 @@ class RoboMaker {
     required String name,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(architecture, 'architecture');
-    ArgumentError.checkNotNull(greengrassGroupId, 'greengrassGroupId');
-    _s.validateStringLength(
-      'greengrassGroupId',
-      greengrassGroupId,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'architecture': architecture.toValue(),
       'greengrassGroupId': greengrassGroupId,
@@ -455,16 +372,6 @@ class RoboMaker {
     required List<SourceConfig> sources,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robotSoftwareSuite, 'robotSoftwareSuite');
-    ArgumentError.checkNotNull(sources, 'sources');
     final $payload = <String, dynamic>{
       'name': name,
       'robotSoftwareSuite': robotSoftwareSuite,
@@ -498,20 +405,6 @@ class RoboMaker {
     required String application,
     String? currentRevisionId,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'currentRevisionId',
-      currentRevisionId,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (currentRevisionId != null) 'currentRevisionId': currentRevisionId,
@@ -561,18 +454,6 @@ class RoboMaker {
     RenderingEngine? renderingEngine,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robotSoftwareSuite, 'robotSoftwareSuite');
-    ArgumentError.checkNotNull(
-        simulationSoftwareSuite, 'simulationSoftwareSuite');
-    ArgumentError.checkNotNull(sources, 'sources');
     final $payload = <String, dynamic>{
       'name': name,
       'robotSoftwareSuite': robotSoftwareSuite,
@@ -610,20 +491,6 @@ class RoboMaker {
     required String application,
     String? currentRevisionId,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'currentRevisionId',
-      currentRevisionId,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (currentRevisionId != null) 'currentRevisionId': currentRevisionId,
@@ -720,22 +587,6 @@ class RoboMaker {
     Map<String, String>? tags,
     VPCConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(iamRole, 'iamRole');
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        maxJobDurationInSeconds, 'maxJobDurationInSeconds');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'iamRole': iamRole,
       'maxJobDurationInSeconds': maxJobDurationInSeconds,
@@ -791,22 +642,6 @@ class RoboMaker {
     String? clientRequestToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(iamRole, 'iamRole');
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputLocation, 'outputLocation');
-    ArgumentError.checkNotNull(worlds, 'worlds');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'iamRole': iamRole,
       'outputLocation': outputLocation,
@@ -858,21 +693,6 @@ class RoboMaker {
     Map<String, String>? tags,
     Map<String, String>? worldTags,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
-    _s.validateStringLength(
-      'template',
-      template,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(worldCount, 'worldCount');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'template': template,
       'worldCount': worldCount,
@@ -921,24 +741,6 @@ class RoboMaker {
     String? templateBody,
     TemplateLocation? templateLocation,
   }) async {
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      262144,
-    );
     final $payload = <String, dynamic>{
       if (clientRequestToken != null) 'clientRequestToken': clientRequestToken,
       if (name != null) 'name': name,
@@ -966,14 +768,6 @@ class RoboMaker {
   Future<void> deleteFleet({
     required String fleet,
   }) async {
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'fleet': fleet,
     };
@@ -996,14 +790,6 @@ class RoboMaker {
   Future<void> deleteRobot({
     required String robot,
   }) async {
-    ArgumentError.checkNotNull(robot, 'robot');
-    _s.validateStringLength(
-      'robot',
-      robot,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'robot': robot,
     };
@@ -1030,20 +816,6 @@ class RoboMaker {
     required String application,
     String? applicationVersion,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationVersion',
-      applicationVersion,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (applicationVersion != null) 'applicationVersion': applicationVersion,
@@ -1071,20 +843,6 @@ class RoboMaker {
     required String application,
     String? applicationVersion,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationVersion',
-      applicationVersion,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (applicationVersion != null) 'applicationVersion': applicationVersion,
@@ -1109,14 +867,6 @@ class RoboMaker {
   Future<void> deleteWorldTemplate({
     required String template,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
-    _s.validateStringLength(
-      'template',
-      template,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'template': template,
     };
@@ -1144,22 +894,6 @@ class RoboMaker {
     required String fleet,
     required String robot,
   }) async {
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robot, 'robot');
-    _s.validateStringLength(
-      'robot',
-      robot,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'fleet': fleet,
       'robot': robot,
@@ -1185,14 +919,6 @@ class RoboMaker {
   Future<DescribeDeploymentJobResponse> describeDeploymentJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -1217,14 +943,6 @@ class RoboMaker {
   Future<DescribeFleetResponse> describeFleet({
     required String fleet,
   }) async {
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'fleet': fleet,
     };
@@ -1249,14 +967,6 @@ class RoboMaker {
   Future<DescribeRobotResponse> describeRobot({
     required String robot,
   }) async {
-    ArgumentError.checkNotNull(robot, 'robot');
-    _s.validateStringLength(
-      'robot',
-      robot,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'robot': robot,
     };
@@ -1285,20 +995,6 @@ class RoboMaker {
     required String application,
     String? applicationVersion,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationVersion',
-      applicationVersion,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (applicationVersion != null) 'applicationVersion': applicationVersion,
@@ -1328,20 +1024,6 @@ class RoboMaker {
     required String application,
     String? applicationVersion,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'applicationVersion',
-      applicationVersion,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       if (applicationVersion != null) 'applicationVersion': applicationVersion,
@@ -1367,14 +1049,6 @@ class RoboMaker {
   Future<DescribeSimulationJobResponse> describeSimulationJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -1398,14 +1072,6 @@ class RoboMaker {
   Future<DescribeSimulationJobBatchResponse> describeSimulationJobBatch({
     required String batch,
   }) async {
-    ArgumentError.checkNotNull(batch, 'batch');
-    _s.validateStringLength(
-      'batch',
-      batch,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'batch': batch,
     };
@@ -1430,14 +1096,6 @@ class RoboMaker {
   Future<DescribeWorldResponse> describeWorld({
     required String world,
   }) async {
-    ArgumentError.checkNotNull(world, 'world');
-    _s.validateStringLength(
-      'world',
-      world,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'world': world,
     };
@@ -1462,14 +1120,6 @@ class RoboMaker {
   Future<DescribeWorldExportJobResponse> describeWorldExportJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -1494,14 +1144,6 @@ class RoboMaker {
   Future<DescribeWorldGenerationJobResponse> describeWorldGenerationJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -1526,14 +1168,6 @@ class RoboMaker {
   Future<DescribeWorldTemplateResponse> describeWorldTemplate({
     required String template,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
-    _s.validateStringLength(
-      'template',
-      template,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'template': template,
     };
@@ -1562,18 +1196,6 @@ class RoboMaker {
     String? generationJob,
     String? template,
   }) async {
-    _s.validateStringLength(
-      'generationJob',
-      generationJob,
-      1,
-      1224,
-    );
-    _s.validateStringLength(
-      'template',
-      template,
-      1,
-      1224,
-    );
     final $payload = <String, dynamic>{
       if (generationJob != null) 'generationJob': generationJob,
       if (template != null) 'template': template,
@@ -1627,12 +1249,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1689,12 +1305,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1750,18 +1360,6 @@ class RoboMaker {
     String? nextToken,
     String? versionQualifier,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'versionQualifier',
-      versionQualifier,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1817,12 +1415,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1879,18 +1471,6 @@ class RoboMaker {
     String? nextToken,
     String? versionQualifier,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'versionQualifier',
-      versionQualifier,
-      1,
-      255,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1936,12 +1516,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -1997,12 +1571,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -2029,14 +1597,6 @@ class RoboMaker {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -2079,12 +1639,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -2132,12 +1686,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -2180,12 +1728,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (maxResults != null) 'maxResults': maxResults,
       if (nextToken != null) 'nextToken': nextToken,
@@ -2231,12 +1773,6 @@ class RoboMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
       if (maxResults != null) 'maxResults': maxResults,
@@ -2268,22 +1804,6 @@ class RoboMaker {
     required String fleet,
     required String robot,
   }) async {
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robot, 'robot');
-    _s.validateStringLength(
-      'robot',
-      robot,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'fleet': fleet,
       'robot': robot,
@@ -2310,14 +1830,6 @@ class RoboMaker {
   Future<void> restartSimulationJob({
     required String job,
   }) async {
-    ArgumentError.checkNotNull(job, 'job');
-    _s.validateStringLength(
-      'job',
-      job,
-      1,
-      1224,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'job': job,
     };
@@ -2357,14 +1869,6 @@ class RoboMaker {
     String? clientRequestToken,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        createSimulationJobRequests, 'createSimulationJobRequests');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'createSimulationJobRequests': createSimulationJobRequests,
       if (batchPolicy != null) 'batchPolicy': batchPolicy,
@@ -2401,20 +1905,6 @@ class RoboMaker {
     required String fleet,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(fleet, 'fleet');
-    _s.validateStringLength(
-      'fleet',
-      fleet,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
     final $payload = <String, dynamic>{
       'fleet': fleet,
       'clientRequestToken': clientRequestToken ?? _s.generateIdempotencyToken(),
@@ -2455,15 +1945,6 @@ class RoboMaker {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -2498,15 +1979,6 @@ class RoboMaker {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -2544,22 +2016,6 @@ class RoboMaker {
     required List<SourceConfig> sources,
     String? currentRevisionId,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robotSoftwareSuite, 'robotSoftwareSuite');
-    ArgumentError.checkNotNull(sources, 'sources');
-    _s.validateStringLength(
-      'currentRevisionId',
-      currentRevisionId,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       'robotSoftwareSuite': robotSoftwareSuite,
@@ -2608,24 +2064,6 @@ class RoboMaker {
     String? currentRevisionId,
     RenderingEngine? renderingEngine,
   }) async {
-    ArgumentError.checkNotNull(application, 'application');
-    _s.validateStringLength(
-      'application',
-      application,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(robotSoftwareSuite, 'robotSoftwareSuite');
-    ArgumentError.checkNotNull(
-        simulationSoftwareSuite, 'simulationSoftwareSuite');
-    ArgumentError.checkNotNull(sources, 'sources');
-    _s.validateStringLength(
-      'currentRevisionId',
-      currentRevisionId,
-      1,
-      40,
-    );
     final $payload = <String, dynamic>{
       'application': application,
       'robotSoftwareSuite': robotSoftwareSuite,
@@ -2667,26 +2105,6 @@ class RoboMaker {
     String? templateBody,
     TemplateLocation? templateLocation,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
-    _s.validateStringLength(
-      'template',
-      template,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'templateBody',
-      templateBody,
-      1,
-      262144,
-    );
     final $payload = <String, dynamic>{
       'template': template,
       if (name != null) 'name': name,

--- a/generated/aws_route53_api/lib/route53-2013-04-01.dart
+++ b/generated/aws_route53_api/lib/route53-2013-04-01.dart
@@ -66,22 +66,6 @@ class Route53 {
     required String hostedZoneId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -132,15 +116,6 @@ class Route53 {
     required VPC vpc,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpc, 'vpc');
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -276,15 +251,6 @@ class Route53 {
     required ChangeBatch changeBatch,
     required String hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(changeBatch, 'changeBatch');
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -348,15 +314,6 @@ class Route53 {
     List<Tag>? addTags,
     List<String>? removeTagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     await _protocol.send(
       method: 'POST',
       requestUri:
@@ -461,15 +418,6 @@ class Route53 {
     required String callerReference,
     required HealthCheckConfig healthCheckConfig,
   }) async {
-    ArgumentError.checkNotNull(callerReference, 'callerReference');
-    _s.validateStringLength(
-      'callerReference',
-      callerReference,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(healthCheckConfig, 'healthCheckConfig');
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/healthcheck',
@@ -607,28 +555,6 @@ class Route53 {
     HostedZoneConfig? hostedZoneConfig,
     VPC? vpc,
   }) async {
-    ArgumentError.checkNotNull(callerReference, 'callerReference');
-    _s.validateStringLength(
-      'callerReference',
-      callerReference,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'delegationSetId',
-      delegationSetId,
-      0,
-      32,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/hostedzone',
@@ -733,40 +659,6 @@ class Route53 {
     required String name,
     required String status,
   }) async {
-    ArgumentError.checkNotNull(callerReference, 'callerReference');
-    _s.validateStringLength(
-      'callerReference',
-      callerReference,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        keyManagementServiceArn, 'keyManagementServiceArn');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
-    _s.validateStringLength(
-      'status',
-      status,
-      5,
-      150,
-      isRequired: true,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/keysigningkey',
@@ -941,16 +833,6 @@ class Route53 {
     required String cloudWatchLogsLogGroupArn,
     required String hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(
-        cloudWatchLogsLogGroupArn, 'cloudWatchLogsLogGroupArn');
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/queryloggingconfig',
@@ -1060,20 +942,6 @@ class Route53 {
     required String callerReference,
     String? hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(callerReference, 'callerReference');
-    _s.validateStringLength(
-      'callerReference',
-      callerReference,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/delegationset',
@@ -1121,28 +989,6 @@ class Route53 {
     required String name,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
-    _s.validateStringLength(
-      'document',
-      document,
-      0,
-      102400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      1024,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/trafficpolicy',
@@ -1207,23 +1053,6 @@ class Route53 {
     required String trafficPolicyId,
     required int trafficPolicyVersion,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ttl, 'ttl');
     _s.validateNumRange(
       'ttl',
       ttl,
@@ -1231,15 +1060,6 @@ class Route53 {
       2147483647,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(trafficPolicyId, 'trafficPolicyId');
-    _s.validateStringLength(
-      'trafficPolicyId',
-      trafficPolicyId,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trafficPolicyVersion, 'trafficPolicyVersion');
     _s.validateNumRange(
       'trafficPolicyVersion',
       trafficPolicyVersion,
@@ -1305,28 +1125,6 @@ class Route53 {
     required String id,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
-    _s.validateStringLength(
-      'document',
-      document,
-      0,
-      102400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      1024,
-    );
     final $result = await _protocol.sendRaw(
       method: 'POST',
       requestUri: '/2013-04-01/trafficpolicy/${Uri.encodeComponent(id)}',
@@ -1380,15 +1178,6 @@ class Route53 {
     required String hostedZoneId,
     required VPC vpc,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpc, 'vpc');
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -1427,22 +1216,6 @@ class Route53 {
     required String hostedZoneId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -1480,14 +1253,6 @@ class Route53 {
   Future<void> deleteHealthCheck({
     required String healthCheckId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckId, 'healthCheckId');
-    _s.validateStringLength(
-      'healthCheckId',
-      healthCheckId,
-      0,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       method: 'DELETE',
       requestUri:
@@ -1563,14 +1328,6 @@ class Route53 {
   Future<DeleteHostedZoneResponse> deleteHostedZone({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'DELETE',
       requestUri: '/2013-04-01/hostedzone/${Uri.encodeComponent(id)}',
@@ -1598,22 +1355,6 @@ class Route53 {
     required String hostedZoneId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'DELETE',
       requestUri:
@@ -1640,14 +1381,6 @@ class Route53 {
   Future<void> deleteQueryLoggingConfig({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
     await _protocol.send(
       method: 'DELETE',
       requestUri: '/2013-04-01/queryloggingconfig/${Uri.encodeComponent(id)}',
@@ -1676,14 +1409,6 @@ class Route53 {
   Future<void> deleteReusableDelegationSet({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
     await _protocol.send(
       method: 'DELETE',
       requestUri: '/2013-04-01/delegationset/${Uri.encodeComponent(id)}',
@@ -1726,15 +1451,6 @@ class Route53 {
     required String id,
     required int version,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
     _s.validateNumRange(
       'version',
       version,
@@ -1771,14 +1487,6 @@ class Route53 {
   Future<void> deleteTrafficPolicyInstance({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
     await _protocol.send(
       method: 'DELETE',
       requestUri:
@@ -1819,15 +1527,6 @@ class Route53 {
     required String hostedZoneId,
     required VPC vpc,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpc, 'vpc');
     await _protocol.send(
       method: 'POST',
       requestUri:
@@ -1861,14 +1560,6 @@ class Route53 {
   Future<DisableHostedZoneDNSSECResponse> disableHostedZoneDNSSEC({
     required String hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -1930,15 +1621,6 @@ class Route53 {
     required VPC vpc,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpc, 'vpc');
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -1973,14 +1655,6 @@ class Route53 {
   Future<EnableHostedZoneDNSSECResponse> enableHostedZoneDNSSEC({
     required String hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -2038,7 +1712,6 @@ class Route53 {
   Future<GetAccountLimitResponse> getAccountLimit({
     required AccountLimitType type,
   }) async {
-    ArgumentError.checkNotNull(type, 'type');
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2073,14 +1746,6 @@ class Route53 {
   Future<GetChangeResponse> getChange({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri: '/2013-04-01/change/${Uri.encodeComponent(id)}',
@@ -2117,14 +1782,6 @@ class Route53 {
   Future<GetDNSSECResponse> getDNSSEC({
     required String hostedZoneId,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2206,24 +1863,6 @@ class Route53 {
     String? countryCode,
     String? subdivisionCode,
   }) async {
-    _s.validateStringLength(
-      'continentCode',
-      continentCode,
-      2,
-      2,
-    );
-    _s.validateStringLength(
-      'countryCode',
-      countryCode,
-      1,
-      2,
-    );
-    _s.validateStringLength(
-      'subdivisionCode',
-      subdivisionCode,
-      1,
-      3,
-    );
     final $query = <String, List<String>>{
       if (continentCode != null) 'continentcode': [continentCode],
       if (countryCode != null) 'countrycode': [countryCode],
@@ -2252,14 +1891,6 @@ class Route53 {
   Future<GetHealthCheckResponse> getHealthCheck({
     required String healthCheckId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckId, 'healthCheckId');
-    _s.validateStringLength(
-      'healthCheckId',
-      healthCheckId,
-      0,
-      64,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2299,14 +1930,6 @@ class Route53 {
       getHealthCheckLastFailureReason({
     required String healthCheckId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckId, 'healthCheckId');
-    _s.validateStringLength(
-      'healthCheckId',
-      healthCheckId,
-      0,
-      64,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2334,14 +1957,6 @@ class Route53 {
   Future<GetHealthCheckStatusResponse> getHealthCheckStatus({
     required String healthCheckId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckId, 'healthCheckId');
-    _s.validateStringLength(
-      'healthCheckId',
-      healthCheckId,
-      0,
-      64,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2362,14 +1977,6 @@ class Route53 {
   Future<GetHostedZoneResponse> getHostedZone({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri: '/2013-04-01/hostedzone/${Uri.encodeComponent(id)}',
@@ -2425,15 +2032,6 @@ class Route53 {
     required String hostedZoneId,
     required HostedZoneLimitType type,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2460,14 +2058,6 @@ class Route53 {
   Future<GetQueryLoggingConfigResponse> getQueryLoggingConfig({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri: '/2013-04-01/queryloggingconfig/${Uri.encodeComponent(id)}',
@@ -2489,14 +2079,6 @@ class Route53 {
   Future<GetReusableDelegationSetResponse> getReusableDelegationSet({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri: '/2013-04-01/delegationset/${Uri.encodeComponent(id)}',
@@ -2529,15 +2111,6 @@ class Route53 {
     required String delegationSetId,
     required ReusableDelegationSetLimitType type,
   }) async {
-    ArgumentError.checkNotNull(delegationSetId, 'delegationSetId');
-    _s.validateStringLength(
-      'delegationSetId',
-      delegationSetId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2566,15 +2139,6 @@ class Route53 {
     required String id,
     required int version,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
     _s.validateNumRange(
       'version',
       version,
@@ -2612,14 +2176,6 @@ class Route53 {
   Future<GetTrafficPolicyInstanceResponse> getTrafficPolicyInstance({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -2697,24 +2253,6 @@ class Route53 {
     String? startCountryCode,
     String? startSubdivisionCode,
   }) async {
-    _s.validateStringLength(
-      'startContinentCode',
-      startContinentCode,
-      2,
-      2,
-    );
-    _s.validateStringLength(
-      'startCountryCode',
-      startCountryCode,
-      1,
-      2,
-    );
-    _s.validateStringLength(
-      'startSubdivisionCode',
-      startSubdivisionCode,
-      1,
-      3,
-    );
     final $query = <String, List<String>>{
       if (maxItems != null) 'maxitems': [maxItems],
       if (startContinentCode != null)
@@ -2761,12 +2299,6 @@ class Route53 {
     String? marker,
     String? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (marker != null) 'marker': [marker],
       if (maxItems != null) 'maxitems': [maxItems],
@@ -2822,18 +2354,6 @@ class Route53 {
     String? marker,
     String? maxItems,
   }) async {
-    _s.validateStringLength(
-      'delegationSetId',
-      delegationSetId,
-      0,
-      32,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (delegationSetId != null) 'delegationsetid': [delegationSetId],
       if (marker != null) 'marker': [marker],
@@ -2951,18 +2471,6 @@ class Route53 {
     String? hostedZoneId,
     String? maxItems,
   }) async {
-    _s.validateStringLength(
-      'dNSName',
-      dNSName,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-    );
     final $query = <String, List<String>>{
       if (dNSName != null) 'dnsname': [dNSName],
       if (hostedZoneId != null) 'hostedzoneid': [hostedZoneId],
@@ -3030,21 +2538,6 @@ class Route53 {
     String? maxItems,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(vPCId, 'vPCId');
-    _s.validateStringLength(
-      'vPCId',
-      vPCId,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vPCRegion, 'vPCRegion');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       'vpcid': [vPCId],
       'vpcregion': [vPCRegion.toValue()],
@@ -3111,18 +2604,6 @@ class Route53 {
     String? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (hostedZoneId != null) 'hostedzoneid': [hostedZoneId],
       if (maxResults != null) 'maxresults': [maxResults],
@@ -3279,26 +2760,6 @@ class Route53 {
     String? startRecordName,
     RRType? startRecordType,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'startRecordIdentifier',
-      startRecordIdentifier,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'startRecordName',
-      startRecordName,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (maxItems != null) 'maxitems': [maxItems],
       if (startRecordIdentifier != null) 'identifier': [startRecordIdentifier],
@@ -3341,12 +2802,6 @@ class Route53 {
     String? marker,
     String? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      64,
-    );
     final $query = <String, List<String>>{
       if (marker != null) 'marker': [marker],
       if (maxItems != null) 'maxitems': [maxItems],
@@ -3391,15 +2846,6 @@ class Route53 {
     required String resourceId,
     required TagResourceType resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final $result = await _protocol.send(
       method: 'GET',
       requestUri:
@@ -3441,8 +2887,6 @@ class Route53 {
     required List<String> resourceIds,
     required TagResourceType resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceIds, 'resourceIds');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final $result = await _protocol.send(
       method: 'POST',
       requestUri:
@@ -3494,12 +2938,6 @@ class Route53 {
     String? maxItems,
     String? trafficPolicyIdMarker,
   }) async {
-    _s.validateStringLength(
-      'trafficPolicyIdMarker',
-      trafficPolicyIdMarker,
-      1,
-      36,
-    );
     final $query = <String, List<String>>{
       if (maxItems != null) 'maxitems': [maxItems],
       if (trafficPolicyIdMarker != null)
@@ -3585,18 +3023,6 @@ class Route53 {
     String? trafficPolicyInstanceNameMarker,
     RRType? trafficPolicyInstanceTypeMarker,
   }) async {
-    _s.validateStringLength(
-      'hostedZoneIdMarker',
-      hostedZoneIdMarker,
-      0,
-      32,
-    );
-    _s.validateStringLength(
-      'trafficPolicyInstanceNameMarker',
-      trafficPolicyInstanceNameMarker,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (hostedZoneIdMarker != null) 'hostedzoneid': [hostedZoneIdMarker],
       if (maxItems != null) 'maxitems': [maxItems],
@@ -3678,20 +3104,6 @@ class Route53 {
     String? trafficPolicyInstanceNameMarker,
     RRType? trafficPolicyInstanceTypeMarker,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'trafficPolicyInstanceNameMarker',
-      trafficPolicyInstanceNameMarker,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       'id': [hostedZoneId],
       if (maxItems != null) 'maxitems': [maxItems],
@@ -3798,33 +3210,12 @@ class Route53 {
     String? trafficPolicyInstanceNameMarker,
     RRType? trafficPolicyInstanceTypeMarker,
   }) async {
-    ArgumentError.checkNotNull(trafficPolicyId, 'trafficPolicyId');
-    _s.validateStringLength(
-      'trafficPolicyId',
-      trafficPolicyId,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trafficPolicyVersion, 'trafficPolicyVersion');
     _s.validateNumRange(
       'trafficPolicyVersion',
       trafficPolicyVersion,
       1,
       1000,
       isRequired: true,
-    );
-    _s.validateStringLength(
-      'hostedZoneIdMarker',
-      hostedZoneIdMarker,
-      0,
-      32,
-    );
-    _s.validateStringLength(
-      'trafficPolicyInstanceNameMarker',
-      trafficPolicyInstanceNameMarker,
-      0,
-      1024,
     );
     final $query = <String, List<String>>{
       'id': [trafficPolicyId],
@@ -3883,20 +3274,6 @@ class Route53 {
     String? maxItems,
     String? trafficPolicyVersionMarker,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'trafficPolicyVersionMarker',
-      trafficPolicyVersionMarker,
-      0,
-      4,
-    );
     final $query = <String, List<String>>{
       if (maxItems != null) 'maxitems': [maxItems],
       if (trafficPolicyVersionMarker != null)
@@ -3945,20 +3322,6 @@ class Route53 {
     String? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
-    );
     final $query = <String, List<String>>{
       if (maxResults != null) 'maxresults': [maxResults],
       if (nextToken != null) 'nexttoken': [nextToken],
@@ -4032,41 +3395,6 @@ class Route53 {
     String? eDNS0ClientSubnetMask,
     String? resolverIP,
   }) async {
-    ArgumentError.checkNotNull(hostedZoneId, 'hostedZoneId');
-    _s.validateStringLength(
-      'hostedZoneId',
-      hostedZoneId,
-      0,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(recordName, 'recordName');
-    _s.validateStringLength(
-      'recordName',
-      recordName,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(recordType, 'recordType');
-    _s.validateStringLength(
-      'eDNS0ClientSubnetIP',
-      eDNS0ClientSubnetIP,
-      0,
-      45,
-    );
-    _s.validateStringLength(
-      'eDNS0ClientSubnetMask',
-      eDNS0ClientSubnetMask,
-      0,
-      3,
-    );
-    _s.validateStringLength(
-      'resolverIP',
-      resolverIP,
-      0,
-      45,
-    );
     final $query = <String, List<String>>{
       'hostedzoneid': [hostedZoneId],
       'recordname': [recordName],
@@ -4478,25 +3806,11 @@ class Route53 {
     String? resourcePath,
     String? searchString,
   }) async {
-    ArgumentError.checkNotNull(healthCheckId, 'healthCheckId');
-    _s.validateStringLength(
-      'healthCheckId',
-      healthCheckId,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'failureThreshold',
       failureThreshold,
       1,
       10,
-    );
-    _s.validateStringLength(
-      'fullyQualifiedDomainName',
-      fullyQualifiedDomainName,
-      0,
-      255,
     );
     _s.validateNumRange(
       'healthCheckVersion',
@@ -4510,29 +3824,11 @@ class Route53 {
       0,
       256,
     );
-    _s.validateStringLength(
-      'iPAddress',
-      iPAddress,
-      0,
-      45,
-    );
     _s.validateNumRange(
       'port',
       port,
       1,
       65535,
-    );
-    _s.validateStringLength(
-      'resourcePath',
-      resourcePath,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'searchString',
-      searchString,
-      0,
-      255,
     );
     final $result = await _protocol.send(
       method: 'POST',
@@ -4584,20 +3880,6 @@ class Route53 {
     required String id,
     String? comment,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      256,
-    );
     final $result = await _protocol.send(
       method: 'POST',
       requestUri: '/2013-04-01/hostedzone/${Uri.encodeComponent(id)}',
@@ -4634,23 +3916,6 @@ class Route53 {
     required String id,
     required int version,
   }) async {
-    ArgumentError.checkNotNull(comment, 'comment');
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
     _s.validateNumRange(
       'version',
       version,
@@ -4726,15 +3991,6 @@ class Route53 {
     required String trafficPolicyId,
     required int trafficPolicyVersion,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ttl, 'ttl');
     _s.validateNumRange(
       'ttl',
       ttl,
@@ -4742,15 +3998,6 @@ class Route53 {
       2147483647,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(trafficPolicyId, 'trafficPolicyId');
-    _s.validateStringLength(
-      'trafficPolicyId',
-      trafficPolicyId,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trafficPolicyVersion, 'trafficPolicyVersion');
     _s.validateNumRange(
       'trafficPolicyVersion',
       trafficPolicyVersion,

--- a/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
+++ b/generated/aws_route53domains_api/lib/route53domains-2014-05-15.dart
@@ -80,15 +80,6 @@ class Route53Domains {
     required String domainName,
     required String password,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -137,14 +128,6 @@ class Route53Domains {
       cancelDomainTransferToAnotherAwsAccount({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -212,20 +195,6 @@ class Route53Domains {
     required String domainName,
     String? idnLangCode,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'idnLangCode',
-      idnLangCode,
-      0,
-      3,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.CheckDomainAvailability'
@@ -284,20 +253,6 @@ class Route53Domains {
     required String domainName,
     String? authCode,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authCode',
-      authCode,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.CheckDomainTransferability'
@@ -335,15 +290,6 @@ class Route53Domains {
     required String domainName,
     required List<String> tagsToDelete,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagsToDelete, 'tagsToDelete');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.DeleteTagsForDomain'
@@ -372,14 +318,6 @@ class Route53Domains {
   Future<void> disableDomainAutoRenew({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.DisableDomainAutoRenew'
@@ -415,14 +353,6 @@ class Route53Domains {
   Future<DisableDomainTransferLockResponse> disableDomainTransferLock({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.DisableDomainTransferLock'
@@ -461,14 +391,6 @@ class Route53Domains {
   Future<void> enableDomainAutoRenew({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.EnableDomainAutoRenew'
@@ -502,14 +424,6 @@ class Route53Domains {
   Future<EnableDomainTransferLockResponse> enableDomainTransferLock({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.EnableDomainTransferLock'
@@ -546,12 +460,6 @@ class Route53Domains {
   Future<GetContactReachabilityStatusResponse> getContactReachabilityStatus({
     String? domainName,
   }) async {
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.GetContactReachabilityStatus'
@@ -582,14 +490,6 @@ class Route53Domains {
   Future<GetDomainDetailResponse> getDomainDetail({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.GetDomainDetail'
@@ -661,16 +561,6 @@ class Route53Domains {
     required bool onlyAvailable,
     required int suggestionCount,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(onlyAvailable, 'onlyAvailable');
-    ArgumentError.checkNotNull(suggestionCount, 'suggestionCount');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.GetDomainSuggestions'
@@ -702,14 +592,6 @@ class Route53Domains {
   Future<GetOperationDetailResponse> getOperationDetail({
     required String operationId,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.GetOperationDetail'
@@ -753,12 +635,6 @@ class Route53Domains {
     String? marker,
     int? maxItems,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      4096,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -813,12 +689,6 @@ class Route53Domains {
     int? maxItems,
     DateTime? submittedSince,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      4096,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -861,14 +731,6 @@ class Route53Domains {
   Future<ListTagsForDomainResponse> listTagsForDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.ListTagsForDomain'
@@ -1041,30 +903,12 @@ class Route53Domains {
     bool? privacyProtectRegistrantContact,
     bool? privacyProtectTechContact,
   }) async {
-    ArgumentError.checkNotNull(adminContact, 'adminContact');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(durationInYears, 'durationInYears');
     _s.validateNumRange(
       'durationInYears',
       durationInYears,
       1,
       10,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(registrantContact, 'registrantContact');
-    ArgumentError.checkNotNull(techContact, 'techContact');
-    _s.validateStringLength(
-      'idnLangCode',
-      idnLangCode,
-      0,
-      3,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1121,14 +965,6 @@ class Route53Domains {
       rejectDomainTransferFromAnotherAwsAccount({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1187,15 +1023,6 @@ class Route53Domains {
     required String domainName,
     int? durationInYears,
   }) async {
-    ArgumentError.checkNotNull(currentExpiryYear, 'currentExpiryYear');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'durationInYears',
       durationInYears,
@@ -1238,12 +1065,6 @@ class Route53Domains {
       resendContactReachabilityEmail({
     String? domainName,
   }) async {
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.ResendContactReachabilityEmail'
@@ -1273,14 +1094,6 @@ class Route53Domains {
   Future<RetrieveDomainAuthCodeResponse> retrieveDomainAuthCode({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.RetrieveDomainAuthCode'
@@ -1454,36 +1267,12 @@ class Route53Domains {
     bool? privacyProtectRegistrantContact,
     bool? privacyProtectTechContact,
   }) async {
-    ArgumentError.checkNotNull(adminContact, 'adminContact');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(durationInYears, 'durationInYears');
     _s.validateNumRange(
       'durationInYears',
       durationInYears,
       1,
       10,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(registrantContact, 'registrantContact');
-    ArgumentError.checkNotNull(techContact, 'techContact');
-    _s.validateStringLength(
-      'authCode',
-      authCode,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'idnLangCode',
-      idnLangCode,
-      0,
-      3,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1571,15 +1360,6 @@ class Route53Domains {
     required String accountId,
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1633,14 +1413,6 @@ class Route53Domains {
     ContactDetail? registrantContact,
     ContactDetail? techContact,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.UpdateDomainContact'
@@ -1725,14 +1497,6 @@ class Route53Domains {
     bool? registrantPrivacy,
     bool? techPrivacy,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.UpdateDomainContactPrivacy'
@@ -1782,15 +1546,6 @@ class Route53Domains {
     required List<Nameserver> nameservers,
     String? fIAuthKey,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(nameservers, 'nameservers');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.UpdateDomainNameservers'
@@ -1831,14 +1586,6 @@ class Route53Domains {
     required String domainName,
     List<Tag>? tagsToUpdate,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Domains_v20140515.UpdateTagsForDomain'
@@ -1894,12 +1641,6 @@ class Route53Domains {
     int? maxItems,
     DateTime? start,
   }) async {
-    _s.validateStringLength(
-      'marker',
-      marker,
-      0,
-      4096,
-    );
     _s.validateNumRange(
       'maxItems',
       maxItems,

--- a/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
+++ b/generated/aws_route53resolver_api/lib/route53resolver-2018-04-01.dart
@@ -114,15 +114,6 @@ class Route53Resolver {
     required IpAddressUpdate ipAddress,
     required String resolverEndpointId,
   }) async {
-    ArgumentError.checkNotNull(ipAddress, 'ipAddress');
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.AssociateResolverEndpointIpAddress'
@@ -179,23 +170,6 @@ class Route53Resolver {
     required String resolverQueryLogConfigId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(
-        resolverQueryLogConfigId, 'resolverQueryLogConfigId');
-    _s.validateStringLength(
-      'resolverQueryLogConfigId',
-      resolverQueryLogConfigId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.AssociateResolverQueryLogConfig'
@@ -247,28 +221,6 @@ class Route53Resolver {
     required String vPCId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(resolverRuleId, 'resolverRuleId');
-    _s.validateStringLength(
-      'resolverRuleId',
-      resolverRuleId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vPCId, 'vPCId');
-    _s.validateStringLength(
-      'vPCId',
-      vPCId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.AssociateResolverRule'
@@ -359,23 +311,6 @@ class Route53Resolver {
     String? name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(creatorRequestId, 'creatorRequestId');
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(direction, 'direction');
-    ArgumentError.checkNotNull(ipAddresses, 'ipAddresses');
-    ArgumentError.checkNotNull(securityGroupIds, 'securityGroupIds');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.CreateResolverEndpoint'
@@ -469,28 +404,6 @@ class Route53Resolver {
     String? creatorRequestId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(destinationArn, 'destinationArn');
-    _s.validateStringLength(
-      'destinationArn',
-      destinationArn,
-      1,
-      600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      1,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.CreateResolverQueryLogConfig'
@@ -583,35 +496,6 @@ class Route53Resolver {
     List<Tag>? tags,
     List<TargetAddress>? targetIps,
   }) async {
-    ArgumentError.checkNotNull(creatorRequestId, 'creatorRequestId');
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleType, 'ruleType');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.CreateResolverRule'
@@ -662,14 +546,6 @@ class Route53Resolver {
   Future<DeleteResolverEndpointResponse> deleteResolverEndpoint({
     required String resolverEndpointId,
   }) async {
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DeleteResolverEndpoint'
@@ -718,15 +594,6 @@ class Route53Resolver {
   Future<DeleteResolverQueryLogConfigResponse> deleteResolverQueryLogConfig({
     required String resolverQueryLogConfigId,
   }) async {
-    ArgumentError.checkNotNull(
-        resolverQueryLogConfigId, 'resolverQueryLogConfigId');
-    _s.validateStringLength(
-      'resolverQueryLogConfigId',
-      resolverQueryLogConfigId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DeleteResolverQueryLogConfig'
@@ -761,14 +628,6 @@ class Route53Resolver {
   Future<DeleteResolverRuleResponse> deleteResolverRule({
     required String resolverRuleId,
   }) async {
-    ArgumentError.checkNotNull(resolverRuleId, 'resolverRuleId');
-    _s.validateStringLength(
-      'resolverRuleId',
-      resolverRuleId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DeleteResolverRule'
@@ -813,15 +672,6 @@ class Route53Resolver {
     required IpAddressUpdate ipAddress,
     required String resolverEndpointId,
   }) async {
-    ArgumentError.checkNotNull(ipAddress, 'ipAddress');
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DisassociateResolverEndpointIpAddress'
@@ -878,23 +728,6 @@ class Route53Resolver {
     required String resolverQueryLogConfigId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(
-        resolverQueryLogConfigId, 'resolverQueryLogConfigId');
-    _s.validateStringLength(
-      'resolverQueryLogConfigId',
-      resolverQueryLogConfigId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DisassociateResolverQueryLogConfig'
@@ -937,22 +770,6 @@ class Route53Resolver {
     required String resolverRuleId,
     required String vPCId,
   }) async {
-    ArgumentError.checkNotNull(resolverRuleId, 'resolverRuleId');
-    _s.validateStringLength(
-      'resolverRuleId',
-      resolverRuleId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vPCId, 'vPCId');
-    _s.validateStringLength(
-      'vPCId',
-      vPCId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.DisassociateResolverRule'
@@ -987,14 +804,6 @@ class Route53Resolver {
   Future<GetResolverDnssecConfigResponse> getResolverDnssecConfig({
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverDnssecConfig'
@@ -1027,14 +836,6 @@ class Route53Resolver {
   Future<GetResolverEndpointResponse> getResolverEndpoint({
     required String resolverEndpointId,
   }) async {
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverEndpoint'
@@ -1070,15 +871,6 @@ class Route53Resolver {
   Future<GetResolverQueryLogConfigResponse> getResolverQueryLogConfig({
     required String resolverQueryLogConfigId,
   }) async {
-    ArgumentError.checkNotNull(
-        resolverQueryLogConfigId, 'resolverQueryLogConfigId');
-    _s.validateStringLength(
-      'resolverQueryLogConfigId',
-      resolverQueryLogConfigId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverQueryLogConfig'
@@ -1116,15 +908,6 @@ class Route53Resolver {
       getResolverQueryLogConfigAssociation({
     required String resolverQueryLogConfigAssociationId,
   }) async {
-    ArgumentError.checkNotNull(resolverQueryLogConfigAssociationId,
-        'resolverQueryLogConfigAssociationId');
-    _s.validateStringLength(
-      'resolverQueryLogConfigAssociationId',
-      resolverQueryLogConfigAssociationId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverQueryLogConfigAssociation'
@@ -1162,14 +945,6 @@ class Route53Resolver {
       getResolverQueryLogConfigPolicy({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverQueryLogConfigPolicy'
@@ -1202,14 +977,6 @@ class Route53Resolver {
   Future<GetResolverRuleResponse> getResolverRule({
     required String resolverRuleId,
   }) async {
-    ArgumentError.checkNotNull(resolverRuleId, 'resolverRuleId');
-    _s.validateStringLength(
-      'resolverRuleId',
-      resolverRuleId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverRule'
@@ -1243,15 +1010,6 @@ class Route53Resolver {
   Future<GetResolverRuleAssociationResponse> getResolverRuleAssociation({
     required String resolverRuleAssociationId,
   }) async {
-    ArgumentError.checkNotNull(
-        resolverRuleAssociationId, 'resolverRuleAssociationId');
-    _s.validateStringLength(
-      'resolverRuleAssociationId',
-      resolverRuleAssociationId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverRuleAssociation'
@@ -1285,14 +1043,6 @@ class Route53Resolver {
   Future<GetResolverRulePolicyResponse> getResolverRulePolicy({
     required String arn,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.GetResolverRulePolicy'
@@ -1404,14 +1154,6 @@ class Route53Resolver {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -1635,12 +1377,6 @@ class Route53Resolver {
       1,
       100,
     );
-    _s.validateStringLength(
-      'sortBy',
-      sortBy,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.ListResolverQueryLogConfigAssociations'
@@ -1801,12 +1537,6 @@ class Route53Resolver {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'sortBy',
-      sortBy,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1985,14 +1715,6 @@ class Route53Resolver {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      255,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2064,23 +1786,6 @@ class Route53Resolver {
     required String arn,
     required String resolverQueryLogConfigPolicy,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        resolverQueryLogConfigPolicy, 'resolverQueryLogConfigPolicy');
-    _s.validateStringLength(
-      'resolverQueryLogConfigPolicy',
-      resolverQueryLogConfigPolicy,
-      0,
-      5000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.PutResolverQueryLogConfigPolicy'
@@ -2143,22 +1848,6 @@ class Route53Resolver {
     required String arn,
     required String resolverRulePolicy,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resolverRulePolicy, 'resolverRulePolicy');
-    _s.validateStringLength(
-      'resolverRulePolicy',
-      resolverRulePolicy,
-      0,
-      5000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.PutResolverRulePolicy'
@@ -2226,15 +1915,6 @@ class Route53Resolver {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.TagResource'
@@ -2298,15 +1978,6 @@ class Route53Resolver {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.UntagResource'
@@ -2346,15 +2017,6 @@ class Route53Resolver {
     required String resourceId,
     required Validation validation,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(validation, 'validation');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.UpdateResolverDnssecConfig'
@@ -2391,20 +2053,6 @@ class Route53Resolver {
     required String resolverEndpointId,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(resolverEndpointId, 'resolverEndpointId');
-    _s.validateStringLength(
-      'resolverEndpointId',
-      resolverEndpointId,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.UpdateResolverEndpoint'
@@ -2445,15 +2093,6 @@ class Route53Resolver {
     required ResolverRuleConfig config,
     required String resolverRuleId,
   }) async {
-    ArgumentError.checkNotNull(config, 'config');
-    ArgumentError.checkNotNull(resolverRuleId, 'resolverRuleId');
-    _s.validateStringLength(
-      'resolverRuleId',
-      resolverRuleId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53Resolver.UpdateResolverRule'

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -132,16 +132,6 @@ class S3 {
     String? expectedBucketOwner,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -308,16 +298,6 @@ class S3 {
     CompletedMultipartUpload? multipartUpload,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -830,16 +810,6 @@ class S3 {
     TaggingDirective? taggingDirective,
     String? websiteRedirectLocation,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(copySource, 'copySource');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-copy-source': copySource.toString(),
       if (acl != null) 'x-amz-acl': acl.toValue(),
@@ -1127,7 +1097,6 @@ class S3 {
     String? grantWriteACP,
     bool? objectLockEnabledForBucket,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (grantFullControl != null)
@@ -1614,15 +1583,6 @@ class S3 {
     String? tagging,
     String? websiteRedirectLocation,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (bucketKeyEnabled != null)
@@ -1738,7 +1698,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -1800,8 +1759,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -1854,7 +1811,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -1908,7 +1864,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -1970,8 +1925,6 @@ class S3 {
     required String bucket,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final $query = <String, List<String>>{
       'id': [id],
     };
@@ -2032,8 +1985,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2092,7 +2043,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2160,8 +2110,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2213,7 +2161,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2271,7 +2218,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2327,7 +2273,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2370,7 +2315,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2424,7 +2368,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2527,15 +2470,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (bypassGovernanceRetention != null)
         'x-amz-bypass-governance-retention':
@@ -2633,15 +2567,6 @@ class S3 {
     String? expectedBucketOwner,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2772,8 +2697,6 @@ class S3 {
     String? mfa,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(delete, 'delete');
     final headers = <String, String>{
       if (bypassGovernanceRetention != null)
         'x-amz-bypass-governance-retention':
@@ -2847,7 +2770,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2910,7 +2832,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -2950,7 +2871,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3015,8 +2935,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3071,7 +2989,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3124,7 +3041,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3191,8 +3107,6 @@ class S3 {
     required String bucket,
     required String id,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final $query = <String, List<String>>{
       'id': [id],
     };
@@ -3259,8 +3173,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3349,7 +3261,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3436,7 +3347,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3481,7 +3391,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3522,7 +3431,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3590,8 +3498,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3627,7 +3533,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3679,7 +3584,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3728,7 +3632,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3785,7 +3688,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3847,7 +3749,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3913,7 +3814,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -3957,7 +3857,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4013,7 +3912,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4065,7 +3963,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4115,7 +4012,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4430,15 +4326,6 @@ class S3 {
     String? sSECustomerKeyMD5,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4615,15 +4502,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4688,15 +4566,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4746,7 +4615,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4801,15 +4669,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4899,15 +4758,6 @@ class S3 {
     String? expectedBucketOwner,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -4975,15 +4825,6 @@ class S3 {
     String? expectedBucketOwner,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5058,7 +4899,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5124,7 +4964,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5340,15 +5179,6 @@ class S3 {
     String? sSECustomerKeyMD5,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5512,7 +5342,6 @@ class S3 {
     String? continuationToken,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5580,7 +5409,6 @@ class S3 {
     required String bucket,
     String? continuationToken,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final $query = <String, List<String>>{
       if (continuationToken != null) 'continuation-token': [continuationToken],
     };
@@ -5658,7 +5486,6 @@ class S3 {
     String? continuationToken,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5742,7 +5569,6 @@ class S3 {
     String? continuationToken,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -5904,7 +5730,6 @@ class S3 {
     String? prefix,
     String? uploadIdMarker,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6006,7 +5831,6 @@ class S3 {
     String? prefix,
     String? versionIdMarker,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6123,7 +5947,6 @@ class S3 {
     String? prefix,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6265,7 +6088,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? startAfter,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6387,16 +6209,6 @@ class S3 {
     int? partNumberMarker,
     RequestPayer? requestPayer,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6511,9 +6323,6 @@ class S3 {
     required String bucket,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(
-        accelerateConfiguration, 'accelerateConfiguration');
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -6772,7 +6581,6 @@ class S3 {
     String? grantWrite,
     String? grantWriteACP,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
@@ -6903,10 +6711,6 @@ class S3 {
     required String id,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(
-        analyticsConfiguration, 'analyticsConfiguration');
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -7016,8 +6820,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(cORSConfiguration, 'cORSConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -7099,9 +6901,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        serverSideEncryptionConfiguration, 'serverSideEncryptionConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -7169,10 +6968,6 @@ class S3 {
     required String id,
     required IntelligentTieringConfiguration intelligentTieringConfiguration,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        intelligentTieringConfiguration, 'intelligentTieringConfiguration');
     final $query = <String, List<String>>{
       'id': [id],
     };
@@ -7293,10 +7088,6 @@ class S3 {
     required InventoryConfiguration inventoryConfiguration,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(
-        inventoryConfiguration, 'inventoryConfiguration');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -7418,7 +7209,6 @@ class S3 {
     String? expectedBucketOwner,
     LifecycleConfiguration? lifecycleConfiguration,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -7540,7 +7330,6 @@ class S3 {
     String? expectedBucketOwner,
     BucketLifecycleConfiguration? lifecycleConfiguration,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -7655,8 +7444,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(bucketLoggingStatus, 'bucketLoggingStatus');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -7743,9 +7530,6 @@ class S3 {
     required MetricsConfiguration metricsConfiguration,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(metricsConfiguration, 'metricsConfiguration');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -7790,9 +7574,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        notificationConfiguration, 'notificationConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -7884,9 +7665,6 @@ class S3 {
     required NotificationConfiguration notificationConfiguration,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        notificationConfiguration, 'notificationConfiguration');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -7947,8 +7725,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(ownershipControls, 'ownershipControls');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8023,8 +7799,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(policy, 'policy');
     final headers = <String, String>{
       if (confirmRemoveSelfBucketAccess != null)
         'x-amz-confirm-remove-self-bucket-access':
@@ -8145,9 +7919,6 @@ class S3 {
     String? expectedBucketOwner,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        replicationConfiguration, 'replicationConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8210,9 +7981,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        requestPaymentConfiguration, 'requestPaymentConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8335,8 +8103,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(tagging, 'tagging');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8429,9 +8195,6 @@ class S3 {
     String? expectedBucketOwner,
     String? mfa,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        versioningConfiguration, 'versioningConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8568,8 +8331,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(websiteConfiguration, 'websiteConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -8911,15 +8672,6 @@ class S3 {
     String? tagging,
     String? websiteRedirectLocation,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (bucketKeyEnabled != null)
@@ -9299,15 +9051,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
@@ -9398,15 +9141,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -9477,7 +9211,6 @@ class S3 {
     RequestPayer? requestPayer,
     String? token,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -9562,15 +9295,6 @@ class S3 {
     ObjectLockRetention? retention,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (bypassGovernanceRetention != null)
         'x-amz-bypass-governance-retention':
@@ -9728,16 +9452,6 @@ class S3 {
     String? expectedBucketOwner,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagging, 'tagging');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -9832,9 +9546,6 @@ class S3 {
     String? contentMD5,
     String? expectedBucketOwner,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(
-        publicAccessBlockConfiguration, 'publicAccessBlockConfiguration');
     final headers = <String, String>{
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
       if (expectedBucketOwner != null)
@@ -10195,15 +9906,6 @@ class S3 {
     RestoreRequest? restoreRequest,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -10436,19 +10138,6 @@ class S3 {
     String? sSECustomerKeyMD5,
     ScanRange? scanRange,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(expression, 'expression');
-    ArgumentError.checkNotNull(expressionType, 'expressionType');
-    ArgumentError.checkNotNull(inputSerialization, 'inputSerialization');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputSerialization, 'outputSerialization');
     final headers = <String, String>{
       if (expectedBucketOwner != null)
         'x-amz-expected-bucket-owner': expectedBucketOwner.toString(),
@@ -10705,17 +10394,6 @@ class S3 {
     Uint8List? sSECustomerKey,
     String? sSECustomerKeyMD5,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partNumber, 'partNumber');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       if (contentLength != null) 'Content-Length': contentLength.toString(),
       if (contentMD5 != null) 'Content-MD5': contentMD5.toString(),
@@ -11092,18 +10770,6 @@ class S3 {
     Uint8List? sSECustomerKey,
     String? sSECustomerKeyMD5,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(copySource, 'copySource');
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(partNumber, 'partNumber');
-    ArgumentError.checkNotNull(uploadId, 'uploadId');
     final headers = <String, String>{
       'x-amz-copy-source': copySource.toString(),
       if (copySourceIfMatch != null)

--- a/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
+++ b/generated/aws_s3control_api/lib/s3control-2018-08-20.dart
@@ -140,30 +140,6 @@ class S3Control {
     PublicAccessBlockConfiguration? publicAccessBlockConfiguration,
     VpcConfiguration? vpcConfiguration,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -329,20 +305,6 @@ class S3Control {
     bool? objectLockEnabledForBucket,
     String? outpostId,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'outpostId',
-      outpostId,
-      1,
-      64,
-    );
     final headers = <String, String>{
       if (acl != null) 'x-amz-acl': acl.toValue(),
       if (grantFullControl != null)
@@ -459,44 +421,12 @@ class S3Control {
     String? description,
     List<S3Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(manifest, 'manifest');
-    ArgumentError.checkNotNull(operation, 'operation');
-    ArgumentError.checkNotNull(priority, 'priority');
     _s.validateNumRange(
       'priority',
       priority,
       0,
       2147483647,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(report, 'report');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
     );
     clientRequestToken ??= _s.generateIdempotencyToken();
     final headers = <String, String>{
@@ -579,22 +509,6 @@ class S3Control {
     required String accountId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -652,22 +566,6 @@ class S3Control {
     required String accountId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -739,22 +637,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -835,22 +717,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -938,22 +804,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1024,22 +874,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1088,22 +922,6 @@ class S3Control {
     required String accountId,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1139,14 +957,6 @@ class S3Control {
   Future<void> deletePublicAccessBlock({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1181,22 +991,6 @@ class S3Control {
     required String accountId,
     required String configId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1231,22 +1025,6 @@ class S3Control {
     required String accountId,
     required String configId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1300,22 +1078,6 @@ class S3Control {
     required String accountId,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1379,22 +1141,6 @@ class S3Control {
     required String accountId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1444,22 +1190,6 @@ class S3Control {
     required String accountId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1488,22 +1218,6 @@ class S3Control {
     required String accountId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1582,22 +1296,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1699,22 +1397,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1807,22 +1489,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1907,22 +1573,6 @@ class S3Control {
     required String accountId,
     required String bucket,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -1972,22 +1622,6 @@ class S3Control {
     required String accountId,
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2026,14 +1660,6 @@ class S3Control {
   Future<GetPublicAccessBlockOutput> getPublicAccessBlock({
     required String accountId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2073,22 +1699,6 @@ class S3Control {
     required String accountId,
     required String configId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2128,22 +1738,6 @@ class S3Control {
     required String accountId,
     required String configId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2228,31 +1822,11 @@ class S3Control {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
@@ -2328,25 +1902,11 @@ class S3Control {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
@@ -2399,31 +1959,11 @@ class S3Control {
     String? nextToken,
     String? outpostId,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'outpostId',
-      outpostId,
-      1,
-      64,
     );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
@@ -2466,14 +2006,6 @@ class S3Control {
     required String accountId,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2548,23 +2080,6 @@ class S3Control {
     required String name,
     required String policy,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2636,22 +2151,6 @@ class S3Control {
     required String bucket,
     LifecycleConfiguration? lifecycleConfiguration,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -2752,23 +2251,6 @@ class S3Control {
     required String policy,
     bool? confirmRemoveSelfBucketAccess,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
       if (confirmRemoveSelfBucketAccess != null)
@@ -2922,23 +2404,6 @@ class S3Control {
     required String bucket,
     required Tagging tagging,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    _s.validateStringLength(
-      'bucket',
-      bucket,
-      3,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagging, 'tagging');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -3043,23 +2508,6 @@ class S3Control {
     required String jobId,
     required List<S3Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -3109,16 +2557,6 @@ class S3Control {
     required String accountId,
     required PublicAccessBlockConfiguration publicAccessBlockConfiguration,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        publicAccessBlockConfiguration, 'publicAccessBlockConfiguration');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -3166,24 +2604,6 @@ class S3Control {
     required StorageLensConfiguration storageLensConfiguration,
     List<StorageLensTag>? tags,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        storageLensConfiguration, 'storageLensConfiguration');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -3237,23 +2657,6 @@ class S3Control {
     required String configId,
     required List<StorageLensTag> tags,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(configId, 'configId');
-    _s.validateStringLength(
-      'configId',
-      configId,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };
@@ -3320,23 +2723,6 @@ class S3Control {
     required String jobId,
     required int priority,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(priority, 'priority');
     _s.validateNumRange(
       'priority',
       priority,
@@ -3412,29 +2798,6 @@ class S3Control {
     required RequestedJobStatus requestedJobStatus,
     String? statusUpdateReason,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    _s.validateStringLength(
-      'accountId',
-      accountId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      5,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(requestedJobStatus, 'requestedJobStatus');
-    _s.validateStringLength(
-      'statusUpdateReason',
-      statusUpdateReason,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'x-amz-account-id': accountId.toString(),
     };

--- a/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
+++ b/generated/aws_sagemaker_a2i_runtime_api/lib/sagemaker-a2i-runtime-2019-11-07.dart
@@ -104,14 +104,6 @@ class AugmentedAIRuntime {
   Future<void> deleteHumanLoop({
     required String humanLoopName,
   }) async {
-    ArgumentError.checkNotNull(humanLoopName, 'humanLoopName');
-    _s.validateStringLength(
-      'humanLoopName',
-      humanLoopName,
-      1,
-      63,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -132,14 +124,6 @@ class AugmentedAIRuntime {
   Future<DescribeHumanLoopResponse> describeHumanLoop({
     required String humanLoopName,
   }) async {
-    ArgumentError.checkNotNull(humanLoopName, 'humanLoopName');
-    _s.validateStringLength(
-      'humanLoopName',
-      humanLoopName,
-      1,
-      63,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -188,25 +172,11 @@ class AugmentedAIRuntime {
     String? nextToken,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(flowDefinitionArn, 'flowDefinitionArn');
-    _s.validateStringLength(
-      'flowDefinitionArn',
-      flowDefinitionArn,
-      0,
-      1024,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final $query = <String, List<String>>{
       'FlowDefinitionArn': [flowDefinitionArn],
@@ -257,23 +227,6 @@ class AugmentedAIRuntime {
     required String humanLoopName,
     HumanLoopDataAttributes? dataAttributes,
   }) async {
-    ArgumentError.checkNotNull(flowDefinitionArn, 'flowDefinitionArn');
-    _s.validateStringLength(
-      'flowDefinitionArn',
-      flowDefinitionArn,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(humanLoopInput, 'humanLoopInput');
-    ArgumentError.checkNotNull(humanLoopName, 'humanLoopName');
-    _s.validateStringLength(
-      'humanLoopName',
-      humanLoopName,
-      1,
-      63,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FlowDefinitionArn': flowDefinitionArn,
       'HumanLoopInput': humanLoopInput,
@@ -301,14 +254,6 @@ class AugmentedAIRuntime {
   Future<void> stopHumanLoop({
     required String humanLoopName,
   }) async {
-    ArgumentError.checkNotNull(humanLoopName, 'humanLoopName');
-    _s.validateStringLength(
-      'humanLoopName',
-      humanLoopName,
-      1,
-      63,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'HumanLoopName': humanLoopName,
     };

--- a/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
+++ b/generated/aws_sagemaker_api/lib/sagemaker-2017-07-24.dart
@@ -108,22 +108,6 @@ class SageMaker {
     required String sourceArn,
     AssociationEdgeType? associationType,
   }) async {
-    ArgumentError.checkNotNull(destinationArn, 'destinationArn');
-    _s.validateStringLength(
-      'destinationArn',
-      destinationArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
-    _s.validateStringLength(
-      'sourceArn',
-      sourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.AddAssociation'
@@ -179,15 +163,6 @@ class SageMaker {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.AddTags'
@@ -223,22 +198,6 @@ class SageMaker {
     required String trialComponentName,
     required String trialName,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.AssociateTrialComponent'
@@ -297,29 +256,6 @@ class SageMaker {
     ActionStatus? status,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      120,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(actionType, 'actionType');
-    _s.validateStringLength(
-      'actionType',
-      actionType,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateAction'
@@ -431,21 +367,6 @@ class SageMaker {
     List<Tag>? tags,
     AlgorithmValidationSpecification? validationSpecification,
   }) async {
-    ArgumentError.checkNotNull(algorithmName, 'algorithmName');
-    _s.validateStringLength(
-      'algorithmName',
-      algorithmName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trainingSpecification, 'trainingSpecification');
-    _s.validateStringLength(
-      'algorithmDescription',
-      algorithmDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateAlgorithm'
@@ -510,31 +431,6 @@ class SageMaker {
     ResourceSpec? resourceSpec,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(appName, 'appName');
-    _s.validateStringLength(
-      'appName',
-      appName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appType, 'appType');
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateApp'
@@ -577,14 +473,6 @@ class SageMaker {
     KernelGatewayImageConfig? kernelGatewayImageConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(appImageConfigName, 'appImageConfigName');
-    _s.validateStringLength(
-      'appImageConfigName',
-      appImageConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateAppImageConfig'
@@ -637,21 +525,6 @@ class SageMaker {
     Map<String, String>? properties,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(artifactType, 'artifactType');
-    _s.validateStringLength(
-      'artifactType',
-      artifactType,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'artifactName',
-      artifactName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateArtifact'
@@ -737,24 +610,6 @@ class SageMaker {
     ProblemType? problemType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(autoMLJobName, 'autoMLJobName');
-    _s.validateStringLength(
-      'autoMLJobName',
-      autoMLJobName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateAutoMLJob'
@@ -814,15 +669,6 @@ class SageMaker {
     required GitConfig gitConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(codeRepositoryName, 'codeRepositoryName');
-    _s.validateStringLength(
-      'codeRepositoryName',
-      codeRepositoryName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gitConfig, 'gitConfig');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateCodeRepository'
@@ -940,25 +786,6 @@ class SageMaker {
     required StoppingCondition stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(compilationJobName, 'compilationJobName');
-    _s.validateStringLength(
-      'compilationJobName',
-      compilationJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputConfig, 'inputConfig');
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stoppingCondition, 'stoppingCondition');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateCompilationJob'
@@ -1016,29 +843,6 @@ class SageMaker {
     Map<String, String>? properties,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(contextName, 'contextName');
-    _s.validateStringLength(
-      'contextName',
-      contextName,
-      1,
-      120,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(contextType, 'contextType');
-    _s.validateStringLength(
-      'contextType',
-      contextType,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateContext'
@@ -1108,28 +912,6 @@ class SageMaker {
     MonitoringStoppingCondition? stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        dataQualityAppSpecification, 'dataQualityAppSpecification');
-    ArgumentError.checkNotNull(dataQualityJobInput, 'dataQualityJobInput');
-    ArgumentError.checkNotNull(
-        dataQualityJobOutputConfig, 'dataQualityJobOutputConfig');
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobResources, 'jobResources');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateDataQualityJobDefinition'
@@ -1185,27 +967,6 @@ class SageMaker {
     String? roleArn,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      800,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateDeviceFleet'
@@ -1333,37 +1094,6 @@ class SageMaker {
     String? kmsKeyId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(authMode, 'authMode');
-    ArgumentError.checkNotNull(defaultUserSettings, 'defaultUserSettings');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
-    _s.validateStringLength(
-      'vpcId',
-      vpcId,
-      0,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'homeEfsFileSystemKmsKeyId',
-      homeEfsFileSystemKmsKeyId,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateDomain'
@@ -1435,53 +1165,6 @@ class SageMaker {
     String? resourceKey,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(compilationJobName, 'compilationJobName');
-    _s.validateStringLength(
-      'compilationJobName',
-      compilationJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(edgePackagingJobName, 'edgePackagingJobName');
-    _s.validateStringLength(
-      'edgePackagingJobName',
-      edgePackagingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelVersion, 'modelVersion');
-    _s.validateStringLength(
-      'modelVersion',
-      modelVersion,
-      1,
-      30,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'resourceKey',
-      resourceKey,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateEdgePackagingJob'
@@ -1617,22 +1300,6 @@ class SageMaker {
     required String endpointName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(endpointConfigName, 'endpointConfigName');
-    _s.validateStringLength(
-      'endpointConfigName',
-      endpointConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateEndpoint'
@@ -1767,21 +1434,6 @@ class SageMaker {
     String? kmsKeyId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(endpointConfigName, 'endpointConfigName');
-    _s.validateStringLength(
-      'endpointConfigName',
-      endpointConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(productionVariants, 'productionVariants');
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateEndpointConfig'
@@ -1855,26 +1507,6 @@ class SageMaker {
     String? displayName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(experimentName, 'experimentName');
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateExperiment'
@@ -2046,44 +1678,6 @@ class SageMaker {
     String? roleArn,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(eventTimeFeatureName, 'eventTimeFeatureName');
-    _s.validateStringLength(
-      'eventTimeFeatureName',
-      eventTimeFeatureName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(featureDefinitions, 'featureDefinitions');
-    ArgumentError.checkNotNull(featureGroupName, 'featureGroupName');
-    _s.validateStringLength(
-      'featureGroupName',
-      featureGroupName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        recordIdentifierFeatureName, 'recordIdentifierFeatureName');
-    _s.validateStringLength(
-      'recordIdentifierFeatureName',
-      recordIdentifierFeatureName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateFeatureGroup'
@@ -2154,24 +1748,6 @@ class SageMaker {
     HumanLoopRequestSource? humanLoopRequestSource,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(flowDefinitionName, 'flowDefinitionName');
-    _s.validateStringLength(
-      'flowDefinitionName',
-      flowDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(humanLoopConfig, 'humanLoopConfig');
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateFlowDefinition'
@@ -2217,15 +1793,6 @@ class SageMaker {
     required UiTemplate uiTemplate,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(humanTaskUiName, 'humanTaskUiName');
-    _s.validateStringLength(
-      'humanTaskUiName',
-      humanTaskUiName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(uiTemplate, 'uiTemplate');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateHumanTaskUi'
@@ -2318,17 +1885,6 @@ class SageMaker {
     List<HyperParameterTrainingJobDefinition>? trainingJobDefinitions,
     HyperParameterTuningJobWarmStartConfig? warmStartConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        hyperParameterTuningJobConfig, 'hyperParameterTuningJobConfig');
-    ArgumentError.checkNotNull(
-        hyperParameterTuningJobName, 'hyperParameterTuningJobName');
-    _s.validateStringLength(
-      'hyperParameterTuningJobName',
-      hyperParameterTuningJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateHyperParameterTuningJob'
@@ -2386,34 +1942,6 @@ class SageMaker {
     String? displayName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateImage'
@@ -2464,28 +1992,6 @@ class SageMaker {
     required String imageName,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(baseImage, 'baseImage');
-    _s.validateStringLength(
-      'baseImage',
-      baseImage,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateImageVersion'
@@ -2654,39 +2160,6 @@ class SageMaker {
     LabelingJobStoppingConditions? stoppingConditions,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(humanTaskConfig, 'humanTaskConfig');
-    ArgumentError.checkNotNull(inputConfig, 'inputConfig');
-    ArgumentError.checkNotNull(labelAttributeName, 'labelAttributeName');
-    _s.validateStringLength(
-      'labelAttributeName',
-      labelAttributeName,
-      1,
-      127,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(labelingJobName, 'labelingJobName');
-    _s.validateStringLength(
-      'labelingJobName',
-      labelingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'labelCategoryConfigS3Uri',
-      labelCategoryConfigS3Uri,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateLabelingJob'
@@ -2806,22 +2279,6 @@ class SageMaker {
     List<Tag>? tags,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(executionRoleArn, 'executionRoleArn');
-    _s.validateStringLength(
-      'executionRoleArn',
-      executionRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModel'
@@ -2889,28 +2346,6 @@ class SageMaker {
     MonitoringStoppingCondition? stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobResources, 'jobResources');
-    ArgumentError.checkNotNull(
-        modelBiasAppSpecification, 'modelBiasAppSpecification');
-    ArgumentError.checkNotNull(modelBiasJobInput, 'modelBiasJobInput');
-    ArgumentError.checkNotNull(
-        modelBiasJobOutputConfig, 'modelBiasJobOutputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModelBiasJobDefinition'
@@ -2984,29 +2419,6 @@ class SageMaker {
     MonitoringStoppingCondition? stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobResources, 'jobResources');
-    ArgumentError.checkNotNull(modelExplainabilityAppSpecification,
-        'modelExplainabilityAppSpecification');
-    ArgumentError.checkNotNull(
-        modelExplainabilityJobInput, 'modelExplainabilityJobInput');
-    ArgumentError.checkNotNull(modelExplainabilityJobOutputConfig,
-        'modelExplainabilityJobOutputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModelExplainabilityJobDefinition'
@@ -3147,30 +2559,6 @@ class SageMaker {
     List<Tag>? tags,
     ModelPackageValidationSpecification? validationSpecification,
   }) async {
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'modelPackageDescription',
-      modelPackageDescription,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'modelPackageName',
-      modelPackageName,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModelPackage'
@@ -3228,20 +2616,6 @@ class SageMaker {
     String? modelPackageGroupDescription,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'modelPackageGroupDescription',
-      modelPackageGroupDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModelPackageGroup'
@@ -3309,28 +2683,6 @@ class SageMaker {
     MonitoringStoppingCondition? stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobResources, 'jobResources');
-    ArgumentError.checkNotNull(
-        modelQualityAppSpecification, 'modelQualityAppSpecification');
-    ArgumentError.checkNotNull(modelQualityJobInput, 'modelQualityJobInput');
-    ArgumentError.checkNotNull(
-        modelQualityJobOutputConfig, 'modelQualityJobOutputConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateModelQualityJobDefinition'
@@ -3384,17 +2736,6 @@ class SageMaker {
     required String monitoringScheduleName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleConfig, 'monitoringScheduleConfig');
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateMonitoringSchedule'
@@ -3584,47 +2925,6 @@ class SageMaker {
     List<Tag>? tags,
     int? volumeSizeInGB,
   }) async {
-    ArgumentError.checkNotNull(instanceType, 'instanceType');
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultCodeRepository',
-      defaultCodeRepository,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'lifecycleConfigName',
-      lifecycleConfigName,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'subnetId',
-      subnetId,
-      0,
-      32,
-    );
     _s.validateNumRange(
       'volumeSizeInGB',
       volumeSizeInGB,
@@ -3707,15 +3007,6 @@ class SageMaker {
     List<NotebookInstanceLifecycleHook>? onCreate,
     List<NotebookInstanceLifecycleHook>? onStart,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceLifecycleConfigName,
-        'notebookInstanceLifecycleConfigName');
-    _s.validateStringLength(
-      'notebookInstanceLifecycleConfigName',
-      notebookInstanceLifecycleConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateNotebookInstanceLifecycleConfig'
@@ -3775,48 +3066,6 @@ class SageMaker {
     String? pipelineDisplayName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(pipelineDefinition, 'pipelineDefinition');
-    _s.validateStringLength(
-      'pipelineDefinition',
-      pipelineDefinition,
-      1,
-      1048576,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
-    _s.validateStringLength(
-      'pipelineDescription',
-      pipelineDescription,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'pipelineDisplayName',
-      pipelineDisplayName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreatePipeline'
@@ -3870,22 +3119,6 @@ class SageMaker {
     required String userProfileName,
     int? sessionExpirationDurationInSeconds,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'sessionExpirationDurationInSeconds',
       sessionExpirationDurationInSeconds,
@@ -3950,14 +3183,6 @@ class SageMaker {
     required String notebookInstanceName,
     int? sessionExpirationDurationInSeconds,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'sessionExpirationDurationInSeconds',
       sessionExpirationDurationInSeconds,
@@ -4040,24 +3265,6 @@ class SageMaker {
     ProcessingStoppingCondition? stoppingCondition,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(appSpecification, 'appSpecification');
-    ArgumentError.checkNotNull(processingJobName, 'processingJobName');
-    _s.validateStringLength(
-      'processingJobName',
-      processingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(processingResources, 'processingResources');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateProcessingJob'
@@ -4117,22 +3324,6 @@ class SageMaker {
     String? projectDescription,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        serviceCatalogProvisioningDetails, 'serviceCatalogProvisioningDetails');
-    _s.validateStringLength(
-      'projectDescription',
-      projectDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateProject'
@@ -4383,27 +3574,6 @@ class SageMaker {
     TensorBoardOutputConfig? tensorBoardOutputConfig,
     VpcConfig? vpcConfig,
   }) async {
-    ArgumentError.checkNotNull(
-        algorithmSpecification, 'algorithmSpecification');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    ArgumentError.checkNotNull(resourceConfig, 'resourceConfig');
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(stoppingCondition, 'stoppingCondition');
-    ArgumentError.checkNotNull(trainingJobName, 'trainingJobName');
-    _s.validateStringLength(
-      'trainingJobName',
-      trainingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateTrainingJob'
@@ -4590,25 +3760,6 @@ class SageMaker {
     ModelClientConfig? modelClientConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transformInput, 'transformInput');
-    ArgumentError.checkNotNull(transformJobName, 'transformJobName');
-    _s.validateStringLength(
-      'transformJobName',
-      transformJobName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(transformOutput, 'transformOutput');
-    ArgumentError.checkNotNull(transformResources, 'transformResources');
     _s.validateNumRange(
       'maxConcurrentTransforms',
       maxConcurrentTransforms,
@@ -4693,28 +3844,6 @@ class SageMaker {
     MetadataProperties? metadataProperties,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(experimentName, 'experimentName');
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateTrial'
@@ -4818,20 +3947,6 @@ class SageMaker {
     TrialComponentStatus? status,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateTrialComponent'
@@ -4904,28 +4019,6 @@ class SageMaker {
     List<Tag>? tags,
     UserSettings? userSettings,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'singleSignOnUserValue',
-      singleSignOnUserValue,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateUserProfile'
@@ -5003,14 +4096,6 @@ class SageMaker {
     SourceIpConfig? sourceIpConfig,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(workforceName, 'workforceName');
-    _s.validateStringLength(
-      'workforceName',
-      workforceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateWorkforce'
@@ -5097,29 +4182,6 @@ class SageMaker {
     List<Tag>? tags,
     String? workforceName,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberDefinitions, 'memberDefinitions');
-    ArgumentError.checkNotNull(workteamName, 'workteamName');
-    _s.validateStringLength(
-      'workteamName',
-      workteamName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'workforceName',
-      workforceName,
-      1,
-      63,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.CreateWorkteam'
@@ -5153,14 +4215,6 @@ class SageMaker {
   Future<DeleteActionResponse> deleteAction({
     required String actionName,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteAction'
@@ -5186,14 +4240,6 @@ class SageMaker {
   Future<void> deleteAlgorithm({
     required String algorithmName,
   }) async {
-    ArgumentError.checkNotNull(algorithmName, 'algorithmName');
-    _s.validateStringLength(
-      'algorithmName',
-      algorithmName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteAlgorithm'
@@ -5232,31 +4278,6 @@ class SageMaker {
     required String domainId,
     required String userProfileName,
   }) async {
-    ArgumentError.checkNotNull(appName, 'appName');
-    _s.validateStringLength(
-      'appName',
-      appName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appType, 'appType');
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteApp'
@@ -5285,14 +4306,6 @@ class SageMaker {
   Future<void> deleteAppImageConfig({
     required String appImageConfigName,
   }) async {
-    ArgumentError.checkNotNull(appImageConfigName, 'appImageConfigName');
-    _s.validateStringLength(
-      'appImageConfigName',
-      appImageConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteAppImageConfig'
@@ -5323,12 +4336,6 @@ class SageMaker {
     String? artifactArn,
     ArtifactSource? source,
   }) async {
-    _s.validateStringLength(
-      'artifactArn',
-      artifactArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteArtifact'
@@ -5361,22 +4368,6 @@ class SageMaker {
     required String destinationArn,
     required String sourceArn,
   }) async {
-    ArgumentError.checkNotNull(destinationArn, 'destinationArn');
-    _s.validateStringLength(
-      'destinationArn',
-      destinationArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
-    _s.validateStringLength(
-      'sourceArn',
-      sourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteAssociation'
@@ -5403,14 +4394,6 @@ class SageMaker {
   Future<void> deleteCodeRepository({
     required String codeRepositoryName,
   }) async {
-    ArgumentError.checkNotNull(codeRepositoryName, 'codeRepositoryName');
-    _s.validateStringLength(
-      'codeRepositoryName',
-      codeRepositoryName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteCodeRepository'
@@ -5436,14 +4419,6 @@ class SageMaker {
   Future<DeleteContextResponse> deleteContext({
     required String contextName,
   }) async {
-    ArgumentError.checkNotNull(contextName, 'contextName');
-    _s.validateStringLength(
-      'contextName',
-      contextName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteContext'
@@ -5471,14 +4446,6 @@ class SageMaker {
   Future<void> deleteDataQualityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteDataQualityJobDefinition'
@@ -5504,14 +4471,6 @@ class SageMaker {
   Future<void> deleteDeviceFleet({
     required String deviceFleetName,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteDeviceFleet'
@@ -5547,14 +4506,6 @@ class SageMaker {
     required String domainId,
     RetentionPolicy? retentionPolicy,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteDomain'
@@ -5585,14 +4536,6 @@ class SageMaker {
   Future<void> deleteEndpoint({
     required String endpointName,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteEndpoint'
@@ -5626,14 +4569,6 @@ class SageMaker {
   Future<void> deleteEndpointConfig({
     required String endpointConfigName,
   }) async {
-    ArgumentError.checkNotNull(endpointConfigName, 'endpointConfigName');
-    _s.validateStringLength(
-      'endpointConfigName',
-      endpointConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteEndpointConfig'
@@ -5661,14 +4596,6 @@ class SageMaker {
   Future<DeleteExperimentResponse> deleteExperiment({
     required String experimentName,
   }) async {
-    ArgumentError.checkNotNull(experimentName, 'experimentName');
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteExperiment'
@@ -5704,14 +4631,6 @@ class SageMaker {
   Future<void> deleteFeatureGroup({
     required String featureGroupName,
   }) async {
-    ArgumentError.checkNotNull(featureGroupName, 'featureGroupName');
-    _s.validateStringLength(
-      'featureGroupName',
-      featureGroupName,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteFeatureGroup'
@@ -5738,14 +4657,6 @@ class SageMaker {
   Future<void> deleteFlowDefinition({
     required String flowDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(flowDefinitionName, 'flowDefinitionName');
-    _s.validateStringLength(
-      'flowDefinitionName',
-      flowDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteFlowDefinition'
@@ -5777,14 +4688,6 @@ class SageMaker {
   Future<void> deleteHumanTaskUi({
     required String humanTaskUiName,
   }) async {
-    ArgumentError.checkNotNull(humanTaskUiName, 'humanTaskUiName');
-    _s.validateStringLength(
-      'humanTaskUiName',
-      humanTaskUiName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteHumanTaskUi'
@@ -5812,14 +4715,6 @@ class SageMaker {
   Future<void> deleteImage({
     required String imageName,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteImage'
@@ -5851,15 +4746,6 @@ class SageMaker {
     required String imageName,
     required int version,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
     _s.validateNumRange(
       'version',
       version,
@@ -5894,14 +4780,6 @@ class SageMaker {
   Future<void> deleteModel({
     required String modelName,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModel'
@@ -5927,14 +4805,6 @@ class SageMaker {
   Future<void> deleteModelBiasJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelBiasJobDefinition'
@@ -5960,14 +4830,6 @@ class SageMaker {
   Future<void> deleteModelExplainabilityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelExplainabilityJobDefinition'
@@ -5998,14 +4860,6 @@ class SageMaker {
   Future<void> deleteModelPackage({
     required String modelPackageName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageName, 'modelPackageName');
-    _s.validateStringLength(
-      'modelPackageName',
-      modelPackageName,
-      1,
-      176,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelPackage'
@@ -6029,14 +4883,6 @@ class SageMaker {
   Future<void> deleteModelPackageGroup({
     required String modelPackageGroupName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      170,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelPackageGroup'
@@ -6060,14 +4906,6 @@ class SageMaker {
   Future<void> deleteModelPackageGroupPolicy({
     required String modelPackageGroupName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelPackageGroupPolicy'
@@ -6093,14 +4931,6 @@ class SageMaker {
   Future<void> deleteModelQualityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteModelQualityJobDefinition'
@@ -6128,15 +4958,6 @@ class SageMaker {
   Future<void> deleteMonitoringSchedule({
     required String monitoringScheduleName,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteMonitoringSchedule'
@@ -6167,14 +4988,6 @@ class SageMaker {
   Future<void> deleteNotebookInstance({
     required String notebookInstanceName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteNotebookInstance'
@@ -6198,15 +5011,6 @@ class SageMaker {
   Future<void> deleteNotebookInstanceLifecycleConfig({
     required String notebookInstanceLifecycleConfigName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceLifecycleConfigName,
-        'notebookInstanceLifecycleConfigName');
-    _s.validateStringLength(
-      'notebookInstanceLifecycleConfigName',
-      notebookInstanceLifecycleConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteNotebookInstanceLifecycleConfig'
@@ -6239,20 +5043,6 @@ class SageMaker {
     required String pipelineName,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeletePipeline'
@@ -6280,14 +5070,6 @@ class SageMaker {
   Future<void> deleteProject({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteProject'
@@ -6323,15 +5105,6 @@ class SageMaker {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteTags'
@@ -6360,14 +5133,6 @@ class SageMaker {
   Future<DeleteTrialResponse> deleteTrial({
     required String trialName,
   }) async {
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteTrial'
@@ -6398,14 +5163,6 @@ class SageMaker {
   Future<DeleteTrialComponentResponse> deleteTrialComponent({
     required String trialComponentName,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteTrialComponent'
@@ -6440,22 +5197,6 @@ class SageMaker {
     required String domainId,
     required String userProfileName,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteUserProfile'
@@ -6490,14 +5231,6 @@ class SageMaker {
   Future<void> deleteWorkforce({
     required String workforceName,
   }) async {
-    ArgumentError.checkNotNull(workforceName, 'workforceName');
-    _s.validateStringLength(
-      'workforceName',
-      workforceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteWorkforce'
@@ -6523,14 +5256,6 @@ class SageMaker {
   Future<DeleteWorkteamResponse> deleteWorkteam({
     required String workteamName,
   }) async {
-    ArgumentError.checkNotNull(workteamName, 'workteamName');
-    _s.validateStringLength(
-      'workteamName',
-      workteamName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeleteWorkteam'
@@ -6561,15 +5286,6 @@ class SageMaker {
     required String deviceFleetName,
     required List<String> deviceNames,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deviceNames, 'deviceNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DeregisterDevices'
@@ -6596,14 +5312,6 @@ class SageMaker {
   Future<DescribeActionResponse> describeAction({
     required String actionName,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeAction'
@@ -6629,14 +5337,6 @@ class SageMaker {
   Future<DescribeAlgorithmOutput> describeAlgorithm({
     required String algorithmName,
   }) async {
-    ArgumentError.checkNotNull(algorithmName, 'algorithmName');
-    _s.validateStringLength(
-      'algorithmName',
-      algorithmName,
-      1,
-      170,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeAlgorithm'
@@ -6676,31 +5376,6 @@ class SageMaker {
     required String domainId,
     required String userProfileName,
   }) async {
-    ArgumentError.checkNotNull(appName, 'appName');
-    _s.validateStringLength(
-      'appName',
-      appName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(appType, 'appType');
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeApp'
@@ -6731,14 +5406,6 @@ class SageMaker {
   Future<DescribeAppImageConfigResponse> describeAppImageConfig({
     required String appImageConfigName,
   }) async {
-    ArgumentError.checkNotNull(appImageConfigName, 'appImageConfigName');
-    _s.validateStringLength(
-      'appImageConfigName',
-      appImageConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeAppImageConfig'
@@ -6766,14 +5433,6 @@ class SageMaker {
   Future<DescribeArtifactResponse> describeArtifact({
     required String artifactArn,
   }) async {
-    ArgumentError.checkNotNull(artifactArn, 'artifactArn');
-    _s.validateStringLength(
-      'artifactArn',
-      artifactArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeArtifact'
@@ -6801,14 +5460,6 @@ class SageMaker {
   Future<DescribeAutoMLJobResponse> describeAutoMLJob({
     required String autoMLJobName,
   }) async {
-    ArgumentError.checkNotNull(autoMLJobName, 'autoMLJobName');
-    _s.validateStringLength(
-      'autoMLJobName',
-      autoMLJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeAutoMLJob'
@@ -6834,14 +5485,6 @@ class SageMaker {
   Future<DescribeCodeRepositoryOutput> describeCodeRepository({
     required String codeRepositoryName,
   }) async {
-    ArgumentError.checkNotNull(codeRepositoryName, 'codeRepositoryName');
-    _s.validateStringLength(
-      'codeRepositoryName',
-      codeRepositoryName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeCodeRepository'
@@ -6873,14 +5516,6 @@ class SageMaker {
   Future<DescribeCompilationJobResponse> describeCompilationJob({
     required String compilationJobName,
   }) async {
-    ArgumentError.checkNotNull(compilationJobName, 'compilationJobName');
-    _s.validateStringLength(
-      'compilationJobName',
-      compilationJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeCompilationJob'
@@ -6908,14 +5543,6 @@ class SageMaker {
   Future<DescribeContextResponse> describeContext({
     required String contextName,
   }) async {
-    ArgumentError.checkNotNull(contextName, 'contextName');
-    _s.validateStringLength(
-      'contextName',
-      contextName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeContext'
@@ -6944,14 +5571,6 @@ class SageMaker {
       describeDataQualityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeDataQualityJobDefinition'
@@ -6987,28 +5606,6 @@ class SageMaker {
     required String deviceName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(deviceName, 'deviceName');
-    _s.validateStringLength(
-      'deviceName',
-      deviceName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeDevice'
@@ -7038,14 +5635,6 @@ class SageMaker {
   Future<DescribeDeviceFleetResponse> describeDeviceFleet({
     required String deviceFleetName,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeDeviceFleet'
@@ -7073,14 +5662,6 @@ class SageMaker {
   Future<DescribeDomainResponse> describeDomain({
     required String domainId,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeDomain'
@@ -7108,14 +5689,6 @@ class SageMaker {
   Future<DescribeEdgePackagingJobResponse> describeEdgePackagingJob({
     required String edgePackagingJobName,
   }) async {
-    ArgumentError.checkNotNull(edgePackagingJobName, 'edgePackagingJobName');
-    _s.validateStringLength(
-      'edgePackagingJobName',
-      edgePackagingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeEdgePackagingJob'
@@ -7141,14 +5714,6 @@ class SageMaker {
   Future<DescribeEndpointOutput> describeEndpoint({
     required String endpointName,
   }) async {
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeEndpoint'
@@ -7175,14 +5740,6 @@ class SageMaker {
   Future<DescribeEndpointConfigOutput> describeEndpointConfig({
     required String endpointConfigName,
   }) async {
-    ArgumentError.checkNotNull(endpointConfigName, 'endpointConfigName');
-    _s.validateStringLength(
-      'endpointConfigName',
-      endpointConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeEndpointConfig'
@@ -7210,14 +5767,6 @@ class SageMaker {
   Future<DescribeExperimentResponse> describeExperiment({
     required String experimentName,
   }) async {
-    ArgumentError.checkNotNull(experimentName, 'experimentName');
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeExperiment'
@@ -7253,20 +5802,6 @@ class SageMaker {
     required String featureGroupName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(featureGroupName, 'featureGroupName');
-    _s.validateStringLength(
-      'featureGroupName',
-      featureGroupName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeFeatureGroup'
@@ -7295,14 +5830,6 @@ class SageMaker {
   Future<DescribeFlowDefinitionResponse> describeFlowDefinition({
     required String flowDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(flowDefinitionName, 'flowDefinitionName');
-    _s.validateStringLength(
-      'flowDefinitionName',
-      flowDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeFlowDefinition'
@@ -7332,14 +5859,6 @@ class SageMaker {
   Future<DescribeHumanTaskUiResponse> describeHumanTaskUi({
     required String humanTaskUiName,
   }) async {
-    ArgumentError.checkNotNull(humanTaskUiName, 'humanTaskUiName');
-    _s.validateStringLength(
-      'humanTaskUiName',
-      humanTaskUiName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeHumanTaskUi'
@@ -7368,15 +5887,6 @@ class SageMaker {
       describeHyperParameterTuningJob({
     required String hyperParameterTuningJobName,
   }) async {
-    ArgumentError.checkNotNull(
-        hyperParameterTuningJobName, 'hyperParameterTuningJobName');
-    _s.validateStringLength(
-      'hyperParameterTuningJobName',
-      hyperParameterTuningJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeHyperParameterTuningJob'
@@ -7404,14 +5914,6 @@ class SageMaker {
   Future<DescribeImageResponse> describeImage({
     required String imageName,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeImage'
@@ -7444,14 +5946,6 @@ class SageMaker {
     required String imageName,
     int? version,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'version',
       version,
@@ -7486,14 +5980,6 @@ class SageMaker {
   Future<DescribeLabelingJobResponse> describeLabelingJob({
     required String labelingJobName,
   }) async {
-    ArgumentError.checkNotNull(labelingJobName, 'labelingJobName');
-    _s.validateStringLength(
-      'labelingJobName',
-      labelingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeLabelingJob'
@@ -7519,14 +6005,6 @@ class SageMaker {
   Future<DescribeModelOutput> describeModel({
     required String modelName,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModel'
@@ -7556,14 +6034,6 @@ class SageMaker {
       describeModelBiasJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModelBiasJobDefinition'
@@ -7593,14 +6063,6 @@ class SageMaker {
       describeModelExplainabilityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModelExplainabilityJobDefinition'
@@ -7631,14 +6093,6 @@ class SageMaker {
   Future<DescribeModelPackageOutput> describeModelPackage({
     required String modelPackageName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageName, 'modelPackageName');
-    _s.validateStringLength(
-      'modelPackageName',
-      modelPackageName,
-      1,
-      176,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModelPackage'
@@ -7664,14 +6118,6 @@ class SageMaker {
   Future<DescribeModelPackageGroupOutput> describeModelPackageGroup({
     required String modelPackageGroupName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      170,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModelPackageGroup'
@@ -7701,14 +6147,6 @@ class SageMaker {
       describeModelQualityJobDefinition({
     required String jobDefinitionName,
   }) async {
-    ArgumentError.checkNotNull(jobDefinitionName, 'jobDefinitionName');
-    _s.validateStringLength(
-      'jobDefinitionName',
-      jobDefinitionName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeModelQualityJobDefinition'
@@ -7737,15 +6175,6 @@ class SageMaker {
   Future<DescribeMonitoringScheduleResponse> describeMonitoringSchedule({
     required String monitoringScheduleName,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeMonitoringSchedule'
@@ -7771,14 +6200,6 @@ class SageMaker {
   Future<DescribeNotebookInstanceOutput> describeNotebookInstance({
     required String notebookInstanceName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeNotebookInstance'
@@ -7809,15 +6230,6 @@ class SageMaker {
       describeNotebookInstanceLifecycleConfig({
     required String notebookInstanceLifecycleConfigName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceLifecycleConfigName,
-        'notebookInstanceLifecycleConfigName');
-    _s.validateStringLength(
-      'notebookInstanceLifecycleConfigName',
-      notebookInstanceLifecycleConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeNotebookInstanceLifecycleConfig'
@@ -7847,14 +6259,6 @@ class SageMaker {
   Future<DescribePipelineResponse> describePipeline({
     required String pipelineName,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribePipeline'
@@ -7883,14 +6287,6 @@ class SageMaker {
       describePipelineDefinitionForExecution({
     required String pipelineExecutionArn,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionArn, 'pipelineExecutionArn');
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribePipelineDefinitionForExecution'
@@ -7919,14 +6315,6 @@ class SageMaker {
   Future<DescribePipelineExecutionResponse> describePipelineExecution({
     required String pipelineExecutionArn,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionArn, 'pipelineExecutionArn');
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribePipelineExecution'
@@ -7955,14 +6343,6 @@ class SageMaker {
   Future<DescribeProcessingJobResponse> describeProcessingJob({
     required String processingJobName,
   }) async {
-    ArgumentError.checkNotNull(processingJobName, 'processingJobName');
-    _s.validateStringLength(
-      'processingJobName',
-      processingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeProcessingJob'
@@ -7988,14 +6368,6 @@ class SageMaker {
   Future<DescribeProjectOutput> describeProject({
     required String projectName,
   }) async {
-    ArgumentError.checkNotNull(projectName, 'projectName');
-    _s.validateStringLength(
-      'projectName',
-      projectName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeProject'
@@ -8022,14 +6394,6 @@ class SageMaker {
   Future<DescribeSubscribedWorkteamResponse> describeSubscribedWorkteam({
     required String workteamArn,
   }) async {
-    ArgumentError.checkNotNull(workteamArn, 'workteamArn');
-    _s.validateStringLength(
-      'workteamArn',
-      workteamArn,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeSubscribedWorkteam'
@@ -8057,14 +6421,6 @@ class SageMaker {
   Future<DescribeTrainingJobResponse> describeTrainingJob({
     required String trainingJobName,
   }) async {
-    ArgumentError.checkNotNull(trainingJobName, 'trainingJobName');
-    _s.validateStringLength(
-      'trainingJobName',
-      trainingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeTrainingJob'
@@ -8092,14 +6448,6 @@ class SageMaker {
   Future<DescribeTransformJobResponse> describeTransformJob({
     required String transformJobName,
   }) async {
-    ArgumentError.checkNotNull(transformJobName, 'transformJobName');
-    _s.validateStringLength(
-      'transformJobName',
-      transformJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeTransformJob'
@@ -8127,14 +6475,6 @@ class SageMaker {
   Future<DescribeTrialResponse> describeTrial({
     required String trialName,
   }) async {
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeTrial'
@@ -8162,14 +6502,6 @@ class SageMaker {
   Future<DescribeTrialComponentResponse> describeTrialComponent({
     required String trialComponentName,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeTrialComponent'
@@ -8202,22 +6534,6 @@ class SageMaker {
     required String domainId,
     required String userProfileName,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeUserProfile'
@@ -8253,14 +6569,6 @@ class SageMaker {
   Future<DescribeWorkforceResponse> describeWorkforce({
     required String workforceName,
   }) async {
-    ArgumentError.checkNotNull(workforceName, 'workforceName');
-    _s.validateStringLength(
-      'workforceName',
-      workforceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeWorkforce'
@@ -8288,14 +6596,6 @@ class SageMaker {
   Future<DescribeWorkteamResponse> describeWorkteam({
     required String workteamName,
   }) async {
-    ArgumentError.checkNotNull(workteamName, 'workteamName');
-    _s.validateStringLength(
-      'workteamName',
-      workteamName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DescribeWorkteam'
@@ -8352,22 +6652,6 @@ class SageMaker {
     required String trialComponentName,
     required String trialName,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.DisassociateTrialComponent'
@@ -8410,14 +6694,6 @@ class SageMaker {
   Future<GetDeviceFleetReportResponse> getDeviceFleetReport({
     required String deviceFleetName,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.GetDeviceFleetReport'
@@ -8447,14 +6723,6 @@ class SageMaker {
   Future<GetModelPackageGroupPolicyOutput> getModelPackageGroupPolicy({
     required String modelPackageGroupName,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.GetModelPackageGroupPolicy'
@@ -8507,7 +6775,6 @@ class SageMaker {
     required ResourceType resource,
     SuggestionQuery? suggestionQuery,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.GetSearchSuggestions'
@@ -8569,29 +6836,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? sourceUri,
   }) async {
-    _s.validateStringLength(
-      'actionType',
-      actionType,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sourceUri',
-      sourceUri,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -8662,18 +6911,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -8757,18 +6994,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListAppImageConfigs'
@@ -8827,29 +7052,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? userProfileNameEquals,
   }) async {
-    _s.validateStringLength(
-      'domainIdEquals',
-      domainIdEquals,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'userProfileNameEquals',
-      userProfileNameEquals,
-      0,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -8918,29 +7125,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? sourceUri,
   }) async {
-    _s.validateStringLength(
-      'artifactType',
-      artifactType,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sourceUri',
-      sourceUri,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9026,41 +7215,11 @@ class SageMaker {
     String? sourceArn,
     String? sourceType,
   }) async {
-    _s.validateStringLength(
-      'destinationArn',
-      destinationArn,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'destinationType',
-      destinationType,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sourceArn',
-      sourceArn,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'sourceType',
-      sourceType,
-      0,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9143,18 +7302,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListAutoMLJobs'
@@ -9220,31 +7367,11 @@ class SageMaker {
     AutoMLSortOrder? sortOrder,
     CandidateStatus? statusEquals,
   }) async {
-    ArgumentError.checkNotNull(autoMLJobName, 'autoMLJobName');
-    _s.validateStringLength(
-      'autoMLJobName',
-      autoMLJobName,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'candidateNameEquals',
-      candidateNameEquals,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9322,18 +7449,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9427,18 +7542,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListCompilationJobs'
@@ -9513,29 +7616,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? sourceUri,
   }) async {
-    _s.validateStringLength(
-      'contextType',
-      contextType,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sourceUri',
-      sourceUri,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9608,29 +7693,11 @@ class SageMaker {
     MonitoringJobDefinitionSortKey? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9706,18 +7773,6 @@ class SageMaker {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListDeviceFleets'
@@ -9773,29 +7828,11 @@ class SageMaker {
     String? modelName,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9837,12 +7874,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9917,24 +7948,6 @@ class SageMaker {
       0,
       100,
     );
-    _s.validateStringLength(
-      'modelNameContains',
-      modelNameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListEdgePackagingJobs'
@@ -10008,18 +8021,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10103,18 +8104,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListEndpoints'
@@ -10184,12 +8173,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10266,18 +8249,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListFeatureGroups'
@@ -10343,12 +8314,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListFlowDefinitions'
@@ -10407,12 +8372,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10495,18 +8454,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListHyperParameterTuningJobs'
@@ -10588,25 +8535,11 @@ class SageMaker {
     ImageVersionSortBy? sortBy,
     ImageVersionSortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10689,18 +8622,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10789,18 +8710,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListLabelingJobs'
@@ -10876,31 +8785,11 @@ class SageMaker {
     ListLabelingJobsForWorkteamSortByOptions? sortBy,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(workteamArn, 'workteamArn');
-    _s.validateStringLength(
-      'workteamArn',
-      workteamArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'jobReferenceCodeContains',
-      jobReferenceCodeContains,
-      1,
-      255,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -10970,29 +8859,11 @@ class SageMaker {
     MonitoringJobDefinitionSortKey? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11064,29 +8935,11 @@ class SageMaker {
     MonitoringJobDefinitionSortKey? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11155,18 +9008,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11264,24 +9105,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      170,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListModelPackages'
@@ -11358,29 +9181,11 @@ class SageMaker {
     MonitoringJobDefinitionSortKey? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11450,18 +9255,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11559,35 +9352,11 @@ class SageMaker {
     SortOrder? sortOrder,
     ExecutionStatus? statusEquals,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'monitoringJobDefinitionName',
-      monitoringJobDefinitionName,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11697,35 +9466,11 @@ class SageMaker {
     SortOrder? sortOrder,
     ScheduleStatus? statusEquals,
   }) async {
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'monitoringJobDefinitionName',
-      monitoringJobDefinitionName,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11817,18 +9562,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -11936,41 +9669,11 @@ class SageMaker {
     NotebookInstanceSortOrder? sortOrder,
     NotebookInstanceStatus? statusEquals,
   }) async {
-    _s.validateStringLength(
-      'additionalCodeRepositoryEquals',
-      additionalCodeRepositoryEquals,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'defaultCodeRepositoryContains',
-      defaultCodeRepositoryContains,
-      0,
-      1024,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'notebookInstanceLifecycleConfigNameContains',
-      notebookInstanceLifecycleConfigNameContains,
-      0,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12041,18 +9744,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListPipelineExecutionSteps'
@@ -12113,25 +9804,11 @@ class SageMaker {
     SortPipelineExecutionsBy? sortBy,
     SortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12180,25 +9857,11 @@ class SageMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionArn, 'pipelineExecutionArn');
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12262,18 +9925,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'pipelineNamePrefix',
-      pipelineNamePrefix,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12358,12 +10009,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListProcessingJobs'
@@ -12437,18 +10082,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      32,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListProjects'
@@ -12501,18 +10134,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListSubscribedWorkteams'
@@ -12551,25 +10172,11 @@ class SageMaker {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      0,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       50,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12647,18 +10254,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListTrainingJobs'
@@ -12727,26 +10322,11 @@ class SageMaker {
     SortOrder? sortOrder,
     TrainingJobStatus? statusEquals,
   }) async {
-    ArgumentError.checkNotNull(
-        hyperParameterTuningJobName, 'hyperParameterTuningJobName');
-    _s.validateStringLength(
-      'hyperParameterTuningJobName',
-      hyperParameterTuningJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12828,18 +10408,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -12938,35 +10506,11 @@ class SageMaker {
     String? sourceArn,
     String? trialName,
   }) async {
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sourceArn',
-      sourceArn,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -13043,29 +10587,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? trialComponentName,
   }) async {
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -13123,29 +10649,11 @@ class SageMaker {
     SortOrder? sortOrder,
     String? userProfileNameContains,
   }) async {
-    _s.validateStringLength(
-      'domainIdEquals',
-      domainIdEquals,
-      0,
-      63,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'userProfileNameContains',
-      userProfileNameContains,
-      0,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -13201,18 +10709,6 @@ class SageMaker {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -13270,18 +10766,6 @@ class SageMaker {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      63,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.ListWorkteams'
@@ -13319,22 +10803,6 @@ class SageMaker {
     required String modelPackageGroupName,
     required String resourcePolicy,
   }) async {
-    ArgumentError.checkNotNull(modelPackageGroupName, 'modelPackageGroupName');
-    _s.validateStringLength(
-      'modelPackageGroupName',
-      modelPackageGroupName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourcePolicy, 'resourcePolicy');
-    _s.validateStringLength(
-      'resourcePolicy',
-      resourcePolicy,
-      1,
-      20480,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.PutModelPackageGroupPolicy'
@@ -13371,15 +10839,6 @@ class SageMaker {
     required List<Device> devices,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(devices, 'devices');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.RegisterDevices'
@@ -13427,21 +10886,6 @@ class SageMaker {
     String? humanTaskUiArn,
     UiTemplate? uiTemplate,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(task, 'task');
-    _s.validateStringLength(
-      'humanTaskUiArn',
-      humanTaskUiArn,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.RenderUiTemplate'
@@ -13507,24 +10951,11 @@ class SageMaker {
     String? sortBy,
     SearchSortOrder? sortOrder,
   }) async {
-    ArgumentError.checkNotNull(resource, 'resource');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'sortBy',
-      sortBy,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -13562,15 +10993,6 @@ class SageMaker {
   Future<void> startMonitoringSchedule({
     required String monitoringScheduleName,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StartMonitoringSchedule'
@@ -13600,14 +11022,6 @@ class SageMaker {
   Future<void> startNotebookInstance({
     required String notebookInstanceName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StartNotebookInstance'
@@ -13652,32 +11066,6 @@ class SageMaker {
     String? pipelineExecutionDisplayName,
     List<Parameter>? pipelineParameters,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
-    _s.validateStringLength(
-      'pipelineExecutionDescription',
-      pipelineExecutionDescription,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'pipelineExecutionDisplayName',
-      pipelineExecutionDisplayName,
-      1,
-      82,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StartPipelineExecution'
@@ -13713,14 +11101,6 @@ class SageMaker {
   Future<void> stopAutoMLJob({
     required String autoMLJobName,
   }) async {
-    ArgumentError.checkNotNull(autoMLJobName, 'autoMLJobName');
-    _s.validateStringLength(
-      'autoMLJobName',
-      autoMLJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopAutoMLJob'
@@ -13756,14 +11136,6 @@ class SageMaker {
   Future<void> stopCompilationJob({
     required String compilationJobName,
   }) async {
-    ArgumentError.checkNotNull(compilationJobName, 'compilationJobName');
-    _s.validateStringLength(
-      'compilationJobName',
-      compilationJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopCompilationJob'
@@ -13787,14 +11159,6 @@ class SageMaker {
   Future<void> stopEdgePackagingJob({
     required String edgePackagingJobName,
   }) async {
-    ArgumentError.checkNotNull(edgePackagingJobName, 'edgePackagingJobName');
-    _s.validateStringLength(
-      'edgePackagingJobName',
-      edgePackagingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopEdgePackagingJob'
@@ -13827,15 +11191,6 @@ class SageMaker {
   Future<void> stopHyperParameterTuningJob({
     required String hyperParameterTuningJobName,
   }) async {
-    ArgumentError.checkNotNull(
-        hyperParameterTuningJobName, 'hyperParameterTuningJobName');
-    _s.validateStringLength(
-      'hyperParameterTuningJobName',
-      hyperParameterTuningJobName,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopHyperParameterTuningJob'
@@ -13863,14 +11218,6 @@ class SageMaker {
   Future<void> stopLabelingJob({
     required String labelingJobName,
   }) async {
-    ArgumentError.checkNotNull(labelingJobName, 'labelingJobName');
-    _s.validateStringLength(
-      'labelingJobName',
-      labelingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopLabelingJob'
@@ -13896,15 +11243,6 @@ class SageMaker {
   Future<void> stopMonitoringSchedule({
     required String monitoringScheduleName,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopMonitoringSchedule'
@@ -13938,14 +11276,6 @@ class SageMaker {
   Future<void> stopNotebookInstance({
     required String notebookInstanceName,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopNotebookInstance'
@@ -13977,20 +11307,6 @@ class SageMaker {
     required String pipelineExecutionArn,
     String? clientRequestToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionArn, 'pipelineExecutionArn');
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopPipelineExecution'
@@ -14020,14 +11336,6 @@ class SageMaker {
   Future<void> stopProcessingJob({
     required String processingJobName,
   }) async {
-    ArgumentError.checkNotNull(processingJobName, 'processingJobName');
-    _s.validateStringLength(
-      'processingJobName',
-      processingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopProcessingJob'
@@ -14060,14 +11368,6 @@ class SageMaker {
   Future<void> stopTrainingJob({
     required String trainingJobName,
   }) async {
-    ArgumentError.checkNotNull(trainingJobName, 'trainingJobName');
-    _s.validateStringLength(
-      'trainingJobName',
-      trainingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopTrainingJob'
@@ -14099,14 +11399,6 @@ class SageMaker {
   Future<void> stopTransformJob({
     required String transformJobName,
   }) async {
-    ArgumentError.checkNotNull(transformJobName, 'transformJobName');
-    _s.validateStringLength(
-      'transformJobName',
-      transformJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.StopTransformJob'
@@ -14149,20 +11441,6 @@ class SageMaker {
     List<String>? propertiesToRemove,
     ActionStatus? status,
   }) async {
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    _s.validateStringLength(
-      'actionName',
-      actionName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateAction'
@@ -14199,14 +11477,6 @@ class SageMaker {
     required String appImageConfigName,
     KernelGatewayImageConfig? kernelGatewayImageConfig,
   }) async {
-    ArgumentError.checkNotNull(appImageConfigName, 'appImageConfigName');
-    _s.validateStringLength(
-      'appImageConfigName',
-      appImageConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateAppImageConfig'
@@ -14249,20 +11519,6 @@ class SageMaker {
     Map<String, String>? properties,
     List<String>? propertiesToRemove,
   }) async {
-    ArgumentError.checkNotNull(artifactArn, 'artifactArn');
-    _s.validateStringLength(
-      'artifactArn',
-      artifactArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'artifactName',
-      artifactName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateArtifact'
@@ -14301,14 +11557,6 @@ class SageMaker {
     required String codeRepositoryName,
     GitConfigForUpdate? gitConfig,
   }) async {
-    ArgumentError.checkNotNull(codeRepositoryName, 'codeRepositoryName');
-    _s.validateStringLength(
-      'codeRepositoryName',
-      codeRepositoryName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateCodeRepository'
@@ -14350,20 +11598,6 @@ class SageMaker {
     Map<String, String>? properties,
     List<String>? propertiesToRemove,
   }) async {
-    ArgumentError.checkNotNull(contextName, 'contextName');
-    _s.validateStringLength(
-      'contextName',
-      contextName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateContext'
@@ -14407,27 +11641,6 @@ class SageMaker {
     String? description,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputConfig, 'outputConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      800,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateDeviceFleet'
@@ -14458,15 +11671,6 @@ class SageMaker {
     required String deviceFleetName,
     required List<Device> devices,
   }) async {
-    ArgumentError.checkNotNull(deviceFleetName, 'deviceFleetName');
-    _s.validateStringLength(
-      'deviceFleetName',
-      deviceFleetName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(devices, 'devices');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateDevices'
@@ -14499,14 +11703,6 @@ class SageMaker {
     required String domainId,
     UserSettings? defaultUserSettings,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateDomain'
@@ -14585,22 +11781,6 @@ class SageMaker {
     List<VariantProperty>? excludeRetainedVariantProperties,
     bool? retainAllVariantProperties,
   }) async {
-    ArgumentError.checkNotNull(endpointConfigName, 'endpointConfigName');
-    _s.validateStringLength(
-      'endpointConfigName',
-      endpointConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateEndpoint'
@@ -14644,16 +11824,6 @@ class SageMaker {
     required List<DesiredWeightAndCapacity> desiredWeightsAndCapacities,
     required String endpointName,
   }) async {
-    ArgumentError.checkNotNull(
-        desiredWeightsAndCapacities, 'desiredWeightsAndCapacities');
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateEndpointWeightsAndCapacities'
@@ -14694,26 +11864,6 @@ class SageMaker {
     String? description,
     String? displayName,
   }) async {
-    ArgumentError.checkNotNull(experimentName, 'experimentName');
-    _s.validateStringLength(
-      'experimentName',
-      experimentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateExperiment'
@@ -14763,32 +11913,6 @@ class SageMaker {
     String? displayName,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateImage'
@@ -14826,21 +11950,6 @@ class SageMaker {
     required String modelPackageArn,
     String? approvalDescription,
   }) async {
-    ArgumentError.checkNotNull(modelApprovalStatus, 'modelApprovalStatus');
-    ArgumentError.checkNotNull(modelPackageArn, 'modelPackageArn');
-    _s.validateStringLength(
-      'modelPackageArn',
-      modelPackageArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'approvalDescription',
-      approvalDescription,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateModelPackage'
@@ -14878,17 +11987,6 @@ class SageMaker {
     required MonitoringScheduleConfig monitoringScheduleConfig,
     required String monitoringScheduleName,
   }) async {
-    ArgumentError.checkNotNull(
-        monitoringScheduleConfig, 'monitoringScheduleConfig');
-    ArgumentError.checkNotNull(
-        monitoringScheduleName, 'monitoringScheduleName');
-    _s.validateStringLength(
-      'monitoringScheduleName',
-      monitoringScheduleName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateMonitoringSchedule'
@@ -15022,32 +12120,6 @@ class SageMaker {
     RootAccess? rootAccess,
     int? volumeSizeInGB,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceName, 'notebookInstanceName');
-    _s.validateStringLength(
-      'notebookInstanceName',
-      notebookInstanceName,
-      0,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultCodeRepository',
-      defaultCodeRepository,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'lifecycleConfigName',
-      lifecycleConfigName,
-      0,
-      63,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     _s.validateNumRange(
       'volumeSizeInGB',
       volumeSizeInGB,
@@ -15113,15 +12185,6 @@ class SageMaker {
     List<NotebookInstanceLifecycleHook>? onCreate,
     List<NotebookInstanceLifecycleHook>? onStart,
   }) async {
-    ArgumentError.checkNotNull(notebookInstanceLifecycleConfigName,
-        'notebookInstanceLifecycleConfigName');
-    _s.validateStringLength(
-      'notebookInstanceLifecycleConfigName',
-      notebookInstanceLifecycleConfigName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateNotebookInstanceLifecycleConfig'
@@ -15166,38 +12229,6 @@ class SageMaker {
     String? pipelineDisplayName,
     String? roleArn,
   }) async {
-    ArgumentError.checkNotNull(pipelineName, 'pipelineName');
-    _s.validateStringLength(
-      'pipelineName',
-      pipelineName,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'pipelineDefinition',
-      pipelineDefinition,
-      1,
-      1048576,
-    );
-    _s.validateStringLength(
-      'pipelineDescription',
-      pipelineDescription,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'pipelineDisplayName',
-      pipelineDisplayName,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdatePipeline'
@@ -15240,26 +12271,6 @@ class SageMaker {
     String? pipelineExecutionDescription,
     String? pipelineExecutionDisplayName,
   }) async {
-    ArgumentError.checkNotNull(pipelineExecutionArn, 'pipelineExecutionArn');
-    _s.validateStringLength(
-      'pipelineExecutionArn',
-      pipelineExecutionArn,
-      0,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'pipelineExecutionDescription',
-      pipelineExecutionDescription,
-      0,
-      3072,
-    );
-    _s.validateStringLength(
-      'pipelineExecutionDisplayName',
-      pipelineExecutionDisplayName,
-      1,
-      82,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdatePipelineExecution'
@@ -15302,14 +12313,6 @@ class SageMaker {
     ProfilerConfigForUpdate? profilerConfig,
     List<ProfilerRuleConfiguration>? profilerRuleConfigurations,
   }) async {
-    ArgumentError.checkNotNull(trainingJobName, 'trainingJobName');
-    _s.validateStringLength(
-      'trainingJobName',
-      trainingJobName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateTrainingJob'
@@ -15347,20 +12350,6 @@ class SageMaker {
     required String trialName,
     String? displayName,
   }) async {
-    ArgumentError.checkNotNull(trialName, 'trialName');
-    _s.validateStringLength(
-      'trialName',
-      trialName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateTrial'
@@ -15435,20 +12424,6 @@ class SageMaker {
     DateTime? startTime,
     TrialComponentStatus? status,
   }) async {
-    ArgumentError.checkNotNull(trialComponentName, 'trialComponentName');
-    _s.validateStringLength(
-      'trialComponentName',
-      trialComponentName,
-      1,
-      120,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      120,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateTrialComponent'
@@ -15499,22 +12474,6 @@ class SageMaker {
     required String userProfileName,
     UserSettings? userSettings,
   }) async {
-    ArgumentError.checkNotNull(domainId, 'domainId');
-    _s.validateStringLength(
-      'domainId',
-      domainId,
-      0,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userProfileName, 'userProfileName');
-    _s.validateStringLength(
-      'userProfileName',
-      userProfileName,
-      0,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateUserProfile'
@@ -15582,14 +12541,6 @@ class SageMaker {
     OidcConfig? oidcConfig,
     SourceIpConfig? sourceIpConfig,
   }) async {
-    ArgumentError.checkNotNull(workforceName, 'workforceName');
-    _s.validateStringLength(
-      'workforceName',
-      workforceName,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateWorkforce'
@@ -15657,20 +12608,6 @@ class SageMaker {
     List<MemberDefinition>? memberDefinitions,
     NotificationConfiguration? notificationConfiguration,
   }) async {
-    ArgumentError.checkNotNull(workteamName, 'workteamName');
-    _s.validateStringLength(
-      'workteamName',
-      workteamName,
-      1,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SageMaker.UpdateWorkteam'

--- a/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
+++ b/generated/aws_sagemaker_runtime_api/lib/runtime.sagemaker-2017-05-13.dart
@@ -151,51 +151,6 @@ class SageMakerRuntime {
     String? targetModel,
     String? targetVariant,
   }) async {
-    ArgumentError.checkNotNull(body, 'body');
-    ArgumentError.checkNotNull(endpointName, 'endpointName');
-    _s.validateStringLength(
-      'endpointName',
-      endpointName,
-      0,
-      63,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'accept',
-      accept,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'customAttributes',
-      customAttributes,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'inferenceId',
-      inferenceId,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'targetModel',
-      targetModel,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'targetVariant',
-      targetVariant,
-      0,
-      63,
-    );
     final headers = <String, String>{
       if (accept != null) 'Accept': accept.toString(),
       if (contentType != null) 'Content-Type': contentType.toString(),

--- a/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
+++ b/generated/aws_savingsplans_api/lib/savingsplans-2019-06-28.dart
@@ -90,8 +90,6 @@ class SavingsPlans {
     Map<String, String>? tags,
     String? upfrontPaymentAmount,
   }) async {
-    ArgumentError.checkNotNull(commitment, 'commitment');
-    ArgumentError.checkNotNull(savingsPlanOfferingId, 'savingsPlanOfferingId');
     final $payload = <String, dynamic>{
       'commitment': commitment,
       'savingsPlanOfferingId': savingsPlanOfferingId,
@@ -123,7 +121,6 @@ class SavingsPlans {
   Future<void> deleteQueuedSavingsPlan({
     required String savingsPlanId,
   }) async {
-    ArgumentError.checkNotNull(savingsPlanId, 'savingsPlanId');
     final $payload = <String, dynamic>{
       'savingsPlanId': savingsPlanId,
     };
@@ -158,18 +155,11 @@ class SavingsPlans {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(savingsPlanId, 'savingsPlanId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
     );
     final $payload = <String, dynamic>{
       'savingsPlanId': savingsPlanId,
@@ -222,12 +212,6 @@ class SavingsPlans {
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
     );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
@@ -299,12 +283,6 @@ class SavingsPlans {
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
     );
     final $payload = <String, dynamic>{
       if (filters != null) 'filters': filters,
@@ -398,12 +376,6 @@ class SavingsPlans {
       0,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      1024,
-    );
     final $payload = <String, dynamic>{
       if (currencies != null)
         'currencies': currencies.map((e) => e.toValue()).toList(),
@@ -442,7 +414,6 @@ class SavingsPlans {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
     };
@@ -472,8 +443,6 @@ class SavingsPlans {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'tags': tags,
@@ -501,8 +470,6 @@ class SavingsPlans {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'resourceArn': resourceArn,
       'tagKeys': tagKeys,

--- a/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
+++ b/generated/aws_schemas_api/lib/schemas-2019-12-02.dart
@@ -70,20 +70,6 @@ class Schemas {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(sourceArn, 'sourceArn');
-    _s.validateStringLength(
-      'sourceArn',
-      sourceArn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'SourceArn': sourceArn,
       if (description != null) 'Description': description,
@@ -120,13 +106,6 @@ class Schemas {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (tags != null) 'tags': tags,
@@ -175,23 +154,6 @@ class Schemas {
     String? description,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      100000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'Content': content,
       'Type': type.toValue(),
@@ -222,7 +184,6 @@ class Schemas {
   Future<void> deleteDiscoverer({
     required String discovererId,
   }) async {
-    ArgumentError.checkNotNull(discovererId, 'discovererId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -245,7 +206,6 @@ class Schemas {
   Future<void> deleteRegistry({
     required String registryName,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -298,8 +258,6 @@ class Schemas {
     required String registryName,
     required String schemaName,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -331,9 +289,6 @@ class Schemas {
     required String schemaName,
     required String schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
-    ArgumentError.checkNotNull(schemaVersion, 'schemaVersion');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -369,9 +324,6 @@ class Schemas {
     required String schemaName,
     String? schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(language, 'language');
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     final $query = <String, List<String>>{
       if (schemaVersion != null) 'schemaVersion': [schemaVersion],
     };
@@ -400,7 +352,6 @@ class Schemas {
   Future<DescribeDiscovererResponse> describeDiscoverer({
     required String discovererId,
   }) async {
-    ArgumentError.checkNotNull(discovererId, 'discovererId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -424,7 +375,6 @@ class Schemas {
   Future<DescribeRegistryResponse> describeRegistry({
     required String registryName,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -456,8 +406,6 @@ class Schemas {
     required String schemaName,
     String? schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     final $query = <String, List<String>>{
       if (schemaVersion != null) 'schemaVersion': [schemaVersion],
     };
@@ -495,9 +443,6 @@ class Schemas {
     required String type,
     String? schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
-    ArgumentError.checkNotNull(type, 'type');
     final $query = <String, List<String>>{
       'type': [type],
       if (schemaVersion != null) 'schemaVersion': [schemaVersion],
@@ -539,9 +484,6 @@ class Schemas {
     required String schemaName,
     String? schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(language, 'language');
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     final $query = <String, List<String>>{
       if (schemaVersion != null) 'schemaVersion': [schemaVersion],
     };
@@ -577,8 +519,6 @@ class Schemas {
     required List<String> events,
     required Type type,
   }) async {
-    ArgumentError.checkNotNull(events, 'events');
-    ArgumentError.checkNotNull(type, 'type');
     final $payload = <String, dynamic>{
       'Events': events,
       'Type': type.toValue(),
@@ -730,8 +670,6 @@ class Schemas {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -772,7 +710,6 @@ class Schemas {
     String? nextToken,
     String? schemaNamePrefix,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
       if (nextToken != null) 'nextToken': [nextToken],
@@ -801,7 +738,6 @@ class Schemas {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -838,9 +774,6 @@ class Schemas {
     required String schemaName,
     String? schemaVersion,
   }) async {
-    ArgumentError.checkNotNull(language, 'language');
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
     final $query = <String, List<String>>{
       if (schemaVersion != null) 'schemaVersion': [schemaVersion],
     };
@@ -878,7 +811,6 @@ class Schemas {
     String? registryName,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
     final $query = <String, List<String>>{
       if (registryName != null) 'registryName': [registryName],
     };
@@ -921,8 +853,6 @@ class Schemas {
     int? limit,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(keywords, 'keywords');
-    ArgumentError.checkNotNull(registryName, 'registryName');
     final $query = <String, List<String>>{
       'keywords': [keywords],
       if (limit != null) 'limit': [limit.toString()],
@@ -953,7 +883,6 @@ class Schemas {
   Future<StartDiscovererResponse> startDiscoverer({
     required String discovererId,
   }) async {
-    ArgumentError.checkNotNull(discovererId, 'discovererId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -978,7 +907,6 @@ class Schemas {
   Future<StopDiscovererResponse> stopDiscoverer({
     required String discovererId,
   }) async {
-    ArgumentError.checkNotNull(discovererId, 'discovererId');
     final response = await _protocol.send(
       payload: null,
       method: 'POST',
@@ -1005,8 +933,6 @@ class Schemas {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -1034,8 +960,6 @@ class Schemas {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1066,13 +990,6 @@ class Schemas {
     required String discovererId,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(discovererId, 'discovererId');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
     };
@@ -1103,13 +1020,6 @@ class Schemas {
     required String registryName,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
     };
@@ -1158,26 +1068,6 @@ class Schemas {
     String? description,
     Type? type,
   }) async {
-    ArgumentError.checkNotNull(registryName, 'registryName');
-    ArgumentError.checkNotNull(schemaName, 'schemaName');
-    _s.validateStringLength(
-      'clientTokenId',
-      clientTokenId,
-      0,
-      36,
-    );
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      100000,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final $payload = <String, dynamic>{
       'ClientTokenId': clientTokenId ?? _s.generateIdempotencyToken(),
       if (content != null) 'Content': content,

--- a/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
+++ b/generated/aws_sdb_api/lib/sdb-2009-04-15.dart
@@ -105,8 +105,6 @@ class SimpleDB {
     required String domainName,
     required List<DeletableItem> items,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(items, 'items');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Items'] = items;
@@ -195,8 +193,6 @@ class SimpleDB {
     required String domainName,
     required List<ReplaceableItem> items,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(items, 'items');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['Items'] = items;
@@ -235,7 +231,6 @@ class SimpleDB {
   Future<void> createDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     await _protocol.send(
@@ -292,8 +287,6 @@ class SimpleDB {
     List<DeletableAttribute>? attributes,
     UpdateCondition? expected,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(itemName, 'itemName');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['ItemName'] = itemName;
@@ -326,7 +319,6 @@ class SimpleDB {
   Future<void> deleteDomain({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     await _protocol.send(
@@ -353,7 +345,6 @@ class SimpleDB {
   Future<DomainMetadataResult> domainMetadata({
     required String domainName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     final $result = await _protocol.send(
@@ -405,8 +396,6 @@ class SimpleDB {
     List<String>? attributeNames,
     bool? consistentRead,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(itemName, 'itemName');
     final $request = <String, dynamic>{};
     $request['DomainName'] = domainName;
     $request['ItemName'] = itemName;
@@ -536,9 +525,6 @@ class SimpleDB {
     required String itemName,
     UpdateCondition? expected,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    ArgumentError.checkNotNull(itemName, 'itemName');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['DomainName'] = domainName;
@@ -598,7 +584,6 @@ class SimpleDB {
     bool? consistentRead,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(selectExpression, 'selectExpression');
     final $request = <String, dynamic>{};
     $request['SelectExpression'] = selectExpression;
     consistentRead?.also((arg) => $request['ConsistentRead'] = arg);

--- a/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
+++ b/generated/aws_secretsmanager_api/lib/secretsmanager-2017-10-17.dart
@@ -140,14 +140,6 @@ class SecretsManager {
   Future<CancelRotateSecretResponse> cancelRotateSecret({
     required String secretId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.CancelRotateSecret'
@@ -461,38 +453,6 @@ class SecretsManager {
     String? secretString,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'secretString',
-      secretString,
-      0,
-      65536,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.CreateSecret'
@@ -574,14 +534,6 @@ class SecretsManager {
   Future<DeleteResourcePolicyResponse> deleteResourcePolicy({
     required String secretId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.DeleteResourcePolicy'
@@ -710,14 +662,6 @@ class SecretsManager {
     bool? forceDeleteWithoutRecovery,
     int? recoveryWindowInDays,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.DeleteSecret'
@@ -800,14 +744,6 @@ class SecretsManager {
   Future<DescribeSecretResponse> describeSecret({
     required String secretId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.DescribeSecret'
@@ -901,12 +837,6 @@ class SecretsManager {
     int? passwordLength,
     bool? requireEachIncludedType,
   }) async {
-    _s.validateStringLength(
-      'excludeCharacters',
-      excludeCharacters,
-      0,
-      4096,
-    );
     _s.validateNumRange(
       'passwordLength',
       passwordLength,
@@ -999,14 +929,6 @@ class SecretsManager {
   Future<GetResourcePolicyResponse> getResourcePolicy({
     required String secretId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.GetResourcePolicy'
@@ -1113,26 +1035,6 @@ class SecretsManager {
     String? versionId,
     String? versionStage,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'versionStage',
-      versionStage,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.GetSecretValue'
@@ -1240,25 +1142,11 @@ class SecretsManager {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1352,12 +1240,6 @@ class SecretsManager {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1465,22 +1347,6 @@ class SecretsManager {
     required String secretId,
     bool? blockPublicPolicy,
   }) async {
-    ArgumentError.checkNotNull(resourcePolicy, 'resourcePolicy');
-    _s.validateStringLength(
-      'resourcePolicy',
-      resourcePolicy,
-      1,
-      20480,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.PutResourcePolicy'
@@ -1729,26 +1595,6 @@ class SecretsManager {
     String? secretString,
     List<String>? versionStages,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'secretString',
-      secretString,
-      0,
-      65536,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.PutSecretValue'
@@ -1824,14 +1670,6 @@ class SecretsManager {
   Future<RestoreSecretResponse> restoreSecret({
     required String secretId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.RestoreSecret'
@@ -1987,26 +1825,6 @@ class SecretsManager {
     String? rotationLambdaARN,
     RotationRulesType? rotationRules,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'rotationLambdaARN',
-      rotationLambdaARN,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.RotateSecret'
@@ -2133,15 +1951,6 @@ class SecretsManager {
     required String secretId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.TagResource'
@@ -2232,15 +2041,6 @@ class SecretsManager {
     required String secretId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.UntagResource'
@@ -2489,38 +2289,6 @@ class SecretsManager {
     Uint8List? secretBinary,
     String? secretString,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'kmsKeyId',
-      kmsKeyId,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'secretString',
-      secretString,
-      0,
-      65536,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.UpdateSecret'
@@ -2644,34 +2412,6 @@ class SecretsManager {
     String? moveToVersionId,
     String? removeFromVersionId,
   }) async {
-    ArgumentError.checkNotNull(secretId, 'secretId');
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionStage, 'versionStage');
-    _s.validateStringLength(
-      'versionStage',
-      versionStage,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'moveToVersionId',
-      moveToVersionId,
-      32,
-      64,
-    );
-    _s.validateStringLength(
-      'removeFromVersionId',
-      removeFromVersionId,
-      32,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.UpdateSecretVersionStage'
@@ -2736,20 +2476,6 @@ class SecretsManager {
     required String resourcePolicy,
     String? secretId,
   }) async {
-    ArgumentError.checkNotNull(resourcePolicy, 'resourcePolicy');
-    _s.validateStringLength(
-      'resourcePolicy',
-      resourcePolicy,
-      1,
-      20480,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretId',
-      secretId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'secretsmanager.ValidateResourcePolicy'

--- a/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
+++ b/generated/aws_securityhub_api/lib/securityhub-2018-10-26.dart
@@ -119,8 +119,6 @@ class SecurityHub {
     required String invitationId,
     required String masterId,
   }) async {
-    ArgumentError.checkNotNull(invitationId, 'invitationId');
-    ArgumentError.checkNotNull(masterId, 'masterId');
     final $payload = <String, dynamic>{
       'InvitationId': invitationId,
       'MasterId': masterId,
@@ -150,8 +148,6 @@ class SecurityHub {
   Future<BatchDisableStandardsResponse> batchDisableStandards({
     required List<String> standardsSubscriptionArns,
   }) async {
-    ArgumentError.checkNotNull(
-        standardsSubscriptionArns, 'standardsSubscriptionArns');
     final $payload = <String, dynamic>{
       'StandardsSubscriptionArns': standardsSubscriptionArns,
     };
@@ -182,8 +178,6 @@ class SecurityHub {
   Future<BatchEnableStandardsResponse> batchEnableStandards({
     required List<StandardsSubscriptionRequest> standardsSubscriptionRequests,
   }) async {
-    ArgumentError.checkNotNull(
-        standardsSubscriptionRequests, 'standardsSubscriptionRequests');
     final $payload = <String, dynamic>{
       'StandardsSubscriptionRequests': standardsSubscriptionRequests,
     };
@@ -258,7 +252,6 @@ class SecurityHub {
   Future<BatchImportFindingsResponse> batchImportFindings({
     required List<AwsSecurityFinding> findings,
   }) async {
-    ArgumentError.checkNotNull(findings, 'findings');
     final $payload = <String, dynamic>{
       'Findings': findings,
     };
@@ -419,7 +412,6 @@ class SecurityHub {
     VerificationState? verificationState,
     WorkflowUpdate? workflow,
   }) async {
-    ArgumentError.checkNotNull(findingIdentifiers, 'findingIdentifiers');
     _s.validateNumRange(
       'confidence',
       confidence,
@@ -478,9 +470,6 @@ class SecurityHub {
     required String id,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(id, 'id');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'Description': description,
       'Id': id,
@@ -526,9 +515,6 @@ class SecurityHub {
     required String groupByAttribute,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(filters, 'filters');
-    ArgumentError.checkNotNull(groupByAttribute, 'groupByAttribute');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'Filters': filters,
       'GroupByAttribute': groupByAttribute,
@@ -599,7 +585,6 @@ class SecurityHub {
   Future<CreateMembersResponse> createMembers({
     required List<AccountDetails> accountDetails,
   }) async {
-    ArgumentError.checkNotNull(accountDetails, 'accountDetails');
     final $payload = <String, dynamic>{
       'AccountDetails': accountDetails,
     };
@@ -628,7 +613,6 @@ class SecurityHub {
   Future<DeclineInvitationsResponse> declineInvitations({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -657,7 +641,6 @@ class SecurityHub {
   Future<DeleteActionTargetResponse> deleteActionTarget({
     required String actionTargetArn,
   }) async {
-    ArgumentError.checkNotNull(actionTargetArn, 'actionTargetArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -681,7 +664,6 @@ class SecurityHub {
   Future<DeleteInsightResponse> deleteInsight({
     required String insightArn,
   }) async {
-    ArgumentError.checkNotNull(insightArn, 'insightArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -709,7 +691,6 @@ class SecurityHub {
   Future<DeleteInvitationsResponse> deleteInvitations({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -738,7 +719,6 @@ class SecurityHub {
   Future<DeleteMembersResponse> deleteMembers({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -958,8 +938,6 @@ class SecurityHub {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        standardsSubscriptionArn, 'standardsSubscriptionArn');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -996,8 +974,6 @@ class SecurityHub {
   Future<void> disableImportFindingsForProduct({
     required String productSubscriptionArn,
   }) async {
-    ArgumentError.checkNotNull(
-        productSubscriptionArn, 'productSubscriptionArn');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1020,7 +996,6 @@ class SecurityHub {
   Future<void> disableOrganizationAdminAccount({
     required String adminAccountId,
   }) async {
-    ArgumentError.checkNotNull(adminAccountId, 'adminAccountId');
     final $payload = <String, dynamic>{
       'AdminAccountId': adminAccountId,
     };
@@ -1099,7 +1074,6 @@ class SecurityHub {
   Future<void> disassociateMembers({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -1129,7 +1103,6 @@ class SecurityHub {
       enableImportFindingsForProduct({
     required String productArn,
   }) async {
-    ArgumentError.checkNotNull(productArn, 'productArn');
     final $payload = <String, dynamic>{
       'ProductArn': productArn,
     };
@@ -1156,7 +1129,6 @@ class SecurityHub {
   Future<void> enableOrganizationAdminAccount({
     required String adminAccountId,
   }) async {
-    ArgumentError.checkNotNull(adminAccountId, 'adminAccountId');
     final $payload = <String, dynamic>{
       'AdminAccountId': adminAccountId,
     };
@@ -1350,7 +1322,6 @@ class SecurityHub {
   Future<GetInsightResultsResponse> getInsightResults({
     required String insightArn,
   }) async {
-    ArgumentError.checkNotNull(insightArn, 'insightArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1470,7 +1441,6 @@ class SecurityHub {
   Future<GetMembersResponse> getMembers({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -1509,7 +1479,6 @@ class SecurityHub {
   Future<InviteMembersResponse> inviteMembers({
     required List<String> accountIds,
   }) async {
-    ArgumentError.checkNotNull(accountIds, 'accountIds');
     final $payload = <String, dynamic>{
       'AccountIds': accountIds,
     };
@@ -1719,7 +1688,6 @@ class SecurityHub {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1744,8 +1712,6 @@ class SecurityHub {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1772,8 +1738,6 @@ class SecurityHub {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1808,7 +1772,6 @@ class SecurityHub {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(actionTargetArn, 'actionTargetArn');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (name != null) 'Name': name,
@@ -1848,7 +1811,6 @@ class SecurityHub {
     NoteUpdate? note,
     RecordState? recordState,
   }) async {
-    ArgumentError.checkNotNull(filters, 'filters');
     final $payload = <String, dynamic>{
       'Filters': filters,
       if (note != null) 'Note': note,
@@ -1887,7 +1849,6 @@ class SecurityHub {
     String? groupByAttribute,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(insightArn, 'insightArn');
     final $payload = <String, dynamic>{
       if (filters != null) 'Filters': filters,
       if (groupByAttribute != null) 'GroupByAttribute': groupByAttribute,
@@ -1922,7 +1883,6 @@ class SecurityHub {
   Future<void> updateOrganizationConfiguration({
     required bool autoEnable,
   }) async {
-    ArgumentError.checkNotNull(autoEnable, 'autoEnable');
     final $payload = <String, dynamic>{
       'AutoEnable': autoEnable,
     };
@@ -1985,7 +1945,6 @@ class SecurityHub {
     ControlStatus? controlStatus,
     String? disabledReason,
   }) async {
-    ArgumentError.checkNotNull(standardsControlArn, 'standardsControlArn');
     final $payload = <String, dynamic>{
       if (controlStatus != null) 'ControlStatus': controlStatus.toValue(),
       if (disabledReason != null) 'DisabledReason': disabledReason,

--- a/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
+++ b/generated/aws_serverlessrepo_api/lib/serverlessrepo-2017-09-08.dart
@@ -224,9 +224,6 @@ class ServerlessApplicationRepository {
     String? templateBody,
     String? templateUrl,
   }) async {
-    ArgumentError.checkNotNull(author, 'author');
-    ArgumentError.checkNotNull(description, 'description');
-    ArgumentError.checkNotNull(name, 'name');
     final $payload = <String, dynamic>{
       'author': author,
       'description': description,
@@ -291,8 +288,6 @@ class ServerlessApplicationRepository {
     String? templateBody,
     String? templateUrl,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(semanticVersion, 'semanticVersion');
     final $payload = <String, dynamic>{
       if (sourceCodeArchiveUrl != null)
         'sourceCodeArchiveUrl': sourceCodeArchiveUrl,
@@ -454,8 +449,6 @@ class ServerlessApplicationRepository {
     List<Tag>? tags,
     String? templateId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(stackName, 'stackName');
     final $payload = <String, dynamic>{
       'stackName': stackName,
       if (capabilities != null) 'capabilities': capabilities,
@@ -502,7 +495,6 @@ class ServerlessApplicationRepository {
     required String applicationId,
     String? semanticVersion,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{
       if (semanticVersion != null) 'semanticVersion': semanticVersion,
     };
@@ -530,7 +522,6 @@ class ServerlessApplicationRepository {
   Future<void> deleteApplication({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -556,7 +547,6 @@ class ServerlessApplicationRepository {
     required String applicationId,
     String? semanticVersion,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $query = <String, List<String>>{
       if (semanticVersion != null) 'semanticVersion': [semanticVersion],
     };
@@ -583,7 +573,6 @@ class ServerlessApplicationRepository {
   Future<GetApplicationPolicyResponse> getApplicationPolicy({
     required String applicationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -613,8 +602,6 @@ class ServerlessApplicationRepository {
     required String applicationId,
     required String templateId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(templateId, 'templateId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -650,7 +637,6 @@ class ServerlessApplicationRepository {
     String? nextToken,
     String? semanticVersion,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -694,7 +680,6 @@ class ServerlessApplicationRepository {
     int? maxItems,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     _s.validateNumRange(
       'maxItems',
       maxItems,
@@ -774,8 +759,6 @@ class ServerlessApplicationRepository {
     required String applicationId,
     required List<ApplicationPolicyStatement> statements,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(statements, 'statements');
     final $payload = <String, dynamic>{
       'statements': statements,
     };
@@ -807,8 +790,6 @@ class ServerlessApplicationRepository {
     required String applicationId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
     final $payload = <String, dynamic>{
       'organizationId': organizationId,
     };
@@ -875,7 +856,6 @@ class ServerlessApplicationRepository {
     String? readmeBody,
     String? readmeUrl,
   }) async {
-    ArgumentError.checkNotNull(applicationId, 'applicationId');
     final $payload = <String, dynamic>{
       if (author != null) 'author': author,
       if (description != null) 'description': description,

--- a/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
+++ b/generated/aws_service_quotas_api/lib/service-quotas-2019-06-24.dart
@@ -105,30 +105,6 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(awsRegion, 'awsRegion');
-    _s.validateStringLength(
-      'awsRegion',
-      awsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -193,22 +169,6 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.GetAWSDefaultServiceQuota'
@@ -271,14 +231,6 @@ class ServiceQuotas {
       getRequestedServiceQuotaChange({
     required String requestId,
   }) async {
-    ArgumentError.checkNotNull(requestId, 'requestId');
-    _s.validateStringLength(
-      'requestId',
-      requestId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.GetRequestedServiceQuotaChange'
@@ -316,22 +268,6 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.GetServiceQuota'
@@ -378,30 +314,6 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(awsRegion, 'awsRegion');
-    _s.validateStringLength(
-      'awsRegion',
-      awsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -449,25 +361,11 @@ class ServiceQuotas {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -523,18 +421,6 @@ class ServiceQuotas {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -592,33 +478,11 @@ class ServiceQuotas {
     String? nextToken,
     RequestStatus? status,
   }) async {
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -675,29 +539,11 @@ class ServiceQuotas {
     String? nextToken,
     String? serviceCode,
   }) async {
-    _s.validateStringLength(
-      'awsRegion',
-      awsRegion,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -748,25 +594,11 @@ class ServiceQuotas {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -813,12 +645,6 @@ class ServiceQuotas {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.ListServices'
@@ -857,14 +683,6 @@ class ServiceQuotas {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.ListTagsForResource'
@@ -914,36 +732,11 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(awsRegion, 'awsRegion');
-    _s.validateStringLength(
-      'awsRegion',
-      awsRegion,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(desiredValue, 'desiredValue');
     _s.validateNumRange(
       'desiredValue',
       desiredValue,
       0,
       10000000000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -994,28 +787,11 @@ class ServiceQuotas {
     required String quotaCode,
     required String serviceCode,
   }) async {
-    ArgumentError.checkNotNull(desiredValue, 'desiredValue');
     _s.validateNumRange(
       'desiredValue',
       desiredValue,
       0,
       10000000000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(quotaCode, 'quotaCode');
-    _s.validateStringLength(
-      'quotaCode',
-      quotaCode,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceCode, 'serviceCode');
-    _s.validateStringLength(
-      'serviceCode',
-      serviceCode,
-      1,
-      63,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -1064,15 +840,6 @@ class ServiceQuotas {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.TagResource'
@@ -1114,15 +881,6 @@ class ServiceQuotas {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'ServiceQuotasV20190624.UntagResource'

--- a/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
+++ b/generated/aws_servicecatalog_api/lib/servicecatalog-2015-12-10.dart
@@ -101,20 +101,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     PortfolioShareType? portfolioShareType,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.AcceptPortfolioShare'
@@ -150,22 +136,6 @@ class ServiceCatalog {
     required String budgetName,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.AssociateBudgetWithResource'
@@ -218,29 +188,6 @@ class ServiceCatalog {
     required PrincipalType principalType,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalARN, 'principalARN');
-    _s.validateStringLength(
-      'principalARN',
-      principalARN,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalType, 'principalType');
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -298,34 +245,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     String? sourcePortfolioId,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'sourcePortfolioId',
-      sourcePortfolioId,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -383,37 +302,6 @@ class ServiceCatalog {
     required String serviceActionId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceActionId, 'serviceActionId');
-    _s.validateStringLength(
-      'serviceActionId',
-      serviceActionId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -452,15 +340,6 @@ class ServiceCatalog {
     required String resourceId,
     required String tagOptionId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagOptionId, 'tagOptionId');
-    _s.validateStringLength(
-      'tagOptionId',
-      tagOptionId,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -506,14 +385,6 @@ class ServiceCatalog {
     required List<ServiceActionAssociation> serviceActionAssociations,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(
-        serviceActionAssociations, 'serviceActionAssociations');
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -563,14 +434,6 @@ class ServiceCatalog {
     required List<ServiceActionAssociation> serviceActionAssociations,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(
-        serviceActionAssociations, 'serviceActionAssociations');
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -652,38 +515,6 @@ class ServiceCatalog {
     String? targetProductId,
     String? targetProductName,
   }) async {
-    ArgumentError.checkNotNull(sourceProductArn, 'sourceProductArn');
-    _s.validateStringLength(
-      'sourceProductArn',
-      sourceProductArn,
-      1,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'targetProductId',
-      targetProductId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'targetProductName',
-      targetProductName,
-      0,
-      8191,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CopyProduct'
@@ -843,49 +674,6 @@ class ServiceCatalog {
     String? description,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(parameters, 'parameters');
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'type',
-      type,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateConstraint'
@@ -957,40 +745,6 @@ class ServiceCatalog {
     String? idempotencyToken,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(displayName, 'displayName');
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(providerName, 'providerName');
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      50,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreatePortfolio'
@@ -1080,20 +834,6 @@ class ServiceCatalog {
     OrganizationNode? organizationNode,
     bool? shareTagOptions,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreatePortfolioShare'
@@ -1194,67 +934,6 @@ class ServiceCatalog {
     String? supportUrl,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      8191,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(owner, 'owner');
-    _s.validateStringLength(
-      'owner',
-      owner,
-      0,
-      8191,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(productType, 'productType');
-    ArgumentError.checkNotNull(
-        provisioningArtifactParameters, 'provisioningArtifactParameters');
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'distributor',
-      distributor,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'supportDescription',
-      supportDescription,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'supportEmail',
-      supportEmail,
-      0,
-      254,
-    );
-    _s.validateStringLength(
-      'supportUrl',
-      supportUrl,
-      0,
-      2083,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateProduct'
@@ -1371,52 +1050,6 @@ class ServiceCatalog {
     List<UpdateProvisioningParameter>? provisioningParameters,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(planName, 'planName');
-    ArgumentError.checkNotNull(planType, 'planType');
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisionedProductName, 'provisionedProductName');
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'pathId',
-      pathId,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateProvisionedProductPlan'
@@ -1492,27 +1125,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(parameters, 'parameters');
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateProvisioningArtifact'
@@ -1601,34 +1213,6 @@ class ServiceCatalog {
     String? description,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
-    ArgumentError.checkNotNull(definitionType, 'definitionType');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateServiceAction'
@@ -1667,22 +1251,6 @@ class ServiceCatalog {
     required String key,
     required String value,
   }) async {
-    ArgumentError.checkNotNull(key, 'key');
-    _s.validateStringLength(
-      'key',
-      key,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(value, 'value');
-    _s.validateStringLength(
-      'value',
-      value,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.CreateTagOption'
@@ -1730,20 +1298,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteConstraint'
@@ -1794,20 +1348,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeletePortfolio'
@@ -1866,20 +1406,6 @@ class ServiceCatalog {
     String? accountId,
     OrganizationNode? organizationNode,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeletePortfolioShare'
@@ -1934,20 +1460,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteProduct'
@@ -1996,20 +1508,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     bool? ignoreErrors,
   }) async {
-    ArgumentError.checkNotNull(planId, 'planId');
-    _s.validateStringLength(
-      'planId',
-      planId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteProvisionedProductPlan'
@@ -2064,29 +1562,6 @@ class ServiceCatalog {
     required String provisioningArtifactId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteProvisioningArtifact'
@@ -2132,20 +1607,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteServiceAction'
@@ -2177,14 +1638,6 @@ class ServiceCatalog {
   Future<void> deleteTagOption({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DeleteTagOption'
@@ -2226,20 +1679,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeConstraint'
@@ -2285,20 +1724,6 @@ class ServiceCatalog {
     required String copyProductToken,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(copyProductToken, 'copyProductToken');
-    _s.validateStringLength(
-      'copyProductToken',
-      copyProductToken,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeCopyProductStatus'
@@ -2345,20 +1770,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribePortfolio'
@@ -2392,14 +1803,6 @@ class ServiceCatalog {
   Future<DescribePortfolioShareStatusOutput> describePortfolioShareStatus({
     required String portfolioShareToken,
   }) async {
-    ArgumentError.checkNotNull(portfolioShareToken, 'portfolioShareToken');
-    _s.validateStringLength(
-      'portfolioShareToken',
-      portfolioShareToken,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribePortfolioShareStatus'
@@ -2461,26 +1864,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2533,24 +1921,6 @@ class ServiceCatalog {
     String? id,
     String? name,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      8191,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeProduct'
@@ -2613,30 +1983,6 @@ class ServiceCatalog {
     String? name,
     String? sourcePortfolioId,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'sourcePortfolioId',
-      sourcePortfolioId,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeProductAsAdmin'
@@ -2684,20 +2030,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeProductView'
@@ -2755,24 +2087,6 @@ class ServiceCatalog {
     String? id,
     String? name,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeProvisionedProduct'
@@ -2828,31 +2142,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(planId, 'planId');
-    _s.validateStringLength(
-      'planId',
-      planId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2919,36 +2213,6 @@ class ServiceCatalog {
     String? provisioningArtifactName,
     bool? verbose,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productName',
-      productName,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactName',
-      provisioningArtifactName,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeProvisioningArtifact'
@@ -3035,48 +2299,6 @@ class ServiceCatalog {
     String? provisioningArtifactId,
     String? provisioningArtifactName,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'pathId',
-      pathId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'pathName',
-      pathName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productName',
-      productName,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactName',
-      provisioningArtifactName,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3151,31 +2373,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3223,20 +2425,6 @@ class ServiceCatalog {
     required String id,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeServiceAction'
@@ -3288,28 +2476,6 @@ class ServiceCatalog {
     required String serviceActionId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(provisionedProductId, 'provisionedProductId');
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceActionId, 'serviceActionId');
-    _s.validateStringLength(
-      'serviceActionId',
-      serviceActionId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3342,14 +2508,6 @@ class ServiceCatalog {
   Future<DescribeTagOptionOutput> describeTagOption({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.DescribeTagOption'
@@ -3413,22 +2571,6 @@ class ServiceCatalog {
     required String budgetName,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(budgetName, 'budgetName');
-    _s.validateStringLength(
-      'budgetName',
-      budgetName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3478,28 +2620,6 @@ class ServiceCatalog {
     required String principalARN,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalARN, 'principalARN');
-    _s.validateStringLength(
-      'principalARN',
-      principalARN,
-      1,
-      1000,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3552,28 +2672,6 @@ class ServiceCatalog {
     required String productId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3629,37 +2727,6 @@ class ServiceCatalog {
     required String serviceActionId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceActionId, 'serviceActionId');
-    _s.validateStringLength(
-      'serviceActionId',
-      serviceActionId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3694,15 +2761,6 @@ class ServiceCatalog {
     required String resourceId,
     required String tagOptionId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(tagOptionId, 'tagOptionId');
-    _s.validateStringLength(
-      'tagOptionId',
-      tagOptionId,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3784,26 +2842,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(planId, 'planId');
-    _s.validateStringLength(
-      'planId',
-      planId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3871,34 +2909,6 @@ class ServiceCatalog {
     String? executeToken,
     Map<String, List<String>>? parameters,
   }) async {
-    ArgumentError.checkNotNull(provisionedProductId, 'provisionedProductId');
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceActionId, 'serviceActionId');
-    _s.validateStringLength(
-      'serviceActionId',
-      serviceActionId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'executeToken',
-      executeToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3993,35 +3003,11 @@ class ServiceCatalog {
     String? provisionedProductId,
     String? provisionedProductName,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
-    );
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      128,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4115,45 +3101,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(physicalId, 'physicalId');
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisionedProductName, 'provisionedProductName');
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.ImportAsProvisionedProduct'
@@ -4226,23 +3173,11 @@ class ServiceCatalog {
     String? pageToken,
     PortfolioShareType? portfolioShareType,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4301,31 +3236,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4387,37 +3302,11 @@ class ServiceCatalog {
     String? pageToken,
     String? productId,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
-    );
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4478,31 +3367,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4585,32 +3454,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(organizationNodeType, 'organizationNodeType');
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4679,37 +3527,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'organizationParentId',
-      organizationParentId,
-      1,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4764,23 +3586,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4837,31 +3647,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4919,31 +3709,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5007,29 +3777,11 @@ class ServiceCatalog {
     String? pageToken,
     String? provisionProductId,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
-    );
-    _s.validateStringLength(
-      'provisionProductId',
-      provisionProductId,
-      1,
-      100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5081,20 +3833,6 @@ class ServiceCatalog {
     required String productId,
     String? acceptLanguage,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.ListProvisioningArtifacts'
@@ -5152,31 +3890,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(serviceActionId, 'serviceActionId');
-    _s.validateStringLength(
-      'serviceActionId',
-      serviceActionId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5240,23 +3958,11 @@ class ServiceCatalog {
     String? pageToken,
     ListRecordHistorySearchFilter? searchFilter,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5313,25 +4019,11 @@ class ServiceCatalog {
     String? pageToken,
     String? resourceType,
   }) async {
-    ArgumentError.checkNotNull(tagOptionId, 'tagOptionId');
-    _s.validateStringLength(
-      'tagOptionId',
-      tagOptionId,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5384,23 +4076,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5464,40 +4144,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5562,31 +4213,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(provisionedProductId, 'provisionedProductId');
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5636,12 +4267,6 @@ class ServiceCatalog {
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5754,63 +4379,6 @@ class ServiceCatalog {
     ProvisioningPreferences? provisioningPreferences,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        provisionedProductName, 'provisionedProductName');
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'pathId',
-      pathId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'pathName',
-      pathName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productName',
-      productName,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'provisionToken',
-      provisionToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactName',
-      provisioningArtifactName,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.ProvisionProduct'
@@ -5892,20 +4460,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     PortfolioShareType? portfolioShareType,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.RejectPortfolioShare'
@@ -5962,23 +4516,11 @@ class ServiceCatalog {
     int? pageSize,
     String? pageToken,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6044,23 +4586,11 @@ class ServiceCatalog {
     ProductViewSortBy? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6139,29 +4669,11 @@ class ServiceCatalog {
     ProductViewSortBy? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       20,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
-    );
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6251,23 +4763,11 @@ class ServiceCatalog {
     String? sortBy,
     SortOrder? sortOrder,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     _s.validateNumRange(
       'pageSize',
       pageSize,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'pageToken',
-      pageToken,
-      0,
-      2024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -6350,30 +4850,6 @@ class ServiceCatalog {
     bool? retainPhysicalResources,
     String? terminateToken,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      1224,
-    );
-    _s.validateStringLength(
-      'terminateToken',
-      terminateToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.TerminateProvisionedProduct'
@@ -6494,26 +4970,6 @@ class ServiceCatalog {
     String? description,
     String? parameters,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateConstraint'
@@ -6585,38 +5041,6 @@ class ServiceCatalog {
     String? providerName,
     List<String>? removeTags,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      2000,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'providerName',
-      providerName,
-      1,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdatePortfolio'
@@ -6698,20 +5122,6 @@ class ServiceCatalog {
     OrganizationNode? organizationNode,
     bool? shareTagOptions,
   }) async {
-    ArgumentError.checkNotNull(portfolioId, 'portfolioId');
-    _s.validateStringLength(
-      'portfolioId',
-      portfolioId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdatePortfolioShare'
@@ -6797,62 +5207,6 @@ class ServiceCatalog {
     String? supportEmail,
     String? supportUrl,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'distributor',
-      distributor,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'owner',
-      owner,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'supportDescription',
-      supportDescription,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'supportEmail',
-      supportEmail,
-      0,
-      254,
-    );
-    _s.validateStringLength(
-      'supportUrl',
-      supportUrl,
-      0,
-      2083,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateProduct'
@@ -6971,66 +5325,6 @@ class ServiceCatalog {
     List<Tag>? tags,
     String? updateToken,
   }) async {
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'pathId',
-      pathId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'pathName',
-      pathName,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'productName',
-      productName,
-      0,
-      8191,
-    );
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisionedProductName',
-      provisionedProductName,
-      1,
-      1224,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-    );
-    _s.validateStringLength(
-      'provisioningArtifactName',
-      provisioningArtifactName,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'updateToken',
-      updateToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateProvisionedProduct'
@@ -7133,28 +5427,6 @@ class ServiceCatalog {
     String? acceptLanguage,
     String? idempotencyToken,
   }) async {
-    ArgumentError.checkNotNull(provisionedProductId, 'provisionedProductId');
-    _s.validateStringLength(
-      'provisionedProductId',
-      provisionedProductId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisionedProductProperties, 'provisionedProductProperties');
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'idempotencyToken',
-      idempotencyToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -7241,41 +5513,6 @@ class ServiceCatalog {
     ProvisioningArtifactGuidance? guidance,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(productId, 'productId');
-    _s.validateStringLength(
-      'productId',
-      productId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisioningArtifactId, 'provisioningArtifactId');
-    _s.validateStringLength(
-      'provisioningArtifactId',
-      provisioningArtifactId,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      8192,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateProvisioningArtifact'
@@ -7338,32 +5575,6 @@ class ServiceCatalog {
     String? description,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'acceptLanguage',
-      acceptLanguage,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateServiceAction'
@@ -7407,20 +5618,6 @@ class ServiceCatalog {
     bool? active,
     String? value,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'value',
-      value,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWS242ServiceCatalogService.UpdateTagOption'

--- a/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
+++ b/generated/aws_servicediscovery_api/lib/servicediscovery-2017-03-14.dart
@@ -91,26 +91,6 @@ class ServiceDiscovery {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.CreateHttpNamespace'
@@ -177,34 +157,6 @@ class ServiceDiscovery {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vpc, 'vpc');
-    _s.validateStringLength(
-      'vpc',
-      vpc,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.CreatePrivateDnsNamespace'
@@ -265,26 +217,6 @@ class ServiceDiscovery {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      0,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.CreatePublicDnsNamespace'
@@ -430,25 +362,6 @@ class ServiceDiscovery {
     String? namespaceId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'namespaceId',
-      namespaceId,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.CreateService'
@@ -488,14 +401,6 @@ class ServiceDiscovery {
   Future<DeleteNamespaceResponse> deleteNamespace({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.DeleteNamespace'
@@ -526,14 +431,6 @@ class ServiceDiscovery {
   Future<void> deleteService({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.DeleteService'
@@ -570,22 +467,6 @@ class ServiceDiscovery {
     required String instanceId,
     required String serviceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.DeregisterInstance'
@@ -652,15 +533,6 @@ class ServiceDiscovery {
     Map<String, String>? optionalParameters,
     Map<String, String>? queryParameters,
   }) async {
-    ArgumentError.checkNotNull(namespaceName, 'namespaceName');
-    _s.validateStringLength(
-      'namespaceName',
-      namespaceName,
-      0,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceName, 'serviceName');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -706,22 +578,6 @@ class ServiceDiscovery {
     required String instanceId,
     required String serviceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.GetInstance'
@@ -790,25 +646,11 @@ class ServiceDiscovery {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -841,14 +683,6 @@ class ServiceDiscovery {
   Future<GetNamespaceResponse> getNamespace({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.GetNamespace'
@@ -882,14 +716,6 @@ class ServiceDiscovery {
   Future<GetOperationResponse> getOperation({
     required String operationId,
   }) async {
-    ArgumentError.checkNotNull(operationId, 'operationId');
-    _s.validateStringLength(
-      'operationId',
-      operationId,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.GetOperation'
@@ -918,14 +744,6 @@ class ServiceDiscovery {
   Future<GetServiceResponse> getService({
     required String id,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.GetService'
@@ -971,25 +789,11 @@ class ServiceDiscovery {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1054,12 +858,6 @@ class ServiceDiscovery {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.ListNamespaces'
@@ -1122,12 +920,6 @@ class ServiceDiscovery {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1192,12 +984,6 @@ class ServiceDiscovery {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.ListServices'
@@ -1229,14 +1015,6 @@ class ServiceDiscovery {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.ListTagsForResource'
@@ -1475,29 +1253,6 @@ class ServiceDiscovery {
     required String serviceId,
     String? creatorRequestId,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'creatorRequestId',
-      creatorRequestId,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.RegisterInstance'
@@ -1537,15 +1292,6 @@ class ServiceDiscovery {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.TagResource'
@@ -1578,15 +1324,6 @@ class ServiceDiscovery {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.UntagResource'
@@ -1636,23 +1373,6 @@ class ServiceDiscovery {
     required String serviceId,
     required CustomHealthStatus status,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'instanceId',
-      instanceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serviceId, 'serviceId');
-    _s.validateStringLength(
-      'serviceId',
-      serviceId,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(status, 'status');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1718,15 +1438,6 @@ class ServiceDiscovery {
     required String id,
     required ServiceChange service,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(service, 'service');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Route53AutoNaming_v20170314.UpdateService'

--- a/generated/aws_ses_api/lib/email-2010-12-01.dart
+++ b/generated/aws_ses_api/lib/email-2010-12-01.dart
@@ -101,8 +101,6 @@ class SES {
     required String originalRuleSetName,
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(originalRuleSetName, 'originalRuleSetName');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['OriginalRuleSetName'] = originalRuleSetName;
     $request['RuleSetName'] = ruleSetName;
@@ -137,7 +135,6 @@ class SES {
   Future<void> createConfigurationSet({
     required ConfigurationSet configurationSet,
   }) async {
-    ArgumentError.checkNotNull(configurationSet, 'configurationSet');
     final $request = <String, dynamic>{};
     $request['ConfigurationSet'] = configurationSet;
     await _protocol.send(
@@ -185,8 +182,6 @@ class SES {
     required String configurationSetName,
     required EventDestination eventDestination,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['EventDestination'] = eventDestination;
@@ -224,8 +219,6 @@ class SES {
     required String configurationSetName,
     required TrackingOptions trackingOptions,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(trackingOptions, 'trackingOptions');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['TrackingOptions'] = trackingOptions;
@@ -288,12 +281,6 @@ class SES {
     required String templateName,
     required String templateSubject,
   }) async {
-    ArgumentError.checkNotNull(failureRedirectionURL, 'failureRedirectionURL');
-    ArgumentError.checkNotNull(fromEmailAddress, 'fromEmailAddress');
-    ArgumentError.checkNotNull(successRedirectionURL, 'successRedirectionURL');
-    ArgumentError.checkNotNull(templateContent, 'templateContent');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    ArgumentError.checkNotNull(templateSubject, 'templateSubject');
     final $request = <String, dynamic>{};
     $request['FailureRedirectionURL'] = failureRedirectionURL;
     $request['FromEmailAddress'] = fromEmailAddress;
@@ -331,7 +318,6 @@ class SES {
   Future<void> createReceiptFilter({
     required ReceiptFilter filter,
   }) async {
-    ArgumentError.checkNotNull(filter, 'filter');
     final $request = <String, dynamic>{};
     $request['Filter'] = filter;
     await _protocol.send(
@@ -379,8 +365,6 @@ class SES {
     required String ruleSetName,
     String? after,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['Rule'] = rule;
     $request['RuleSetName'] = ruleSetName;
@@ -427,7 +411,6 @@ class SES {
   Future<void> createReceiptRuleSet({
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleSetName'] = ruleSetName;
     await _protocol.send(
@@ -461,7 +444,6 @@ class SES {
   Future<void> createTemplate({
     required Template template,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
     final $request = <String, dynamic>{};
     $request['Template'] = template;
     await _protocol.send(
@@ -492,7 +474,6 @@ class SES {
   Future<void> deleteConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     await _protocol.send(
@@ -530,8 +511,6 @@ class SES {
     required String configurationSetName,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['EventDestinationName'] = eventDestinationName;
@@ -572,7 +551,6 @@ class SES {
   Future<void> deleteConfigurationSetTrackingOptions({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     await _protocol.send(
@@ -603,7 +581,6 @@ class SES {
   Future<void> deleteCustomVerificationEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateName'] = templateName;
     await _protocol.send(
@@ -629,7 +606,6 @@ class SES {
   Future<void> deleteIdentity({
     required String identity,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     await _protocol.send(
@@ -675,15 +651,6 @@ class SES {
     required String identity,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     $request['PolicyName'] = policyName;
@@ -713,7 +680,6 @@ class SES {
   Future<void> deleteReceiptFilter({
     required String filterName,
   }) async {
-    ArgumentError.checkNotNull(filterName, 'filterName');
     final $request = <String, dynamic>{};
     $request['FilterName'] = filterName;
     await _protocol.send(
@@ -748,8 +714,6 @@ class SES {
     required String ruleName,
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleName'] = ruleName;
     $request['RuleSetName'] = ruleSetName;
@@ -784,7 +748,6 @@ class SES {
   Future<void> deleteReceiptRuleSet({
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleSetName'] = ruleSetName;
     await _protocol.send(
@@ -809,7 +772,6 @@ class SES {
   Future<void> deleteTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateName'] = templateName;
     await _protocol.send(
@@ -833,7 +795,6 @@ class SES {
   Future<void> deleteVerifiedEmailAddress({
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final $request = <String, dynamic>{};
     $request['EmailAddress'] = emailAddress;
     await _protocol.send(
@@ -891,7 +852,6 @@ class SES {
     required String configurationSetName,
     List<ConfigurationSetAttribute>? configurationSetAttributeNames,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     configurationSetAttributeNames?.also((arg) =>
@@ -931,8 +891,6 @@ class SES {
     required String ruleName,
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleName'] = ruleName;
     $request['RuleSetName'] = ruleSetName;
@@ -965,7 +923,6 @@ class SES {
   Future<DescribeReceiptRuleSetResponse> describeReceiptRuleSet({
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleSetName'] = ruleSetName;
     final $result = await _protocol.send(
@@ -1020,7 +977,6 @@ class SES {
       getCustomVerificationEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateName'] = templateName;
     final $result = await _protocol.send(
@@ -1073,7 +1029,6 @@ class SES {
   Future<GetIdentityDkimAttributesResponse> getIdentityDkimAttributes({
     required List<String> identities,
   }) async {
-    ArgumentError.checkNotNull(identities, 'identities');
     final $request = <String, dynamic>{};
     $request['Identities'] = identities;
     final $result = await _protocol.send(
@@ -1102,7 +1057,6 @@ class SES {
       getIdentityMailFromDomainAttributes({
     required List<String> identities,
   }) async {
-    ArgumentError.checkNotNull(identities, 'identities');
     final $request = <String, dynamic>{};
     $request['Identities'] = identities;
     final $result = await _protocol.send(
@@ -1138,7 +1092,6 @@ class SES {
       getIdentityNotificationAttributes({
     required List<String> identities,
   }) async {
-    ArgumentError.checkNotNull(identities, 'identities');
     final $request = <String, dynamic>{};
     $request['Identities'] = identities;
     final $result = await _protocol.send(
@@ -1188,8 +1141,6 @@ class SES {
     required String identity,
     required List<String> policyNames,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
-    ArgumentError.checkNotNull(policyNames, 'policyNames');
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     $request['PolicyNames'] = policyNames;
@@ -1237,7 +1188,6 @@ class SES {
       getIdentityVerificationAttributes({
     required List<String> identities,
   }) async {
-    ArgumentError.checkNotNull(identities, 'identities');
     final $request = <String, dynamic>{};
     $request['Identities'] = identities;
     final $result = await _protocol.send(
@@ -1305,7 +1255,6 @@ class SES {
   Future<GetTemplateResponse> getTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateName'] = templateName;
     final $result = await _protocol.send(
@@ -1479,7 +1428,6 @@ class SES {
   Future<ListIdentityPoliciesResponse> listIdentityPolicies({
     required String identity,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     final $result = await _protocol.send(
@@ -1623,7 +1571,6 @@ class SES {
     required String configurationSetName,
     DeliveryOptions? deliveryOptions,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     deliveryOptions?.also((arg) => $request['DeliveryOptions'] = arg);
@@ -1682,23 +1629,6 @@ class SES {
     required String policy,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     $request['Policy'] = policy;
@@ -1741,8 +1671,6 @@ class SES {
     required List<String> ruleNames,
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(ruleNames, 'ruleNames');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleNames'] = ruleNames;
     $request['RuleSetName'] = ruleSetName;
@@ -1811,10 +1739,6 @@ class SES {
     String? explanation,
     MessageDsn? messageDsn,
   }) async {
-    ArgumentError.checkNotNull(bounceSender, 'bounceSender');
-    ArgumentError.checkNotNull(
-        bouncedRecipientInfoList, 'bouncedRecipientInfoList');
-    ArgumentError.checkNotNull(originalMessageId, 'originalMessageId');
     final $request = <String, dynamic>{};
     $request['BounceSender'] = bounceSender;
     $request['BouncedRecipientInfoList'] = bouncedRecipientInfoList;
@@ -2011,15 +1935,6 @@ class SES {
     String? sourceArn,
     String? templateArn,
   }) async {
-    ArgumentError.checkNotNull(destinations, 'destinations');
-    ArgumentError.checkNotNull(source, 'source');
-    ArgumentError.checkNotNull(template, 'template');
-    _s.validateStringLength(
-      'defaultTemplateData',
-      defaultTemplateData,
-      0,
-      262144,
-    );
     final $request = <String, dynamic>{};
     $request['Destinations'] = destinations;
     $request['Source'] = source;
@@ -2080,8 +1995,6 @@ class SES {
     required String templateName,
     String? configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['EmailAddress'] = emailAddress;
     $request['TemplateName'] = templateName;
@@ -2259,9 +2172,6 @@ class SES {
     String? sourceArn,
     List<MessageTag>? tags,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(message, 'message');
-    ArgumentError.checkNotNull(source, 'source');
     final $request = <String, dynamic>{};
     $request['Destination'] = destination;
     $request['Message'] = message;
@@ -2555,7 +2465,6 @@ class SES {
     String? sourceArn,
     List<MessageTag>? tags,
   }) async {
-    ArgumentError.checkNotNull(rawMessage, 'rawMessage');
     final $request = <String, dynamic>{};
     $request['RawMessage'] = rawMessage;
     configurationSetName?.also((arg) => $request['ConfigurationSetName'] = arg);
@@ -2759,17 +2668,6 @@ class SES {
     List<MessageTag>? tags,
     String? templateArn,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(source, 'source');
-    ArgumentError.checkNotNull(template, 'template');
-    ArgumentError.checkNotNull(templateData, 'templateData');
-    _s.validateStringLength(
-      'templateData',
-      templateData,
-      0,
-      262144,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['Destination'] = destination;
     $request['Source'] = source;
@@ -2861,8 +2759,6 @@ class SES {
     required bool dkimEnabled,
     required String identity,
   }) async {
-    ArgumentError.checkNotNull(dkimEnabled, 'dkimEnabled');
-    ArgumentError.checkNotNull(identity, 'identity');
     final $request = <String, dynamic>{};
     $request['DkimEnabled'] = dkimEnabled;
     $request['Identity'] = identity;
@@ -2911,8 +2807,6 @@ class SES {
     required bool forwardingEnabled,
     required String identity,
   }) async {
-    ArgumentError.checkNotNull(forwardingEnabled, 'forwardingEnabled');
-    ArgumentError.checkNotNull(identity, 'identity');
     final $request = <String, dynamic>{};
     $request['ForwardingEnabled'] = forwardingEnabled;
     $request['Identity'] = identity;
@@ -2961,9 +2855,6 @@ class SES {
     required String identity,
     required NotificationType notificationType,
   }) async {
-    ArgumentError.checkNotNull(enabled, 'enabled');
-    ArgumentError.checkNotNull(identity, 'identity');
-    ArgumentError.checkNotNull(notificationType, 'notificationType');
     final $request = <String, dynamic>{};
     $request['Enabled'] = enabled;
     $request['Identity'] = identity;
@@ -3022,7 +2913,6 @@ class SES {
     BehaviorOnMXFailure? behaviorOnMXFailure,
     String? mailFromDomain,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     behaviorOnMXFailure
@@ -3079,8 +2969,6 @@ class SES {
     required NotificationType notificationType,
     String? snsTopic,
   }) async {
-    ArgumentError.checkNotNull(identity, 'identity');
-    ArgumentError.checkNotNull(notificationType, 'notificationType');
     final $request = <String, dynamic>{};
     $request['Identity'] = identity;
     $request['NotificationType'] = notificationType.toValue();
@@ -3124,8 +3012,6 @@ class SES {
     required String ruleSetName,
     String? after,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['RuleName'] = ruleName;
     $request['RuleSetName'] = ruleSetName;
@@ -3163,15 +3049,6 @@ class SES {
     required String templateData,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateData, 'templateData');
-    _s.validateStringLength(
-      'templateData',
-      templateData,
-      0,
-      262144,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateData'] = templateData;
     $request['TemplateName'] = templateName;
@@ -3249,8 +3126,6 @@ class SES {
     required String configurationSetName,
     required EventDestination eventDestination,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['EventDestination'] = eventDestination;
@@ -3288,8 +3163,6 @@ class SES {
     required String configurationSetName,
     required bool enabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(enabled, 'enabled');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['Enabled'] = enabled;
@@ -3326,8 +3199,6 @@ class SES {
     required String configurationSetName,
     required bool enabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(enabled, 'enabled');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['Enabled'] = enabled;
@@ -3364,8 +3235,6 @@ class SES {
     required String configurationSetName,
     required TrackingOptions trackingOptions,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(trackingOptions, 'trackingOptions');
     final $request = <String, dynamic>{};
     $request['ConfigurationSetName'] = configurationSetName;
     $request['TrackingOptions'] = trackingOptions;
@@ -3428,7 +3297,6 @@ class SES {
     String? templateContent,
     String? templateSubject,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
     final $request = <String, dynamic>{};
     $request['TemplateName'] = templateName;
     failureRedirectionURL
@@ -3474,8 +3342,6 @@ class SES {
     required ReceiptRule rule,
     required String ruleSetName,
   }) async {
-    ArgumentError.checkNotNull(rule, 'rule');
-    ArgumentError.checkNotNull(ruleSetName, 'ruleSetName');
     final $request = <String, dynamic>{};
     $request['Rule'] = rule;
     $request['RuleSetName'] = ruleSetName;
@@ -3505,7 +3371,6 @@ class SES {
   Future<void> updateTemplate({
     required Template template,
   }) async {
-    ArgumentError.checkNotNull(template, 'template');
     final $request = <String, dynamic>{};
     $request['Template'] = template;
     await _protocol.send(
@@ -3568,7 +3433,6 @@ class SES {
   Future<VerifyDomainDkimResponse> verifyDomainDkim({
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
     final $request = <String, dynamic>{};
     $request['Domain'] = domain;
     final $result = await _protocol.send(
@@ -3598,7 +3462,6 @@ class SES {
   Future<VerifyDomainIdentityResponse> verifyDomainIdentity({
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
     final $request = <String, dynamic>{};
     $request['Domain'] = domain;
     final $result = await _protocol.send(
@@ -3623,7 +3486,6 @@ class SES {
   Future<void> verifyEmailAddress({
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final $request = <String, dynamic>{};
     $request['EmailAddress'] = emailAddress;
     await _protocol.send(
@@ -3650,7 +3512,6 @@ class SES {
   Future<void> verifyEmailIdentity({
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final $request = <String, dynamic>{};
     $request['EmailAddress'] = emailAddress;
     await _protocol.send(

--- a/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
+++ b/generated/aws_sesv2_api/lib/sesv2-2019-09-27.dart
@@ -95,7 +95,6 @@ class SESV2 {
     List<Tag>? tags,
     TrackingOptions? trackingOptions,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       'ConfigurationSetName': configurationSetName,
       if (deliveryOptions != null) 'DeliveryOptions': deliveryOptions,
@@ -143,9 +142,6 @@ class SESV2 {
     required EventDestinationDefinition eventDestination,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $payload = <String, dynamic>{
       'EventDestination': eventDestination,
       'EventDestinationName': eventDestinationName,
@@ -189,8 +185,6 @@ class SESV2 {
     List<TopicPreference>? topicPreferences,
     bool? unsubscribeAll,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final $payload = <String, dynamic>{
       'EmailAddress': emailAddress,
       if (attributesData != null) 'AttributesData': attributesData,
@@ -231,7 +225,6 @@ class SESV2 {
     List<Tag>? tags,
     List<Topic>? topics,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
     final $payload = <String, dynamic>{
       'ContactListName': contactListName,
       if (description != null) 'Description': description,
@@ -293,19 +286,6 @@ class SESV2 {
     required String templateName,
     required String templateSubject,
   }) async {
-    ArgumentError.checkNotNull(failureRedirectionURL, 'failureRedirectionURL');
-    ArgumentError.checkNotNull(fromEmailAddress, 'fromEmailAddress');
-    ArgumentError.checkNotNull(successRedirectionURL, 'successRedirectionURL');
-    ArgumentError.checkNotNull(templateContent, 'templateContent');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateSubject, 'templateSubject');
     final $payload = <String, dynamic>{
       'FailureRedirectionURL': failureRedirectionURL,
       'FromEmailAddress': fromEmailAddress,
@@ -344,7 +324,6 @@ class SESV2 {
     required String poolName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
     final $payload = <String, dynamic>{
       'PoolName': poolName,
       if (tags != null) 'Tags': tags,
@@ -399,8 +378,6 @@ class SESV2 {
     String? reportName,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    ArgumentError.checkNotNull(fromEmailAddress, 'fromEmailAddress');
     final $payload = <String, dynamic>{
       'Content': content,
       'FromEmailAddress': fromEmailAddress,
@@ -472,14 +449,6 @@ class SESV2 {
     DkimSigningAttributes? dkimSigningAttributes,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'EmailIdentity': emailIdentity,
       if (dkimSigningAttributes != null)
@@ -536,30 +505,6 @@ class SESV2 {
     required String policy,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Policy': policy,
     };
@@ -595,15 +540,6 @@ class SESV2 {
     required EmailTemplateContent templateContent,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateContent, 'templateContent');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'TemplateContent': templateContent,
       'TemplateName': templateName,
@@ -631,8 +567,6 @@ class SESV2 {
     required ImportDataSource importDataSource,
     required ImportDestination importDestination,
   }) async {
-    ArgumentError.checkNotNull(importDataSource, 'importDataSource');
-    ArgumentError.checkNotNull(importDestination, 'importDestination');
     final $payload = <String, dynamic>{
       'ImportDataSource': importDataSource,
       'ImportDestination': importDestination,
@@ -664,7 +598,6 @@ class SESV2 {
   Future<void> deleteConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -697,8 +630,6 @@ class SESV2 {
     required String configurationSetName,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -723,8 +654,6 @@ class SESV2 {
     required String contactListName,
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -746,7 +675,6 @@ class SESV2 {
   Future<void> deleteContactList({
     required String contactListName,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -775,14 +703,6 @@ class SESV2 {
   Future<void> deleteCustomVerificationEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -804,7 +724,6 @@ class SESV2 {
   Future<void> deleteDedicatedIpPool({
     required String poolName,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -828,14 +747,6 @@ class SESV2 {
   Future<void> deleteEmailIdentity({
     required String emailIdentity,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -875,22 +786,6 @@ class SESV2 {
     required String emailIdentity,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      64,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -913,14 +808,6 @@ class SESV2 {
   Future<void> deleteEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -941,7 +828,6 @@ class SESV2 {
   Future<void> deleteSuppressedDestination({
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final response = await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -980,7 +866,6 @@ class SESV2 {
   Future<GetBlacklistReportsResponse> getBlacklistReports({
     required List<String> blacklistItemNames,
   }) async {
-    ArgumentError.checkNotNull(blacklistItemNames, 'blacklistItemNames');
     final $query = <String, List<String>>{
       'BlacklistItemNames': blacklistItemNames,
     };
@@ -1014,7 +899,6 @@ class SESV2 {
   Future<GetConfigurationSetResponse> getConfigurationSet({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1045,7 +929,6 @@ class SESV2 {
       getConfigurationSetEventDestinations({
     required String configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1071,8 +954,6 @@ class SESV2 {
     required String contactListName,
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1095,7 +976,6 @@ class SESV2 {
   Future<GetContactListResponse> getContactList({
     required String contactListName,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1127,14 +1007,6 @@ class SESV2 {
       getCustomVerificationEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1160,7 +1032,6 @@ class SESV2 {
   Future<GetDedicatedIpResponse> getDedicatedIp({
     required String ip,
   }) async {
-    ArgumentError.checkNotNull(ip, 'ip');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1246,7 +1117,6 @@ class SESV2 {
   Future<GetDeliverabilityTestReportResponse> getDeliverabilityTestReport({
     required String reportId,
   }) async {
-    ArgumentError.checkNotNull(reportId, 'reportId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1272,7 +1142,6 @@ class SESV2 {
       getDomainDeliverabilityCampaign({
     required String campaignId,
   }) async {
-    ArgumentError.checkNotNull(campaignId, 'campaignId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1306,16 +1175,6 @@ class SESV2 {
     required DateTime endDate,
     required DateTime startDate,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(endDate, 'endDate');
-    ArgumentError.checkNotNull(startDate, 'startDate');
     final $query = <String, List<String>>{
       'EndDate': [_s.iso8601ToJson(endDate).toString()],
       'StartDate': [_s.iso8601ToJson(startDate).toString()],
@@ -1344,14 +1203,6 @@ class SESV2 {
   Future<GetEmailIdentityResponse> getEmailIdentity({
     required String emailIdentity,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1386,14 +1237,6 @@ class SESV2 {
   Future<GetEmailIdentityPoliciesResponse> getEmailIdentityPolicies({
     required String emailIdentity,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1418,14 +1261,6 @@ class SESV2 {
   Future<GetEmailTemplateResponse> getEmailTemplate({
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1446,14 +1281,6 @@ class SESV2 {
   Future<GetImportJobResponse> getImportJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1475,7 +1302,6 @@ class SESV2 {
   Future<GetSuppressedDestinationResponse> getSuppressedDestination({
     required String emailAddress,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -1593,7 +1419,6 @@ class SESV2 {
     String? nextToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
     final $query = <String, List<String>>{
       if (nextToken != null) 'NextToken': [nextToken],
       if (pageSize != null) 'PageSize': [pageSize.toString()],
@@ -1768,9 +1593,6 @@ class SESV2 {
     String? nextToken,
     int? pageSize,
   }) async {
-    ArgumentError.checkNotNull(endDate, 'endDate');
-    ArgumentError.checkNotNull(startDate, 'startDate');
-    ArgumentError.checkNotNull(subscribedDomain, 'subscribedDomain');
     final $query = <String, List<String>>{
       'EndDate': [_s.iso8601ToJson(endDate).toString()],
       'StartDate': [_s.iso8601ToJson(startDate).toString()],
@@ -1978,7 +1800,6 @@ class SESV2 {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final $query = <String, List<String>>{
       'ResourceArn': [resourceArn],
     };
@@ -2063,23 +1884,6 @@ class SESV2 {
     ContactLanguage? contactLanguage,
     bool? productionAccessEnabled,
   }) async {
-    ArgumentError.checkNotNull(mailType, 'mailType');
-    ArgumentError.checkNotNull(useCaseDescription, 'useCaseDescription');
-    _s.validateStringLength(
-      'useCaseDescription',
-      useCaseDescription,
-      1,
-      5000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(websiteURL, 'websiteURL');
-    _s.validateStringLength(
-      'websiteURL',
-      websiteURL,
-      1,
-      1000,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'MailType': mailType.toValue(),
       'UseCaseDescription': useCaseDescription,
@@ -2189,7 +1993,6 @@ class SESV2 {
     String? sendingPoolName,
     TlsPolicy? tlsPolicy,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (sendingPoolName != null) 'SendingPoolName': sendingPoolName,
       if (tlsPolicy != null) 'TlsPolicy': tlsPolicy.toValue(),
@@ -2222,7 +2025,6 @@ class SESV2 {
     required String configurationSetName,
     bool? reputationMetricsEnabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (reputationMetricsEnabled != null)
         'ReputationMetricsEnabled': reputationMetricsEnabled,
@@ -2255,7 +2057,6 @@ class SESV2 {
     required String configurationSetName,
     bool? sendingEnabled,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (sendingEnabled != null) 'SendingEnabled': sendingEnabled,
     };
@@ -2299,7 +2100,6 @@ class SESV2 {
     required String configurationSetName,
     List<SuppressionListReason>? suppressedReasons,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (suppressedReasons != null)
         'SuppressedReasons': suppressedReasons.map((e) => e.toValue()).toList(),
@@ -2330,7 +2130,6 @@ class SESV2 {
     required String configurationSetName,
     String? customRedirectDomain,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
     final $payload = <String, dynamic>{
       if (customRedirectDomain != null)
         'CustomRedirectDomain': customRedirectDomain,
@@ -2369,8 +2168,6 @@ class SESV2 {
     required String destinationPoolName,
     required String ip,
   }) async {
-    ArgumentError.checkNotNull(destinationPoolName, 'destinationPoolName');
-    ArgumentError.checkNotNull(ip, 'ip');
     final $payload = <String, dynamic>{
       'DestinationPoolName': destinationPoolName,
     };
@@ -2399,8 +2196,6 @@ class SESV2 {
     required String ip,
     required int warmupPercentage,
   }) async {
-    ArgumentError.checkNotNull(ip, 'ip');
-    ArgumentError.checkNotNull(warmupPercentage, 'warmupPercentage');
     final $payload = <String, dynamic>{
       'WarmupPercentage': warmupPercentage,
     };
@@ -2440,7 +2235,6 @@ class SESV2 {
     required bool dashboardEnabled,
     List<DomainDeliverabilityTrackingOption>? subscribedDomains,
   }) async {
-    ArgumentError.checkNotNull(dashboardEnabled, 'dashboardEnabled');
     final $payload = <String, dynamic>{
       'DashboardEnabled': dashboardEnabled,
       if (subscribedDomains != null) 'SubscribedDomains': subscribedDomains,
@@ -2472,14 +2266,6 @@ class SESV2 {
     required String emailIdentity,
     bool? signingEnabled,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (signingEnabled != null) 'SigningEnabled': signingEnabled,
     };
@@ -2548,16 +2334,6 @@ class SESV2 {
     required DkimSigningAttributesOrigin signingAttributesOrigin,
     DkimSigningAttributes? signingAttributes,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        signingAttributesOrigin, 'signingAttributesOrigin');
     final $payload = <String, dynamic>{
       'SigningAttributesOrigin': signingAttributesOrigin.toValue(),
       if (signingAttributes != null) 'SigningAttributes': signingAttributes,
@@ -2612,14 +2388,6 @@ class SESV2 {
     required String emailIdentity,
     bool? emailForwardingEnabled,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (emailForwardingEnabled != null)
         'EmailForwardingEnabled': emailForwardingEnabled,
@@ -2678,14 +2446,6 @@ class SESV2 {
     BehaviorOnMxFailure? behaviorOnMxFailure,
     String? mailFromDomain,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       if (behaviorOnMxFailure != null)
         'BehaviorOnMxFailure': behaviorOnMxFailure.toValue(),
@@ -2716,8 +2476,6 @@ class SESV2 {
     required String emailAddress,
     required SuppressionListReason reason,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
-    ArgumentError.checkNotNull(reason, 'reason');
     final $payload = <String, dynamic>{
       'EmailAddress': emailAddress,
       'Reason': reason.toValue(),
@@ -2814,8 +2572,6 @@ class SESV2 {
     String? fromEmailAddressIdentityArn,
     List<String>? replyToAddresses,
   }) async {
-    ArgumentError.checkNotNull(bulkEmailEntries, 'bulkEmailEntries');
-    ArgumentError.checkNotNull(defaultContent, 'defaultContent');
     final $payload = <String, dynamic>{
       'BulkEmailEntries': bulkEmailEntries,
       'DefaultContent': defaultContent,
@@ -2877,15 +2633,6 @@ class SESV2 {
     required String templateName,
     String? configurationSetName,
   }) async {
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'EmailAddress': emailAddress,
       'TemplateName': templateName,
@@ -3014,7 +2761,6 @@ class SESV2 {
     ListManagementOptions? listManagementOptions,
     List<String>? replyToAddresses,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
     final $payload = <String, dynamic>{
       'Content': content,
       if (configurationSetName != null)
@@ -3071,8 +2817,6 @@ class SESV2 {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceArn': resourceArn,
       'Tags': tags,
@@ -3105,22 +2849,6 @@ class SESV2 {
     required String templateData,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateData, 'templateData');
-    _s.validateStringLength(
-      'templateData',
-      templateData,
-      0,
-      262144,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'TemplateData': templateData,
     };
@@ -3158,8 +2886,6 @@ class SESV2 {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'ResourceArn': [resourceArn],
       'TagKeys': tagKeys,
@@ -3200,9 +2926,6 @@ class SESV2 {
     required EventDestinationDefinition eventDestination,
     required String eventDestinationName,
   }) async {
-    ArgumentError.checkNotNull(configurationSetName, 'configurationSetName');
-    ArgumentError.checkNotNull(eventDestination, 'eventDestination');
-    ArgumentError.checkNotNull(eventDestinationName, 'eventDestinationName');
     final $payload = <String, dynamic>{
       'EventDestination': eventDestination,
     };
@@ -3246,8 +2969,6 @@ class SESV2 {
     List<TopicPreference>? topicPreferences,
     bool? unsubscribeAll,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
-    ArgumentError.checkNotNull(emailAddress, 'emailAddress');
     final $payload = <String, dynamic>{
       if (attributesData != null) 'AttributesData': attributesData,
       if (topicPreferences != null) 'TopicPreferences': topicPreferences,
@@ -3283,7 +3004,6 @@ class SESV2 {
     String? description,
     List<Topic>? topics,
   }) async {
-    ArgumentError.checkNotNull(contactListName, 'contactListName');
     final $payload = <String, dynamic>{
       if (description != null) 'Description': description,
       if (topics != null) 'Topics': topics,
@@ -3343,19 +3063,6 @@ class SESV2 {
     required String templateName,
     required String templateSubject,
   }) async {
-    ArgumentError.checkNotNull(failureRedirectionURL, 'failureRedirectionURL');
-    ArgumentError.checkNotNull(fromEmailAddress, 'fromEmailAddress');
-    ArgumentError.checkNotNull(successRedirectionURL, 'successRedirectionURL');
-    ArgumentError.checkNotNull(templateContent, 'templateContent');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(templateSubject, 'templateSubject');
     final $payload = <String, dynamic>{
       'FailureRedirectionURL': failureRedirectionURL,
       'FromEmailAddress': fromEmailAddress,
@@ -3412,30 +3119,6 @@ class SESV2 {
     required String policy,
     required String policyName,
   }) async {
-    ArgumentError.checkNotNull(emailIdentity, 'emailIdentity');
-    _s.validateStringLength(
-      'emailIdentity',
-      emailIdentity,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(policyName, 'policyName');
-    _s.validateStringLength(
-      'policyName',
-      policyName,
-      1,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'Policy': policy,
     };
@@ -3470,15 +3153,6 @@ class SESV2 {
     required EmailTemplateContent templateContent,
     required String templateName,
   }) async {
-    ArgumentError.checkNotNull(templateContent, 'templateContent');
-    ArgumentError.checkNotNull(templateName, 'templateName');
-    _s.validateStringLength(
-      'templateName',
-      templateName,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'TemplateContent': templateContent,
     };

--- a/generated/aws_sfn_api/lib/states-2016-11-23.dart
+++ b/generated/aws_sfn_api/lib/states-2016-11-23.dart
@@ -117,14 +117,6 @@ class SFN {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      80,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.CreateActivity'
@@ -252,30 +244,6 @@ class SFN {
     TracingConfiguration? tracingConfiguration,
     StateMachineType? type,
   }) async {
-    ArgumentError.checkNotNull(definition, 'definition');
-    _s.validateStringLength(
-      'definition',
-      definition,
-      1,
-      1048576,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      80,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.CreateStateMachine'
@@ -311,14 +279,6 @@ class SFN {
   Future<void> deleteActivity({
     required String activityArn,
   }) async {
-    ArgumentError.checkNotNull(activityArn, 'activityArn');
-    _s.validateStringLength(
-      'activityArn',
-      activityArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DeleteActivity'
@@ -351,14 +311,6 @@ class SFN {
   Future<void> deleteStateMachine({
     required String stateMachineArn,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DeleteStateMachine'
@@ -389,14 +341,6 @@ class SFN {
   Future<DescribeActivityOutput> describeActivity({
     required String activityArn,
   }) async {
-    ArgumentError.checkNotNull(activityArn, 'activityArn');
-    _s.validateStringLength(
-      'activityArn',
-      activityArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DescribeActivity'
@@ -430,14 +374,6 @@ class SFN {
   Future<DescribeExecutionOutput> describeExecution({
     required String executionArn,
   }) async {
-    ArgumentError.checkNotNull(executionArn, 'executionArn');
-    _s.validateStringLength(
-      'executionArn',
-      executionArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DescribeExecution'
@@ -470,14 +406,6 @@ class SFN {
   Future<DescribeStateMachineOutput> describeStateMachine({
     required String stateMachineArn,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DescribeStateMachine'
@@ -513,14 +441,6 @@ class SFN {
       describeStateMachineForExecution({
     required String executionArn,
   }) async {
-    ArgumentError.checkNotNull(executionArn, 'executionArn');
-    _s.validateStringLength(
-      'executionArn',
-      executionArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.DescribeStateMachineForExecution'
@@ -574,20 +494,6 @@ class SFN {
     required String activityArn,
     String? workerName,
   }) async {
-    ArgumentError.checkNotNull(activityArn, 'activityArn');
-    _s.validateStringLength(
-      'activityArn',
-      activityArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'workerName',
-      workerName,
-      1,
-      80,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.GetActivityTask'
@@ -658,25 +564,11 @@ class SFN {
     String? nextToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(executionArn, 'executionArn');
-    _s.validateStringLength(
-      'executionArn',
-      executionArn,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -741,12 +633,6 @@ class SFN {
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -817,25 +703,11 @@ class SFN {
     String? nextToken,
     ExecutionStatus? statusFilter,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      3096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -899,12 +771,6 @@ class SFN {
       0,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.ListStateMachines'
@@ -938,14 +804,6 @@ class SFN {
   Future<ListTagsForResourceOutput> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.ListTagsForResource'
@@ -990,26 +848,6 @@ class SFN {
     String? cause,
     String? error,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cause',
-      cause,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'error',
-      error,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.SendTaskFailure'
@@ -1064,14 +902,6 @@ class SFN {
   Future<void> sendTaskHeartbeat({
     required String taskToken,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.SendTaskHeartbeat'
@@ -1112,22 +942,6 @@ class SFN {
     required String output,
     required String taskToken,
   }) async {
-    ArgumentError.checkNotNull(output, 'output');
-    _s.validateStringLength(
-      'output',
-      output,
-      0,
-      262144,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.SendTaskSuccess'
@@ -1216,32 +1030,6 @@ class SFN {
     String? name,
     String? traceHeader,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'input',
-      input,
-      0,
-      262144,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      80,
-    );
-    _s.validateStringLength(
-      'traceHeader',
-      traceHeader,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.StartExecution'
@@ -1299,32 +1087,6 @@ class SFN {
     String? name,
     String? traceHeader,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'input',
-      input,
-      0,
-      262144,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      80,
-    );
-    _s.validateStringLength(
-      'traceHeader',
-      traceHeader,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.StartSyncExecution'
@@ -1366,26 +1128,6 @@ class SFN {
     String? cause,
     String? error,
   }) async {
-    ArgumentError.checkNotNull(executionArn, 'executionArn');
-    _s.validateStringLength(
-      'executionArn',
-      executionArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cause',
-      cause,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'error',
-      error,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.StopExecution'
@@ -1435,15 +1177,6 @@ class SFN {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.TagResource'
@@ -1476,15 +1209,6 @@ class SFN {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.UntagResource'
@@ -1548,26 +1272,6 @@ class SFN {
     String? roleArn,
     TracingConfiguration? tracingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(stateMachineArn, 'stateMachineArn');
-    _s.validateStringLength(
-      'stateMachineArn',
-      stateMachineArn,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'definition',
-      definition,
-      1,
-      1048576,
-    );
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'AWSStepFunctions.UpdateStateMachine'

--- a/generated/aws_shield_api/lib/shield-2016-06-02.dart
+++ b/generated/aws_shield_api/lib/shield-2016-06-02.dart
@@ -78,14 +78,6 @@ class Shield {
   Future<void> associateDRTLogBucket({
     required String logBucket,
   }) async {
-    ArgumentError.checkNotNull(logBucket, 'logBucket');
-    _s.validateStringLength(
-      'logBucket',
-      logBucket,
-      3,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.AssociateDRTLogBucket'
@@ -162,14 +154,6 @@ class Shield {
   Future<void> associateDRTRole({
     required String roleArn,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.AssociateDRTRole'
@@ -215,22 +199,6 @@ class Shield {
     required String healthCheckArn,
     required String protectionId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckArn, 'healthCheckArn');
-    _s.validateStringLength(
-      'healthCheckArn',
-      healthCheckArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(protectionId, 'protectionId');
-    _s.validateStringLength(
-      'protectionId',
-      protectionId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.AssociateHealthCheck'
@@ -290,7 +258,6 @@ class Shield {
   Future<void> associateProactiveEngagementDetails({
     required List<EmergencyContact> emergencyContactList,
   }) async {
-    ArgumentError.checkNotNull(emergencyContactList, 'emergencyContactList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.AssociateProactiveEngagementDetails'
@@ -373,22 +340,6 @@ class Shield {
     required String name,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.CreateProtection'
@@ -473,16 +424,6 @@ class Shield {
     List<String>? members,
     ProtectedResourceType? resourceType,
   }) async {
-    ArgumentError.checkNotNull(aggregation, 'aggregation');
-    ArgumentError.checkNotNull(pattern, 'pattern');
-    ArgumentError.checkNotNull(protectionGroupId, 'protectionGroupId');
-    _s.validateStringLength(
-      'protectionGroupId',
-      protectionGroupId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.CreateProtectionGroup'
@@ -536,14 +477,6 @@ class Shield {
   Future<void> deleteProtection({
     required String protectionId,
   }) async {
-    ArgumentError.checkNotNull(protectionId, 'protectionId');
-    _s.validateStringLength(
-      'protectionId',
-      protectionId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DeleteProtection'
@@ -573,14 +506,6 @@ class Shield {
   Future<void> deleteProtectionGroup({
     required String protectionGroupId,
   }) async {
-    ArgumentError.checkNotNull(protectionGroupId, 'protectionGroupId');
-    _s.validateStringLength(
-      'protectionGroupId',
-      protectionGroupId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DeleteProtectionGroup'
@@ -629,14 +554,6 @@ class Shield {
   Future<DescribeAttackResponse> describeAttack({
     required String attackId,
   }) async {
-    ArgumentError.checkNotNull(attackId, 'attackId');
-    _s.validateStringLength(
-      'attackId',
-      attackId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DescribeAttack'
@@ -754,18 +671,6 @@ class Shield {
     String? protectionId,
     String? resourceArn,
   }) async {
-    _s.validateStringLength(
-      'protectionId',
-      protectionId,
-      1,
-      36,
-    );
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DescribeProtection'
@@ -797,14 +702,6 @@ class Shield {
   Future<DescribeProtectionGroupResponse> describeProtectionGroup({
     required String protectionGroupId,
   }) async {
-    ArgumentError.checkNotNull(protectionGroupId, 'protectionGroupId');
-    _s.validateStringLength(
-      'protectionGroupId',
-      protectionGroupId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DescribeProtectionGroup'
@@ -891,14 +788,6 @@ class Shield {
   Future<void> disassociateDRTLogBucket({
     required String logBucket,
   }) async {
-    ArgumentError.checkNotNull(logBucket, 'logBucket');
-    _s.validateStringLength(
-      'logBucket',
-      logBucket,
-      3,
-      63,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DisassociateDRTLogBucket'
@@ -973,22 +862,6 @@ class Shield {
     required String healthCheckArn,
     required String protectionId,
   }) async {
-    ArgumentError.checkNotNull(healthCheckArn, 'healthCheckArn');
-    _s.validateStringLength(
-      'healthCheckArn',
-      healthCheckArn,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(protectionId, 'protectionId');
-    _s.validateStringLength(
-      'protectionId',
-      protectionId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.DisassociateHealthCheck'
@@ -1103,12 +976,6 @@ class Shield {
       0,
       10000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.ListAttacks'
@@ -1161,12 +1028,6 @@ class Shield {
       0,
       10000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.ListProtectionGroups'
@@ -1215,12 +1076,6 @@ class Shield {
       maxResults,
       0,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1273,25 +1128,11 @@ class Shield {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(protectionGroupId, 'protectionGroupId');
-    _s.validateStringLength(
-      'protectionGroupId',
-      protectionGroupId,
-      1,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       10000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1411,16 +1252,6 @@ class Shield {
     List<String>? members,
     ProtectedResourceType? resourceType,
   }) async {
-    ArgumentError.checkNotNull(aggregation, 'aggregation');
-    ArgumentError.checkNotNull(pattern, 'pattern');
-    ArgumentError.checkNotNull(protectionGroupId, 'protectionGroupId');
-    _s.validateStringLength(
-      'protectionGroupId',
-      protectionGroupId,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShield_20160616.UpdateProtectionGroup'

--- a/generated/aws_signer_api/lib/signer-2017-08-25.dart
+++ b/generated/aws_signer_api/lib/signer-2017-08-25.dart
@@ -108,23 +108,6 @@ class Signer {
     String? profileVersion,
     String? revisionId,
   }) async {
-    ArgumentError.checkNotNull(action, 'action');
-    ArgumentError.checkNotNull(principal, 'principal');
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(statementId, 'statementId');
-    _s.validateStringLength(
-      'profileVersion',
-      profileVersion,
-      10,
-      10,
-    );
     final $payload = <String, dynamic>{
       'action': action,
       'principal': principal,
@@ -157,14 +140,6 @@ class Signer {
   Future<void> cancelSigningProfile({
     required String profileName,
   }) async {
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -187,7 +162,6 @@ class Signer {
   Future<DescribeSigningJobResponse> describeSigningJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -209,7 +183,6 @@ class Signer {
   Future<GetSigningPlatformResponse> getSigningPlatform({
     required String platformId,
   }) async {
-    ArgumentError.checkNotNull(platformId, 'platformId');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -235,20 +208,6 @@ class Signer {
     required String profileName,
     String? profileOwner,
   }) async {
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'profileOwner',
-      profileOwner,
-      12,
-      12,
-    );
     final $query = <String, List<String>>{
       if (profileOwner != null) 'profileOwner': [profileOwner],
     };
@@ -279,14 +238,6 @@ class Signer {
     required String profileName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
     final $query = <String, List<String>>{
       if (nextToken != null) 'nextToken': [nextToken],
     };
@@ -364,12 +315,6 @@ class Signer {
     DateTime? signatureExpiresBefore,
     SigningStatus? status,
   }) async {
-    _s.validateStringLength(
-      'jobInvoker',
-      jobInvoker,
-      12,
-      12,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -543,7 +488,6 @@ class Signer {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -599,15 +543,6 @@ class Signer {
     Map<String, String>? signingParameters,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(platformId, 'platformId');
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'platformId': platformId,
       if (overrides != null) 'overrides': overrides,
@@ -649,16 +584,6 @@ class Signer {
     required String revisionId,
     required String statementId,
   }) async {
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(revisionId, 'revisionId');
-    ArgumentError.checkNotNull(statementId, 'statementId');
     final $query = <String, List<String>>{
       'revisionId': [revisionId],
     };
@@ -695,21 +620,6 @@ class Signer {
     required String reason,
     String? jobOwner,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    ArgumentError.checkNotNull(reason, 'reason');
-    _s.validateStringLength(
-      'reason',
-      reason,
-      1,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'jobOwner',
-      jobOwner,
-      12,
-      12,
-    );
     final $payload = <String, dynamic>{
       'reason': reason,
       if (jobOwner != null) 'jobOwner': jobOwner,
@@ -751,31 +661,6 @@ class Signer {
     required String profileVersion,
     required String reason,
   }) async {
-    ArgumentError.checkNotNull(effectiveTime, 'effectiveTime');
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(profileVersion, 'profileVersion');
-    _s.validateStringLength(
-      'profileVersion',
-      profileVersion,
-      10,
-      10,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(reason, 'reason');
-    _s.validateStringLength(
-      'reason',
-      reason,
-      1,
-      500,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'effectiveTime': unixTimestampToJson(effectiveTime),
       'profileVersion': profileVersion,
@@ -853,22 +738,6 @@ class Signer {
     String? clientRequestToken,
     String? profileOwner,
   }) async {
-    ArgumentError.checkNotNull(destination, 'destination');
-    ArgumentError.checkNotNull(profileName, 'profileName');
-    _s.validateStringLength(
-      'profileName',
-      profileName,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'profileOwner',
-      profileOwner,
-      12,
-      12,
-    );
     final $payload = <String, dynamic>{
       'destination': destination,
       'profileName': profileName,
@@ -904,8 +773,6 @@ class Signer {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'tags': tags,
     };
@@ -934,8 +801,6 @@ class Signer {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };

--- a/generated/aws_sms_api/lib/sms-2016-10-24.dart
+++ b/generated/aws_sms_api/lib/sms-2016-10-24.dart
@@ -183,8 +183,6 @@ class SMS {
     String? roleName,
     bool? runOnce,
   }) async {
-    ArgumentError.checkNotNull(seedReplicationTime, 'seedReplicationTime');
-    ArgumentError.checkNotNull(serverId, 'serverId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -331,7 +329,6 @@ class SMS {
   Future<void> deleteAppValidationConfiguration({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -366,7 +363,6 @@ class SMS {
   Future<void> deleteReplicationJob({
     required String replicationJobId,
   }) async {
-    ArgumentError.checkNotNull(replicationJobId, 'replicationJobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -420,7 +416,6 @@ class SMS {
   Future<void> disassociateConnector({
     required String connectorId,
   }) async {
-    ArgumentError.checkNotNull(connectorId, 'connectorId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -625,7 +620,6 @@ class SMS {
   Future<GetAppValidationConfigurationResponse> getAppValidationConfiguration({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -658,7 +652,6 @@ class SMS {
   Future<GetAppValidationOutputResponse> getAppValidationOutput({
     required String appId,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -774,7 +767,6 @@ class SMS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(replicationJobId, 'replicationJobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSServerMigrationService_V2016_10_24.GetReplicationRuns'
@@ -990,7 +982,6 @@ class SMS {
     required String appId,
     NotificationContext? notificationContext,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1122,7 +1113,6 @@ class SMS {
     List<ServerGroupValidationConfiguration>?
         serverGroupValidationConfigurations,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1193,7 +1183,6 @@ class SMS {
     required String appId,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(appId, 'appId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1235,7 +1224,6 @@ class SMS {
     required String replicationJobId,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(replicationJobId, 'replicationJobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1440,7 +1428,6 @@ class SMS {
     int? numberOfRecentAmisToKeep,
     String? roleName,
   }) async {
-    ArgumentError.checkNotNull(replicationJobId, 'replicationJobId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':

--- a/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
+++ b/generated/aws_snowball_api/lib/snowball-2016-06-30.dart
@@ -70,14 +70,6 @@ class Snowball {
   Future<void> cancelCluster({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.CancelCluster'
@@ -110,14 +102,6 @@ class Snowball {
   Future<void> cancelJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.CancelJob'
@@ -147,7 +131,6 @@ class Snowball {
   Future<CreateAddressResult> createAddress({
     required Address address,
   }) async {
-    ArgumentError.checkNotNull(address, 'address');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.CreateAddress'
@@ -278,43 +261,6 @@ class Snowball {
     SnowballType? snowballType,
     TaxDocuments? taxDocuments,
   }) async {
-    ArgumentError.checkNotNull(addressId, 'addressId');
-    _s.validateStringLength(
-      'addressId',
-      addressId,
-      40,
-      40,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(jobType, 'jobType');
-    ArgumentError.checkNotNull(resources, 'resources');
-    ArgumentError.checkNotNull(roleARN, 'roleARN');
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(shippingOption, 'shippingOption');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'forwardingAddressId',
-      forwardingAddressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'kmsKeyARN',
-      kmsKeyARN,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.CreateCluster'
@@ -469,42 +415,6 @@ class Snowball {
     SnowballType? snowballType,
     TaxDocuments? taxDocuments,
   }) async {
-    _s.validateStringLength(
-      'addressId',
-      addressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      39,
-      39,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'forwardingAddressId',
-      forwardingAddressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'kmsKeyARN',
-      kmsKeyARN,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.CreateJob'
@@ -561,14 +471,6 @@ class Snowball {
     required String jobId,
     ShippingOption? shippingOption,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -599,14 +501,6 @@ class Snowball {
   Future<DescribeAddressResult> describeAddress({
     required String addressId,
   }) async {
-    ArgumentError.checkNotNull(addressId, 'addressId');
-    _s.validateStringLength(
-      'addressId',
-      addressId,
-      40,
-      40,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.DescribeAddress'
@@ -650,12 +544,6 @@ class Snowball {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.DescribeAddresses'
@@ -685,14 +573,6 @@ class Snowball {
   Future<DescribeClusterResult> describeCluster({
     required String clusterId,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.DescribeCluster'
@@ -722,14 +602,6 @@ class Snowball {
   Future<DescribeJobResult> describeJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.DescribeJob'
@@ -761,12 +633,6 @@ class Snowball {
   Future<DescribeReturnShippingLabelResult> describeReturnShippingLabel({
     String? jobId,
   }) async {
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -815,14 +681,6 @@ class Snowball {
   Future<GetJobManifestResult> getJobManifest({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.GetJobManifest'
@@ -864,14 +722,6 @@ class Snowball {
   Future<GetJobUnlockCodeResult> getJobUnlockCode({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.GetJobUnlockCode'
@@ -924,14 +774,6 @@ class Snowball {
   Future<GetSoftwareUpdatesResult> getSoftwareUpdates({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.GetSoftwareUpdates'
@@ -975,25 +817,11 @@ class Snowball {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      39,
-      39,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1038,12 +866,6 @@ class Snowball {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1092,12 +914,6 @@ class Snowball {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.ListCompatibleImages'
@@ -1143,12 +959,6 @@ class Snowball {
       maxResults,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1152921504606846976,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1221,38 +1031,6 @@ class Snowball {
     String? roleARN,
     ShippingOption? shippingOption,
   }) async {
-    ArgumentError.checkNotNull(clusterId, 'clusterId');
-    _s.validateStringLength(
-      'clusterId',
-      clusterId,
-      39,
-      39,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'addressId',
-      addressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'forwardingAddressId',
-      forwardingAddressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.UpdateCluster'
@@ -1335,38 +1113,6 @@ class Snowball {
     ShippingOption? shippingOption,
     SnowballCapacity? snowballCapacityPreference,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'addressId',
-      addressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1152921504606846976,
-    );
-    _s.validateStringLength(
-      'forwardingAddressId',
-      forwardingAddressId,
-      40,
-      40,
-    );
-    _s.validateStringLength(
-      'roleARN',
-      roleARN,
-      0,
-      255,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.UpdateJob'
@@ -1412,15 +1158,6 @@ class Snowball {
     required String jobId,
     required ShipmentState shipmentState,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      39,
-      39,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(shipmentState, 'shipmentState');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSIESnowballJobManagementService.UpdateJobShipmentState'

--- a/generated/aws_sns_api/lib/sns-2010-03-31.dart
+++ b/generated/aws_sns_api/lib/sns-2010-03-31.dart
@@ -90,10 +90,6 @@ class SNS {
     required String label,
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(awsAccountId, 'awsAccountId');
-    ArgumentError.checkNotNull(actionName, 'actionName');
-    ArgumentError.checkNotNull(label, 'label');
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['AWSAccountId'] = awsAccountId;
     $request['ActionName'] = actionName;
@@ -128,7 +124,6 @@ class SNS {
   Future<CheckIfPhoneNumberIsOptedOutResponse> checkIfPhoneNumberIsOptedOut({
     required String phoneNumber,
   }) async {
-    ArgumentError.checkNotNull(phoneNumber, 'phoneNumber');
     final $request = <String, dynamic>{};
     $request['phoneNumber'] = phoneNumber;
     final $result = await _protocol.send(
@@ -176,8 +171,6 @@ class SNS {
     required String topicArn,
     String? authenticateOnUnsubscribe,
   }) async {
-    ArgumentError.checkNotNull(token, 'token');
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['Token'] = token;
     $request['TopicArn'] = topicArn;
@@ -262,9 +255,6 @@ class SNS {
     required String name,
     required String platform,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(platform, 'platform');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['Name'] = name;
@@ -333,9 +323,6 @@ class SNS {
     Map<String, String>? attributes,
     String? customUserData,
   }) async {
-    ArgumentError.checkNotNull(
-        platformApplicationArn, 'platformApplicationArn');
-    ArgumentError.checkNotNull(token, 'token');
     final $request = <String, dynamic>{};
     $request['PlatformApplicationArn'] = platformApplicationArn;
     $request['Token'] = token;
@@ -464,7 +451,6 @@ class SNS {
     Map<String, String>? attributes,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final $request = <String, dynamic>{};
     $request['Name'] = name;
     attributes?.also((arg) => $request['Attributes'] = arg);
@@ -500,7 +486,6 @@ class SNS {
   Future<void> deleteEndpoint({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final $request = <String, dynamic>{};
     $request['EndpointArn'] = endpointArn;
     await _protocol.send(
@@ -530,8 +515,6 @@ class SNS {
   Future<void> deletePlatformApplication({
     required String platformApplicationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        platformApplicationArn, 'platformApplicationArn');
     final $request = <String, dynamic>{};
     $request['PlatformApplicationArn'] = platformApplicationArn;
     await _protocol.send(
@@ -564,7 +547,6 @@ class SNS {
   Future<void> deleteTopic({
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['TopicArn'] = topicArn;
     await _protocol.send(
@@ -595,7 +577,6 @@ class SNS {
   Future<GetEndpointAttributesResponse> getEndpointAttributes({
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final $request = <String, dynamic>{};
     $request['EndpointArn'] = endpointArn;
     final $result = await _protocol.send(
@@ -629,8 +610,6 @@ class SNS {
       getPlatformApplicationAttributes({
     required String platformApplicationArn,
   }) async {
-    ArgumentError.checkNotNull(
-        platformApplicationArn, 'platformApplicationArn');
     final $request = <String, dynamic>{};
     $request['PlatformApplicationArn'] = platformApplicationArn;
     final $result = await _protocol.send(
@@ -695,7 +674,6 @@ class SNS {
   Future<GetSubscriptionAttributesResponse> getSubscriptionAttributes({
     required String subscriptionArn,
   }) async {
-    ArgumentError.checkNotNull(subscriptionArn, 'subscriptionArn');
     final $request = <String, dynamic>{};
     $request['SubscriptionArn'] = subscriptionArn;
     final $result = await _protocol.send(
@@ -726,7 +704,6 @@ class SNS {
   Future<GetTopicAttributesResponse> getTopicAttributes({
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['TopicArn'] = topicArn;
     final $result = await _protocol.send(
@@ -774,8 +751,6 @@ class SNS {
     required String platformApplicationArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        platformApplicationArn, 'platformApplicationArn');
     final $request = <String, dynamic>{};
     $request['PlatformApplicationArn'] = platformApplicationArn;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -929,7 +904,6 @@ class SNS {
     required String topicArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['TopicArn'] = topicArn;
     nextToken?.also((arg) => $request['NextToken'] = arg);
@@ -963,14 +937,6 @@ class SNS {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     final $result = await _protocol.send(
@@ -1034,7 +1000,6 @@ class SNS {
   Future<void> optInPhoneNumber({
     required String phoneNumber,
   }) async {
-    ArgumentError.checkNotNull(phoneNumber, 'phoneNumber');
     final $request = <String, dynamic>{};
     $request['phoneNumber'] = phoneNumber;
     await _protocol.send(
@@ -1252,7 +1217,6 @@ class SNS {
     String? targetArn,
     String? topicArn,
   }) async {
-    ArgumentError.checkNotNull(message, 'message');
     final $request = <String, dynamic>{};
     $request['Message'] = message;
     messageAttributes?.also((arg) => $request['MessageAttributes'] = arg);
@@ -1294,8 +1258,6 @@ class SNS {
     required String label,
     required String topicArn,
   }) async {
-    ArgumentError.checkNotNull(label, 'label');
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['Label'] = label;
     $request['TopicArn'] = topicArn;
@@ -1352,8 +1314,6 @@ class SNS {
     required Map<String, String> attributes,
     required String endpointArn,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(endpointArn, 'endpointArn');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['EndpointArn'] = endpointArn;
@@ -1443,9 +1403,6 @@ class SNS {
     required Map<String, String> attributes,
     required String platformApplicationArn,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(
-        platformApplicationArn, 'platformApplicationArn');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes;
     $request['PlatformApplicationArn'] = platformApplicationArn;
@@ -1573,7 +1530,6 @@ class SNS {
   Future<void> setSMSAttributes({
     required Map<String, String> attributes,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
     final $request = <String, dynamic>{};
     $request['attributes'] = attributes;
     await _protocol.send(
@@ -1640,8 +1596,6 @@ class SNS {
     required String subscriptionArn,
     String? attributeValue,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(subscriptionArn, 'subscriptionArn');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['SubscriptionArn'] = subscriptionArn;
@@ -1740,8 +1694,6 @@ class SNS {
     required String topicArn,
     String? attributeValue,
   }) async {
-    ArgumentError.checkNotNull(attributeName, 'attributeName');
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['AttributeName'] = attributeName;
     $request['TopicArn'] = topicArn;
@@ -1900,8 +1852,6 @@ class SNS {
     String? endpoint,
     bool? returnSubscriptionArn,
   }) async {
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    ArgumentError.checkNotNull(topicArn, 'topicArn');
     final $request = <String, dynamic>{};
     $request['Protocol'] = protocol;
     $request['TopicArn'] = topicArn;
@@ -1970,15 +1920,6 @@ class SNS {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     $request['Tags'] = tags;
@@ -2017,7 +1958,6 @@ class SNS {
   Future<void> unsubscribe({
     required String subscriptionArn,
   }) async {
-    ArgumentError.checkNotNull(subscriptionArn, 'subscriptionArn');
     final $request = <String, dynamic>{};
     $request['SubscriptionArn'] = subscriptionArn;
     await _protocol.send(
@@ -2053,15 +1993,6 @@ class SNS {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['ResourceArn'] = resourceArn;
     $request['TagKeys'] = tagKeys;

--- a/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
+++ b/generated/aws_sqs_api/lib/sqs-2012-11-05.dart
@@ -209,10 +209,6 @@ class SQS {
     required String label,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(awsAccountIds, 'awsAccountIds');
-    ArgumentError.checkNotNull(actions, 'actions');
-    ArgumentError.checkNotNull(label, 'label');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['AWSAccountIds'] = awsAccountIds;
     $request['Actions'] = actions;
@@ -315,9 +311,6 @@ class SQS {
     required String receiptHandle,
     required int visibilityTimeout,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
-    ArgumentError.checkNotNull(receiptHandle, 'receiptHandle');
-    ArgumentError.checkNotNull(visibilityTimeout, 'visibilityTimeout');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     $request['ReceiptHandle'] = receiptHandle;
@@ -370,8 +363,6 @@ class SQS {
     required List<ChangeMessageVisibilityBatchRequestEntry> entries,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['Entries'] = entries;
     $request['QueueUrl'] = queueUrl;
@@ -740,7 +731,6 @@ class SQS {
     Map<QueueAttributeName, String>? attributes,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(queueName, 'queueName');
     final $request = <String, dynamic>{};
     $request['QueueName'] = queueName;
     attributes?.also((arg) =>
@@ -799,8 +789,6 @@ class SQS {
     required String queueUrl,
     required String receiptHandle,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
-    ArgumentError.checkNotNull(receiptHandle, 'receiptHandle');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     $request['ReceiptHandle'] = receiptHandle;
@@ -849,8 +837,6 @@ class SQS {
     required List<DeleteMessageBatchRequestEntry> entries,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['Entries'] = entries;
     $request['QueueUrl'] = queueUrl;
@@ -897,7 +883,6 @@ class SQS {
   Future<void> deleteQueue({
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     await _protocol.send(
@@ -1133,7 +1118,6 @@ class SQS {
     required String queueUrl,
     List<QueueAttributeName>? attributeNames,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     attributeNames?.also((arg) =>
@@ -1178,7 +1162,6 @@ class SQS {
     required String queueName,
     String? queueOwnerAWSAccountId,
   }) async {
-    ArgumentError.checkNotNull(queueName, 'queueName');
     final $request = <String, dynamic>{};
     $request['QueueName'] = queueName;
     queueOwnerAWSAccountId
@@ -1234,7 +1217,6 @@ class SQS {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     maxResults?.also((arg) => $request['MaxResults'] = arg);
@@ -1271,7 +1253,6 @@ class SQS {
   Future<ListQueueTagsResult> listQueueTags({
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     final $result = await _protocol.send(
@@ -1371,7 +1352,6 @@ class SQS {
   Future<void> purgeQueue({
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     await _protocol.send(
@@ -1647,7 +1627,6 @@ class SQS {
     int? visibilityTimeout,
     int? waitTimeSeconds,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     attributeNames?.also((arg) =>
@@ -1707,8 +1686,6 @@ class SQS {
     required String label,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(label, 'label');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['Label'] = label;
     $request['QueueUrl'] = queueUrl;
@@ -1913,8 +1890,6 @@ class SQS {
     Map<MessageSystemAttributeNameForSends, MessageSystemAttributeValue>?
         messageSystemAttributes,
   }) async {
-    ArgumentError.checkNotNull(messageBody, 'messageBody');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['MessageBody'] = messageBody;
     $request['QueueUrl'] = queueUrl;
@@ -1993,8 +1968,6 @@ class SQS {
     required List<SendMessageBatchRequestEntry> entries,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['Entries'] = entries;
     $request['QueueUrl'] = queueUrl;
@@ -2259,8 +2232,6 @@ class SQS {
     required Map<QueueAttributeName, String> attributes,
     required String queueUrl,
   }) async {
-    ArgumentError.checkNotNull(attributes, 'attributes');
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
     final $request = <String, dynamic>{};
     $request['Attributes'] = attributes.map((k, v) => MapEntry(k.toValue(), v));
     $request['QueueUrl'] = queueUrl;
@@ -2321,8 +2292,6 @@ class SQS {
     required String queueUrl,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
-    ArgumentError.checkNotNull(tags, 'tags');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     $request['Tags'] = tags;
@@ -2360,8 +2329,6 @@ class SQS {
     required String queueUrl,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(queueUrl, 'queueUrl');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $request = <String, dynamic>{};
     $request['QueueUrl'] = queueUrl;
     $request['TagKeys'] = tagKeys;

--- a/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
+++ b/generated/aws_ssm_api/lib/ssm-2014-11-06.dart
@@ -122,9 +122,6 @@ class SSM {
     required ResourceTypeForTagging resourceType,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.AddTagsToResource'
@@ -163,14 +160,6 @@ class SSM {
     required String commandId,
     List<String>? instanceIds,
   }) async {
-    ArgumentError.checkNotNull(commandId, 'commandId');
-    _s.validateStringLength(
-      'commandId',
-      commandId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CancelCommand'
@@ -201,14 +190,6 @@ class SSM {
       cancelMaintenanceWindowExecution({
     required String windowExecutionId,
   }) async {
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CancelMaintenanceWindowExecution'
@@ -314,26 +295,6 @@ class SSM {
     int? registrationLimit,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(iamRole, 'iamRole');
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      0,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultInstanceName',
-      defaultInstanceName,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'registrationLimit',
       registrationLimit,
@@ -530,31 +491,6 @@ class SSM {
     List<TargetLocation>? targetLocations,
     List<Target>? targets,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'automationTargetParameterName',
-      automationTargetParameterName,
-      1,
-      50,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'scheduleExpression',
-      scheduleExpression,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreateAssociation'
@@ -619,7 +555,6 @@ class SSM {
   Future<CreateAssociationBatchResult> createAssociationBatch({
     required List<CreateAssociationBatchRequestEntry> entries,
   }) async {
-    ArgumentError.checkNotNull(entries, 'entries');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreateAssociationBatch'
@@ -764,21 +699,6 @@ class SSM {
     String? targetType,
     String? versionName,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'targetType',
-      targetType,
-      0,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreateDocument'
@@ -916,9 +836,6 @@ class SSM {
     String? startDate,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(
-        allowUnassociatedTargets, 'allowUnassociatedTargets');
-    ArgumentError.checkNotNull(cutoff, 'cutoff');
     _s.validateNumRange(
       'cutoff',
       cutoff,
@@ -926,41 +843,12 @@ class SSM {
       23,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(duration, 'duration');
     _s.validateNumRange(
       'duration',
       duration,
       1,
       24,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(schedule, 'schedule');
-    _s.validateStringLength(
-      'schedule',
-      schedule,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
     );
     _s.validateNumRange(
       'scheduleOffset',
@@ -1125,47 +1013,11 @@ class SSM {
     String? severity,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(source, 'source');
-    _s.validateStringLength(
-      'source',
-      source,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(title, 'title');
-    _s.validateStringLength(
-      'title',
-      title,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'category',
-      category,
-      1,
-      64,
-    );
     _s.validateNumRange(
       'priority',
       priority,
       1,
       5,
-    );
-    _s.validateStringLength(
-      'severity',
-      severity,
-      1,
-      64,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1222,14 +1074,6 @@ class SSM {
     required String resourceId,
     Map<String, MetadataValue>? metadata,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1024,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreateOpsMetadata'
@@ -1367,26 +1211,6 @@ class SSM {
     List<PatchSource>? sources,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreatePatchBaseline'
@@ -1486,20 +1310,6 @@ class SSM {
     ResourceDataSyncSource? syncSource,
     String? syncType,
   }) async {
-    ArgumentError.checkNotNull(syncName, 'syncName');
-    _s.validateStringLength(
-      'syncName',
-      syncName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'syncType',
-      syncType,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.CreateResourceDataSync'
@@ -1534,7 +1344,6 @@ class SSM {
   Future<void> deleteActivation({
     required String activationId,
   }) async {
-    ArgumentError.checkNotNull(activationId, 'activationId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteActivation'
@@ -1632,7 +1441,6 @@ class SSM {
     bool? force,
     String? versionName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteDocument'
@@ -1695,14 +1503,6 @@ class SSM {
     bool? dryRun,
     InventorySchemaDeleteOption? schemaDeleteOption,
   }) async {
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteInventory'
@@ -1734,14 +1534,6 @@ class SSM {
   Future<DeleteMaintenanceWindowResult> deleteMaintenanceWindow({
     required String windowId,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteMaintenanceWindow'
@@ -1771,14 +1563,6 @@ class SSM {
   Future<void> deleteOpsMetadata({
     required String opsMetadataArn,
   }) async {
-    ArgumentError.checkNotNull(opsMetadataArn, 'opsMetadataArn');
-    _s.validateStringLength(
-      'opsMetadataArn',
-      opsMetadataArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteOpsMetadata'
@@ -1805,14 +1589,6 @@ class SSM {
   Future<void> deleteParameter({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteParameter'
@@ -1838,7 +1614,6 @@ class SSM {
   Future<DeleteParametersResult> deleteParameters({
     required List<String> names,
   }) async {
-    ArgumentError.checkNotNull(names, 'names');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteParameters'
@@ -1867,14 +1642,6 @@ class SSM {
   Future<DeletePatchBaselineResult> deletePatchBaseline({
     required String baselineId,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeletePatchBaseline'
@@ -1910,20 +1677,6 @@ class SSM {
     required String syncName,
     String? syncType,
   }) async {
-    ArgumentError.checkNotNull(syncName, 'syncName');
-    _s.validateStringLength(
-      'syncName',
-      syncName,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'syncType',
-      syncType,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeleteResourceDataSync'
@@ -1954,7 +1707,6 @@ class SSM {
   Future<void> deregisterManagedInstance({
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeregisterManagedInstance'
@@ -1987,22 +1739,6 @@ class SSM {
     required String baselineId,
     required String patchGroup,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patchGroup, 'patchGroup');
-    _s.validateStringLength(
-      'patchGroup',
-      patchGroup,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeregisterPatchBaselineForPatchGroup'
@@ -2045,22 +1781,6 @@ class SSM {
     required String windowTargetId,
     bool? safe,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowTargetId, 'windowTargetId');
-    _s.validateStringLength(
-      'windowTargetId',
-      windowTargetId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeregisterTargetFromMaintenanceWindow'
@@ -2097,22 +1817,6 @@ class SSM {
     required String windowId,
     required String windowTaskId,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowTaskId, 'windowTaskId');
-    _s.validateStringLength(
-      'windowTaskId',
-      windowTaskId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DeregisterTaskFromMaintenanceWindow'
@@ -2278,8 +1982,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    ArgumentError.checkNotNull(executionId, 'executionId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2340,7 +2042,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2454,14 +2155,6 @@ class SSM {
     String? nextToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(automationExecutionId, 'automationExecutionId');
-    _s.validateStringLength(
-      'automationExecutionId',
-      automationExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2556,7 +2249,6 @@ class SSM {
     String? documentVersion,
     String? versionName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DescribeDocument'
@@ -2596,8 +2288,6 @@ class SSM {
     required String name,
     required DocumentPermissionType permissionType,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(permissionType, 'permissionType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DescribeDocumentPermission'
@@ -2640,7 +2330,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2692,14 +2381,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2750,7 +2431,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2874,7 +2554,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceIds, 'instanceIds');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2934,14 +2613,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(patchGroup, 'patchGroup');
-    _s.validateStringLength(
-      'patchGroup',
-      patchGroup,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -2999,7 +2670,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3109,22 +2779,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3184,14 +2838,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3254,14 +2900,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3333,12 +2971,6 @@ class SSM {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DescribeMaintenanceWindowSchedule'
@@ -3390,14 +3022,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3458,14 +3082,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3567,8 +3183,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(targets, 'targets');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -3847,14 +3461,6 @@ class SSM {
   Future<DescribePatchGroupStateResult> describePatchGroupState({
     required String patchGroup,
   }) async {
-    ArgumentError.checkNotNull(patchGroup, 'patchGroup');
-    _s.validateStringLength(
-      'patchGroup',
-      patchGroup,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.DescribePatchGroupState'
@@ -4003,8 +3609,6 @@ class SSM {
     String? nextToken,
     PatchSet? patchSet,
   }) async {
-    ArgumentError.checkNotNull(operatingSystem, 'operatingSystem');
-    ArgumentError.checkNotNull(property, 'property');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4061,7 +3665,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(state, 'state');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4101,14 +3704,6 @@ class SSM {
   Future<GetAutomationExecutionResult> getAutomationExecution({
     required String automationExecutionId,
   }) async {
-    ArgumentError.checkNotNull(automationExecutionId, 'automationExecutionId');
-    _s.validateStringLength(
-      'automationExecutionId',
-      automationExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetAutomationExecution'
@@ -4163,7 +3758,6 @@ class SSM {
     required List<String> calendarNames,
     String? atTime,
   }) async {
-    ArgumentError.checkNotNull(calendarNames, 'calendarNames');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetCalendarState'
@@ -4212,21 +3806,6 @@ class SSM {
     required String instanceId,
     String? pluginName,
   }) async {
-    ArgumentError.checkNotNull(commandId, 'commandId');
-    _s.validateStringLength(
-      'commandId',
-      commandId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    _s.validateStringLength(
-      'pluginName',
-      pluginName,
-      4,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetCommandInvocation'
@@ -4258,14 +3837,6 @@ class SSM {
   Future<GetConnectionStatusResponse> getConnectionStatus({
     required String target,
   }) async {
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'target',
-      target,
-      1,
-      400,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetConnectionStatus'
@@ -4336,15 +3907,6 @@ class SSM {
     required String instanceId,
     required String snapshotId,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(snapshotId, 'snapshotId');
-    _s.validateStringLength(
-      'snapshotId',
-      snapshotId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetDeployablePatchSnapshotForInstance'
@@ -4391,7 +3953,6 @@ class SSM {
     String? documentVersion,
     String? versionName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetDocument'
@@ -4520,12 +4081,6 @@ class SSM {
       50,
       200,
     );
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetInventorySchema'
@@ -4559,14 +4114,6 @@ class SSM {
   Future<GetMaintenanceWindowResult> getMaintenanceWindow({
     required String windowId,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetMaintenanceWindow'
@@ -4595,14 +4142,6 @@ class SSM {
   Future<GetMaintenanceWindowExecutionResult> getMaintenanceWindowExecution({
     required String windowExecutionId,
   }) async {
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetMaintenanceWindowExecution'
@@ -4638,22 +4177,6 @@ class SSM {
     required String taskId,
     required String windowExecutionId,
   }) async {
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetMaintenanceWindowExecutionTask'
@@ -4693,30 +4216,6 @@ class SSM {
     required String taskId,
     required String windowExecutionId,
   }) async {
-    ArgumentError.checkNotNull(invocationId, 'invocationId');
-    _s.validateStringLength(
-      'invocationId',
-      invocationId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskId, 'taskId');
-    _s.validateStringLength(
-      'taskId',
-      taskId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowExecutionId, 'windowExecutionId');
-    _s.validateStringLength(
-      'windowExecutionId',
-      windowExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation'
@@ -4759,22 +4258,6 @@ class SSM {
     required String windowId,
     required String windowTaskId,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowTaskId, 'windowTaskId');
-    _s.validateStringLength(
-      'windowTaskId',
-      windowTaskId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetMaintenanceWindowTask'
@@ -4815,7 +4298,6 @@ class SSM {
   Future<GetOpsItemResponse> getOpsItem({
     required String opsItemId,
   }) async {
-    ArgumentError.checkNotNull(opsItemId, 'opsItemId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetOpsItem'
@@ -4856,14 +4338,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(opsMetadataArn, 'opsMetadataArn');
-    _s.validateStringLength(
-      'opsMetadataArn',
-      opsMetadataArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -4933,12 +4407,6 @@ class SSM {
       1,
       50,
     );
-    _s.validateStringLength(
-      'syncName',
-      syncName,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetOpsSummary'
@@ -4980,14 +4448,6 @@ class SSM {
     required String name,
     bool? withDecryption,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetParameter'
@@ -5035,14 +4495,6 @@ class SSM {
     String? nextToken,
     bool? withDecryption,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5087,7 +4539,6 @@ class SSM {
     required List<String> names,
     bool? withDecryption,
   }) async {
-    ArgumentError.checkNotNull(names, 'names');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetParameters'
@@ -5173,14 +4624,6 @@ class SSM {
     bool? recursive,
     bool? withDecryption,
   }) async {
-    ArgumentError.checkNotNull(path, 'path');
-    _s.validateStringLength(
-      'path',
-      path,
-      1,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5221,14 +4664,6 @@ class SSM {
   Future<GetPatchBaselineResult> getPatchBaseline({
     required String baselineId,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetPatchBaseline'
@@ -5262,14 +4697,6 @@ class SSM {
     required String patchGroup,
     OperatingSystem? operatingSystem,
   }) async {
-    ArgumentError.checkNotNull(patchGroup, 'patchGroup');
-    _s.validateStringLength(
-      'patchGroup',
-      patchGroup,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetPatchBaselineForPatchGroup'
@@ -5320,14 +4747,6 @@ class SSM {
   Future<GetServiceSettingResult> getServiceSetting({
     required String settingId,
   }) async {
-    ArgumentError.checkNotNull(settingId, 'settingId');
-    _s.validateStringLength(
-      'settingId',
-      settingId,
-      1,
-      1000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.GetServiceSetting'
@@ -5410,15 +4829,6 @@ class SSM {
     required String name,
     int? parameterVersion,
   }) async {
-    ArgumentError.checkNotNull(labels, 'labels');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.LabelParameterVersion'
@@ -5460,7 +4870,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5587,12 +4996,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'commandId',
-      commandId,
-      36,
-      36,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5660,12 +5063,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'commandId',
-      commandId,
-      36,
-      36,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5842,8 +5239,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(metadata, 'metadata');
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -5894,7 +5289,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6016,15 +5410,6 @@ class SSM {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(typeName, 'typeName');
-    _s.validateStringLength(
-      'typeName',
-      typeName,
-      1,
-      100,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -6245,12 +5630,6 @@ class SSM {
       1,
       50,
     );
-    _s.validateStringLength(
-      'syncType',
-      syncType,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.ListResourceDataSync'
@@ -6286,8 +5665,6 @@ class SSM {
     required String resourceId,
     required ResourceTypeForTagging resourceType,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.ListTagsForResource'
@@ -6346,14 +5723,6 @@ class SSM {
     List<String>? accountIdsToRemove,
     String? sharedDocumentVersion,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    ArgumentError.checkNotNull(permissionType, 'permissionType');
-    _s.validateStringLength(
-      'sharedDocumentVersion',
-      sharedDocumentVersion,
-      0,
-      8,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.ModifyDocumentPermission'
@@ -6499,38 +5868,6 @@ class SSM {
     String? itemContentHash,
     ComplianceUploadType? uploadType,
   }) async {
-    ArgumentError.checkNotNull(complianceType, 'complianceType');
-    _s.validateStringLength(
-      'complianceType',
-      complianceType,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(executionSummary, 'executionSummary');
-    ArgumentError.checkNotNull(items, 'items');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    _s.validateStringLength(
-      'resourceType',
-      resourceType,
-      1,
-      50,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'itemContentHash',
-      itemContentHash,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.PutComplianceItems'
@@ -6579,8 +5916,6 @@ class SSM {
     required String instanceId,
     required List<InventoryItem> items,
   }) async {
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(items, 'items');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.PutInventory'
@@ -6887,45 +6222,6 @@ class SSM {
     ParameterTier? tier,
     ParameterType? type,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(value, 'value');
-    _s.validateStringLength(
-      'allowedPattern',
-      allowedPattern,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'dataType',
-      dataType,
-      0,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'policies',
-      policies,
-      1,
-      4096,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.PutParameter'
@@ -6971,14 +6267,6 @@ class SSM {
   Future<RegisterDefaultPatchBaselineResult> registerDefaultPatchBaseline({
     required String baselineId,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.RegisterDefaultPatchBaseline'
@@ -7016,22 +6304,6 @@ class SSM {
     required String baselineId,
     required String patchGroup,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(patchGroup, 'patchGroup');
-    _s.validateStringLength(
-      'patchGroup',
-      patchGroup,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.RegisterPatchBaselineForPatchGroup'
@@ -7128,40 +6400,6 @@ class SSM {
     String? name,
     String? ownerInformation,
   }) async {
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(targets, 'targets');
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
-    _s.validateStringLength(
-      'ownerInformation',
-      ownerInformation,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.RegisterTargetWithMaintenanceWindow'
@@ -7323,53 +6561,6 @@ class SSM {
     MaintenanceWindowTaskInvocationParameters? taskInvocationParameters,
     Map<String, MaintenanceWindowTaskParameterValueExpression>? taskParameters,
   }) async {
-    ArgumentError.checkNotNull(taskArn, 'taskArn');
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskType, 'taskType');
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
     _s.validateNumRange(
       'priority',
       priority,
@@ -7446,9 +6637,6 @@ class SSM {
     required ResourceTypeForTagging resourceType,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    ArgumentError.checkNotNull(resourceType, 'resourceType');
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.RemoveTagsFromResource'
@@ -7500,14 +6688,6 @@ class SSM {
   Future<ResetServiceSettingResult> resetServiceSetting({
     required String settingId,
   }) async {
-    ArgumentError.checkNotNull(settingId, 'settingId');
-    _s.validateStringLength(
-      'settingId',
-      settingId,
-      1,
-      1000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.ResetServiceSetting'
@@ -7543,14 +6723,6 @@ class SSM {
   Future<ResumeSessionResponse> resumeSession({
     required String sessionId,
   }) async {
-    ArgumentError.checkNotNull(sessionId, 'sessionId');
-    _s.validateStringLength(
-      'sessionId',
-      sessionId,
-      1,
-      96,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.ResumeSession'
@@ -7609,15 +6781,6 @@ class SSM {
     required SignalType signalType,
     Map<String, List<String>>? payload,
   }) async {
-    ArgumentError.checkNotNull(automationExecutionId, 'automationExecutionId');
-    _s.validateStringLength(
-      'automationExecutionId',
-      automationExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(signalType, 'signalType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.SendAutomationSignal'
@@ -7781,49 +6944,6 @@ class SSM {
     List<Target>? targets,
     int? timeoutSeconds,
   }) async {
-    ArgumentError.checkNotNull(documentName, 'documentName');
-    _s.validateStringLength(
-      'comment',
-      comment,
-      0,
-      100,
-    );
-    _s.validateStringLength(
-      'documentHash',
-      documentHash,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'outputS3BucketName',
-      outputS3BucketName,
-      3,
-      63,
-    );
-    _s.validateStringLength(
-      'outputS3KeyPrefix',
-      outputS3KeyPrefix,
-      0,
-      500,
-    );
-    _s.validateStringLength(
-      'outputS3Region',
-      outputS3Region,
-      3,
-      20,
-    );
     _s.validateNumRange(
       'timeoutSeconds',
       timeoutSeconds,
@@ -7879,7 +6999,6 @@ class SSM {
   Future<void> startAssociationsOnce({
     required List<String> associationIds,
   }) async {
-    ArgumentError.checkNotNull(associationIds, 'associationIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.StartAssociationsOnce'
@@ -7999,31 +7118,6 @@ class SSM {
     String? targetParameterName,
     List<Target>? targets,
   }) async {
-    ArgumentError.checkNotNull(documentName, 'documentName');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      36,
-      36,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'targetParameterName',
-      targetParameterName,
-      1,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.StartAutomationExecution'
@@ -8128,20 +7222,6 @@ class SSM {
     DateTime? scheduledTime,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(documentName, 'documentName');
-    ArgumentError.checkNotNull(runbooks, 'runbooks');
-    _s.validateStringLength(
-      'changeRequestName',
-      changeRequestName,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      36,
-      36,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.StartChangeRequestExecution'
@@ -8204,14 +7284,6 @@ class SSM {
     String? documentName,
     Map<String, List<String>>? parameters,
   }) async {
-    ArgumentError.checkNotNull(target, 'target');
-    _s.validateStringLength(
-      'target',
-      target,
-      1,
-      400,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.StartSession'
@@ -8248,14 +7320,6 @@ class SSM {
     required String automationExecutionId,
     StopType? type,
   }) async {
-    ArgumentError.checkNotNull(automationExecutionId, 'automationExecutionId');
-    _s.validateStringLength(
-      'automationExecutionId',
-      automationExecutionId,
-      36,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.StopAutomationExecution'
@@ -8285,14 +7349,6 @@ class SSM {
   Future<TerminateSessionResponse> terminateSession({
     required String sessionId,
   }) async {
-    ArgumentError.checkNotNull(sessionId, 'sessionId');
-    _s.validateStringLength(
-      'sessionId',
-      sessionId,
-      1,
-      96,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.TerminateSession'
@@ -8477,31 +7533,6 @@ class SSM {
     List<TargetLocation>? targetLocations,
     List<Target>? targets,
   }) async {
-    ArgumentError.checkNotNull(associationId, 'associationId');
-    _s.validateStringLength(
-      'automationTargetParameterName',
-      automationTargetParameterName,
-      1,
-      50,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'scheduleExpression',
-      scheduleExpression,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateAssociation'
@@ -8563,9 +7594,6 @@ class SSM {
     required String instanceId,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(associationStatus, 'associationStatus');
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateAssociationStatus'
@@ -8635,21 +7663,6 @@ class SSM {
     String? targetType,
     String? versionName,
   }) async {
-    ArgumentError.checkNotNull(content, 'content');
-    _s.validateStringLength(
-      'content',
-      content,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'targetType',
-      targetType,
-      0,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateDocument'
@@ -8691,8 +7704,6 @@ class SSM {
     required String documentVersion,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(documentVersion, 'documentVersion');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateDocumentDefaultVersion'
@@ -8733,8 +7744,6 @@ class SSM {
     required String name,
     String? documentVersion,
   }) async {
-    ArgumentError.checkNotNull(documentReviews, 'documentReviews');
-    ArgumentError.checkNotNull(name, 'name');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateDocumentMetadata'
@@ -8845,43 +7854,17 @@ class SSM {
     String? scheduleTimezone,
     String? startDate,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'cutoff',
       cutoff,
       0,
       23,
     );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
     _s.validateNumRange(
       'duration',
       duration,
       1,
       24,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
-    _s.validateStringLength(
-      'schedule',
-      schedule,
-      1,
-      256,
     );
     _s.validateNumRange(
       'scheduleOffset',
@@ -8983,40 +7966,6 @@ class SSM {
     bool? replace,
     List<Target>? targets,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowTargetId, 'windowTargetId');
-    _s.validateStringLength(
-      'windowTargetId',
-      windowTargetId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
-    _s.validateStringLength(
-      'ownerInformation',
-      ownerInformation,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateMaintenanceWindowTarget'
@@ -9238,57 +8187,11 @@ class SSM {
     MaintenanceWindowTaskInvocationParameters? taskInvocationParameters,
     Map<String, MaintenanceWindowTaskParameterValueExpression>? taskParameters,
   }) async {
-    ArgumentError.checkNotNull(windowId, 'windowId');
-    _s.validateStringLength(
-      'windowId',
-      windowId,
-      20,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(windowTaskId, 'windowTaskId');
-    _s.validateStringLength(
-      'windowTaskId',
-      windowTaskId,
-      36,
-      36,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'maxConcurrency',
-      maxConcurrency,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'maxErrors',
-      maxErrors,
-      1,
-      7,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
     _s.validateNumRange(
       'priority',
       priority,
       0,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'taskArn',
-      taskArn,
-      1,
-      1600,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9339,15 +8242,6 @@ class SSM {
     required String iamRole,
     required String instanceId,
   }) async {
-    ArgumentError.checkNotNull(iamRole, 'iamRole');
-    _s.validateStringLength(
-      'iamRole',
-      iamRole,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceId, 'instanceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateManagedInstanceRole'
@@ -9484,36 +8378,11 @@ class SSM {
     OpsItemStatus? status,
     String? title,
   }) async {
-    ArgumentError.checkNotNull(opsItemId, 'opsItemId');
-    _s.validateStringLength(
-      'category',
-      category,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
     _s.validateNumRange(
       'priority',
       priority,
       1,
       5,
-    );
-    _s.validateStringLength(
-      'severity',
-      severity,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'title',
-      title,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -9572,14 +8441,6 @@ class SSM {
     List<String>? keysToDelete,
     Map<String, MetadataValue>? metadataToUpdate,
   }) async {
-    ArgumentError.checkNotNull(opsMetadataArn, 'opsMetadataArn');
-    _s.validateStringLength(
-      'opsMetadataArn',
-      opsMetadataArn,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateOpsMetadata'
@@ -9696,26 +8557,6 @@ class SSM {
     bool? replace,
     List<PatchSource>? sources,
   }) async {
-    ArgumentError.checkNotNull(baselineId, 'baselineId');
-    _s.validateStringLength(
-      'baselineId',
-      baselineId,
-      20,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      3,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdatePatchBaseline'
@@ -9780,23 +8621,6 @@ class SSM {
     required ResourceDataSyncSource syncSource,
     required String syncType,
   }) async {
-    ArgumentError.checkNotNull(syncName, 'syncName');
-    _s.validateStringLength(
-      'syncName',
-      syncName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(syncSource, 'syncSource');
-    ArgumentError.checkNotNull(syncType, 'syncType');
-    _s.validateStringLength(
-      'syncType',
-      syncType,
-      1,
-      64,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateResourceDataSync'
@@ -9878,22 +8702,6 @@ class SSM {
     required String settingId,
     required String settingValue,
   }) async {
-    ArgumentError.checkNotNull(settingId, 'settingId');
-    _s.validateStringLength(
-      'settingId',
-      settingId,
-      1,
-      1000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(settingValue, 'settingValue');
-    _s.validateStringLength(
-      'settingValue',
-      settingValue,
-      1,
-      4096,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AmazonSSM.UpdateServiceSetting'

--- a/generated/aws_sso_api/lib/sso-2019-06-10.dart
+++ b/generated/aws_sso_api/lib/sso-2019-06-10.dart
@@ -91,9 +91,6 @@ class SSO {
     required String accountId,
     required String roleName,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(roleName, 'roleName');
     final headers = <String, String>{
       'x-amz-sso_bearer_token': accessToken.toString(),
     };
@@ -141,8 +138,6 @@ class SSO {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
-    ArgumentError.checkNotNull(accountId, 'accountId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -197,7 +192,6 @@ class SSO {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -238,7 +232,6 @@ class SSO {
   Future<void> logout({
     required String accessToken,
   }) async {
-    ArgumentError.checkNotNull(accessToken, 'accessToken');
     final headers = <String, String>{
       'x-amz-sso_bearer_token': accessToken.toString(),
     };

--- a/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
+++ b/generated/aws_sso_api/lib/sso-admin-2020-07-20.dart
@@ -81,30 +81,6 @@ class SSOAdmin {
     required String managedPolicyArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(managedPolicyArn, 'managedPolicyArn');
-    _s.validateStringLength(
-      'managedPolicyArn',
-      managedPolicyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.AttachManagedPolicyToPermissionSet'
@@ -182,33 +158,6 @@ class SSOAdmin {
     required String targetId,
     required TargetType targetType,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalId, 'principalId');
-    _s.validateStringLength(
-      'principalId',
-      principalId,
-      1,
-      47,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalType, 'principalType');
-    ArgumentError.checkNotNull(targetId, 'targetId');
-    ArgumentError.checkNotNull(targetType, 'targetType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.CreateAccountAssignment'
@@ -261,16 +210,6 @@ class SSOAdmin {
         instanceAccessControlAttributeConfiguration,
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(instanceAccessControlAttributeConfiguration,
-        'instanceAccessControlAttributeConfiguration');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -335,40 +274,6 @@ class SSOAdmin {
     String? sessionDuration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      32,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      700,
-    );
-    _s.validateStringLength(
-      'relayState',
-      relayState,
-      1,
-      240,
-    );
-    _s.validateStringLength(
-      'sessionDuration',
-      sessionDuration,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.CreatePermissionSet'
@@ -437,33 +342,6 @@ class SSOAdmin {
     required String targetId,
     required TargetType targetType,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalId, 'principalId');
-    _s.validateStringLength(
-      'principalId',
-      principalId,
-      1,
-      47,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(principalType, 'principalType');
-    ArgumentError.checkNotNull(targetId, 'targetId');
-    ArgumentError.checkNotNull(targetType, 'targetType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.DeleteAccountAssignment'
@@ -509,22 +387,6 @@ class SSOAdmin {
     required String instanceArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.DeleteInlinePolicyFromPermissionSet'
@@ -562,14 +424,6 @@ class SSOAdmin {
   Future<void> deleteInstanceAccessControlAttributeConfiguration({
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -609,22 +463,6 @@ class SSOAdmin {
     required String instanceArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.DeletePermissionSet'
@@ -664,16 +502,6 @@ class SSOAdmin {
     required String accountAssignmentCreationRequestId,
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(accountAssignmentCreationRequestId,
-        'accountAssignmentCreationRequestId');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -718,16 +546,6 @@ class SSOAdmin {
     required String accountAssignmentDeletionRequestId,
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(accountAssignmentDeletionRequestId,
-        'accountAssignmentDeletionRequestId');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -769,14 +587,6 @@ class SSOAdmin {
       describeInstanceAccessControlAttributeConfiguration({
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -818,22 +628,6 @@ class SSOAdmin {
     required String instanceArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.DescribePermissionSet'
@@ -876,16 +670,6 @@ class SSOAdmin {
     required String instanceArn,
     required String provisionPermissionSetRequestId,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        provisionPermissionSetRequestId, 'provisionPermissionSetRequestId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -935,30 +719,6 @@ class SSOAdmin {
     required String managedPolicyArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(managedPolicyArn, 'managedPolicyArn');
-    _s.validateStringLength(
-      'managedPolicyArn',
-      managedPolicyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.DetachManagedPolicyFromPermissionSet'
@@ -999,22 +759,6 @@ class SSOAdmin {
     required String instanceArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.GetInlinePolicyForPermissionSet'
@@ -1066,25 +810,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1140,25 +870,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1217,34 +933,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1305,33 +998,11 @@ class SSOAdmin {
     String? nextToken,
     ProvisioningStatus? provisioningStatus,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1380,12 +1051,6 @@ class SSOAdmin {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1438,33 +1103,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1520,25 +1163,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1588,25 +1217,11 @@ class SSOAdmin {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1664,26 +1279,11 @@ class SSOAdmin {
     String? nextToken,
     ProvisioningStatus? provisioningStatus,
   }) async {
-    ArgumentError.checkNotNull(accountId, 'accountId');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1736,28 +1336,6 @@ class SSOAdmin {
     required String resourceArn,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      10,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.ListTagsForResource'
@@ -1810,23 +1388,6 @@ class SSOAdmin {
     required ProvisionTargetType targetType,
     String? targetId,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetType, 'targetType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.ProvisionPermissionSet'
@@ -1881,30 +1442,6 @@ class SSOAdmin {
     required String instanceArn,
     required String permissionSetArn,
   }) async {
-    ArgumentError.checkNotNull(inlinePolicy, 'inlinePolicy');
-    _s.validateStringLength(
-      'inlinePolicy',
-      inlinePolicy,
-      1,
-      10240,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.PutInlinePolicyToPermissionSet'
@@ -1950,23 +1487,6 @@ class SSOAdmin {
     required String resourceArn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      10,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.TagResource'
@@ -2011,23 +1531,6 @@ class SSOAdmin {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      10,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.UntagResource'
@@ -2073,16 +1576,6 @@ class SSOAdmin {
         instanceAccessControlAttributeConfiguration,
     required String instanceArn,
   }) async {
-    ArgumentError.checkNotNull(instanceAccessControlAttributeConfiguration,
-        'instanceAccessControlAttributeConfiguration');
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2138,40 +1631,6 @@ class SSOAdmin {
     String? relayState,
     String? sessionDuration,
   }) async {
-    ArgumentError.checkNotNull(instanceArn, 'instanceArn');
-    _s.validateStringLength(
-      'instanceArn',
-      instanceArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionSetArn, 'permissionSetArn');
-    _s.validateStringLength(
-      'permissionSetArn',
-      permissionSetArn,
-      10,
-      1224,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      700,
-    );
-    _s.validateStringLength(
-      'relayState',
-      relayState,
-      1,
-      240,
-    );
-    _s.validateStringLength(
-      'sessionDuration',
-      sessionDuration,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'SWBExternalService.UpdatePermissionSet'

--- a/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
+++ b/generated/aws_sso_oidc_api/lib/sso-oidc-2019-06-10.dart
@@ -130,10 +130,6 @@ class SSOOIDC {
     String? refreshToken,
     List<String>? scope,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    ArgumentError.checkNotNull(clientSecret, 'clientSecret');
-    ArgumentError.checkNotNull(deviceCode, 'deviceCode');
-    ArgumentError.checkNotNull(grantType, 'grantType');
     final $payload = <String, dynamic>{
       'clientId': clientId,
       'clientSecret': clientSecret,
@@ -178,8 +174,6 @@ class SSOOIDC {
     required String clientType,
     List<String>? scopes,
   }) async {
-    ArgumentError.checkNotNull(clientName, 'clientName');
-    ArgumentError.checkNotNull(clientType, 'clientType');
     final $payload = <String, dynamic>{
       'clientName': clientName,
       'clientType': clientType,
@@ -222,9 +216,6 @@ class SSOOIDC {
     required String clientSecret,
     required String startUrl,
   }) async {
-    ArgumentError.checkNotNull(clientId, 'clientId');
-    ArgumentError.checkNotNull(clientSecret, 'clientSecret');
-    ArgumentError.checkNotNull(startUrl, 'startUrl');
     final $payload = <String, dynamic>{
       'clientId': clientId,
       'clientSecret': clientSecret,

--- a/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
+++ b/generated/aws_storagegateway_api/lib/storagegateway-2013-06-30.dart
@@ -142,56 +142,6 @@ class StorageGateway {
     List<Tag>? tags,
     String? tapeDriveType,
   }) async {
-    ArgumentError.checkNotNull(activationKey, 'activationKey');
-    _s.validateStringLength(
-      'activationKey',
-      activationKey,
-      1,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayName, 'gatewayName');
-    _s.validateStringLength(
-      'gatewayName',
-      gatewayName,
-      2,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayRegion, 'gatewayRegion');
-    _s.validateStringLength(
-      'gatewayRegion',
-      gatewayRegion,
-      1,
-      25,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayTimezone, 'gatewayTimezone');
-    _s.validateStringLength(
-      'gatewayTimezone',
-      gatewayTimezone,
-      3,
-      10,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'gatewayType',
-      gatewayType,
-      2,
-      20,
-    );
-    _s.validateStringLength(
-      'mediumChangerType',
-      mediumChangerType,
-      2,
-      50,
-    );
-    _s.validateStringLength(
-      'tapeDriveType',
-      tapeDriveType,
-      2,
-      50,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ActivateGateway'
@@ -238,15 +188,6 @@ class StorageGateway {
     required List<String> diskIds,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(diskIds, 'diskIds');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AddCache'
@@ -308,15 +249,6 @@ class StorageGateway {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AddTagsToResource'
@@ -355,15 +287,6 @@ class StorageGateway {
     required List<String> diskIds,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(diskIds, 'diskIds');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AddUploadBuffer'
@@ -407,15 +330,6 @@ class StorageGateway {
     required List<String> diskIds,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(diskIds, 'diskIds');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AddWorkingStorage'
@@ -473,22 +387,6 @@ class StorageGateway {
     required String tapeARN,
     bool? bypassGovernanceRetention,
   }) async {
-    ArgumentError.checkNotNull(poolId, 'poolId');
-    _s.validateStringLength(
-      'poolId',
-      poolId,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AssignTapePool'
@@ -555,35 +453,6 @@ class StorageGateway {
     String? diskId,
     String? targetName,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'diskId',
-      diskId,
-      1,
-      300,
-    );
-    _s.validateStringLength(
-      'targetName',
-      targetName,
-      1,
-      200,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.AttachVolume'
@@ -620,22 +489,6 @@ class StorageGateway {
     required String gatewayARN,
     required String tapeARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CancelArchival'
@@ -670,22 +523,6 @@ class StorageGateway {
     required String gatewayARN,
     required String tapeARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CancelRetrieval'
@@ -801,44 +638,6 @@ class StorageGateway {
     String? sourceVolumeARN,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      5,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(targetName, 'targetName');
-    _s.validateStringLength(
-      'targetName',
-      targetName,
-      1,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(volumeSizeInBytes, 'volumeSizeInBytes');
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'sourceVolumeARN',
-      sourceVolumeARN,
-      50,
-      500,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateCachediSCSIVolume'
@@ -1025,68 +824,6 @@ class StorageGateway {
     String? squash,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      5,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(locationARN, 'locationARN');
-    _s.validateStringLength(
-      'locationARN',
-      locationARN,
-      16,
-      1400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'role',
-      role,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultStorageClass',
-      defaultStorageClass,
-      5,
-      50,
-    );
-    _s.validateStringLength(
-      'fileShareName',
-      fileShareName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'notificationPolicy',
-      notificationPolicy,
-      2,
-      100,
-    );
-    _s.validateStringLength(
-      'squash',
-      squash,
-      5,
-      15,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateNFSFileShare'
@@ -1321,74 +1058,6 @@ class StorageGateway {
     List<Tag>? tags,
     List<String>? validUserList,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      5,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(locationARN, 'locationARN');
-    _s.validateStringLength(
-      'locationARN',
-      locationARN,
-      16,
-      1400,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'role',
-      role,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'auditDestinationARN',
-      auditDestinationARN,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'authentication',
-      authentication,
-      5,
-      15,
-    );
-    _s.validateStringLength(
-      'defaultStorageClass',
-      defaultStorageClass,
-      5,
-      50,
-    );
-    _s.validateStringLength(
-      'fileShareName',
-      fileShareName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'notificationPolicy',
-      notificationPolicy,
-      2,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateSMBFileShare'
@@ -1496,22 +1165,6 @@ class StorageGateway {
     required String volumeARN,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snapshotDescription, 'snapshotDescription');
-    _s.validateStringLength(
-      'snapshotDescription',
-      snapshotDescription,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateSnapshot'
@@ -1586,22 +1239,6 @@ class StorageGateway {
     required String volumeARN,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(snapshotDescription, 'snapshotDescription');
-    _s.validateStringLength(
-      'snapshotDescription',
-      snapshotDescription,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -1712,38 +1349,6 @@ class StorageGateway {
     String? snapshotId,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(diskId, 'diskId');
-    _s.validateStringLength(
-      'diskId',
-      diskId,
-      1,
-      300,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(networkInterfaceId, 'networkInterfaceId');
-    ArgumentError.checkNotNull(preserveExistingData, 'preserveExistingData');
-    ArgumentError.checkNotNull(targetName, 'targetName');
-    _s.validateStringLength(
-      'targetName',
-      targetName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateStorediSCSIVolume'
@@ -1812,15 +1417,6 @@ class StorageGateway {
     RetentionLockType? retentionLockType,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(poolName, 'poolName');
-    _s.validateStringLength(
-      'poolName',
-      poolName,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(storageClass, 'storageClass');
     _s.validateNumRange(
       'retentionLockTimeInDays',
       retentionLockTimeInDays,
@@ -1928,35 +1524,6 @@ class StorageGateway {
     List<Tag>? tags,
     bool? worm,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeBarcode, 'tapeBarcode');
-    _s.validateStringLength(
-      'tapeBarcode',
-      tapeBarcode,
-      7,
-      16,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeSizeInBytes, 'tapeSizeInBytes');
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'poolId',
-      poolId,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.CreateTapeWithBarcode'
@@ -2072,50 +1639,12 @@ class StorageGateway {
     List<Tag>? tags,
     bool? worm,
   }) async {
-    ArgumentError.checkNotNull(clientToken, 'clientToken');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      5,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(numTapesToCreate, 'numTapesToCreate');
     _s.validateNumRange(
       'numTapesToCreate',
       numTapesToCreate,
       1,
       10,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeBarcodePrefix, 'tapeBarcodePrefix');
-    _s.validateStringLength(
-      'tapeBarcodePrefix',
-      tapeBarcodePrefix,
-      1,
-      4,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeSizeInBytes, 'tapeSizeInBytes');
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'poolId',
-      poolId,
-      1,
-      100,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2154,14 +1683,6 @@ class StorageGateway {
       deleteAutomaticTapeCreationPolicy({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2201,22 +1722,6 @@ class StorageGateway {
     required String bandwidthType,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(bandwidthType, 'bandwidthType');
-    _s.validateStringLength(
-      'bandwidthType',
-      bandwidthType,
-      3,
-      25,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteBandwidthRateLimit'
@@ -2254,22 +1759,6 @@ class StorageGateway {
     required String initiatorName,
     required String targetARN,
   }) async {
-    ArgumentError.checkNotNull(initiatorName, 'initiatorName');
-    _s.validateStringLength(
-      'initiatorName',
-      initiatorName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetARN, 'targetARN');
-    _s.validateStringLength(
-      'targetARN',
-      targetARN,
-      50,
-      800,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteChapCredentials'
@@ -2310,14 +1799,6 @@ class StorageGateway {
     required String fileShareARN,
     bool? forceDelete,
   }) async {
-    ArgumentError.checkNotNull(fileShareARN, 'fileShareARN');
-    _s.validateStringLength(
-      'fileShareARN',
-      fileShareARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteFileShare'
@@ -2362,14 +1843,6 @@ class StorageGateway {
   Future<DeleteGatewayOutput> deleteGateway({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteGateway'
@@ -2412,14 +1885,6 @@ class StorageGateway {
   Future<DeleteSnapshotScheduleOutput> deleteSnapshotSchedule({
     required String volumeARN,
   }) async {
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteSnapshotSchedule'
@@ -2463,22 +1928,6 @@ class StorageGateway {
     required String tapeARN,
     bool? bypassGovernanceRetention,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteTape'
@@ -2520,14 +1969,6 @@ class StorageGateway {
     required String tapeARN,
     bool? bypassGovernanceRetention,
   }) async {
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteTapeArchive'
@@ -2560,14 +2001,6 @@ class StorageGateway {
   Future<DeleteTapePoolOutput> deleteTapePool({
     required String poolARN,
   }) async {
-    ArgumentError.checkNotNull(poolARN, 'poolARN');
-    _s.validateStringLength(
-      'poolARN',
-      poolARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteTapePool'
@@ -2613,14 +2046,6 @@ class StorageGateway {
   Future<DeleteVolumeOutput> deleteVolume({
     required String volumeARN,
   }) async {
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DeleteVolume'
@@ -2649,14 +2074,6 @@ class StorageGateway {
       describeAvailabilityMonitorTest({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeAvailabilityMonitorTest'
@@ -2691,14 +2108,6 @@ class StorageGateway {
   Future<DescribeBandwidthRateLimitOutput> describeBandwidthRateLimit({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeBandwidthRateLimit'
@@ -2743,14 +2152,6 @@ class StorageGateway {
       describeBandwidthRateLimitSchedule({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -2781,14 +2182,6 @@ class StorageGateway {
   Future<DescribeCacheOutput> describeCache({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeCache'
@@ -2824,7 +2217,6 @@ class StorageGateway {
   Future<DescribeCachediSCSIVolumesOutput> describeCachediSCSIVolumes({
     required List<String> volumeARNs,
   }) async {
-    ArgumentError.checkNotNull(volumeARNs, 'volumeARNs');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeCachediSCSIVolumes'
@@ -2858,14 +2250,6 @@ class StorageGateway {
   Future<DescribeChapCredentialsOutput> describeChapCredentials({
     required String targetARN,
   }) async {
-    ArgumentError.checkNotNull(targetARN, 'targetARN');
-    _s.validateStringLength(
-      'targetARN',
-      targetARN,
-      50,
-      800,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeChapCredentials'
@@ -2894,14 +2278,6 @@ class StorageGateway {
   Future<DescribeGatewayInformationOutput> describeGatewayInformation({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeGatewayInformation'
@@ -2929,14 +2305,6 @@ class StorageGateway {
   Future<DescribeMaintenanceStartTimeOutput> describeMaintenanceStartTime({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeMaintenanceStartTime'
@@ -2967,7 +2335,6 @@ class StorageGateway {
   Future<DescribeNFSFileSharesOutput> describeNFSFileShares({
     required List<String> fileShareARNList,
   }) async {
-    ArgumentError.checkNotNull(fileShareARNList, 'fileShareARNList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeNFSFileShares'
@@ -2998,7 +2365,6 @@ class StorageGateway {
   Future<DescribeSMBFileSharesOutput> describeSMBFileShares({
     required List<String> fileShareARNList,
   }) async {
-    ArgumentError.checkNotNull(fileShareARNList, 'fileShareARNList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeSMBFileShares'
@@ -3025,14 +2391,6 @@ class StorageGateway {
   Future<DescribeSMBSettingsOutput> describeSMBSettings({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeSMBSettings'
@@ -3065,14 +2423,6 @@ class StorageGateway {
   Future<DescribeSnapshotScheduleOutput> describeSnapshotSchedule({
     required String volumeARN,
   }) async {
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeSnapshotSchedule'
@@ -3107,7 +2457,6 @@ class StorageGateway {
   Future<DescribeStorediSCSIVolumesOutput> describeStorediSCSIVolumes({
     required List<String> volumeARNs,
   }) async {
-    ArgumentError.checkNotNull(volumeARNs, 'volumeARNs');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeStorediSCSIVolumes'
@@ -3158,12 +2507,6 @@ class StorageGateway {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeTapeArchives'
@@ -3207,25 +2550,11 @@ class StorageGateway {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3279,25 +2608,11 @@ class StorageGateway {
     String? marker,
     List<String>? tapeARNs,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3331,14 +2646,6 @@ class StorageGateway {
   Future<DescribeUploadBufferOutput> describeUploadBuffer({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeUploadBuffer'
@@ -3388,25 +2695,11 @@ class StorageGateway {
     String? marker,
     List<String>? vTLDeviceARNs,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3446,14 +2739,6 @@ class StorageGateway {
   Future<DescribeWorkingStorageOutput> describeWorkingStorage({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DescribeWorkingStorage'
@@ -3496,14 +2781,6 @@ class StorageGateway {
     required String volumeARN,
     bool? forceDetach,
   }) async {
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DetachVolume'
@@ -3538,14 +2815,6 @@ class StorageGateway {
   Future<DisableGatewayOutput> disableGateway({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.DisableGateway'
@@ -3611,44 +2880,6 @@ class StorageGateway {
     String? organizationalUnit,
     int? timeoutInSeconds,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      1,
-      1024,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'organizationalUnit',
-      organizationalUnit,
-      1,
-      1024,
-    );
     _s.validateNumRange(
       'timeoutInSeconds',
       timeoutInSeconds,
@@ -3692,12 +2923,6 @@ class StorageGateway {
       listAutomaticTapeCreationPolicies({
     String? gatewayARN,
   }) async {
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -3742,23 +2967,11 @@ class StorageGateway {
     int? limit,
     String? marker,
   }) async {
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3813,12 +3026,6 @@ class StorageGateway {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListGateways'
@@ -3855,14 +3062,6 @@ class StorageGateway {
   Future<ListLocalDisksOutput> listLocalDisks({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListLocalDisks'
@@ -3903,25 +3102,11 @@ class StorageGateway {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      50,
-      500,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3980,12 +3165,6 @@ class StorageGateway {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListTapePools'
@@ -4039,12 +3218,6 @@ class StorageGateway {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListTapes'
@@ -4079,14 +3252,6 @@ class StorageGateway {
   Future<ListVolumeInitiatorsOutput> listVolumeInitiators({
     required String volumeARN,
   }) async {
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListVolumeInitiators'
@@ -4119,14 +3284,6 @@ class StorageGateway {
   Future<ListVolumeRecoveryPointsOutput> listVolumeRecoveryPoints({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ListVolumeRecoveryPoints'
@@ -4175,23 +3332,11 @@ class StorageGateway {
     int? limit,
     String? marker,
   }) async {
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      1000,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4234,14 +3379,6 @@ class StorageGateway {
   Future<NotifyWhenUploadedOutput> notifyWhenUploaded({
     required String fileShareARN,
   }) async {
-    ArgumentError.checkNotNull(fileShareARN, 'fileShareARN');
-    _s.validateStringLength(
-      'fileShareARN',
-      fileShareARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.NotifyWhenUploaded'
@@ -4325,14 +3462,6 @@ class StorageGateway {
     List<String>? folderList,
     bool? recursive,
   }) async {
-    ArgumentError.checkNotNull(fileShareARN, 'fileShareARN');
-    _s.validateStringLength(
-      'fileShareARN',
-      fileShareARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.RefreshCache'
@@ -4370,15 +3499,6 @@ class StorageGateway {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.RemoveTagsFromResource'
@@ -4419,14 +3539,6 @@ class StorageGateway {
   Future<ResetCacheOutput> resetCache({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ResetCache'
@@ -4474,22 +3586,6 @@ class StorageGateway {
     required String gatewayARN,
     required String tapeARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.RetrieveTapeArchive'
@@ -4531,22 +3627,6 @@ class StorageGateway {
     required String gatewayARN,
     required String tapeARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tapeARN, 'tapeARN');
-    _s.validateStringLength(
-      'tapeARN',
-      tapeARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.RetrieveTapeRecoveryPoint'
@@ -4580,22 +3660,6 @@ class StorageGateway {
     required String gatewayARN,
     required String localConsolePassword,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(localConsolePassword, 'localConsolePassword');
-    _s.validateStringLength(
-      'localConsolePassword',
-      localConsolePassword,
-      6,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.SetLocalConsolePassword'
@@ -4632,22 +3696,6 @@ class StorageGateway {
     required String gatewayARN,
     required String password,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      6,
-      512,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.SetSMBGuestPassword'
@@ -4696,14 +3744,6 @@ class StorageGateway {
   Future<ShutdownGatewayOutput> shutdownGateway({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.ShutdownGateway'
@@ -4737,14 +3777,6 @@ class StorageGateway {
   Future<StartAvailabilityMonitorTestOutput> startAvailabilityMonitorTest({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.StartAvailabilityMonitorTest'
@@ -4782,14 +3814,6 @@ class StorageGateway {
   Future<StartGatewayOutput> startGateway({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.StartGateway'
@@ -4829,16 +3853,6 @@ class StorageGateway {
     required List<AutomaticTapeCreationRule> automaticTapeCreationRules,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(
-        automaticTapeCreationRules, 'automaticTapeCreationRules');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -4885,14 +3899,6 @@ class StorageGateway {
     int? averageDownloadRateLimitInBitsPerSec,
     int? averageUploadRateLimitInBitsPerSec,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'averageDownloadRateLimitInBitsPerSec',
       averageDownloadRateLimitInBitsPerSec,
@@ -4947,16 +3953,6 @@ class StorageGateway {
     required List<BandwidthRateLimitInterval> bandwidthRateLimitIntervals,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(
-        bandwidthRateLimitIntervals, 'bandwidthRateLimitIntervals');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateBandwidthRateLimitSchedule'
@@ -5017,37 +4013,6 @@ class StorageGateway {
     required String targetARN,
     String? secretToAuthenticateTarget,
   }) async {
-    ArgumentError.checkNotNull(initiatorName, 'initiatorName');
-    _s.validateStringLength(
-      'initiatorName',
-      initiatorName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        secretToAuthenticateInitiator, 'secretToAuthenticateInitiator');
-    _s.validateStringLength(
-      'secretToAuthenticateInitiator',
-      secretToAuthenticateInitiator,
-      1,
-      100,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetARN, 'targetARN');
-    _s.validateStringLength(
-      'targetARN',
-      targetARN,
-      50,
-      800,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'secretToAuthenticateTarget',
-      secretToAuthenticateTarget,
-      1,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateChapCredentials'
@@ -5098,32 +4063,6 @@ class StorageGateway {
     String? gatewayName,
     String? gatewayTimezone,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'cloudWatchLogGroupARN',
-      cloudWatchLogGroupARN,
-      0,
-      562,
-    );
-    _s.validateStringLength(
-      'gatewayName',
-      gatewayName,
-      2,
-      255,
-    );
-    _s.validateStringLength(
-      'gatewayTimezone',
-      gatewayTimezone,
-      3,
-      10,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateGatewayInformation'
@@ -5169,14 +4108,6 @@ class StorageGateway {
   Future<UpdateGatewaySoftwareNowOutput> updateGatewaySoftwareNow({
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateGatewaySoftwareNow'
@@ -5228,15 +4159,6 @@ class StorageGateway {
     int? dayOfMonth,
     int? dayOfWeek,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(hourOfDay, 'hourOfDay');
     _s.validateNumRange(
       'hourOfDay',
       hourOfDay,
@@ -5244,7 +4166,6 @@ class StorageGateway {
       23,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(minuteOfHour, 'minuteOfHour');
     _s.validateNumRange(
       'minuteOfHour',
       minuteOfHour,
@@ -5425,44 +4346,6 @@ class StorageGateway {
     bool? requesterPays,
     String? squash,
   }) async {
-    ArgumentError.checkNotNull(fileShareARN, 'fileShareARN');
-    _s.validateStringLength(
-      'fileShareARN',
-      fileShareARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultStorageClass',
-      defaultStorageClass,
-      5,
-      50,
-    );
-    _s.validateStringLength(
-      'fileShareName',
-      fileShareName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'notificationPolicy',
-      notificationPolicy,
-      2,
-      100,
-    );
-    _s.validateStringLength(
-      'squash',
-      squash,
-      5,
-      15,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateNFSFileShare'
@@ -5657,44 +4540,6 @@ class StorageGateway {
     bool? sMBACLEnabled,
     List<String>? validUserList,
   }) async {
-    ArgumentError.checkNotNull(fileShareARN, 'fileShareARN');
-    _s.validateStringLength(
-      'fileShareARN',
-      fileShareARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'auditDestinationARN',
-      auditDestinationARN,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'defaultStorageClass',
-      defaultStorageClass,
-      5,
-      50,
-    );
-    _s.validateStringLength(
-      'fileShareName',
-      fileShareName,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'kMSKey',
-      kMSKey,
-      7,
-      2048,
-    );
-    _s.validateStringLength(
-      'notificationPolicy',
-      notificationPolicy,
-      2,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateSMBFileShare'
@@ -5748,15 +4593,6 @@ class StorageGateway {
     required bool fileSharesVisible,
     required String gatewayARN,
   }) async {
-    ArgumentError.checkNotNull(fileSharesVisible, 'fileSharesVisible');
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateSMBFileShareVisibility'
@@ -5808,15 +4644,6 @@ class StorageGateway {
     required String gatewayARN,
     required SMBSecurityStrategy sMBSecurityStrategy,
   }) async {
-    ArgumentError.checkNotNull(gatewayARN, 'gatewayARN');
-    _s.validateStringLength(
-      'gatewayARN',
-      gatewayARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sMBSecurityStrategy, 'sMBSecurityStrategy');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateSMBSecurityStrategy'
@@ -5884,7 +4711,6 @@ class StorageGateway {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(recurrenceInHours, 'recurrenceInHours');
     _s.validateNumRange(
       'recurrenceInHours',
       recurrenceInHours,
@@ -5892,27 +4718,12 @@ class StorageGateway {
       24,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(startAt, 'startAt');
     _s.validateNumRange(
       'startAt',
       startAt,
       0,
       23,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(volumeARN, 'volumeARN');
-    _s.validateStringLength(
-      'volumeARN',
-      volumeARN,
-      50,
-      500,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5957,22 +4768,6 @@ class StorageGateway {
     required String deviceType,
     required String vTLDeviceARN,
   }) async {
-    ArgumentError.checkNotNull(deviceType, 'deviceType');
-    _s.validateStringLength(
-      'deviceType',
-      deviceType,
-      2,
-      50,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vTLDeviceARN, 'vTLDeviceARN');
-    _s.validateStringLength(
-      'vTLDeviceARN',
-      vTLDeviceARN,
-      50,
-      500,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'StorageGateway_20130630.UpdateVTLDeviceType'

--- a/generated/aws_sts_api/lib/sts-2011-06-15.dart
+++ b/generated/aws_sts_api/lib/sts-2011-06-15.dart
@@ -414,51 +414,11 @@ class STS {
     String? tokenCode,
     List<String>? transitiveTagKeys,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleSessionName, 'roleSessionName');
-    _s.validateStringLength(
-      'roleSessionName',
-      roleSessionName,
-      2,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'durationSeconds',
       durationSeconds,
       900,
       43200,
-    );
-    _s.validateStringLength(
-      'externalId',
-      externalId,
-      2,
-      1224,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-    );
-    _s.validateStringLength(
-      'tokenCode',
-      tokenCode,
-      6,
-      6,
     );
     final $request = <String, dynamic>{};
     $request['RoleArn'] = roleArn;
@@ -746,41 +706,11 @@ class STS {
     String? policy,
     List<PolicyDescriptorType>? policyArns,
   }) async {
-    ArgumentError.checkNotNull(principalArn, 'principalArn');
-    _s.validateStringLength(
-      'principalArn',
-      principalArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sAMLAssertion, 'sAMLAssertion');
-    _s.validateStringLength(
-      'sAMLAssertion',
-      sAMLAssertion,
-      4,
-      100000,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'durationSeconds',
       durationSeconds,
       900,
       43200,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      2048,
     );
     final $request = <String, dynamic>{};
     $request['PrincipalArn'] = principalArn;
@@ -1107,47 +1037,11 @@ class STS {
     List<PolicyDescriptorType>? policyArns,
     String? providerId,
   }) async {
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleSessionName, 'roleSessionName');
-    _s.validateStringLength(
-      'roleSessionName',
-      roleSessionName,
-      2,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webIdentityToken, 'webIdentityToken');
-    _s.validateStringLength(
-      'webIdentityToken',
-      webIdentityToken,
-      4,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'durationSeconds',
       durationSeconds,
       900,
       43200,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'providerId',
-      providerId,
-      4,
-      2048,
     );
     final $request = <String, dynamic>{};
     $request['RoleArn'] = roleArn;
@@ -1221,14 +1115,6 @@ class STS {
   Future<DecodeAuthorizationMessageResponse> decodeAuthorizationMessage({
     required String encodedMessage,
   }) async {
-    ArgumentError.checkNotNull(encodedMessage, 'encodedMessage');
-    _s.validateStringLength(
-      'encodedMessage',
-      encodedMessage,
-      1,
-      10240,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['EncodedMessage'] = encodedMessage;
     final $result = await _protocol.send(
@@ -1281,14 +1167,6 @@ class STS {
   Future<GetAccessKeyInfoResponse> getAccessKeyInfo({
     required String accessKeyId,
   }) async {
-    ArgumentError.checkNotNull(accessKeyId, 'accessKeyId');
-    _s.validateStringLength(
-      'accessKeyId',
-      accessKeyId,
-      16,
-      128,
-      isRequired: true,
-    );
     final $request = <String, dynamic>{};
     $request['AccessKeyId'] = accessKeyId;
     final $result = await _protocol.send(
@@ -1589,25 +1467,11 @@ class STS {
     List<PolicyDescriptorType>? policyArns,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      2,
-      32,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'durationSeconds',
       durationSeconds,
       900,
       129600,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      2048,
     );
     final $request = <String, dynamic>{};
     $request['Name'] = name;
@@ -1738,18 +1602,6 @@ class STS {
       durationSeconds,
       900,
       129600,
-    );
-    _s.validateStringLength(
-      'serialNumber',
-      serialNumber,
-      9,
-      256,
-    );
-    _s.validateStringLength(
-      'tokenCode',
-      tokenCode,
-      6,
-      6,
     );
     final $request = <String, dynamic>{};
     durationSeconds?.also((arg) => $request['DurationSeconds'] = arg);

--- a/generated/aws_support_api/lib/support-2013-04-15.dart
+++ b/generated/aws_support_api/lib/support-2013-04-15.dart
@@ -116,7 +116,6 @@ class Support {
     required List<Attachment> attachments,
     String? attachmentSetId,
   }) async {
-    ArgumentError.checkNotNull(attachments, 'attachments');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.AddAttachmentsToSet'
@@ -183,14 +182,6 @@ class Support {
     String? caseId,
     List<String>? ccEmailAddresses,
   }) async {
-    ArgumentError.checkNotNull(communicationBody, 'communicationBody');
-    _s.validateStringLength(
-      'communicationBody',
-      communicationBody,
-      1,
-      8000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.AddCommunicationToCase'
@@ -328,15 +319,6 @@ class Support {
     String? serviceCode,
     String? severityCode,
   }) async {
-    ArgumentError.checkNotNull(communicationBody, 'communicationBody');
-    _s.validateStringLength(
-      'communicationBody',
-      communicationBody,
-      1,
-      8000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subject, 'subject');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.CreateCase'
@@ -394,7 +376,6 @@ class Support {
   Future<DescribeAttachmentResponse> describeAttachment({
     required String attachmentId,
   }) async {
-    ArgumentError.checkNotNull(attachmentId, 'attachmentId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.DescribeAttachment'
@@ -588,7 +569,6 @@ class Support {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(caseId, 'caseId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
@@ -759,7 +739,6 @@ class Support {
       describeTrustedAdvisorCheckRefreshStatuses({
     required List<String> checkIds,
   }) async {
-    ArgumentError.checkNotNull(checkIds, 'checkIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -840,7 +819,6 @@ class Support {
     required String checkId,
     String? language,
   }) async {
-    ArgumentError.checkNotNull(checkId, 'checkId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.DescribeTrustedAdvisorCheckResult'
@@ -890,7 +868,6 @@ class Support {
       describeTrustedAdvisorCheckSummaries({
     required List<String> checkIds,
   }) async {
-    ArgumentError.checkNotNull(checkIds, 'checkIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.DescribeTrustedAdvisorCheckSummaries'
@@ -940,7 +917,6 @@ class Support {
   Future<DescribeTrustedAdvisorChecksResponse> describeTrustedAdvisorChecks({
     required String language,
   }) async {
-    ArgumentError.checkNotNull(language, 'language');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.DescribeTrustedAdvisorChecks'
@@ -992,7 +968,6 @@ class Support {
   Future<RefreshTrustedAdvisorCheckResponse> refreshTrustedAdvisorCheck({
     required String checkId,
   }) async {
-    ArgumentError.checkNotNull(checkId, 'checkId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSSupport_20130415.RefreshTrustedAdvisorCheck'

--- a/generated/aws_swf_api/lib/swf-2012-01-25.dart
+++ b/generated/aws_swf_api/lib/swf-2012-01-25.dart
@@ -166,14 +166,6 @@ class SWF {
     TagFilter? tagFilter,
     WorkflowTypeFilter? typeFilter,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.CountClosedWorkflowExecutions'
@@ -288,15 +280,6 @@ class SWF {
     TagFilter? tagFilter,
     WorkflowTypeFilter? typeFilter,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTimeFilter, 'startTimeFilter');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.CountOpenWorkflowExecutions'
@@ -365,15 +348,6 @@ class SWF {
     required String domain,
     required TaskList taskList,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskList, 'taskList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.CountPendingActivityTasks'
@@ -439,15 +413,6 @@ class SWF {
     required String domain,
     required TaskList taskList,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskList, 'taskList');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.CountPendingDecisionTasks'
@@ -526,15 +491,6 @@ class SWF {
     required ActivityType activityType,
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(activityType, 'activityType');
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DeprecateActivityType'
@@ -598,14 +554,6 @@ class SWF {
   Future<void> deprecateDomain({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DeprecateDomain'
@@ -682,15 +630,6 @@ class SWF {
     required String domain,
     required WorkflowType workflowType,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowType, 'workflowType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DeprecateWorkflowType'
@@ -764,15 +703,6 @@ class SWF {
     required ActivityType activityType,
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(activityType, 'activityType');
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DescribeActivityType'
@@ -830,14 +760,6 @@ class SWF {
   Future<DomainDetail> describeDomain({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DescribeDomain'
@@ -901,15 +823,6 @@ class SWF {
     required String domain,
     required WorkflowExecution execution,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(execution, 'execution');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DescribeWorkflowExecution'
@@ -983,15 +896,6 @@ class SWF {
     required String domain,
     required WorkflowType workflowType,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowType, 'workflowType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.DescribeWorkflowType'
@@ -1081,26 +985,11 @@ class SWF {
     String? nextPageToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(execution, 'execution');
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1198,32 +1087,11 @@ class SWF {
     String? nextPageToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(registrationStatus, 'registrationStatus');
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1392,25 +1260,11 @@ class SWF {
     TagFilter? tagFilter,
     WorkflowTypeFilter? typeFilter,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1506,18 +1360,11 @@ class SWF {
     String? nextPageToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(registrationStatus, 'registrationStatus');
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1656,26 +1503,11 @@ class SWF {
     TagFilter? tagFilter,
     WorkflowTypeFilter? typeFilter,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(startTimeFilter, 'startTimeFilter');
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1713,14 +1545,6 @@ class SWF {
   Future<ListTagsForResourceOutput> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.ListTagsForResource'
@@ -1810,32 +1634,11 @@ class SWF {
     String? nextPageToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(registrationStatus, 'registrationStatus');
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -1929,21 +1732,6 @@ class SWF {
     required TaskList taskList,
     String? identity,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskList, 'taskList');
-    _s.validateStringLength(
-      'identity',
-      identity,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.PollForActivityTask'
@@ -2079,32 +1867,11 @@ class SWF {
     String? nextPageToken,
     bool? reverseOrder,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(taskList, 'taskList');
-    _s.validateStringLength(
-      'identity',
-      identity,
-      0,
-      256,
-    );
     _s.validateNumRange(
       'maximumPageSize',
       maximumPageSize,
       0,
       1000,
-    );
-    _s.validateStringLength(
-      'nextPageToken',
-      nextPageToken,
-      0,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
@@ -2208,20 +1975,6 @@ class SWF {
     required String taskToken,
     String? details,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'details',
-      details,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RecordActivityTaskHeartbeat'
@@ -2394,60 +2147,6 @@ class SWF {
     String? defaultTaskStartToCloseTimeout,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultTaskHeartbeatTimeout',
-      defaultTaskHeartbeatTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'defaultTaskScheduleToCloseTimeout',
-      defaultTaskScheduleToCloseTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'defaultTaskScheduleToStartTimeout',
-      defaultTaskScheduleToStartTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'defaultTaskStartToCloseTimeout',
-      defaultTaskStartToCloseTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RegisterActivityType'
@@ -2553,29 +2252,6 @@ class SWF {
     String? description,
     List<ResourceTag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowExecutionRetentionPeriodInDays,
-        'workflowExecutionRetentionPeriodInDays');
-    _s.validateStringLength(
-      'workflowExecutionRetentionPeriodInDays',
-      workflowExecutionRetentionPeriodInDays,
-      1,
-      8,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RegisterDomain'
@@ -2770,54 +2446,6 @@ class SWF {
     String? defaultTaskStartToCloseTimeout,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(version, 'version');
-    _s.validateStringLength(
-      'version',
-      version,
-      1,
-      64,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'defaultExecutionStartToCloseTimeout',
-      defaultExecutionStartToCloseTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'defaultLambdaRole',
-      defaultLambdaRole,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'defaultTaskStartToCloseTimeout',
-      defaultTaskStartToCloseTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1024,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RegisterWorkflowType'
@@ -2906,28 +2534,6 @@ class SWF {
     required String workflowId,
     String? runId,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowId, 'workflowId');
-    _s.validateStringLength(
-      'workflowId',
-      workflowId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'runId',
-      runId,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RequestCancelWorkflowExecution'
@@ -3011,20 +2617,6 @@ class SWF {
     required String taskToken,
     String? details,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'details',
-      details,
-      0,
-      32768,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RespondActivityTaskCanceled'
@@ -3107,20 +2699,6 @@ class SWF {
     required String taskToken,
     String? result,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'result',
-      result,
-      0,
-      32768,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RespondActivityTaskCompleted'
@@ -3201,26 +2779,6 @@ class SWF {
     String? details,
     String? reason,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'details',
-      details,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'reason',
-      reason,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RespondActivityTaskFailed'
@@ -3285,20 +2843,6 @@ class SWF {
     List<Decision>? decisions,
     String? executionContext,
   }) async {
-    ArgumentError.checkNotNull(taskToken, 'taskToken');
-    _s.validateStringLength(
-      'taskToken',
-      taskToken,
-      1,
-      1024,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'executionContext',
-      executionContext,
-      0,
-      32768,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.RespondDecisionTaskCompleted'
@@ -3383,42 +2927,6 @@ class SWF {
     String? input,
     String? runId,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(signalName, 'signalName');
-    _s.validateStringLength(
-      'signalName',
-      signalName,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowId, 'workflowId');
-    _s.validateStringLength(
-      'workflowId',
-      workflowId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'input',
-      input,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'runId',
-      runId,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.SignalWorkflowExecution'
@@ -3663,47 +3171,6 @@ class SWF {
     String? taskPriority,
     String? taskStartToCloseTimeout,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowId, 'workflowId');
-    _s.validateStringLength(
-      'workflowId',
-      workflowId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowType, 'workflowType');
-    _s.validateStringLength(
-      'executionStartToCloseTimeout',
-      executionStartToCloseTimeout,
-      0,
-      8,
-    );
-    _s.validateStringLength(
-      'input',
-      input,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'lambdaRole',
-      lambdaRole,
-      1,
-      1600,
-    );
-    _s.validateStringLength(
-      'taskStartToCloseTimeout',
-      taskStartToCloseTimeout,
-      0,
-      8,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.StartWorkflowExecution'
@@ -3756,15 +3223,6 @@ class SWF {
     required String resourceArn,
     required List<ResourceTag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.TagResource'
@@ -3881,40 +3339,6 @@ class SWF {
     String? reason,
     String? runId,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowId, 'workflowId');
-    _s.validateStringLength(
-      'workflowId',
-      workflowId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'details',
-      details,
-      0,
-      32768,
-    );
-    _s.validateStringLength(
-      'reason',
-      reason,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'runId',
-      runId,
-      0,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.TerminateWorkflowExecution'
@@ -3994,15 +3418,6 @@ class SWF {
     required ActivityType activityType,
     required String domain,
   }) async {
-    ArgumentError.checkNotNull(activityType, 'activityType');
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.UndeprecateActivityType'
@@ -4063,14 +3478,6 @@ class SWF {
   Future<void> undeprecateDomain({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.UndeprecateDomain'
@@ -4145,15 +3552,6 @@ class SWF {
     required String domain,
     required WorkflowType workflowType,
   }) async {
-    ArgumentError.checkNotNull(domain, 'domain');
-    _s.validateStringLength(
-      'domain',
-      domain,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(workflowType, 'workflowType');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.UndeprecateWorkflowType'
@@ -4186,15 +3584,6 @@ class SWF {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.0',
       'X-Amz-Target': 'SimpleWorkflowService.UntagResource'

--- a/generated/aws_textract_api/lib/textract-2018-06-27.dart
+++ b/generated/aws_textract_api/lib/textract-2018-06-27.dart
@@ -126,8 +126,6 @@ class Textract {
     required List<FeatureType> featureTypes,
     HumanLoopConfig? humanLoopConfig,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
-    ArgumentError.checkNotNull(featureTypes, 'featureTypes');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Textract.AnalyzeDocument'
@@ -188,7 +186,6 @@ class Textract {
   Future<DetectDocumentTextResponse> detectDocumentText({
     required Document document,
   }) async {
-    ArgumentError.checkNotNull(document, 'document');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Textract.DetectDocumentText'
@@ -291,25 +288,11 @@ class Textract {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -397,25 +380,11 @@ class Textract {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      64,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      255,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -524,26 +493,6 @@ class Textract {
     NotificationChannel? notificationChannel,
     OutputConfig? outputConfig,
   }) async {
-    ArgumentError.checkNotNull(documentLocation, 'documentLocation');
-    ArgumentError.checkNotNull(featureTypes, 'featureTypes');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'kMSKeyId',
-      kMSKeyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Textract.StartDocumentAnalysis'
@@ -647,25 +596,6 @@ class Textract {
     NotificationChannel? notificationChannel,
     OutputConfig? outputConfig,
   }) async {
-    ArgumentError.checkNotNull(documentLocation, 'documentLocation');
-    _s.validateStringLength(
-      'clientRequestToken',
-      clientRequestToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobTag',
-      jobTag,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'kMSKeyId',
-      kMSKeyId,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Textract.StartDocumentTextDetection'

--- a/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
+++ b/generated/aws_transcribe_api/lib/transcribe-2017-10-26.dart
@@ -83,17 +83,6 @@ class TranscribeService {
     required CLMLanguageCode languageCode,
     required String modelName,
   }) async {
-    ArgumentError.checkNotNull(baseModelName, 'baseModelName');
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.CreateLanguageModel'
@@ -162,23 +151,6 @@ class TranscribeService {
     required String vocabularyFileUri,
     required String vocabularyName,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(vocabularyFileUri, 'vocabularyFileUri');
-    _s.validateStringLength(
-      'vocabularyFileUri',
-      vocabularyFileUri,
-      1,
-      2000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.CreateMedicalVocabulary'
@@ -237,21 +209,6 @@ class TranscribeService {
     List<String>? phrases,
     String? vocabularyFileUri,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vocabularyFileUri',
-      vocabularyFileUri,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.CreateVocabulary'
@@ -320,21 +277,6 @@ class TranscribeService {
     String? vocabularyFilterFileUri,
     List<String>? words,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(vocabularyFilterName, 'vocabularyFilterName');
-    _s.validateStringLength(
-      'vocabularyFilterName',
-      vocabularyFilterName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vocabularyFilterFileUri',
-      vocabularyFilterFileUri,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.CreateVocabularyFilter'
@@ -368,14 +310,6 @@ class TranscribeService {
   Future<void> deleteLanguageModel({
     required String modelName,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteLanguageModel'
@@ -405,15 +339,6 @@ class TranscribeService {
   Future<void> deleteMedicalTranscriptionJob({
     required String medicalTranscriptionJobName,
   }) async {
-    ArgumentError.checkNotNull(
-        medicalTranscriptionJobName, 'medicalTranscriptionJobName');
-    _s.validateStringLength(
-      'medicalTranscriptionJobName',
-      medicalTranscriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteMedicalTranscriptionJob'
@@ -442,14 +367,6 @@ class TranscribeService {
   Future<void> deleteMedicalVocabulary({
     required String vocabularyName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteMedicalVocabulary'
@@ -478,14 +395,6 @@ class TranscribeService {
   Future<void> deleteTranscriptionJob({
     required String transcriptionJobName,
   }) async {
-    ArgumentError.checkNotNull(transcriptionJobName, 'transcriptionJobName');
-    _s.validateStringLength(
-      'transcriptionJobName',
-      transcriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteTranscriptionJob'
@@ -514,14 +423,6 @@ class TranscribeService {
   Future<void> deleteVocabulary({
     required String vocabularyName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteVocabulary'
@@ -550,14 +451,6 @@ class TranscribeService {
   Future<void> deleteVocabularyFilter({
     required String vocabularyFilterName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyFilterName, 'vocabularyFilterName');
-    _s.validateStringLength(
-      'vocabularyFilterName',
-      vocabularyFilterName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DeleteVocabularyFilter'
@@ -592,14 +485,6 @@ class TranscribeService {
   Future<DescribeLanguageModelResponse> describeLanguageModel({
     required String modelName,
   }) async {
-    ArgumentError.checkNotNull(modelName, 'modelName');
-    _s.validateStringLength(
-      'modelName',
-      modelName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.DescribeLanguageModel'
@@ -634,15 +519,6 @@ class TranscribeService {
   Future<GetMedicalTranscriptionJobResponse> getMedicalTranscriptionJob({
     required String medicalTranscriptionJobName,
   }) async {
-    ArgumentError.checkNotNull(
-        medicalTranscriptionJobName, 'medicalTranscriptionJobName');
-    _s.validateStringLength(
-      'medicalTranscriptionJobName',
-      medicalTranscriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.GetMedicalTranscriptionJob'
@@ -674,14 +550,6 @@ class TranscribeService {
   Future<GetMedicalVocabularyResponse> getMedicalVocabulary({
     required String vocabularyName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.GetMedicalVocabulary'
@@ -717,14 +585,6 @@ class TranscribeService {
   Future<GetTranscriptionJobResponse> getTranscriptionJob({
     required String transcriptionJobName,
   }) async {
-    ArgumentError.checkNotNull(transcriptionJobName, 'transcriptionJobName');
-    _s.validateStringLength(
-      'transcriptionJobName',
-      transcriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.GetTranscriptionJob'
@@ -756,14 +616,6 @@ class TranscribeService {
   Future<GetVocabularyResponse> getVocabulary({
     required String vocabularyName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.GetVocabulary'
@@ -794,14 +646,6 @@ class TranscribeService {
   Future<GetVocabularyFilterResponse> getVocabularyFilter({
     required String vocabularyFilterName,
   }) async {
-    ArgumentError.checkNotNull(vocabularyFilterName, 'vocabularyFilterName');
-    _s.validateStringLength(
-      'vocabularyFilterName',
-      vocabularyFilterName,
-      1,
-      200,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.GetVocabularyFilter'
@@ -859,18 +703,6 @@ class TranscribeService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.ListLanguageModels'
@@ -924,23 +756,11 @@ class TranscribeService {
     String? nextToken,
     TranscriptionJobStatus? status,
   }) async {
-    _s.validateStringLength(
-      'jobNameContains',
-      jobNameContains,
-      1,
-      200,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1001,18 +821,6 @@ class TranscribeService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.ListMedicalVocabularies'
@@ -1064,23 +872,11 @@ class TranscribeService {
     String? nextToken,
     TranscriptionJobStatus? status,
   }) async {
-    _s.validateStringLength(
-      'jobNameContains',
-      jobNameContains,
-      1,
-      200,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1140,18 +936,6 @@ class TranscribeService {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.ListVocabularies'
@@ -1201,18 +985,6 @@ class TranscribeService {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nameContains',
-      nameContains,
-      1,
-      200,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1363,44 +1135,11 @@ class TranscribeService {
     String? outputKey,
     MedicalTranscriptionSetting? settings,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(media, 'media');
-    ArgumentError.checkNotNull(
-        medicalTranscriptionJobName, 'medicalTranscriptionJobName');
-    _s.validateStringLength(
-      'medicalTranscriptionJobName',
-      medicalTranscriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(outputBucketName, 'outputBucketName');
-    _s.validateStringLength(
-      'outputBucketName',
-      outputBucketName,
-      0,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(specialty, 'specialty');
-    ArgumentError.checkNotNull(type, 'type');
     _s.validateNumRange(
       'mediaSampleRateHertz',
       mediaSampleRateHertz,
       8000,
       48000,
-    );
-    _s.validateStringLength(
-      'outputEncryptionKMSKeyId',
-      outputEncryptionKMSKeyId,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'outputKey',
-      outputKey,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1588,38 +1327,11 @@ class TranscribeService {
     String? outputKey,
     Settings? settings,
   }) async {
-    ArgumentError.checkNotNull(media, 'media');
-    ArgumentError.checkNotNull(transcriptionJobName, 'transcriptionJobName');
-    _s.validateStringLength(
-      'transcriptionJobName',
-      transcriptionJobName,
-      1,
-      200,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'mediaSampleRateHertz',
       mediaSampleRateHertz,
       8000,
       48000,
-    );
-    _s.validateStringLength(
-      'outputBucketName',
-      outputBucketName,
-      0,
-      64,
-    );
-    _s.validateStringLength(
-      'outputEncryptionKMSKeyId',
-      outputEncryptionKMSKeyId,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'outputKey',
-      outputKey,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1703,21 +1415,6 @@ class TranscribeService {
     required String vocabularyName,
     String? vocabularyFileUri,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vocabularyFileUri',
-      vocabularyFileUri,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.UpdateMedicalVocabulary'
@@ -1779,21 +1476,6 @@ class TranscribeService {
     List<String>? phrases,
     String? vocabularyFileUri,
   }) async {
-    ArgumentError.checkNotNull(languageCode, 'languageCode');
-    ArgumentError.checkNotNull(vocabularyName, 'vocabularyName');
-    _s.validateStringLength(
-      'vocabularyName',
-      vocabularyName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vocabularyFileUri',
-      vocabularyFileUri,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.UpdateVocabulary'
@@ -1854,20 +1536,6 @@ class TranscribeService {
     String? vocabularyFilterFileUri,
     List<String>? words,
   }) async {
-    ArgumentError.checkNotNull(vocabularyFilterName, 'vocabularyFilterName');
-    _s.validateStringLength(
-      'vocabularyFilterName',
-      vocabularyFilterName,
-      1,
-      200,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'vocabularyFilterFileUri',
-      vocabularyFilterFileUri,
-      1,
-      2000,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'Transcribe.UpdateVocabularyFilter'

--- a/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
+++ b/generated/aws_transfer_api/lib/transfer-2018-11-05.dart
@@ -223,30 +223,6 @@ class Transfer {
     String? securityPolicyName,
     List<Tag>? tags,
   }) async {
-    _s.validateStringLength(
-      'certificate',
-      certificate,
-      0,
-      1600,
-    );
-    _s.validateStringLength(
-      'hostKey',
-      hostKey,
-      0,
-      4096,
-    );
-    _s.validateStringLength(
-      'loggingRole',
-      loggingRole,
-      20,
-      2048,
-    );
-    _s.validateStringLength(
-      'securityPolicyName',
-      securityPolicyName,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.CreateServer'
@@ -395,48 +371,6 @@ class Transfer {
     String? sshPublicKeyBody,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(role, 'role');
-    _s.validateStringLength(
-      'role',
-      role,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'homeDirectory',
-      homeDirectory,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'sshPublicKeyBody',
-      sshPublicKeyBody,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.CreateUser'
@@ -480,14 +414,6 @@ class Transfer {
   Future<void> deleteServer({
     required String serverId,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DeleteServer'
@@ -528,30 +454,6 @@ class Transfer {
     required String sshPublicKeyId,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sshPublicKeyId, 'sshPublicKeyId');
-    _s.validateStringLength(
-      'sshPublicKeyId',
-      sshPublicKeyId,
-      21,
-      21,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DeleteSshPublicKey'
@@ -594,22 +496,6 @@ class Transfer {
     required String serverId,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DeleteUser'
@@ -644,14 +530,6 @@ class Transfer {
   Future<DescribeSecurityPolicyResponse> describeSecurityPolicy({
     required String securityPolicyName,
   }) async {
-    ArgumentError.checkNotNull(securityPolicyName, 'securityPolicyName');
-    _s.validateStringLength(
-      'securityPolicyName',
-      securityPolicyName,
-      0,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DescribeSecurityPolicy'
@@ -687,14 +565,6 @@ class Transfer {
   Future<DescribeServerResponse> describeServer({
     required String serverId,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DescribeServer'
@@ -736,22 +606,6 @@ class Transfer {
     required String serverId,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.DescribeUser'
@@ -799,30 +653,6 @@ class Transfer {
     required String sshPublicKeyBody,
     required String userName,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sshPublicKeyBody, 'sshPublicKeyBody');
-    _s.validateStringLength(
-      'sshPublicKeyBody',
-      sshPublicKeyBody,
-      0,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.ImportSshPublicKey'
@@ -871,12 +701,6 @@ class Transfer {
       1,
       1000,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      6144,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.ListSecurityPolicies'
@@ -922,12 +746,6 @@ class Transfer {
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      6144,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -976,25 +794,11 @@ class Transfer {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      1600,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      6144,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1043,25 +847,11 @@ class Transfer {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1000,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      6144,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1105,14 +895,6 @@ class Transfer {
   Future<void> startServer({
     required String serverId,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.StartServer'
@@ -1156,14 +938,6 @@ class Transfer {
   Future<void> stopServer({
     required String serverId,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.StopServer'
@@ -1203,15 +977,6 @@ class Transfer {
     required String arn,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.TagResource'
@@ -1277,34 +1042,6 @@ class Transfer {
     String? sourceIp,
     String? userPassword,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'sourceIp',
-      sourceIp,
-      0,
-      32,
-    );
-    _s.validateStringLength(
-      'userPassword',
-      userPassword,
-      0,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.TestIdentityProvider'
@@ -1351,15 +1088,6 @@ class Transfer {
     required String arn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(arn, 'arn');
-    _s.validateStringLength(
-      'arn',
-      arn,
-      20,
-      1600,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.UntagResource'
@@ -1531,38 +1259,6 @@ class Transfer {
     List<Protocol>? protocols,
     String? securityPolicyName,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'certificate',
-      certificate,
-      0,
-      1600,
-    );
-    _s.validateStringLength(
-      'hostKey',
-      hostKey,
-      0,
-      4096,
-    );
-    _s.validateStringLength(
-      'loggingRole',
-      loggingRole,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'securityPolicyName',
-      securityPolicyName,
-      0,
-      100,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.UpdateServer'
@@ -1696,40 +1392,6 @@ class Transfer {
     String? policy,
     String? role,
   }) async {
-    ArgumentError.checkNotNull(serverId, 'serverId');
-    _s.validateStringLength(
-      'serverId',
-      serverId,
-      19,
-      19,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userName, 'userName');
-    _s.validateStringLength(
-      'userName',
-      userName,
-      3,
-      100,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'homeDirectory',
-      homeDirectory,
-      0,
-      1024,
-    );
-    _s.validateStringLength(
-      'policy',
-      policy,
-      0,
-      2048,
-    );
-    _s.validateStringLength(
-      'role',
-      role,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'TransferService.UpdateUser'

--- a/generated/aws_translate_api/lib/translate-2017-07-01.dart
+++ b/generated/aws_translate_api/lib/translate-2017-07-01.dart
@@ -82,27 +82,6 @@ class Translate {
     String? description,
     EncryptionKey? encryptionKey,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parallelDataConfig, 'parallelDataConfig');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.CreateParallelData'
@@ -137,14 +116,6 @@ class Translate {
   Future<DeleteParallelDataResponse> deleteParallelData({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.DeleteParallelData'
@@ -175,14 +146,6 @@ class Translate {
   Future<void> deleteTerminology({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.DeleteTerminology'
@@ -214,14 +177,6 @@ class Translate {
   Future<DescribeTextTranslationJobResponse> describeTextTranslationJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target':
@@ -253,14 +208,6 @@ class Translate {
   Future<GetParallelDataResponse> getParallelData({
     required String name,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.GetParallelData'
@@ -296,15 +243,6 @@ class Translate {
     required String name,
     required TerminologyDataFormat terminologyDataFormat,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(terminologyDataFormat, 'terminologyDataFormat');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.GetTerminology'
@@ -364,22 +302,6 @@ class Translate {
     String? description,
     EncryptionKey? encryptionKey,
   }) async {
-    ArgumentError.checkNotNull(mergeStrategy, 'mergeStrategy');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(terminologyData, 'terminologyData');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.ImportTerminology'
@@ -424,12 +346,6 @@ class Translate {
       1,
       500,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.ListParallelData'
@@ -470,12 +386,6 @@ class Translate {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -524,12 +434,6 @@ class Translate {
       maxResults,
       1,
       500,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      0,
-      8192,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -619,37 +523,6 @@ class Translate {
     List<String>? parallelDataNames,
     List<String>? terminologyNames,
   }) async {
-    ArgumentError.checkNotNull(dataAccessRoleArn, 'dataAccessRoleArn');
-    _s.validateStringLength(
-      'dataAccessRoleArn',
-      dataAccessRoleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(inputDataConfig, 'inputDataConfig');
-    ArgumentError.checkNotNull(outputDataConfig, 'outputDataConfig');
-    ArgumentError.checkNotNull(sourceLanguageCode, 'sourceLanguageCode');
-    _s.validateStringLength(
-      'sourceLanguageCode',
-      sourceLanguageCode,
-      2,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetLanguageCodes, 'targetLanguageCodes');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'jobName',
-      jobName,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.StartTextTranslationJob'
@@ -698,14 +571,6 @@ class Translate {
   Future<StopTextTranslationJobResponse> stopTextTranslationJob({
     required String jobId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      32,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.StopTextTranslationJob'
@@ -768,30 +633,6 @@ class Translate {
     required String text,
     List<String>? terminologyNames,
   }) async {
-    ArgumentError.checkNotNull(sourceLanguageCode, 'sourceLanguageCode');
-    _s.validateStringLength(
-      'sourceLanguageCode',
-      sourceLanguageCode,
-      2,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(targetLanguageCode, 'targetLanguageCode');
-    _s.validateStringLength(
-      'targetLanguageCode',
-      targetLanguageCode,
-      2,
-      5,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      5000,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.TranslateText'
@@ -843,27 +684,6 @@ class Translate {
     String? clientToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(parallelDataConfig, 'parallelDataConfig');
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSShineFrontendService_20170701.UpdateParallelData'

--- a/generated/aws_waf_api/lib/waf-2015-08-24.dart
+++ b/generated/aws_waf_api/lib/waf-2015-08-24.dart
@@ -130,22 +130,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateByteMatchSet'
@@ -225,22 +209,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateGeoMatchSet'
@@ -320,22 +288,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateIPSet'
@@ -507,32 +459,6 @@ class WAF {
     required int rateLimit,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rateKey, 'rateKey');
-    ArgumentError.checkNotNull(rateLimit, 'rateLimit');
     _s.validateNumRange(
       'rateLimit',
       rateLimit,
@@ -625,22 +551,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateRegexMatchSet'
@@ -717,22 +627,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateRegexPatternSet'
@@ -849,30 +743,6 @@ class WAF {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateRule'
@@ -959,30 +829,6 @@ class WAF {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateRuleGroup'
@@ -1067,22 +913,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateSizeConstraintSet'
@@ -1162,22 +992,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateSqlInjectionMatchSet'
@@ -1294,31 +1108,6 @@ class WAF {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(defaultAction, 'defaultAction');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateWebACL'
@@ -1395,23 +1184,6 @@ class WAF {
     required String s3BucketName,
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(ignoreUnsupportedType, 'ignoreUnsupportedType');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    _s.validateStringLength(
-      's3BucketName',
-      s3BucketName,
-      3,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateWebACLMigrationStack'
@@ -1492,22 +1264,6 @@ class WAF {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.CreateXssMatchSet'
@@ -1579,22 +1335,6 @@ class WAF {
     required String byteMatchSetId,
     required String changeToken,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteByteMatchSet'
@@ -1666,22 +1406,6 @@ class WAF {
     required String changeToken,
     required String geoMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteGeoMatchSet'
@@ -1752,22 +1476,6 @@ class WAF {
     required String changeToken,
     required String iPSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteIPSet'
@@ -1811,14 +1519,6 @@ class WAF {
   Future<void> deleteLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteLoggingConfiguration'
@@ -1862,14 +1562,6 @@ class WAF {
   Future<void> deletePermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeletePermissionPolicy'
@@ -1940,22 +1632,6 @@ class WAF {
     required String changeToken,
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteRateBasedRule'
@@ -2028,22 +1704,6 @@ class WAF {
     required String changeToken,
     required String regexMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteRegexMatchSet'
@@ -2097,22 +1757,6 @@ class WAF {
     required String changeToken,
     required String regexPatternSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteRegexPatternSet'
@@ -2185,22 +1829,6 @@ class WAF {
     required String changeToken,
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteRule'
@@ -2274,22 +1902,6 @@ class WAF {
     required String changeToken,
     required String ruleGroupId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteRuleGroup'
@@ -2362,22 +1974,6 @@ class WAF {
     required String changeToken,
     required String sizeConstraintSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteSizeConstraintSet'
@@ -2451,23 +2047,6 @@ class WAF {
     required String changeToken,
     required String sqlInjectionMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteSqlInjectionMatchSet'
@@ -2535,22 +2114,6 @@ class WAF {
     required String changeToken,
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteWebACL'
@@ -2622,22 +2185,6 @@ class WAF {
     required String changeToken,
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.DeleteXssMatchSet'
@@ -2681,14 +2228,6 @@ class WAF {
   Future<GetByteMatchSetResponse> getByteMatchSet({
     required String byteMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetByteMatchSet'
@@ -2792,14 +2331,6 @@ class WAF {
   Future<GetChangeTokenStatusResponse> getChangeTokenStatus({
     required String changeToken,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetChangeTokenStatus'
@@ -2843,14 +2374,6 @@ class WAF {
   Future<GetGeoMatchSetResponse> getGeoMatchSet({
     required String geoMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetGeoMatchSet'
@@ -2893,14 +2416,6 @@ class WAF {
   Future<GetIPSetResponse> getIPSet({
     required String iPSetId,
   }) async {
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetIPSet'
@@ -2941,14 +2456,6 @@ class WAF {
   Future<GetLoggingConfigurationResponse> getLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetLoggingConfiguration'
@@ -2989,14 +2496,6 @@ class WAF {
   Future<GetPermissionPolicyResponse> getPermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetPermissionPolicy'
@@ -3041,14 +2540,6 @@ class WAF {
   Future<GetRateBasedRuleResponse> getRateBasedRule({
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRateBasedRule'
@@ -3100,20 +2591,6 @@ class WAF {
     required String ruleId,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRateBasedRuleManagedKeys'
@@ -3158,14 +2635,6 @@ class WAF {
   Future<GetRegexMatchSetResponse> getRegexMatchSet({
     required String regexMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRegexMatchSet'
@@ -3209,14 +2678,6 @@ class WAF {
   Future<GetRegexPatternSetResponse> getRegexPatternSet({
     required String regexPatternSetId,
   }) async {
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRegexPatternSet'
@@ -3260,14 +2721,6 @@ class WAF {
   Future<GetRuleResponse> getRule({
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRule'
@@ -3314,14 +2767,6 @@ class WAF {
   Future<GetRuleGroupResponse> getRuleGroup({
     required String ruleGroupId,
   }) async {
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetRuleGroup'
@@ -3407,29 +2852,11 @@ class WAF {
     required TimeWindow timeWindow,
     required String webAclId,
   }) async {
-    ArgumentError.checkNotNull(maxItems, 'maxItems');
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(timeWindow, 'timeWindow');
-    ArgumentError.checkNotNull(webAclId, 'webAclId');
-    _s.validateStringLength(
-      'webAclId',
-      webAclId,
-      1,
-      128,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -3478,14 +2905,6 @@ class WAF {
   Future<GetSizeConstraintSetResponse> getSizeConstraintSet({
     required String sizeConstraintSetId,
   }) async {
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetSizeConstraintSet'
@@ -3529,15 +2948,6 @@ class WAF {
   Future<GetSqlInjectionMatchSetResponse> getSqlInjectionMatchSet({
     required String sqlInjectionMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetSqlInjectionMatchSet'
@@ -3580,14 +2990,6 @@ class WAF {
   Future<GetWebACLResponse> getWebACL({
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetWebACL'
@@ -3631,14 +3033,6 @@ class WAF {
   Future<GetXssMatchSetResponse> getXssMatchSet({
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.GetXssMatchSet'
@@ -3704,18 +3098,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListActivatedRulesInRuleGroup'
@@ -3778,12 +3160,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListByteMatchSets'
@@ -3844,12 +3220,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListGeoMatchSets'
@@ -3907,12 +3277,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -3977,12 +3341,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListLoggingConfigurations'
@@ -4042,12 +3400,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4109,12 +3461,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4178,12 +3524,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListRegexPatternSets'
@@ -4242,12 +3582,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4308,12 +3642,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4376,12 +3704,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListSizeConstraintSets'
@@ -4443,12 +3765,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListSqlInjectionMatchSets'
@@ -4508,12 +3824,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4576,25 +3886,11 @@ class WAF {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4657,12 +3953,6 @@ class WAF {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.ListWebACLs'
@@ -4722,12 +4012,6 @@ class WAF {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4802,7 +4086,6 @@ class WAF {
   Future<PutLoggingConfigurationResponse> putLoggingConfiguration({
     required LoggingConfiguration loggingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(loggingConfiguration, 'loggingConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.PutLoggingConfiguration'
@@ -4892,22 +4175,6 @@ class WAF {
     required String policy,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      395000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.PutPermissionPolicy'
@@ -4964,15 +4231,6 @@ class WAF {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.TagResource'
@@ -5018,15 +4276,6 @@ class WAF {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UntagResource'
@@ -5151,23 +4400,6 @@ class WAF {
     required String changeToken,
     required List<ByteMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateByteMatchSet'
@@ -5284,23 +4516,6 @@ class WAF {
     required String geoMatchSetId,
     required List<GeoMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateGeoMatchSet'
@@ -5445,23 +4660,6 @@ class WAF {
     required String iPSetId,
     required List<IPSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateIPSet'
@@ -5583,15 +4781,6 @@ class WAF {
     required String ruleId,
     required List<RuleUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rateLimit, 'rateLimit');
     _s.validateNumRange(
       'rateLimit',
       rateLimit,
@@ -5599,15 +4788,6 @@ class WAF {
       2000000000,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateRateBasedRule'
@@ -5717,23 +4897,6 @@ class WAF {
     required String regexMatchSetId,
     required List<RegexMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateRegexMatchSet'
@@ -5842,23 +5005,6 @@ class WAF {
     required String regexPatternSetId,
     required List<RegexPatternSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateRegexPatternSet'
@@ -5982,23 +5128,6 @@ class WAF {
     required String ruleId,
     required List<RuleUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateRule'
@@ -6097,23 +5226,6 @@ class WAF {
     required String ruleGroupId,
     required List<RuleGroupUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateRuleGroup'
@@ -6247,23 +5359,6 @@ class WAF {
     required String sizeConstraintSetId,
     required List<SizeConstraintSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateSizeConstraintSet'
@@ -6386,24 +5481,6 @@ class WAF {
     required String sqlInjectionMatchSetId,
     required List<SqlInjectionMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateSqlInjectionMatchSet'
@@ -6575,22 +5652,6 @@ class WAF {
     WafAction? defaultAction,
     List<WebACLUpdate>? updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateWebACL'
@@ -6713,23 +5774,6 @@ class WAF {
     required List<XssMatchSetUpdate> updates,
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20150824.UpdateXssMatchSet'

--- a/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
+++ b/generated/aws_waf_regional_api/lib/waf-regional-2016-11-28.dart
@@ -117,22 +117,6 @@ class WAFRegional {
     required String resourceArn,
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.AssociateWebACL'
@@ -213,22 +197,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateByteMatchSet'
@@ -308,22 +276,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateGeoMatchSet'
@@ -403,22 +355,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateIPSet'
@@ -590,32 +526,6 @@ class WAFRegional {
     required int rateLimit,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rateKey, 'rateKey');
-    ArgumentError.checkNotNull(rateLimit, 'rateLimit');
     _s.validateNumRange(
       'rateLimit',
       rateLimit,
@@ -708,22 +618,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateRegexMatchSet'
@@ -800,22 +694,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateRegexPatternSet'
@@ -932,30 +810,6 @@ class WAFRegional {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateRule'
@@ -1042,30 +896,6 @@ class WAFRegional {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateRuleGroup'
@@ -1150,22 +980,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateSizeConstraintSet'
@@ -1245,22 +1059,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateSqlInjectionMatchSet'
@@ -1377,31 +1175,6 @@ class WAFRegional {
     required String name,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(defaultAction, 'defaultAction');
-    ArgumentError.checkNotNull(metricName, 'metricName');
-    _s.validateStringLength(
-      'metricName',
-      metricName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateWebACL'
@@ -1478,23 +1251,6 @@ class WAFRegional {
     required String s3BucketName,
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(ignoreUnsupportedType, 'ignoreUnsupportedType');
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    _s.validateStringLength(
-      's3BucketName',
-      s3BucketName,
-      3,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateWebACLMigrationStack'
@@ -1575,22 +1331,6 @@ class WAFRegional {
     required String changeToken,
     required String name,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.CreateXssMatchSet'
@@ -1662,22 +1402,6 @@ class WAFRegional {
     required String byteMatchSetId,
     required String changeToken,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteByteMatchSet'
@@ -1749,22 +1473,6 @@ class WAFRegional {
     required String changeToken,
     required String geoMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteGeoMatchSet'
@@ -1835,22 +1543,6 @@ class WAFRegional {
     required String changeToken,
     required String iPSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteIPSet'
@@ -1894,14 +1586,6 @@ class WAFRegional {
   Future<void> deleteLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteLoggingConfiguration'
@@ -1945,14 +1629,6 @@ class WAFRegional {
   Future<void> deletePermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeletePermissionPolicy'
@@ -2023,22 +1699,6 @@ class WAFRegional {
     required String changeToken,
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteRateBasedRule'
@@ -2111,22 +1771,6 @@ class WAFRegional {
     required String changeToken,
     required String regexMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteRegexMatchSet'
@@ -2180,22 +1824,6 @@ class WAFRegional {
     required String changeToken,
     required String regexPatternSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteRegexPatternSet'
@@ -2268,22 +1896,6 @@ class WAFRegional {
     required String changeToken,
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteRule'
@@ -2357,22 +1969,6 @@ class WAFRegional {
     required String changeToken,
     required String ruleGroupId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteRuleGroup'
@@ -2445,22 +2041,6 @@ class WAFRegional {
     required String changeToken,
     required String sizeConstraintSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteSizeConstraintSet'
@@ -2534,23 +2114,6 @@ class WAFRegional {
     required String changeToken,
     required String sqlInjectionMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteSqlInjectionMatchSet'
@@ -2618,22 +2181,6 @@ class WAFRegional {
     required String changeToken,
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteWebACL'
@@ -2705,22 +2252,6 @@ class WAFRegional {
     required String changeToken,
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DeleteXssMatchSet'
@@ -2782,14 +2313,6 @@ class WAFRegional {
   Future<void> disassociateWebACL({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.DisassociateWebACL'
@@ -2830,14 +2353,6 @@ class WAFRegional {
   Future<GetByteMatchSetResponse> getByteMatchSet({
     required String byteMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetByteMatchSet'
@@ -2941,14 +2456,6 @@ class WAFRegional {
   Future<GetChangeTokenStatusResponse> getChangeTokenStatus({
     required String changeToken,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetChangeTokenStatus'
@@ -2992,14 +2499,6 @@ class WAFRegional {
   Future<GetGeoMatchSetResponse> getGeoMatchSet({
     required String geoMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetGeoMatchSet'
@@ -3042,14 +2541,6 @@ class WAFRegional {
   Future<GetIPSetResponse> getIPSet({
     required String iPSetId,
   }) async {
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetIPSet'
@@ -3090,14 +2581,6 @@ class WAFRegional {
   Future<GetLoggingConfigurationResponse> getLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetLoggingConfiguration'
@@ -3138,14 +2621,6 @@ class WAFRegional {
   Future<GetPermissionPolicyResponse> getPermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetPermissionPolicy'
@@ -3190,14 +2665,6 @@ class WAFRegional {
   Future<GetRateBasedRuleResponse> getRateBasedRule({
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRateBasedRule'
@@ -3249,20 +2716,6 @@ class WAFRegional {
     required String ruleId,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRateBasedRuleManagedKeys'
@@ -3307,14 +2760,6 @@ class WAFRegional {
   Future<GetRegexMatchSetResponse> getRegexMatchSet({
     required String regexMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRegexMatchSet'
@@ -3358,14 +2803,6 @@ class WAFRegional {
   Future<GetRegexPatternSetResponse> getRegexPatternSet({
     required String regexPatternSetId,
   }) async {
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRegexPatternSet'
@@ -3409,14 +2846,6 @@ class WAFRegional {
   Future<GetRuleResponse> getRule({
     required String ruleId,
   }) async {
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRule'
@@ -3463,14 +2892,6 @@ class WAFRegional {
   Future<GetRuleGroupResponse> getRuleGroup({
     required String ruleGroupId,
   }) async {
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetRuleGroup'
@@ -3556,29 +2977,11 @@ class WAFRegional {
     required TimeWindow timeWindow,
     required String webAclId,
   }) async {
-    ArgumentError.checkNotNull(maxItems, 'maxItems');
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(timeWindow, 'timeWindow');
-    ArgumentError.checkNotNull(webAclId, 'webAclId');
-    _s.validateStringLength(
-      'webAclId',
-      webAclId,
-      1,
-      128,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -3627,14 +3030,6 @@ class WAFRegional {
   Future<GetSizeConstraintSetResponse> getSizeConstraintSet({
     required String sizeConstraintSetId,
   }) async {
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetSizeConstraintSet'
@@ -3678,15 +3073,6 @@ class WAFRegional {
   Future<GetSqlInjectionMatchSetResponse> getSqlInjectionMatchSet({
     required String sqlInjectionMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetSqlInjectionMatchSet'
@@ -3729,14 +3115,6 @@ class WAFRegional {
   Future<GetWebACLResponse> getWebACL({
     required String webACLId,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetWebACL'
@@ -3797,14 +3175,6 @@ class WAFRegional {
   Future<GetWebACLForResourceResponse> getWebACLForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetWebACLForResource'
@@ -3848,14 +3218,6 @@ class WAFRegional {
   Future<GetXssMatchSetResponse> getXssMatchSet({
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.GetXssMatchSet'
@@ -3921,18 +3283,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListActivatedRulesInRuleGroup'
@@ -3995,12 +3345,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListByteMatchSets'
@@ -4061,12 +3405,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListGeoMatchSets'
@@ -4124,12 +3462,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4194,12 +3526,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListLoggingConfigurations'
@@ -4259,12 +3585,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4326,12 +3646,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4395,12 +3709,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListRegexPatternSets'
@@ -4450,14 +3758,6 @@ class WAFRegional {
     required String webACLId,
     ResourceType? resourceType,
   }) async {
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListResourcesForWebACL'
@@ -4516,12 +3816,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4582,12 +3876,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4650,12 +3938,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListSizeConstraintSets'
@@ -4717,12 +3999,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListSqlInjectionMatchSets'
@@ -4782,12 +4058,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4850,25 +4120,11 @@ class WAFRegional {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -4931,12 +4187,6 @@ class WAFRegional {
       0,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.ListWebACLs'
@@ -4996,12 +4246,6 @@ class WAFRegional {
       limit,
       0,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      1224,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -5076,7 +4320,6 @@ class WAFRegional {
   Future<PutLoggingConfigurationResponse> putLoggingConfiguration({
     required LoggingConfiguration loggingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(loggingConfiguration, 'loggingConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.PutLoggingConfiguration'
@@ -5166,22 +4409,6 @@ class WAFRegional {
     required String policy,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      395000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      1,
-      1224,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.PutPermissionPolicy'
@@ -5238,15 +4465,6 @@ class WAFRegional {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.TagResource'
@@ -5292,15 +4510,6 @@ class WAFRegional {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1224,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UntagResource'
@@ -5425,23 +4634,6 @@ class WAFRegional {
     required String changeToken,
     required List<ByteMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(byteMatchSetId, 'byteMatchSetId');
-    _s.validateStringLength(
-      'byteMatchSetId',
-      byteMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateByteMatchSet'
@@ -5558,23 +4750,6 @@ class WAFRegional {
     required String geoMatchSetId,
     required List<GeoMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(geoMatchSetId, 'geoMatchSetId');
-    _s.validateStringLength(
-      'geoMatchSetId',
-      geoMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateGeoMatchSet'
@@ -5719,23 +4894,6 @@ class WAFRegional {
     required String iPSetId,
     required List<IPSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(iPSetId, 'iPSetId');
-    _s.validateStringLength(
-      'iPSetId',
-      iPSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateIPSet'
@@ -5857,15 +5015,6 @@ class WAFRegional {
     required String ruleId,
     required List<RuleUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(rateLimit, 'rateLimit');
     _s.validateNumRange(
       'rateLimit',
       rateLimit,
@@ -5873,15 +5022,6 @@ class WAFRegional {
       2000000000,
       isRequired: true,
     );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateRateBasedRule'
@@ -5991,23 +5131,6 @@ class WAFRegional {
     required String regexMatchSetId,
     required List<RegexMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexMatchSetId, 'regexMatchSetId');
-    _s.validateStringLength(
-      'regexMatchSetId',
-      regexMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateRegexMatchSet'
@@ -6116,23 +5239,6 @@ class WAFRegional {
     required String regexPatternSetId,
     required List<RegexPatternSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regexPatternSetId, 'regexPatternSetId');
-    _s.validateStringLength(
-      'regexPatternSetId',
-      regexPatternSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateRegexPatternSet'
@@ -6256,23 +5362,6 @@ class WAFRegional {
     required String ruleId,
     required List<RuleUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleId, 'ruleId');
-    _s.validateStringLength(
-      'ruleId',
-      ruleId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateRule'
@@ -6371,23 +5460,6 @@ class WAFRegional {
     required String ruleGroupId,
     required List<RuleGroupUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleGroupId, 'ruleGroupId');
-    _s.validateStringLength(
-      'ruleGroupId',
-      ruleGroupId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateRuleGroup'
@@ -6521,23 +5593,6 @@ class WAFRegional {
     required String sizeConstraintSetId,
     required List<SizeConstraintSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sizeConstraintSetId, 'sizeConstraintSetId');
-    _s.validateStringLength(
-      'sizeConstraintSetId',
-      sizeConstraintSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateSizeConstraintSet'
@@ -6660,24 +5715,6 @@ class WAFRegional {
     required String sqlInjectionMatchSetId,
     required List<SqlInjectionMatchSetUpdate> updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        sqlInjectionMatchSetId, 'sqlInjectionMatchSetId');
-    _s.validateStringLength(
-      'sqlInjectionMatchSetId',
-      sqlInjectionMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateSqlInjectionMatchSet'
@@ -6849,22 +5886,6 @@ class WAFRegional {
     WafAction? defaultAction,
     List<WebACLUpdate>? updates,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateWebACL'
@@ -6987,23 +6008,6 @@ class WAFRegional {
     required List<XssMatchSetUpdate> updates,
     required String xssMatchSetId,
   }) async {
-    ArgumentError.checkNotNull(changeToken, 'changeToken');
-    _s.validateStringLength(
-      'changeToken',
-      changeToken,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(updates, 'updates');
-    ArgumentError.checkNotNull(xssMatchSetId, 'xssMatchSetId');
-    _s.validateStringLength(
-      'xssMatchSetId',
-      xssMatchSetId,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_Regional_20161128.UpdateXssMatchSet'

--- a/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
+++ b/generated/aws_wafv2_api/lib/wafv2-2019-07-29.dart
@@ -176,22 +176,6 @@ class WAFV2 {
     required String resourceArn,
     required String webACLArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLArn, 'webACLArn');
-    _s.validateStringLength(
-      'webACLArn',
-      webACLArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.AssociateWebACL'
@@ -261,8 +245,6 @@ class WAFV2 {
     required List<Rule> rules,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(rules, 'rules');
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.CheckCapacity'
@@ -376,23 +358,6 @@ class WAFV2 {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(addresses, 'addresses');
-    ArgumentError.checkNotNull(iPAddressVersion, 'iPAddressVersion');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.CreateIPSet'
@@ -473,22 +438,6 @@ class WAFV2 {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regularExpressionList, 'regularExpressionList');
-    ArgumentError.checkNotNull(scope, 'scope');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.CreateRegexPatternSet'
@@ -601,29 +550,12 @@ class WAFV2 {
     List<Rule>? rules,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(capacity, 'capacity');
     _s.validateNumRange(
       'capacity',
       capacity,
       1,
       1152921504606846976,
       isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(visibilityConfig, 'visibilityConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -732,23 +664,6 @@ class WAFV2 {
     List<Rule>? rules,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(defaultAction, 'defaultAction');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(visibilityConfig, 'visibilityConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.CreateWebACL'
@@ -802,22 +717,6 @@ class WAFV2 {
     required String webACLArn,
     required String webACLLockToken,
   }) async {
-    ArgumentError.checkNotNull(webACLArn, 'webACLArn');
-    _s.validateStringLength(
-      'webACLArn',
-      webACLArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLLockToken, 'webACLLockToken');
-    _s.validateStringLength(
-      'webACLLockToken',
-      webACLLockToken,
-      1,
-      36,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteFirewallManagerRuleGroups'
@@ -897,31 +796,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteIPSet'
@@ -962,14 +836,6 @@ class WAFV2 {
   Future<void> deleteLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteLoggingConfiguration'
@@ -1002,14 +868,6 @@ class WAFV2 {
   Future<void> deletePermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeletePermissionPolicy'
@@ -1085,31 +943,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteRegexPatternSet'
@@ -1189,31 +1022,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteRuleGroup'
@@ -1296,31 +1104,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DeleteWebACL'
@@ -1386,23 +1169,6 @@ class WAFV2 {
     required Scope scope,
     required String vendorName,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(vendorName, 'vendorName');
-    _s.validateStringLength(
-      'vendorName',
-      vendorName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DescribeManagedRuleGroup'
@@ -1471,14 +1237,6 @@ class WAFV2 {
   Future<void> disassociateWebACL({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.DisassociateWebACL'
@@ -1540,23 +1298,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetIPSet'
@@ -1597,14 +1338,6 @@ class WAFV2 {
   Future<GetLoggingConfigurationResponse> getLoggingConfiguration({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetLoggingConfiguration'
@@ -1637,14 +1370,6 @@ class WAFV2 {
   Future<GetPermissionPolicyResponse> getPermissionPolicy({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetPermissionPolicy'
@@ -1716,31 +1441,6 @@ class WAFV2 {
     required String webACLId,
     required String webACLName,
   }) async {
-    ArgumentError.checkNotNull(ruleName, 'ruleName');
-    _s.validateStringLength(
-      'ruleName',
-      ruleName,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(webACLId, 'webACLId');
-    _s.validateStringLength(
-      'webACLId',
-      webACLId,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(webACLName, 'webACLName');
-    _s.validateStringLength(
-      'webACLName',
-      webACLName,
-      1,
-      128,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetRateBasedStatementManagedKeys'
@@ -1806,23 +1506,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetRegexPatternSet'
@@ -1888,23 +1571,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetRuleGroup'
@@ -1996,30 +1662,11 @@ class WAFV2 {
     required TimeWindow timeWindow,
     required String webAclArn,
   }) async {
-    ArgumentError.checkNotNull(maxItems, 'maxItems');
     _s.validateNumRange(
       'maxItems',
       maxItems,
       1,
       500,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ruleMetricName, 'ruleMetricName');
-    _s.validateStringLength(
-      'ruleMetricName',
-      ruleMetricName,
-      1,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(timeWindow, 'timeWindow');
-    ArgumentError.checkNotNull(webAclArn, 'webAclArn');
-    _s.validateStringLength(
-      'webAclArn',
-      webAclArn,
-      20,
-      2048,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -2089,23 +1736,6 @@ class WAFV2 {
     required String name,
     required Scope scope,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetWebACL'
@@ -2146,14 +1776,6 @@ class WAFV2 {
   Future<GetWebACLForResourceResponse> getWebACLForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.GetWebACLForResource'
@@ -2223,18 +1845,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(scope, 'scope');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2305,18 +1920,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(scope, 'scope');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2392,12 +2000,6 @@ class WAFV2 {
       1,
       100,
     );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.ListLoggingConfigurations'
@@ -2467,18 +2069,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(scope, 'scope');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2528,14 +2123,6 @@ class WAFV2 {
     required String webACLArn,
     ResourceType? resourceType,
   }) async {
-    ArgumentError.checkNotNull(webACLArn, 'webACLArn');
-    _s.validateStringLength(
-      'webACLArn',
-      webACLArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.ListResourcesForWebACL'
@@ -2604,18 +2191,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(scope, 'scope');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2682,25 +2262,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2771,18 +2337,11 @@ class WAFV2 {
     int? limit,
     String? nextMarker,
   }) async {
-    ArgumentError.checkNotNull(scope, 'scope');
     _s.validateNumRange(
       'limit',
       limit,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextMarker',
-      nextMarker,
-      1,
-      256,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2855,7 +2414,6 @@ class WAFV2 {
   Future<PutLoggingConfigurationResponse> putLoggingConfiguration({
     required LoggingConfiguration loggingConfiguration,
   }) async {
-    ArgumentError.checkNotNull(loggingConfiguration, 'loggingConfiguration');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.PutLoggingConfiguration'
@@ -2938,22 +2496,6 @@ class WAFV2 {
     required String policy,
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(policy, 'policy');
-    _s.validateStringLength(
-      'policy',
-      policy,
-      1,
-      395000,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.PutPermissionPolicy'
@@ -3005,15 +2547,6 @@ class WAFV2 {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.TagResource'
@@ -3060,15 +2593,6 @@ class WAFV2 {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.UntagResource'
@@ -3184,38 +2708,6 @@ class WAFV2 {
     required Scope scope,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(addresses, 'addresses');
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.UpdateIPSet'
@@ -3306,38 +2798,6 @@ class WAFV2 {
     required Scope scope,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(regularExpressionList, 'regularExpressionList');
-    ArgumentError.checkNotNull(scope, 'scope');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.UpdateRegexPatternSet'
@@ -3445,38 +2905,6 @@ class WAFV2 {
     String? description,
     List<Rule>? rules,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(visibilityConfig, 'visibilityConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.UpdateRuleGroup'
@@ -3595,39 +3023,6 @@ class WAFV2 {
     String? description,
     List<Rule>? rules,
   }) async {
-    ArgumentError.checkNotNull(defaultAction, 'defaultAction');
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(lockToken, 'lockToken');
-    _s.validateStringLength(
-      'lockToken',
-      lockToken,
-      1,
-      36,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(scope, 'scope');
-    ArgumentError.checkNotNull(visibilityConfig, 'visibilityConfig');
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'AWSWAF_20190729.UpdateWebACL'

--- a/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
+++ b/generated/aws_workdocs_api/lib/workdocs-2016-05-01.dart
@@ -107,28 +107,6 @@ class WorkDocs {
     required String versionId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -162,20 +140,6 @@ class WorkDocs {
     required String userId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -217,21 +181,6 @@ class WorkDocs {
     String? authenticationToken,
     NotificationOptions? notificationOptions,
   }) async {
-    ArgumentError.checkNotNull(principals, 'principals');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -301,48 +250,6 @@ class WorkDocs {
     String? threadId,
     CommentVisibilityType? visibility,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(text, 'text');
-    _s.validateStringLength(
-      'text',
-      text,
-      1,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'parentId',
-      parentId,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'threadId',
-      threadId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -396,27 +303,6 @@ class WorkDocs {
     String? authenticationToken,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(customMetadata, 'customMetadata');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -464,26 +350,6 @@ class WorkDocs {
     String? authenticationToken,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(parentFolderId, 'parentFolderId');
-    _s.validateStringLength(
-      'parentFolderId',
-      parentFolderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -526,21 +392,6 @@ class WorkDocs {
     required String resourceId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(labels, 'labels');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -588,24 +439,6 @@ class WorkDocs {
     required SubscriptionProtocolType protocol,
     required SubscriptionType subscriptionType,
   }) async {
-    ArgumentError.checkNotNull(endpoint, 'endpoint');
-    _s.validateStringLength(
-      'endpoint',
-      endpoint,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(protocol, 'protocol');
-    ArgumentError.checkNotNull(subscriptionType, 'subscriptionType');
     final $payload = <String, dynamic>{
       'Endpoint': endpoint,
       'Protocol': protocol.toValue(),
@@ -668,62 +501,6 @@ class WorkDocs {
     StorageRuleType? storageRule,
     String? timeZoneId,
   }) async {
-    ArgumentError.checkNotNull(givenName, 'givenName');
-    _s.validateStringLength(
-      'givenName',
-      givenName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      4,
-      32,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(surname, 'surname');
-    _s.validateStringLength(
-      'surname',
-      surname,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'emailAddress',
-      emailAddress,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'timeZoneId',
-      timeZoneId,
-      1,
-      256,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -767,20 +544,6 @@ class WorkDocs {
     required String userId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -822,36 +585,6 @@ class WorkDocs {
     required String versionId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(commentId, 'commentId');
-    _s.validateStringLength(
-      'commentId',
-      commentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -899,26 +632,6 @@ class WorkDocs {
     List<String>? keys,
     String? versionId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -960,20 +673,6 @@ class WorkDocs {
     required String documentId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -1008,20 +707,6 @@ class WorkDocs {
     required String folderId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -1055,20 +740,6 @@ class WorkDocs {
     required String folderId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -1108,20 +779,6 @@ class WorkDocs {
     bool? deleteAll,
     List<String>? labels,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -1156,22 +813,6 @@ class WorkDocs {
     required String organizationId,
     required String subscriptionId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(subscriptionId, 'subscriptionId');
-    _s.validateStringLength(
-      'subscriptionId',
-      subscriptionId,
-      1,
-      256,
-      isRequired: true,
-    );
     await _protocol.send(
       payload: null,
       method: 'DELETE',
@@ -1199,20 +840,6 @@ class WorkDocs {
     required String userId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -1285,47 +912,11 @@ class WorkDocs {
     DateTime? startTime,
     String? userId,
   }) async {
-    _s.validateStringLength(
-      'activityTypes',
-      activityTypes,
-      1,
-      1024,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1387,39 +978,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1482,43 +1045,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'fields',
-      fields,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'include',
-      include,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1593,37 +1124,11 @@ class WorkDocs {
     ResourceSortType? sort,
     FolderContentType? type,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'include',
-      include,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1679,37 +1184,11 @@ class WorkDocs {
     String? marker,
     String? organizationId,
   }) async {
-    ArgumentError.checkNotNull(searchQuery, 'searchQuery');
-    _s.validateStringLength(
-      'searchQuery',
-      searchQuery,
-      1,
-      512,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1753,25 +1232,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final $query = <String, List<String>>{
       if (limit != null) 'limit': [limit.toString()],
@@ -1818,37 +1283,11 @@ class WorkDocs {
     String? marker,
     String? principalId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'principalId',
-      principalId,
-      1,
-      256,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -1904,25 +1343,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(authenticationToken, 'authenticationToken');
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Authentication': authenticationToken.toString(),
@@ -2001,47 +1426,11 @@ class WorkDocs {
     UserSortType? sort,
     String? userIds,
   }) async {
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'fields',
-      fields,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      1,
-      256,
-    );
-    _s.validateStringLength(
-      'query',
-      query,
-      1,
-      512,
-    );
-    _s.validateStringLength(
-      'userIds',
-      userIds,
-      1,
-      2000,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -2091,14 +1480,6 @@ class WorkDocs {
   Future<GetCurrentUserResponse> getCurrentUser({
     required String authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(authenticationToken, 'authenticationToken');
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Authentication': authenticationToken.toString(),
     };
@@ -2136,20 +1517,6 @@ class WorkDocs {
     String? authenticationToken,
     bool? includeCustomMetadata,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2206,37 +1573,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'fields',
-      fields,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -2291,34 +1632,6 @@ class WorkDocs {
     String? fields,
     bool? includeCustomMetadata,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'fields',
-      fields,
-      1,
-      256,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2364,20 +1677,6 @@ class WorkDocs {
     String? authenticationToken,
     bool? includeCustomMetadata,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2434,37 +1733,11 @@ class WorkDocs {
     int? limit,
     String? marker,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'fields',
-      fields,
-      1,
-      256,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -2519,29 +1792,11 @@ class WorkDocs {
     String? marker,
     String? userId,
   }) async {
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       999,
-    );
-    _s.validateStringLength(
-      'marker',
-      marker,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
     );
     final headers = <String, String>{
       if (authenticationToken != null)
@@ -2620,38 +1875,6 @@ class WorkDocs {
     String? id,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(parentFolderId, 'parentFolderId');
-    _s.validateStringLength(
-      'parentFolderId',
-      parentFolderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'contentType',
-      contentType,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2696,20 +1919,6 @@ class WorkDocs {
     required String resourceId,
     String? authenticationToken,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2750,28 +1959,6 @@ class WorkDocs {
     String? authenticationToken,
     PrincipalType? principalType,
   }) async {
-    ArgumentError.checkNotNull(principalId, 'principalId');
-    _s.validateStringLength(
-      'principalId',
-      principalId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2827,32 +2014,6 @@ class WorkDocs {
     String? parentFolderId,
     ResourceStateType? resourceState,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'parentFolderId',
-      parentFolderId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2904,28 +2065,6 @@ class WorkDocs {
     String? authenticationToken,
     DocumentVersionStatus? versionStatus,
   }) async {
-    ArgumentError.checkNotNull(documentId, 'documentId');
-    _s.validateStringLength(
-      'documentId',
-      documentId,
-      1,
-      128,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(versionId, 'versionId');
-    _s.validateStringLength(
-      'versionId',
-      versionId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -2980,32 +2119,6 @@ class WorkDocs {
     String? parentFolderId,
     ResourceStateType? resourceState,
   }) async {
-    ArgumentError.checkNotNull(folderId, 'folderId');
-    _s.validateStringLength(
-      'folderId',
-      folderId,
-      1,
-      128,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      255,
-    );
-    _s.validateStringLength(
-      'parentFolderId',
-      parentFolderId,
-      1,
-      128,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),
@@ -3075,38 +2188,6 @@ class WorkDocs {
     String? timeZoneId,
     UserType? type,
   }) async {
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      1,
-      256,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'authenticationToken',
-      authenticationToken,
-      1,
-      8199,
-    );
-    _s.validateStringLength(
-      'givenName',
-      givenName,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'surname',
-      surname,
-      1,
-      64,
-    );
-    _s.validateStringLength(
-      'timeZoneId',
-      timeZoneId,
-      1,
-      256,
-    );
     final headers = <String, String>{
       if (authenticationToken != null)
         'Authentication': authenticationToken.toString(),

--- a/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
+++ b/generated/aws_worklink_api/lib/worklink-2018-09-25.dart
@@ -83,29 +83,6 @@ class WorkLink {
     required String fleetArn,
     String? displayName,
   }) async {
-    ArgumentError.checkNotNull(acmCertificateArn, 'acmCertificateArn');
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
     final $payload = <String, dynamic>{
       'AcmCertificateArn': acmCertificateArn,
       'DomainName': domainName,
@@ -146,22 +123,6 @@ class WorkLink {
     required String fleetArn,
     String? domainName,
   }) async {
-    ArgumentError.checkNotNull(
-        authorizationProviderType, 'authorizationProviderType');
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-    );
     final $payload = <String, dynamic>{
       'AuthorizationProviderType': authorizationProviderType.toValue(),
       'FleetArn': fleetArn,
@@ -201,28 +162,6 @@ class WorkLink {
     required String fleetArn,
     String? displayName,
   }) async {
-    ArgumentError.checkNotNull(certificate, 'certificate');
-    _s.validateStringLength(
-      'certificate',
-      certificate,
-      1,
-      8192,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
     final $payload = <String, dynamic>{
       'Certificate': certificate,
       'FleetArn': fleetArn,
@@ -266,20 +205,6 @@ class WorkLink {
     bool? optimizeForEndUserLocation,
     Map<String, String>? tags,
   }) async {
-    ArgumentError.checkNotNull(fleetName, 'fleetName');
-    _s.validateStringLength(
-      'fleetName',
-      fleetName,
-      1,
-      48,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
     final $payload = <String, dynamic>{
       'FleetName': fleetName,
       if (displayName != null) 'DisplayName': displayName,
@@ -310,14 +235,6 @@ class WorkLink {
   Future<void> deleteFleet({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -344,14 +261,6 @@ class WorkLink {
       describeAuditStreamConfiguration({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -379,14 +288,6 @@ class WorkLink {
       describeCompanyNetworkConfiguration({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -416,22 +317,6 @@ class WorkLink {
     required String deviceId,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(deviceId, 'deviceId');
-    _s.validateStringLength(
-      'deviceId',
-      deviceId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DeviceId': deviceId,
       'FleetArn': fleetArn,
@@ -459,14 +344,6 @@ class WorkLink {
       describeDevicePolicyConfiguration({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -496,22 +373,6 @@ class WorkLink {
     required String domainName,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'FleetArn': fleetArn,
@@ -539,14 +400,6 @@ class WorkLink {
   Future<DescribeFleetMetadataResponse> describeFleetMetadata({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -573,14 +426,6 @@ class WorkLink {
       describeIdentityProviderConfiguration({
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
     };
@@ -611,22 +456,6 @@ class WorkLink {
     required String fleetArn,
     required String websiteCaId,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(websiteCaId, 'websiteCaId');
-    _s.validateStringLength(
-      'websiteCaId',
-      websiteCaId,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       'WebsiteCaId': websiteCaId,
@@ -658,22 +487,6 @@ class WorkLink {
     required String domainName,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'FleetArn': fleetArn,
@@ -706,23 +519,6 @@ class WorkLink {
     required String authorizationProviderId,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(
-        authorizationProviderId, 'authorizationProviderId');
-    _s.validateStringLength(
-      'authorizationProviderId',
-      authorizationProviderId,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'AuthorizationProviderId': authorizationProviderId,
       'FleetArn': fleetArn,
@@ -752,22 +548,6 @@ class WorkLink {
     required String fleetArn,
     required String websiteCaId,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(websiteCaId, 'websiteCaId');
-    _s.validateStringLength(
-      'websiteCaId',
-      websiteCaId,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       'WebsiteCaId': websiteCaId,
@@ -802,25 +582,11 @@ class WorkLink {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
@@ -858,25 +624,11 @@ class WorkLink {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
@@ -915,12 +667,6 @@ class WorkLink {
       1,
       1152921504606846976,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
-    );
     final $payload = <String, dynamic>{
       if (maxResults != null) 'MaxResults': maxResults,
       if (nextToken != null) 'NextToken': nextToken,
@@ -943,14 +689,6 @@ class WorkLink {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceArn,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final response = await _protocol.send(
       payload: null,
       method: 'GET',
@@ -984,25 +722,11 @@ class WorkLink {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
@@ -1041,25 +765,11 @@ class WorkLink {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       1152921504606846976,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      4096,
     );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
@@ -1092,22 +802,6 @@ class WorkLink {
     required String domainName,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'FleetArn': fleetArn,
@@ -1137,22 +831,6 @@ class WorkLink {
     required String domainName,
     required String fleetArn,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'FleetArn': fleetArn,
@@ -1183,22 +861,6 @@ class WorkLink {
     required String fleetArn,
     required String username,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(username, 'username');
-    _s.validateStringLength(
-      'username',
-      username,
-      1,
-      256,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       'Username': username,
@@ -1226,15 +888,6 @@ class WorkLink {
     required String resourceArn,
     required Map<String, String> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'Tags': tags,
     };
@@ -1259,15 +912,6 @@ class WorkLink {
     required String resourceArn,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceArn, 'resourceArn');
-    _s.validateStringLength(
-      'resourceArn',
-      resourceArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $query = <String, List<String>>{
       'tagKeys': tagKeys,
     };
@@ -1297,14 +941,6 @@ class WorkLink {
     required String fleetArn,
     String? auditStreamArn,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       if (auditStreamArn != null) 'AuditStreamArn': auditStreamArn,
@@ -1343,17 +979,6 @@ class WorkLink {
     required List<String> subnetIds,
     required String vpcId,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(securityGroupIds, 'securityGroupIds');
-    ArgumentError.checkNotNull(subnetIds, 'subnetIds');
-    ArgumentError.checkNotNull(vpcId, 'vpcId');
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       'SecurityGroupIds': securityGroupIds,
@@ -1386,20 +1011,6 @@ class WorkLink {
     required String fleetArn,
     String? deviceCaCertificate,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'deviceCaCertificate',
-      deviceCaCertificate,
-      1,
-      32768,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       if (deviceCaCertificate != null)
@@ -1434,28 +1045,6 @@ class WorkLink {
     required String fleetArn,
     String? displayName,
   }) async {
-    ArgumentError.checkNotNull(domainName, 'domainName');
-    _s.validateStringLength(
-      'domainName',
-      domainName,
-      1,
-      253,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
     final $payload = <String, dynamic>{
       'DomainName': domainName,
       'FleetArn': fleetArn,
@@ -1492,20 +1081,6 @@ class WorkLink {
     String? displayName,
     bool? optimizeForEndUserLocation,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      100,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       if (displayName != null) 'DisplayName': displayName,
@@ -1542,21 +1117,6 @@ class WorkLink {
     required IdentityProviderType identityProviderType,
     String? identityProviderSamlMetadata,
   }) async {
-    ArgumentError.checkNotNull(fleetArn, 'fleetArn');
-    _s.validateStringLength(
-      'fleetArn',
-      fleetArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(identityProviderType, 'identityProviderType');
-    _s.validateStringLength(
-      'identityProviderSamlMetadata',
-      identityProviderSamlMetadata,
-      1,
-      204800,
-    );
     final $payload = <String, dynamic>{
       'FleetArn': fleetArn,
       'IdentityProviderType': identityProviderType.toValue(),

--- a/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
+++ b/generated/aws_workmail_api/lib/workmail-2017-10-01.dart
@@ -106,30 +106,6 @@ class WorkMail {
     required String organizationId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.AssociateDelegateToResource'
@@ -172,30 +148,6 @@ class WorkMail {
     required String memberId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    _s.validateStringLength(
-      'groupId',
-      groupId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.AssociateMemberToGroup'
@@ -238,28 +190,6 @@ class WorkMail {
     required String organizationId,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CancelMailboxExportJob'
@@ -304,30 +234,6 @@ class WorkMail {
     required String entityId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(alias, 'alias');
-    _s.validateStringLength(
-      'alias',
-      alias,
-      1,
-      254,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CreateAlias'
@@ -367,22 +273,6 @@ class WorkMail {
     required String name,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CreateGroup'
@@ -460,32 +350,6 @@ class WorkMail {
     bool? enableInteroperability,
     String? kmsKeyArn,
   }) async {
-    ArgumentError.checkNotNull(alias, 'alias');
-    _s.validateStringLength(
-      'alias',
-      alias,
-      1,
-      62,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      12,
-      12,
-    );
-    _s.validateStringLength(
-      'kmsKeyArn',
-      kmsKeyArn,
-      20,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CreateOrganization'
@@ -535,23 +399,6 @@ class WorkMail {
     required String organizationId,
     required ResourceType type,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      20,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(type, 'type');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CreateResource'
@@ -603,38 +450,6 @@ class WorkMail {
     required String organizationId,
     required String password,
   }) async {
-    ArgumentError.checkNotNull(displayName, 'displayName');
-    _s.validateStringLength(
-      'displayName',
-      displayName,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      0,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.CreateUser'
@@ -670,22 +485,6 @@ class WorkMail {
     required String name,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteAccessControlRule'
@@ -728,30 +527,6 @@ class WorkMail {
     required String entityId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(alias, 'alias');
-    _s.validateStringLength(
-      'alias',
-      alias,
-      1,
-      254,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteAlias'
@@ -789,22 +564,6 @@ class WorkMail {
     required String groupId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    _s.validateStringLength(
-      'groupId',
-      groupId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteGroup'
@@ -845,30 +604,6 @@ class WorkMail {
     required String granteeId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(granteeId, 'granteeId');
-    _s.validateStringLength(
-      'granteeId',
-      granteeId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteMailboxPermissions'
@@ -911,21 +646,6 @@ class WorkMail {
     required String organizationId,
     String? clientToken,
   }) async {
-    ArgumentError.checkNotNull(deleteDirectory, 'deleteDirectory');
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      128,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteOrganization'
@@ -963,22 +683,6 @@ class WorkMail {
     required String organizationId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteResource'
@@ -1011,22 +715,6 @@ class WorkMail {
     required String id,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(id, 'id');
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteRetentionPolicy'
@@ -1068,22 +756,6 @@ class WorkMail {
     required String organizationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeleteUser'
@@ -1122,22 +794,6 @@ class WorkMail {
     required String entityId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DeregisterFromWorkMail'
@@ -1171,22 +827,6 @@ class WorkMail {
     required String groupId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    _s.validateStringLength(
-      'groupId',
-      groupId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DescribeGroup'
@@ -1222,22 +862,6 @@ class WorkMail {
     required String jobId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(jobId, 'jobId');
-    _s.validateStringLength(
-      'jobId',
-      jobId,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DescribeMailboxExportJob'
@@ -1268,14 +892,6 @@ class WorkMail {
   Future<DescribeOrganizationResponse> describeOrganization({
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DescribeOrganization'
@@ -1311,22 +927,6 @@ class WorkMail {
     required String organizationId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DescribeResource'
@@ -1362,22 +962,6 @@ class WorkMail {
     required String organizationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DescribeUser'
@@ -1420,30 +1004,6 @@ class WorkMail {
     required String organizationId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DisassociateDelegateFromResource'
@@ -1486,30 +1046,6 @@ class WorkMail {
     required String memberId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    _s.validateStringLength(
-      'groupId',
-      groupId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(memberId, 'memberId');
-    _s.validateStringLength(
-      'memberId',
-      memberId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.DisassociateMemberFromGroup'
@@ -1555,38 +1091,6 @@ class WorkMail {
     required String organizationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(action, 'action');
-    _s.validateStringLength(
-      'action',
-      action,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ipAddress, 'ipAddress');
-    _s.validateStringLength(
-      'ipAddress',
-      ipAddress,
-      1,
-      15,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.GetAccessControlEffect'
@@ -1620,14 +1124,6 @@ class WorkMail {
   Future<GetDefaultRetentionPolicyResponse> getDefaultRetentionPolicy({
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.GetDefaultRetentionPolicy'
@@ -1662,22 +1158,6 @@ class WorkMail {
     required String organizationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.GetMailboxDetails'
@@ -1707,14 +1187,6 @@ class WorkMail {
   Future<ListAccessControlRulesResponse> listAccessControlRules({
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.ListAccessControlRules'
@@ -1760,33 +1232,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1837,33 +1287,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    _s.validateStringLength(
-      'groupId',
-      groupId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1907,25 +1335,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1967,25 +1381,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2035,33 +1435,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2103,12 +1481,6 @@ class WorkMail {
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2157,33 +1529,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      12,
-      256,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2226,25 +1576,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2275,14 +1611,6 @@ class WorkMail {
   Future<ListTagsForResourceResponse> listTagsForResource({
     required String resourceARN,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.ListTagsForResource'
@@ -2321,25 +1649,11 @@ class WorkMail {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      1024,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -2419,31 +1733,6 @@ class WorkMail {
     List<String>? notUserIds,
     List<String>? userIds,
   }) async {
-    ArgumentError.checkNotNull(description, 'description');
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      255,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(effect, 'effect');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.PutAccessControlRule'
@@ -2504,31 +1793,6 @@ class WorkMail {
     required String organizationId,
     required List<PermissionType> permissionValues,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(granteeId, 'granteeId');
-    _s.validateStringLength(
-      'granteeId',
-      granteeId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(permissionValues, 'permissionValues');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.PutMailboxPermissions'
@@ -2576,35 +1840,6 @@ class WorkMail {
     String? description,
     String? id,
   }) async {
-    ArgumentError.checkNotNull(folderConfigurations, 'folderConfigurations');
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      256,
-    );
-    _s.validateStringLength(
-      'id',
-      id,
-      1,
-      64,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.PutRetentionPolicy'
@@ -2663,30 +1898,6 @@ class WorkMail {
     required String entityId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(email, 'email');
-    _s.validateStringLength(
-      'email',
-      email,
-      1,
-      254,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.RegisterToWorkMail'
@@ -2731,30 +1942,6 @@ class WorkMail {
     required String password,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(password, 'password');
-    _s.validateStringLength(
-      'password',
-      password,
-      0,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.ResetPassword'
@@ -2820,66 +2007,6 @@ class WorkMail {
     String? clientToken,
     String? description,
   }) async {
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(kmsKeyArn, 'kmsKeyArn');
-    _s.validateStringLength(
-      'kmsKeyArn',
-      kmsKeyArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(roleArn, 'roleArn');
-    _s.validateStringLength(
-      'roleArn',
-      roleArn,
-      20,
-      2048,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3BucketName, 's3BucketName');
-    _s.validateStringLength(
-      's3BucketName',
-      s3BucketName,
-      1,
-      63,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(s3Prefix, 's3Prefix');
-    _s.validateStringLength(
-      's3Prefix',
-      s3Prefix,
-      1,
-      1023,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'clientToken',
-      clientToken,
-      1,
-      128,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      0,
-      1023,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.StartMailboxExportJob'
@@ -2921,15 +2048,6 @@ class WorkMail {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.TagResource'
@@ -2961,15 +2079,6 @@ class WorkMail {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.UntagResource'
@@ -3010,28 +2119,11 @@ class WorkMail {
     required String organizationId,
     required String userId,
   }) async {
-    ArgumentError.checkNotNull(mailboxQuota, 'mailboxQuota');
     _s.validateNumRange(
       'mailboxQuota',
       mailboxQuota,
       1,
       1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(userId, 'userId');
-    _s.validateStringLength(
-      'userId',
-      userId,
-      12,
-      256,
       isRequired: true,
     );
     final headers = <String, String>{
@@ -3083,30 +2175,6 @@ class WorkMail {
     required String entityId,
     required String organizationId,
   }) async {
-    ArgumentError.checkNotNull(email, 'email');
-    _s.validateStringLength(
-      'email',
-      email,
-      1,
-      254,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(entityId, 'entityId');
-    _s.validateStringLength(
-      'entityId',
-      entityId,
-      12,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.UpdatePrimaryEmailAddress'
@@ -3159,28 +2227,6 @@ class WorkMail {
     BookingOptions? bookingOptions,
     String? name,
   }) async {
-    ArgumentError.checkNotNull(organizationId, 'organizationId');
-    _s.validateStringLength(
-      'organizationId',
-      organizationId,
-      34,
-      34,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      34,
-      34,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      20,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkMailService.UpdateResource'

--- a/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
+++ b/generated/aws_workmailmessageflow_api/lib/workmailmessageflow-2019-05-01.dart
@@ -57,14 +57,6 @@ class WorkMailMessageFlow {
   Future<GetRawMessageContentResponse> getRawMessageContent({
     required String messageId,
   }) async {
-    ArgumentError.checkNotNull(messageId, 'messageId');
-    _s.validateStringLength(
-      'messageId',
-      messageId,
-      1,
-      120,
-      isRequired: true,
-    );
     final response = await _protocol.sendRaw(
       payload: null,
       method: 'GET',

--- a/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
+++ b/generated/aws_workspaces_api/lib/workspaces-2015-04-08.dart
@@ -75,22 +75,6 @@ class WorkSpaces {
     required String aliasId,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'aliasId',
-      aliasId,
-      13,
-      68,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.AssociateConnectionAlias'
@@ -129,15 +113,6 @@ class WorkSpaces {
     required String directoryId,
     required List<String> groupIds,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupIds, 'groupIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.AssociateIpGroups'
@@ -175,8 +150,6 @@ class WorkSpaces {
     required String groupId,
     required List<IpRuleItem> userRules,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    ArgumentError.checkNotNull(userRules, 'userRules');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.AuthorizeIpRules'
@@ -243,29 +216,6 @@ class WorkSpaces {
     String? description,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(name, 'name');
-    _s.validateStringLength(
-      'name',
-      name,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(sourceImageId, 'sourceImageId');
-    ArgumentError.checkNotNull(sourceRegion, 'sourceRegion');
-    _s.validateStringLength(
-      'sourceRegion',
-      sourceRegion,
-      1,
-      31,
-      isRequired: true,
-    );
-    _s.validateStringLength(
-      'description',
-      description,
-      1,
-      256,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.CopyWorkspaceImage'
@@ -316,14 +266,6 @@ class WorkSpaces {
     required String connectionString,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(connectionString, 'connectionString');
-    _s.validateStringLength(
-      'connectionString',
-      connectionString,
-      1,
-      255,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.CreateConnectionAlias'
@@ -380,7 +322,6 @@ class WorkSpaces {
     List<Tag>? tags,
     List<IpRuleItem>? userRules,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.CreateIpGroup'
@@ -419,15 +360,6 @@ class WorkSpaces {
     required String resourceId,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.CreateTags'
@@ -458,7 +390,6 @@ class WorkSpaces {
   Future<CreateWorkspacesResult> createWorkspaces({
     required List<WorkspaceRequest> workspaces,
   }) async {
-    ArgumentError.checkNotNull(workspaces, 'workspaces');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.CreateWorkspaces'
@@ -508,14 +439,6 @@ class WorkSpaces {
   Future<void> deleteConnectionAlias({
     required String aliasId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'aliasId',
-      aliasId,
-      13,
-      68,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DeleteConnectionAlias'
@@ -547,7 +470,6 @@ class WorkSpaces {
   Future<void> deleteIpGroup({
     required String groupId,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DeleteIpGroup'
@@ -580,15 +502,6 @@ class WorkSpaces {
     required String resourceId,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DeleteTags'
@@ -619,7 +532,6 @@ class WorkSpaces {
   Future<void> deleteWorkspaceImage({
     required String imageId,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DeleteWorkspaceImage'
@@ -669,14 +581,6 @@ class WorkSpaces {
   Future<void> deregisterWorkspaceDirectory({
     required String directoryId,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      10,
-      65,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DeregisterWorkspaceDirectory'
@@ -724,12 +628,6 @@ class WorkSpaces {
   Future<DescribeAccountModificationsResult> describeAccountModifications({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeAccountModifications'
@@ -760,7 +658,6 @@ class WorkSpaces {
   Future<DescribeClientPropertiesResult> describeClientProperties({
     required List<String> resourceIds,
   }) async {
-    ArgumentError.checkNotNull(resourceIds, 'resourceIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeClientProperties'
@@ -805,25 +702,11 @@ class WorkSpaces {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'aliasId',
-      aliasId,
-      13,
-      68,
-      isRequired: true,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -878,18 +761,6 @@ class WorkSpaces {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeConnectionAliases'
@@ -936,12 +807,6 @@ class WorkSpaces {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeIpGroups'
@@ -973,14 +838,6 @@ class WorkSpaces {
   Future<DescribeTagsResult> describeTags({
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeTags'
@@ -1024,12 +881,6 @@ class WorkSpaces {
     String? nextToken,
     String? owner,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeWorkspaceBundles'
@@ -1076,12 +927,6 @@ class WorkSpaces {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeWorkspaceDirectories'
@@ -1124,18 +969,11 @@ class WorkSpaces {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(imageId, 'imageId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1187,12 +1025,6 @@ class WorkSpaces {
       1,
       25,
     );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeWorkspaceImages'
@@ -1225,7 +1057,6 @@ class WorkSpaces {
   Future<DescribeWorkspaceSnapshotsResult> describeWorkspaceSnapshots({
     required String workspaceId,
   }) async {
-    ArgumentError.checkNotNull(workspaceId, 'workspaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeWorkspaceSnapshots'
@@ -1289,29 +1120,11 @@ class WorkSpaces {
     String? userName,
     List<String>? workspaceIds,
   }) async {
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      10,
-      65,
-    );
     _s.validateNumRange(
       'limit',
       limit,
       1,
       25,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
-    _s.validateStringLength(
-      'userName',
-      userName,
-      1,
-      63,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1351,12 +1164,6 @@ class WorkSpaces {
     String? nextToken,
     List<String>? workspaceIds,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DescribeWorkspacesConnectionStatus'
@@ -1399,14 +1206,6 @@ class WorkSpaces {
   Future<void> disassociateConnectionAlias({
     required String aliasId,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'aliasId',
-      aliasId,
-      13,
-      68,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DisassociateConnectionAlias'
@@ -1440,15 +1239,6 @@ class WorkSpaces {
     required String directoryId,
     required List<String> groupIds,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(groupIds, 'groupIds');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.DisassociateIpGroups'
@@ -1521,24 +1311,6 @@ class WorkSpaces {
     List<Application>? applications,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(ec2ImageId, 'ec2ImageId');
-    ArgumentError.checkNotNull(imageDescription, 'imageDescription');
-    _s.validateStringLength(
-      'imageDescription',
-      imageDescription,
-      1,
-      256,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(imageName, 'imageName');
-    _s.validateStringLength(
-      'imageName',
-      imageName,
-      1,
-      64,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(ingestionProcess, 'ingestionProcess');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ImportWorkspaceImage'
@@ -1596,19 +1368,11 @@ class WorkSpaces {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(
-        managementCidrRangeConstraint, 'managementCidrRangeConstraint');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       5,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2048,
     );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
@@ -1662,8 +1426,6 @@ class WorkSpaces {
     required String bundleId,
     required String sourceWorkspaceId,
   }) async {
-    ArgumentError.checkNotNull(bundleId, 'bundleId');
-    ArgumentError.checkNotNull(sourceWorkspaceId, 'sourceWorkspaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.MigrateWorkspace'
@@ -1741,15 +1503,6 @@ class WorkSpaces {
     required ClientProperties clientProperties,
     required String resourceId,
   }) async {
-    ArgumentError.checkNotNull(clientProperties, 'clientProperties');
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      1,
-      1152921504606846976,
-      isRequired: true,
-    );
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifyClientProperties'
@@ -1785,16 +1538,6 @@ class WorkSpaces {
     required String resourceId,
     required SelfservicePermissions selfservicePermissions,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        selfservicePermissions, 'selfservicePermissions');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifySelfservicePermissions'
@@ -1829,16 +1572,6 @@ class WorkSpaces {
     required String resourceId,
     required WorkspaceAccessProperties workspaceAccessProperties,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        workspaceAccessProperties, 'workspaceAccessProperties');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifyWorkspaceAccessProperties'
@@ -1872,16 +1605,6 @@ class WorkSpaces {
     required String resourceId,
     required WorkspaceCreationProperties workspaceCreationProperties,
   }) async {
-    ArgumentError.checkNotNull(resourceId, 'resourceId');
-    _s.validateStringLength(
-      'resourceId',
-      resourceId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        workspaceCreationProperties, 'workspaceCreationProperties');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifyWorkspaceCreationProperties'
@@ -1921,8 +1644,6 @@ class WorkSpaces {
     required String workspaceId,
     required WorkspaceProperties workspaceProperties,
   }) async {
-    ArgumentError.checkNotNull(workspaceId, 'workspaceId');
-    ArgumentError.checkNotNull(workspaceProperties, 'workspaceProperties');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifyWorkspaceProperties'
@@ -1961,8 +1682,6 @@ class WorkSpaces {
     required String workspaceId,
     required TargetWorkspaceState workspaceState,
   }) async {
-    ArgumentError.checkNotNull(workspaceId, 'workspaceId');
-    ArgumentError.checkNotNull(workspaceState, 'workspaceState');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.ModifyWorkspaceState'
@@ -1993,8 +1712,6 @@ class WorkSpaces {
   Future<RebootWorkspacesResult> rebootWorkspaces({
     required List<RebootRequest> rebootWorkspaceRequests,
   }) async {
-    ArgumentError.checkNotNull(
-        rebootWorkspaceRequests, 'rebootWorkspaceRequests');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.RebootWorkspaces'
@@ -2032,8 +1749,6 @@ class WorkSpaces {
   Future<RebuildWorkspacesResult> rebuildWorkspaces({
     required List<RebuildRequest> rebuildWorkspaceRequests,
   }) async {
-    ArgumentError.checkNotNull(
-        rebuildWorkspaceRequests, 'rebuildWorkspaceRequests');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.RebuildWorkspaces'
@@ -2113,15 +1828,6 @@ class WorkSpaces {
     List<Tag>? tags,
     Tenancy? tenancy,
   }) async {
-    ArgumentError.checkNotNull(directoryId, 'directoryId');
-    _s.validateStringLength(
-      'directoryId',
-      directoryId,
-      10,
-      65,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(enableWorkDocs, 'enableWorkDocs');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.RegisterWorkspaceDirectory'
@@ -2166,7 +1872,6 @@ class WorkSpaces {
   Future<void> restoreWorkspace({
     required String workspaceId,
   }) async {
-    ArgumentError.checkNotNull(workspaceId, 'workspaceId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.RestoreWorkspace'
@@ -2199,8 +1904,6 @@ class WorkSpaces {
     required String groupId,
     required List<String> userRules,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    ArgumentError.checkNotNull(userRules, 'userRules');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.RevokeIpRules'
@@ -2228,8 +1931,6 @@ class WorkSpaces {
   Future<StartWorkspacesResult> startWorkspaces({
     required List<StartRequest> startWorkspaceRequests,
   }) async {
-    ArgumentError.checkNotNull(
-        startWorkspaceRequests, 'startWorkspaceRequests');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.StartWorkspaces'
@@ -2259,7 +1960,6 @@ class WorkSpaces {
   Future<StopWorkspacesResult> stopWorkspaces({
     required List<StopRequest> stopWorkspaceRequests,
   }) async {
-    ArgumentError.checkNotNull(stopWorkspaceRequests, 'stopWorkspaceRequests');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.StopWorkspaces'
@@ -2317,8 +2017,6 @@ class WorkSpaces {
   Future<TerminateWorkspacesResult> terminateWorkspaces({
     required List<TerminateRequest> terminateWorkspaceRequests,
   }) async {
-    ArgumentError.checkNotNull(
-        terminateWorkspaceRequests, 'terminateWorkspaceRequests');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.TerminateWorkspaces'
@@ -2382,16 +2080,6 @@ class WorkSpaces {
     required String aliasId,
     required ConnectionAliasPermission connectionAliasPermission,
   }) async {
-    ArgumentError.checkNotNull(aliasId, 'aliasId');
-    _s.validateStringLength(
-      'aliasId',
-      aliasId,
-      13,
-      68,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(
-        connectionAliasPermission, 'connectionAliasPermission');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.UpdateConnectionAliasPermission'
@@ -2427,8 +2115,6 @@ class WorkSpaces {
     required String groupId,
     required List<IpRuleItem> userRules,
   }) async {
-    ArgumentError.checkNotNull(groupId, 'groupId');
-    ArgumentError.checkNotNull(userRules, 'userRules');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.UpdateRulesOfIpGroup'
@@ -2502,9 +2188,6 @@ class WorkSpaces {
     required String imageId,
     required String sharedAccountId,
   }) async {
-    ArgumentError.checkNotNull(allowCopyImage, 'allowCopyImage');
-    ArgumentError.checkNotNull(imageId, 'imageId');
-    ArgumentError.checkNotNull(sharedAccountId, 'sharedAccountId');
     final headers = <String, String>{
       'Content-Type': 'application/x-amz-json-1.1',
       'X-Amz-Target': 'WorkspacesService.UpdateWorkspaceImagePermission'

--- a/generated/aws_xray_api/lib/xray-2016-04-12.dart
+++ b/generated/aws_xray_api/lib/xray-2016-04-12.dart
@@ -64,7 +64,6 @@ class XRay {
     required List<String> traceIds,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(traceIds, 'traceIds');
     final $payload = <String, dynamic>{
       'TraceIds': traceIds,
       if (nextToken != null) 'NextToken': nextToken,
@@ -141,14 +140,6 @@ class XRay {
     InsightsConfiguration? insightsConfiguration,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(groupName, 'groupName');
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'GroupName': groupName,
       if (filterExpression != null) 'FilterExpression': filterExpression,
@@ -215,7 +206,6 @@ class XRay {
     required SamplingRule samplingRule,
     List<Tag>? tags,
   }) async {
-    ArgumentError.checkNotNull(samplingRule, 'samplingRule');
     final $payload = <String, dynamic>{
       'SamplingRule': samplingRule,
       if (tags != null) 'Tags': tags,
@@ -243,18 +233,6 @@ class XRay {
     String? groupARN,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       if (groupARN != null) 'GroupARN': groupARN,
       if (groupName != null) 'GroupName': groupName,
@@ -324,18 +302,6 @@ class XRay {
     String? groupARN,
     String? groupName,
   }) async {
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       if (groupARN != null) 'GroupARN': groupARN,
       if (groupName != null) 'GroupName': groupName,
@@ -359,12 +325,6 @@ class XRay {
   Future<GetGroupsResult> getGroups({
     String? nextToken,
   }) async {
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      100,
-    );
     final $payload = <String, dynamic>{
       if (nextToken != null) 'NextToken': nextToken,
     };
@@ -390,7 +350,6 @@ class XRay {
   Future<GetInsightResult> getInsight({
     required String insightId,
   }) async {
-    ArgumentError.checkNotNull(insightId, 'insightId');
     final $payload = <String, dynamic>{
       'InsightId': insightId,
     };
@@ -425,18 +384,11 @@ class XRay {
     int? maxResults,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(insightId, 'insightId');
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       50,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2000,
     );
     final $payload = <String, dynamic>{
       'InsightId': insightId,
@@ -482,15 +434,6 @@ class XRay {
     required DateTime startTime,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(insightId, 'insightId');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2000,
-    );
     final $payload = <String, dynamic>{
       'EndTime': unixTimestampToJson(endTime),
       'InsightId': insightId,
@@ -544,31 +487,11 @@ class XRay {
     String? nextToken,
     List<InsightState>? states,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     _s.validateNumRange(
       'maxResults',
       maxResults,
       1,
       100,
-    );
-    _s.validateStringLength(
-      'nextToken',
-      nextToken,
-      1,
-      2000,
     );
     final $payload = <String, dynamic>{
       'EndTime': unixTimestampToJson(endTime),
@@ -644,8 +567,6 @@ class XRay {
   Future<GetSamplingTargetsResult> getSamplingTargets({
     required List<SamplingStatisticsDocument> samplingStatisticsDocuments,
   }) async {
-    ArgumentError.checkNotNull(
-        samplingStatisticsDocuments, 'samplingStatisticsDocuments');
     final $payload = <String, dynamic>{
       'SamplingStatisticsDocuments': samplingStatisticsDocuments,
     };
@@ -691,20 +612,6 @@ class XRay {
     String? groupName,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       'EndTime': unixTimestampToJson(endTime),
       'StartTime': unixTimestampToJson(startTime),
@@ -763,26 +670,6 @@ class XRay {
     String? nextToken,
     int? period,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
-    _s.validateStringLength(
-      'entitySelectorExpression',
-      entitySelectorExpression,
-      1,
-      500,
-    );
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       'EndTime': unixTimestampToJson(endTime),
       'StartTime': unixTimestampToJson(startTime),
@@ -817,7 +704,6 @@ class XRay {
     required List<String> traceIds,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(traceIds, 'traceIds');
     final $payload = <String, dynamic>{
       'TraceIds': traceIds,
       if (nextToken != null) 'NextToken': nextToken,
@@ -889,8 +775,6 @@ class XRay {
     SamplingStrategy? samplingStrategy,
     TimeRangeType? timeRangeType,
   }) async {
-    ArgumentError.checkNotNull(endTime, 'endTime');
-    ArgumentError.checkNotNull(startTime, 'startTime');
     final $payload = <String, dynamic>{
       'EndTime': unixTimestampToJson(endTime),
       'StartTime': unixTimestampToJson(startTime),
@@ -927,14 +811,6 @@ class XRay {
     required String resourceARN,
     String? nextToken,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       if (nextToken != null) 'NextToken': nextToken,
@@ -981,13 +857,6 @@ class XRay {
     required EncryptionType type,
     String? keyId,
   }) async {
-    ArgumentError.checkNotNull(type, 'type');
-    _s.validateStringLength(
-      'keyId',
-      keyId,
-      1,
-      3000,
-    );
     final $payload = <String, dynamic>{
       'Type': type.toValue(),
       if (keyId != null) 'KeyId': keyId,
@@ -1023,25 +892,6 @@ class XRay {
     String? hostname,
     String? resourceARN,
   }) async {
-    ArgumentError.checkNotNull(telemetryRecords, 'telemetryRecords');
-    _s.validateStringLength(
-      'eC2InstanceId',
-      eC2InstanceId,
-      0,
-      20,
-    );
-    _s.validateStringLength(
-      'hostname',
-      hostname,
-      0,
-      255,
-    );
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      0,
-      500,
-    );
     final $payload = <String, dynamic>{
       'TelemetryRecords': telemetryRecords,
       if (eC2InstanceId != null) 'EC2InstanceId': eC2InstanceId,
@@ -1127,7 +977,6 @@ class XRay {
   Future<PutTraceSegmentsResult> putTraceSegments({
     required List<String> traceSegmentDocuments,
   }) async {
-    ArgumentError.checkNotNull(traceSegmentDocuments, 'traceSegmentDocuments');
     final $payload = <String, dynamic>{
       'TraceSegmentDocuments': traceSegmentDocuments,
     };
@@ -1185,15 +1034,6 @@ class XRay {
     required String resourceARN,
     required List<Tag> tags,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tags, 'tags');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'Tags': tags,
@@ -1223,15 +1063,6 @@ class XRay {
     required String resourceARN,
     required List<String> tagKeys,
   }) async {
-    ArgumentError.checkNotNull(resourceARN, 'resourceARN');
-    _s.validateStringLength(
-      'resourceARN',
-      resourceARN,
-      1,
-      1011,
-      isRequired: true,
-    );
-    ArgumentError.checkNotNull(tagKeys, 'tagKeys');
     final $payload = <String, dynamic>{
       'ResourceARN': resourceARN,
       'TagKeys': tagKeys,
@@ -1278,18 +1109,6 @@ class XRay {
     String? groupName,
     InsightsConfiguration? insightsConfiguration,
   }) async {
-    _s.validateStringLength(
-      'groupARN',
-      groupARN,
-      1,
-      400,
-    );
-    _s.validateStringLength(
-      'groupName',
-      groupName,
-      1,
-      32,
-    );
     final $payload = <String, dynamic>{
       if (filterExpression != null) 'FilterExpression': filterExpression,
       if (groupARN != null) 'GroupARN': groupARN,
@@ -1316,7 +1135,6 @@ class XRay {
   Future<UpdateSamplingRuleResult> updateSamplingRule({
     required SamplingRuleUpdate samplingRuleUpdate,
   }) async {
-    ArgumentError.checkNotNull(samplingRuleUpdate, 'samplingRuleUpdate');
     final $payload = <String, dynamic>{
       'SamplingRuleUpdate': samplingRuleUpdate,
     };

--- a/generator/lib/builders/library_builder.dart
+++ b/generator/lib/builders/library_builder.dart
@@ -134,19 +134,21 @@ ${builder.constructor()}
     writeln(') async {');
     for (final member in parameterShape?.members ?? <Member>[]) {
       final name = member.fieldName;
-      if (member.isRequired) {
-        writeln('    ArgumentError.checkNotNull($name, \'$name\');');
-      }
 
       if (member.shapeClass?.max != null || member.shapeClass?.min != null) {
         final max = member.shapeClass?.max ?? pow(2, 60).toInt();
         final min = member.shapeClass?.min ?? pow(2, -60).toInt();
 
+        // Below code is commented out for the time being, since string length
+        // in the service definitions are sometime incorrect
+        /*
         if (member.dartType == 'String') {
           final isRequired = member.isRequired ? 'isRequired: true,' : '';
           writeln(
               "_s.validateStringLength('$name', $name, $min, $max, $isRequired);");
-        } else if (member.dartType == 'int' || member.dartType == 'double') {
+        }
+        */
+        if (member.dartType == 'int' || member.dartType == 'double') {
           final isRequired = member.isRequired ? 'isRequired: true,' : '';
           writeln(
               "_s.validateNumRange('$name', $name, $min, $max, $isRequired);");

--- a/shared_aws_api/test/generated/input/query/map_with_enum_key.dart
+++ b/shared_aws_api/test/generated/input/query/map_with_enum_key.dart
@@ -56,7 +56,6 @@ class MapWithEnumKey {
     required String queueName,
     Map<QueueAttributeName, String>? attributes,
   }) async {
-    ArgumentError.checkNotNull(queueName, 'queueName');
     final $request = <String, dynamic>{};
     $request['QueueName'] = queueName;
     attributes?.also((arg) =>

--- a/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/serialize_blobs_in_body.dart
@@ -51,7 +51,6 @@ class SerializeBlobsInBody {
     required String foo,
     Uint8List? bar,
   }) async {
-    ArgumentError.checkNotNull(foo, 'foo');
     final $payload = <String, dynamic>{
       if (bar != null) 'Bar': base64Encode(bar),
     };

--- a/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
+++ b/shared_aws_api/test/generated/input/rest-json/streaming_payload.dart
@@ -52,7 +52,6 @@ class StreamingPayload {
     Uint8List? body,
     String? checksum,
   }) async {
-    ArgumentError.checkNotNull(vaultName, 'vaultName');
     final headers = <String, String>{
       if (checksum != null) 'x-amz-sha256-tree-hash': checksum.toString(),
     };

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_list_maps_in_querystring.dart
@@ -51,7 +51,6 @@ class StringToStringListMapsInQuerystring {
     required String pipelineId,
     Map<String, List<String>>? queryDoc,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (queryDoc != null)
         for (var e in queryDoc.entries) e.key: e.value,

--- a/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-json/string_to_string_maps_in_querystring.dart
@@ -51,7 +51,6 @@ class StringToStringMapsInQuerystring {
     required String pipelineId,
     Map<String, String>? queryDoc,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (queryDoc != null)
         for (var e in queryDoc.entries) e.key: [e.value],

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_and_querystring_params.dart
@@ -52,7 +52,6 @@ class URIParameterAndQuerystringParams {
     String? ascending,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (ascending != null) 'Ascending': [ascending],
       if (pageToken != null) 'PageToken': [pageToken],

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_location_name.dart
@@ -50,7 +50,6 @@ class URIParameterOnlyWithLocationName {
   Future<void> operationName0({
     required String foo,
   }) async {
-    ArgumentError.checkNotNull(foo, 'foo');
     await _protocol.send(
       payload: null,
       method: 'GET',

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_only_with_no_location_name.dart
@@ -50,7 +50,6 @@ class URIParameterOnlyWithNoLocationName {
   Future<void> operationName0({
     required String pipelineId,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     await _protocol.send(
       payload: null,
       method: 'GET',

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_and_json_body.dart
@@ -53,7 +53,6 @@ class URIParameterQuerystringParamsAndJSONBody {
     StructType? config,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (ascending != null) 'Ascending': [ascending],
       if (pageToken != null) 'PageToken': [pageToken],

--- a/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body.dart
+++ b/shared_aws_api/test/generated/input/rest-json/uri_parameter_querystring_params_headers_and_json_body.dart
@@ -54,7 +54,6 @@ class URIParameterQuerystringParamsHeadersAndJSONBody {
     StructType? config,
     String? pageToken,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final headers = <String, String>{
       if (checksum != null) 'x-amz-checksum': checksum.toString(),
     };

--- a/shared_aws_api/test/generated/input/rest-xml/enum.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/enum.dart
@@ -54,7 +54,6 @@ class Enum {
     List<EnumType>? listEnums,
     List<EnumType>? uRIListEnums,
   }) async {
-    ArgumentError.checkNotNull(uRIFooEnum, 'uRIFooEnum');
     final headers = <String, String>{
       if (headerEnum != null) 'x-amz-enum': headerEnum.toValue(),
     };
@@ -85,7 +84,6 @@ class Enum {
     List<EnumType>? listEnums,
     List<EnumType>? uRIListEnums,
   }) async {
-    ArgumentError.checkNotNull(uRIFooEnum, 'uRIFooEnum');
     final headers = <String, String>{
       if (headerEnum != null) 'x-amz-enum': headerEnum.toValue(),
     };

--- a/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/greedy_keys.dart
@@ -51,8 +51,6 @@ class GreedyKeys {
     required String bucket,
     required String key,
   }) async {
-    ArgumentError.checkNotNull(bucket, 'bucket');
-    ArgumentError.checkNotNull(key, 'key');
     await _protocol.send(
       method: 'GET',
       requestUri:

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_list_maps_in_querystring.dart
@@ -51,7 +51,6 @@ class StringToStringListMapsInQuerystring {
     required String pipelineId,
     Map<String, List<String>>? queryDoc,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (queryDoc != null)
         for (var e in queryDoc.entries) e.key: e.value,

--- a/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
+++ b/shared_aws_api/test/generated/input/rest-xml/string_to_string_maps_in_querystring.dart
@@ -51,7 +51,6 @@ class StringToStringMapsInQuerystring {
     required String pipelineId,
     Map<String, String>? queryDoc,
   }) async {
-    ArgumentError.checkNotNull(pipelineId, 'pipelineId');
     final $query = <String, List<String>>{
       if (queryDoc != null)
         for (var e in queryDoc.entries) e.key: [e.value],


### PR DESCRIPTION
- Remove `validateStringLength` calls. This is unfortunate but I have several experiences where the validation was incorrect and prevented me to submit valid strings (uri/arns in my case). And the server was correctly accepting my strings.
- Remove ArgumentError.checkNotNull which are useless with null-safety