### PR TITLE
Remove double-encode of request URI when generating signature

### DIFF
--- a/shared_aws_api/lib/src/protocol/_sign.dart
+++ b/shared_aws_api/lib/src/protocol/_sign.dart
@@ -34,7 +34,7 @@ void signAws4HmacSha256({
   final payloadHash = sha256.convert(rq.bodyBytes).toString();
   final canonical = [
     rq.method.toUpperCase(),
-    Uri.encodeFull(rq.url.path),
+    rq.url.path,
     canonicalQueryParametersAll(rq.url.queryParametersAll),
     ...canonicalHeaders,
     '',


### PR DESCRIPTION
Fixes #402 