### PR TITLE
Force space character encoding for canonical query parameters

### DIFF
--- a/aws_client/lib/src/shared/src/utils/query_string.dart
+++ b/aws_client/lib/src/shared/src/utils/query_string.dart
@@ -8,7 +8,7 @@ String canonicalQueryParametersAll(Map<String, List<String>> query) {
   for (var key in query.keys) {
     for (var value in query[key]!) {
       items.add(
-          '${Uri.encodeQueryComponent(key)}=${Uri.encodeQueryComponent(value)}');
+          '${Uri.encodeQueryComponent(key).replaceAll('+', '%20')}=${Uri.encodeQueryComponent(value).replaceAll('+', '%20')}');
     }
   }
   items.sort();


### PR DESCRIPTION
Hi
I am facing some issues while trying to list objects in buckets hosted in CEPH S3

Using both `listObjects` and `listObjectsV2` when nextMarker/nextContinuationToken contain spaces.

`Uri.encodeQueryComponent` encodes spaces with `+` sign, while server encodes as `%20` which leads to `SignatureDoesNotMatch` error

I've checked this signature calculation mismatch on vanilla AWS S3 and it can be reproduced with old `listObjects` method and objects with spaces in names


