### PR TITLE
Fix Payload root element name

### DIFF
--- a/aws_client/lib/src/generated/s3/v2006_03_01.dart
+++ b/aws_client/lib/src/generated/s3/v2006_03_01.dart
@@ -418,7 +418,7 @@ class S3 {
           '/${Uri.encodeComponent(bucket)}/${key.split('/').map(Uri.encodeComponent).join('/')}',
       queryParams: $query,
       headers: headers,
-      payload: multipartUpload?.toXml('MultipartUpload'),
+      payload: multipartUpload?.toXml('CompleteMultipartUpload'),
       exceptionFnMap: _exceptionFns,
     );
     final $elem = await _s.xmlFromResponse($result);

--- a/generated/aws_s3_api/lib/s3-2006-03-01.dart
+++ b/generated/aws_s3_api/lib/s3-2006-03-01.dart
@@ -418,7 +418,7 @@ class S3 {
           '/${Uri.encodeComponent(bucket)}/${key.split('/').map(Uri.encodeComponent).join('/')}',
       queryParams: $query,
       headers: headers,
-      payload: multipartUpload?.toXml('MultipartUpload'),
+      payload: multipartUpload?.toXml('CompleteMultipartUpload'),
       exceptionFnMap: _exceptionFns,
     );
     final $elem = await _s.xmlFromResponse($result);

--- a/generator/lib/builders/protocols/rest_xml_builder.dart
+++ b/generator/lib/builders/protocols/rest_xml_builder.dart
@@ -66,7 +66,7 @@ class RestXmlServiceBuilder extends ServiceBuilder {
         payloadArg = payloadMember.fieldName;
       } else {
         payloadArg =
-            '${payloadMember.fieldName}${payloadMember.isRequired ? '' : '?'}.toXml(\'${shapeClass.payload}\')';
+            '${payloadMember.fieldName}${payloadMember.isRequired ? '' : '?'}.toXml(\'${payloadMember.locationName ?? shapeClass.payload}\')';
       }
     } else if (shapeClass != null) {
       final bodyMembers = shapeClass.members.where((m) => m.isBody);


### PR DESCRIPTION
Hi
YetAnotherCompleteMultipartUpload fix

But in this case it is fixed in generator code, not in generated like in https://github.com/agilord/aws_client/pull/413


All other commits were auto-generated


The only place where needed element name were in api schema is locationName from payload memeber

As you can see it turned out that `CompleteMultiPartUpload` was the only place with naming mismatch